### PR TITLE
GitHub Actions CI jobs

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,112 @@
+name: Solidity
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "solidity/**"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  contracts-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+        
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/**'
+  contracts-build-and-test:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build contracts
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test
+
+  contracts-lint:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+  contracts-slither:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.5
+
+      - name: Install Solidity
+        env:
+          SOLC_VERSION: 0.7.6 # according to solidity.version in hardhat.config.js
+        run: |
+          pip3 install solc-select
+          solc-select install $SOLC_VERSION
+          solc-select use $SOLC_VERSION
+
+      - name: Install Slither
+        env:
+          SLITHER_VERSION: 0.8.0
+        run: pip3 install slither-analyzer==$SLITHER_VERSION
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run Slither
+        run: slither .


### PR DESCRIPTION
Depends on #1 

The following jobs are defined:
- contracts build and test,
- contracts linting for `.sol` code and `.js` tests,
- slither static analyzer for contracts.

This solution does not cache `node_modules` and it needs to be addressed separately. 

Apologies for force-pushes, this is still a working draft and I need to test things. 