### PR TITLE
Burnable TBTC ERC20 token with permit

### DIFF
--- a/solidity/contracts/TBTCToken.sol
+++ b/solidity/contracts/TBTCToken.sol
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: MIT
-
-pragma solidity <0.9.0;
-
-contract TBTCToken {}

--- a/solidity/contracts/token/ERC20WithPermit.sol
+++ b/solidity/contracts/token/ERC20WithPermit.sol
@@ -21,22 +21,24 @@ import "./IERC20WithPermit.sol";
 contract ERC20WithPermit is IERC20WithPermit, Ownable {
     using SafeMath for uint256;
 
-    uint8 public constant decimals = 18;
-
-    string public name;
-    string public symbol;
-
-    uint256 public override totalSupply;
     mapping(address => uint256) public override balanceOf;
     mapping(address => mapping(address => uint256)) public override allowance;
 
-    uint256 public cachedChainId;
-    bytes32 public cachedDomainSeparator;
+    mapping(address => uint256) public override nonces;
+
+    uint256 public immutable cachedChainId;
+    bytes32 public immutable cachedDomainSeparator;
 
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 public constant override PERMIT_TYPEHASH =
         0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
-    mapping(address => uint256) public override nonces;
+
+    uint256 public override totalSupply;
+
+    string public name;
+    string public symbol;
+
+    uint8 public constant decimals = 18;
 
     constructor(string memory _name, string memory _symbol) {
         name = _name;

--- a/solidity/contracts/token/ERC20WithPermit.sol
+++ b/solidity/contracts/token/ERC20WithPermit.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./IERC20WithPermit.sol";
+
+/// @title  ERC20WithPermit
+/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
+///         authorize a transfer of their token with a signature conforming
+///         EIP712 standard instead of an on-chain transaction from their
+///         address. Anyone can submit this signature on the user's behalf by
+///         calling the permit function, as specified in EIP2612 standard,
+///         paying gas fees, and possibly performing other actions in the same
+///         transaction.
+/// @dev    By the time of implementing this contract there is no other audited
+///         EIP2612 token implementation other than Uniswap V2 on which this
+///         code is based on.
+contract ERC20WithPermit is IERC20WithPermit, Ownable {
+    using SafeMath for uint256;
+
+    uint8 public constant decimals = 18;
+
+    string public name;
+    string public symbol;
+
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    bytes32 public override DOMAIN_SEPARATOR;
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant override PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    mapping(address => uint256) public override nonces;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+
+        uint256 chainId;
+        /* solhint-disable-next-line no-inline-assembly */
+        assembly {
+            chainId := chainid()
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(name)),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    function transfer(address recipient, uint256 amount)
+        external
+        override
+        returns (bool)
+    {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external override returns (bool) {
+        if (allowance[sender][msg.sender] != uint256(-1)) {
+            _approve(
+                sender,
+                msg.sender,
+                allowance[sender][msg.sender].sub(
+                    amount,
+                    "Transfer amount exceeds allowance"
+                )
+            );
+        }
+        _transfer(sender, recipient, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount)
+        external
+        override
+        returns (bool)
+    {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        /* solhint-disable-next-line not-rely-on-time */
+        require(deadline >= block.timestamp, "Permission expired");
+
+        // Validate `s` and `v` values for a malleability concern described in EIP2.
+        // Only signatures with `s` value in the lower half of the secp256k1
+        // curve's order and `v` value of 27 or 28 are considered valid.
+        require(
+            uint256(s) <=
+                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+            "Invalid signature 's' value"
+        );
+        require(v == 27 || v == 28, "Invalid signature 'v' value");
+
+        bytes32 digest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(
+                        abi.encode(
+                            PERMIT_TYPEHASH,
+                            owner,
+                            spender,
+                            amount,
+                            nonces[owner]++,
+                            deadline
+                        )
+                    )
+                )
+            );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "Invalid signature"
+        );
+        _approve(owner, spender, amount);
+    }
+
+    function mint(address recipient, uint256 amount) external onlyOwner {
+        require(recipient != address(0), "Mint to the zero address");
+        totalSupply = totalSupply.add(amount);
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(address(0), recipient, amount);
+    }
+
+    function burn(uint256 amount) external override {
+        _burn(msg.sender, amount);
+    }
+
+    function burnFrom(address account, uint256 amount) external override {
+        _approve(
+            account,
+            msg.sender,
+            allowance[account][msg.sender].sub(
+                amount,
+                "Burn amount exceeds allowance"
+            )
+        );
+        _burn(account, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal {
+        balanceOf[account] = balanceOf[account].sub(
+            amount,
+            "Burn amount exceeds balance"
+        );
+        totalSupply = totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) private {
+        require(sender != address(0), "Transfer from the zero address");
+        require(recipient != address(0), "Transfer to the zero address");
+        balanceOf[sender] = balanceOf[sender].sub(
+            amount,
+            "Transfer amount exceeds balance"
+        );
+        balanceOf[recipient] = balanceOf[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) private {
+        require(owner != address(0), "Approve from the zero address");
+        require(spender != address(0), "Approve to the zero address");
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}

--- a/solidity/contracts/token/IERC20WithPermit.sol
+++ b/solidity/contracts/token/IERC20WithPermit.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title  IERC20WithPermit
+/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
+///         authorize a transfer of their token with a signature conforming
+///         EIP712 standard instead of an on-chain transaction from their
+///         address. Anyone can submit this signature on the user's behalf by
+///         calling the permit function, as specified in EIP2612 standard,
+///         paying gas fees, and possibly performing other actions in the same
+///         transaction.
+interface IERC20WithPermit is IERC20 {
+    /// @notice EIP2612 approval made with secp256k1 signature.
+    ///         Users can authorize a transfer of their tokens with a signature
+    ///         conforming EIP712 standard, rather than an on-chain transaction
+    ///         from their address. Anyone can submit this signature on the
+    ///         user's behalf by calling the permit function, paying gas fees,
+    ///         and possibly performing other actions in the same transaction.
+    /// @dev    The deadline argument can be set to uint(-1) to create permits
+    ///         that effectively never expire.
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /// @notice Destroys `amount` tokens from the caller.
+    function burn(uint256 amount) external;
+
+    /// @notice Destroys `amount` of tokens from `account`, deducting the amount
+    ///         from caller's allowance.
+    function burnFrom(address account, uint256 amount) external;
+
+    /// @notice Returns hash of EIP712 Domain struct with the token name as
+    ///         a signing domain and token contract as a verifying contract.
+    ///         Used to construct EIP2612 signature provided to `permit`
+    ///         function.
+    /* solhint-disable-next-line func-name-mixedcase */
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    /// @notice Returns the current nonce for EIP2612 permission for the
+    ///         provided token owner for a replay protection. Used to construct
+    ///         EIP2612 signature provided to `permit` function.
+    function nonces(address owner) external view returns (uint256);
+
+    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612
+    ///         signature provided to `permit` function.
+    /* solhint-disable-next-line func-name-mixedcase */
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+}

--- a/solidity/contracts/token/TBTCToken.sol
+++ b/solidity/contracts/token/TBTCToken.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "./ERC20WithPermit.sol";
+
+contract TBTCToken is ERC20WithPermit {
+    constructor() ERC20WithPermit("TBTC v2 migration", "TBTC") {}
+}

--- a/solidity/test/helpers/contract-test-helpers.js
+++ b/solidity/test/helpers/contract-test-helpers.js
@@ -3,5 +3,11 @@ function to1e18(n) {
   return ethers.BigNumber.from(n).mul(decimalMultiplier)
 }
 
+async function lastBlockTime() {
+  return (await ethers.provider.getBlock("latest")).timestamp
+}
+
 module.exports.to1e18 = to1e18
+module.exports.lastBlockTime = lastBlockTime
+
 module.exports.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"

--- a/solidity/test/helpers/contract-test-helpers.js
+++ b/solidity/test/helpers/contract-test-helpers.js
@@ -1,0 +1,7 @@
+function to1e18(n) {
+  const decimalMultiplier = ethers.BigNumber.from(10).pow(18)
+  return ethers.BigNumber.from(n).mul(decimalMultiplier)
+}
+
+module.exports.to1e18 = to1e18
+module.exports.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"

--- a/solidity/test/token/ERC20WithPermit.test.js
+++ b/solidity/test/token/ERC20WithPermit.test.js
@@ -1,0 +1,1008 @@
+const { expect } = require("chai")
+const { to1e18, ZERO_ADDRESS } = require("../helpers/contract-test-helpers")
+
+describe("ERC20WithPermit", () => {
+  // default Hardhat's networks blockchain, see https://hardhat.org/config/
+  const hardhatNetworkId = 31337
+
+  const initialSupply = to1e18(100)
+
+  let owner
+  let initialHolder
+  let recipient
+  let anotherAccount
+
+  let token
+
+  beforeEach(async () => {
+    ;[owner, initialHolder, recipient, anotherAccount] =
+      await ethers.getSigners()
+
+    const ERC20WithPermit = await ethers.getContractFactory("ERC20WithPermit")
+    token = await ERC20WithPermit.deploy("My Token", "MT")
+    await token.deployed()
+
+    await token.mint(initialHolder.address, initialSupply)
+  })
+
+  it("should have a name", async () => {
+    expect(await token.name()).to.equal("My Token")
+  })
+
+  it("should have a symbol", async () => {
+    expect(await token.symbol()).to.equal("MT")
+  })
+
+  it("should have 18 decimals", async () => {
+    expect(await token.decimals()).to.equal(18)
+  })
+
+  describe("totalSupply", () => {
+    it("should return the total amount of tokens", async () => {
+      expect(await token.totalSupply()).to.equal(initialSupply)
+    })
+  })
+
+  describe("permit_typehash", () => {
+    it("should be keccak256 of EIP2612 Permit message", async () => {
+      const expected = ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes(
+          "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        )
+      )
+      expect(await token.PERMIT_TYPEHASH()).to.equal(expected)
+    })
+  })
+
+  describe("domain_separator", () => {
+    it("should be keccak256 of EIP712 domain struct", async () => {
+      const keccak256 = ethers.utils.keccak256
+      const defaultAbiCoder = ethers.utils.defaultAbiCoder
+      const toUtf8Bytes = ethers.utils.toUtf8Bytes
+
+      const expected = keccak256(
+        defaultAbiCoder.encode(
+          ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+          [
+            keccak256(
+              toUtf8Bytes(
+                "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+              )
+            ),
+            keccak256(toUtf8Bytes("My Token")),
+            keccak256(toUtf8Bytes("1")),
+            hardhatNetworkId,
+            token.address,
+          ]
+        )
+      )
+      expect(await token.DOMAIN_SEPARATOR()).to.equal(expected)
+    })
+  })
+
+  describe("balanceOf", () => {
+    context("when the requested account has no tokens", () => {
+      it("should return zero", async () => {
+        expect(await token.balanceOf(anotherAccount.address)).to.equal(0)
+      })
+    })
+
+    context("when the requested account has some tokens", () => {
+      it("should return the total amount of tokens", async () => {
+        expect(await token.balanceOf(initialHolder.address)).to.equal(
+          initialSupply
+        )
+      })
+    })
+  })
+
+  describe("transfer", () => {
+    context("when the recipient is not the zero address", () => {
+      context("when the sender does not have enough balance", () => {
+        const amount = initialSupply.add(1)
+
+        it("should revert", async () => {
+          await expect(
+            token.connect(initialHolder).transfer(recipient.address, amount)
+          ).to.be.revertedWith("Transfer amount exceeds balance")
+        })
+      })
+
+      context("when the sender transfers all balance", () => {
+        const amount = initialSupply
+
+        it("should transfer the requested amount", async () => {
+          await token.connect(initialHolder).transfer(recipient.address, amount)
+
+          expect(await token.balanceOf(initialHolder.address)).to.equal(0)
+
+          expect(await token.balanceOf(recipient.address)).to.equal(amount)
+        })
+
+        it("should emit a transfer event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .transfer(recipient.address, amount)
+
+          await expect(tx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, recipient.address, amount)
+        })
+      })
+
+      context("when the sender transfers zero tokens", () => {
+        const amount = ethers.BigNumber.from(0)
+
+        it("should transfer the requested amount", async () => {
+          await token.connect(initialHolder).transfer(recipient.address, amount)
+
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            initialSupply
+          )
+
+          expect(await token.balanceOf(recipient.address)).to.equal(0)
+        })
+
+        it("should emit a transfer event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .transfer(recipient.address, amount)
+
+          await expect(tx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, recipient.address, amount)
+        })
+      })
+    })
+
+    context("when the recipient is the zero address", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).transfer(ZERO_ADDRESS, initialSupply)
+        ).to.be.revertedWith("Transfer to the zero address")
+      })
+    })
+  })
+
+  describe("transferFrom", () => {
+    context("when the token owner is not the zero address", () => {
+      context("when the recipient is not the zero address", () => {
+        context("when the spender has enough approved balance", () => {
+          const allowance = initialSupply
+          beforeEach(async function () {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+          })
+
+          context("when the token owner has enough balance", () => {
+            const amount = initialSupply
+
+            it("should transfer the requested amount", async () => {
+              await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              expect(await token.balanceOf(initialHolder.address)).to.equal(0)
+
+              expect(await token.balanceOf(recipient.address)).to.equal(amount)
+            })
+
+            it("should decrease the spender allowance", async () => {
+              await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              expect(
+                await token.allowance(
+                  initialHolder.address,
+                  anotherAccount.address
+                )
+              ).to.equal(0)
+            })
+
+            it("should emit a transfer event", async () => {
+              const tx = await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              await expect(tx)
+                .to.emit(token, "Transfer")
+                .withArgs(initialHolder.address, recipient.address, amount)
+            })
+
+            it("should emit an approval event", async () => {
+              const tx = await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              await expect(tx)
+                .to.emit(token, "Approval")
+                .withArgs(
+                  initialHolder.address,
+                  anotherAccount.address,
+                  allowance.sub(amount)
+                )
+            })
+          })
+
+          context("when the token owner does not have enough balance", () => {
+            const amount = initialSupply
+
+            beforeEach(async () => {
+              await token
+                .connect(initialHolder)
+                .transfer(anotherAccount.address, 1)
+            })
+
+            it("should revert", async () => {
+              await expect(
+                token
+                  .connect(anotherAccount)
+                  .transferFrom(
+                    initialHolder.address,
+                    recipient.address,
+                    amount
+                  )
+              ).to.be.revertedWith("Transfer amount exceeds balance")
+            })
+          })
+        })
+
+        context(
+          "when the spender does not have enough approved balance",
+          () => {
+            const allowance = initialSupply.sub(1)
+
+            beforeEach(async () => {
+              await token
+                .connect(initialHolder)
+                .approve(anotherAccount.address, allowance)
+            })
+
+            context("when the token owner has enough balance", () => {
+              const amount = initialSupply
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(
+                      initialHolder.address,
+                      recipient.address,
+                      amount
+                    )
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+
+            context("when the token owner does not have enough balance", () => {
+              const amount = initialSupply
+
+              beforeEach(async () => {
+                await token
+                  .connect(initialHolder)
+                  .transfer(anotherAccount.address, 1)
+              })
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(
+                      initialHolder.address,
+                      recipient.address,
+                      amount
+                    )
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+
+            context("when the token owner is the zero address", () => {
+              const allowance = initialSupply
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(ZERO_ADDRESS, recipient.address, allowance)
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+          }
+        )
+      })
+
+      context("when the recipient is the zero address", () => {
+        const allowance = initialSupply
+
+        beforeEach(async () => {
+          await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+        })
+
+        it("should revert", async () => {
+          await expect(
+            token
+              .connect(anotherAccount)
+              .transferFrom(initialHolder.address, ZERO_ADDRESS, allowance)
+          ).to.be.revertedWith("Transfer to the zero address")
+        })
+      })
+    })
+  })
+
+  describe("approve", () => {
+    context("when the spender is not the zero address", () => {
+      context("when the sender has enough balance", () => {
+        const allowance = initialSupply
+
+        it("should emit an approval event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(initialHolder.address, anotherAccount.address, allowance)
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const newAllowance = to1e18(100)
+
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, newAllowance)
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(newAllowance)
+          })
+        })
+      })
+
+      context("when the sender does not have enough balance", () => {
+        const allowance = initialSupply.add(1)
+
+        it("should emit an approval event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(initialHolder.address, anotherAccount.address, allowance)
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, to1e18(1))
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+    })
+
+    context("when the spender is the zero address", () => {
+      const allowance = initialSupply
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).approve(ZERO_ADDRESS, allowance)
+        ).to.be.revertedWith("Approve to the zero address")
+      })
+    })
+  })
+
+  describe("mint", () => {
+    const amount = to1e18(50)
+    it("should reject a zero account", async () => {
+      await expect(
+        token.connect(owner).mint(ZERO_ADDRESS, amount)
+      ).to.be.revertedWith("Mint to the zero address")
+    })
+
+    context("when called not by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).mint(initialHolder.address, amount)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("for a non zero account", () => {
+      let mintTx
+      beforeEach("minting", async () => {
+        mintTx = await token.connect(owner).mint(anotherAccount.address, amount)
+      })
+
+      it("should incement totalSupply", async () => {
+        const expectedSupply = initialSupply.add(amount)
+        expect(await token.totalSupply()).to.equal(expectedSupply)
+      })
+
+      it("should increment recipient balance", async () => {
+        expect(await token.balanceOf(anotherAccount.address)).to.equal(amount)
+      })
+
+      it("should emit Transfer event", async () => {
+        await expect(mintTx)
+          .to.emit(token, "Transfer")
+          .withArgs(ZERO_ADDRESS, anotherAccount.address, amount)
+      })
+    })
+  })
+
+  describe("burn", () => {
+    it("should reject burning more than balance", async () => {
+      await expect(
+        token.connect(initialHolder).burn(initialSupply.add(1))
+      ).to.be.revertedWith("Burn amount exceeds balance")
+    })
+
+    const describeBurn = (description, amount) => {
+      describe(description, () => {
+        let burnTx
+        beforeEach("burning", async () => {
+          burnTx = await token.connect(initialHolder).burn(amount)
+        })
+
+        it("should decrement totalSupply", async () => {
+          const expectedSupply = initialSupply.sub(amount)
+          expect(await token.totalSupply()).to.equal(expectedSupply)
+        })
+
+        it("should decrement owner's balance", async () => {
+          const expectedBalance = initialSupply.sub(amount)
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            expectedBalance
+          )
+        })
+
+        it("should emit Transfer event", async () => {
+          await expect(burnTx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
+        })
+      })
+    }
+
+    describeBurn("for entire balance", initialSupply)
+    describeBurn("for less amount than balance", initialSupply.sub(1))
+  })
+
+  describe("burnFrom", () => {
+    it("should reject burning more than balance", async () => {
+      await token
+        .connect(initialHolder)
+        .approve(anotherAccount.address, initialSupply.add(1))
+      await expect(
+        token
+          .connect(anotherAccount)
+          .burnFrom(initialHolder.address, initialSupply.add(1))
+      ).to.be.revertedWith("Burn amount exceeds balance")
+    })
+
+    it("should reject burning more than the allowance", async () => {
+      await token
+        .connect(initialHolder)
+        .approve(anotherAccount.address, initialSupply.sub(1))
+      await expect(
+        token
+          .connect(anotherAccount)
+          .burnFrom(initialHolder.address, initialSupply)
+      ).to.be.revertedWith("Burn amount exceeds allowance")
+    })
+
+    const describeBurnFrom = (description, amount) => {
+      describe(description, () => {
+        let burnTx
+        beforeEach("burning from", async () => {
+          await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, amount)
+          burnTx = await token
+            .connect(anotherAccount)
+            .burnFrom(initialHolder.address, amount)
+        })
+
+        it("should decrement totalSupply", async () => {
+          const expectedSupply = initialSupply.sub(amount)
+          expect(await token.totalSupply()).to.equal(expectedSupply)
+        })
+
+        it("should decrement owner's balance", async () => {
+          const expectedBalance = initialSupply.sub(amount)
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            expectedBalance
+          )
+        })
+
+        it("should decrement allowance", async () => {
+          const allowance = await token.allowance(
+            initialHolder.address,
+            anotherAccount.address
+          )
+
+          expect(allowance).to.equal(0)
+        })
+
+        it("should emit Transfer event", async () => {
+          await expect(burnTx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
+        })
+      })
+    }
+
+    describeBurnFrom("for entire balance", initialSupply)
+    describeBurnFrom("for less amount than balance", initialSupply.sub(1))
+  })
+
+  describe("permit", () => {
+    const timestamp2020 = 1577836633 // Jan 1, 2020
+    const timestamp2030 = 1893452400 // Jan 1, 2030
+
+    const permittingHolderBalance = to1e18(650000)
+    let permittingHolder
+
+    beforeEach(async () => {
+      permittingHolder = await ethers.Wallet.createRandom()
+      await token.mint(permittingHolder.address, permittingHolderBalance)
+    })
+
+    const getApproval = async (amount, spender, deadline) => {
+      // We use ethers.utils.SigningKey for a Wallet instead of
+      // Signer.signMessage to do not add '\x19Ethereum Signed Message:\n'
+      // prefix to the signed message. The '\x19` protection (see EIP191 for
+      // more details on '\x19' rationale and format) is already included in
+      // EIP2612 permit signed message and '\x19Ethereum Signed Message:\n'
+      // should not be used there.
+      const signingKey = new ethers.utils.SigningKey(
+        permittingHolder.privateKey
+      )
+
+      const domainSeparator = await token.DOMAIN_SEPARATOR()
+      const permitTypehash = await token.PERMIT_TYPEHASH()
+      const nonce = await token.nonces(permittingHolder.address)
+
+      const approvalDigest = ethers.utils.keccak256(
+        ethers.utils.solidityPack(
+          ["bytes1", "bytes1", "bytes32", "bytes32"],
+          [
+            "0x19",
+            "0x01",
+            domainSeparator,
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                [
+                  "bytes32",
+                  "address",
+                  "address",
+                  "uint256",
+                  "uint256",
+                  "uint256",
+                ],
+                [
+                  permitTypehash,
+                  permittingHolder.address,
+                  spender,
+                  amount,
+                  nonce,
+                  deadline,
+                ]
+              )
+            ),
+          ]
+        )
+      )
+
+      return ethers.utils.splitSignature(
+        await signingKey.signDigest(approvalDigest)
+      )
+    }
+
+    context("when permission expired", () => {
+      it("should revert", async () => {
+        const deadline = timestamp2020
+        const signature = await getApproval(
+          permittingHolderBalance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await expect(
+          token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              permittingHolderBalance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+        ).to.be.revertedWith("Permission expired")
+      })
+    })
+
+    context("when permission has an invalid signature", () => {
+      it("should revert", async () => {
+        const deadline = timestamp2030
+        const signature = await getApproval(
+          permittingHolderBalance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await expect(
+          token.connect(anotherAccount).permit(
+            anotherAccount.address, // does not match the signature
+            anotherAccount.address,
+            permittingHolderBalance,
+            deadline,
+            signature.v,
+            signature.r,
+            signature.s
+          )
+        ).to.be.revertedWith("Invalid signature")
+      })
+    })
+
+    context("when the spender is not the zero address", () => {
+      context("when the sender has enough balance", () => {
+        const allowance = permittingHolderBalance
+        it("should emit an approval event", async () => {
+          const deadline = timestamp2030
+          const signature = await getApproval(
+            allowance,
+            anotherAccount.address,
+            deadline
+          )
+
+          const tx = await token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance
+            )
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            const deadline = timestamp2030
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            const deadline = timestamp2030
+            const initialAllowance = allowance.sub(10)
+            const signature = await getApproval(
+              initialAllowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                initialAllowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const deadline = timestamp2030
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+
+      context("when the sender does not have enough balance", () => {
+        const allowance = permittingHolderBalance.add(1)
+        it("should emit an approval event", async () => {
+          const deadline = timestamp2030
+          const signature = await getApproval(
+            allowance,
+            anotherAccount.address,
+            deadline
+          )
+
+          const tx = await token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance
+            )
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            const deadline = timestamp2030
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            const deadline = timestamp2030
+            const initialAllowance = allowance.sub(10)
+            const signature = await getApproval(
+              initialAllowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                initialAllowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const deadline = timestamp2030
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+    })
+
+    context("when the spender is the zero address", () => {
+      const allowance = permittingHolderBalance
+      it("should revert", async () => {
+        const deadline = timestamp2030
+        const signature = await getApproval(allowance, ZERO_ADDRESS, deadline)
+
+        await expect(
+          token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              ZERO_ADDRESS,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+        ).to.be.revertedWith("Approve to the zero address")
+      })
+    })
+
+    context("when given never expiring permit", () => {
+      // uint(-1)
+      const allowance = ethers.BigNumber.from(
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+      )
+
+      beforeEach(async () => {
+        const deadline = timestamp2030
+        const signature = await getApproval(
+          allowance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await token
+          .connect(anotherAccount)
+          .permit(
+            permittingHolder.address,
+            anotherAccount.address,
+            allowance,
+            deadline,
+            signature.v,
+            signature.r,
+            signature.s
+          )
+      })
+      it("should not reduce approved amount", async () => {
+        expect(
+          await token.allowance(
+            permittingHolder.address,
+            anotherAccount.address
+          )
+        ).to.equal(allowance)
+
+        await token
+          .connect(anotherAccount)
+          .transferFrom(
+            permittingHolder.address,
+            recipient.address,
+            to1e18(100)
+          )
+
+        expect(
+          await token.allowance(
+            permittingHolder.address,
+            anotherAccount.address
+          )
+        ).to.equal(allowance)
+      })
+    })
+  })
+})

--- a/solidity/test/token/ERC20WithPermit.test.js
+++ b/solidity/test/token/ERC20WithPermit.test.js
@@ -1,8 +1,8 @@
 const { expect } = require("chai")
-const { 
+const {
   lastBlockTime,
   to1e18,
-  ZERO_ADDRESS
+  ZERO_ADDRESS,
 } = require("../helpers/contract-test-helpers")
 
 describe("ERC20WithPermit", () => {


### PR DESCRIPTION
TBTC is now a burnable ERC20 token with EIP2612 permit functionality.
User can authorize a transfer of their token with a signature conforming
EIP712 standard instead of an on-chain transaction from their address.
Anyone can submit this signature on the user's behalf by calling the
permit function, as specified in EP2612, paying gas fees, and possibly
performing other actions in the same transaction.

By the time of implementing this contract, to my knowledge, there is no other
audited EIP2612 token implementation than Uniswap V2 on which this code is
based on. OpenZeppelin has quite recently added permit to their ERC20
but this code is in a draft state, was released in the most recent
v4.0.0, and to my understanding was not audited yet and may have
breaking changes in the future. On the contrary, Uniswap implementation
was audited and is even referenced from the EIP as an implementation
example.

This implementation mostly mirrors `UniswapV2ERC20`, and is [identical to
the implementation we use in coverage pools](https://github.com/keep-network/coverage-pools/blob/main/contracts/ERC20WithPermit.sol). It adds some tweaks from
OpenZeppelin ERC20 implementation such as more meaningful revert messages
and `Approval` event emitted on calls to `transferFrom`. This allows
applications to reconstruct the allowance for all accounts just by
listening to the event.

Unit tests were based on OpenZeppelin ERC20 unit tests with our own
tests implementation for EIP2612 and EIP712.

In the future, we will add more functionalities to the token, such as
`approveAndCall` and recovering tokens mistakenly sent to TBTC token
address but all of that in a separate PR.