### PR TITLE
Allow TBTC contract owner to recover misfunded ERC20/ERC721 tokens

### DIFF
--- a/solidity/contracts/test/TestERC20.sol
+++ b/solidity/contracts/test/TestERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "../token/ERC20WithPermit.sol";
+
+contract TestERC20 is ERC20WithPermit {
+    string public constant NAME = "Test ERC20 Token";
+    string public constant SYMBOL = "TT";
+
+    constructor() ERC20WithPermit(NAME, SYMBOL) {}
+}

--- a/solidity/contracts/test/TestERC721.sol
+++ b/solidity/contracts/test/TestERC721.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract TestERC721 is ERC721 {
+    string public constant NAME = "Test ERC721 Token";
+    string public constant SYMBOL = "TT";
+
+    constructor() ERC721(NAME, SYMBOL) {}
+
+    function mint(address to, uint256 tokenId) public {
+        _mint(to, tokenId);
+    }
+}

--- a/solidity/contracts/token/MisfundRecovery.sol
+++ b/solidity/contracts/token/MisfundRecovery.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title  MisfundRecovery
+/// @notice Allows the owner of the token contract extending MisfundRecovery
+///         to recover any ERC20 and ERC721 sent mistakenly to the token
+///         contract address.
+contract MisfundRecovery is Ownable {
+    using SafeERC20 for IERC20;
+
+    function recoverERC20(
+        IERC20 token,
+        address recipient,
+        uint256 amount
+    ) external onlyOwner {
+        token.safeTransfer(recipient, amount);
+    }
+
+    function recoverERC721(
+        IERC721 token,
+        address recipient,
+        uint256 tokenId,
+        bytes calldata data
+    ) external onlyOwner {
+        token.safeTransferFrom(address(this), recipient, tokenId, data);
+    }
+}

--- a/solidity/contracts/token/TBTCToken.sol
+++ b/solidity/contracts/token/TBTCToken.sol
@@ -3,7 +3,8 @@
 pragma solidity <0.9.0;
 
 import "./ERC20WithPermit.sol";
+import "./MisfundRecovery.sol";
 
-contract TBTCToken is ERC20WithPermit {
+contract TBTCToken is ERC20WithPermit, MisfundRecovery {
     constructor() ERC20WithPermit("TBTC v2 migration", "TBTC") {}
 }

--- a/solidity/test/token/MisfundRecovery.test.js
+++ b/solidity/test/token/MisfundRecovery.test.js
@@ -1,0 +1,88 @@
+const { to1e18 } = require("../helpers/contract-test-helpers")
+
+const { expect } = require("chai")
+
+describe("MisfundRecovery", () => {
+  let recoveryOwner
+  let thirdParty
+
+  let randomERC20
+  let randomERC721
+
+  let recovery
+
+  beforeEach(async () => {
+    ;[deployer, recoveryOwner, thirdParty] = await ethers.getSigners()
+
+    const MisfundRecovery = await ethers.getContractFactory("MisfundRecovery")
+    recovery = await MisfundRecovery.deploy()
+    await recovery.deployed()
+
+    const TestERC20 = await ethers.getContractFactory("TestERC20")
+    randomERC20 = await TestERC20.deploy()
+    await randomERC20.deployed()
+
+    const TestERC721 = await ethers.getContractFactory("TestERC721")
+    randomERC721 = await TestERC721.deploy()
+    await randomERC721.deployed()
+
+    await recovery.connect(deployer).transferOwnership(recoveryOwner.address)
+  })
+
+  describe("recoverERC20", () => {
+    const amount = to1e18(725)
+
+    beforeEach(async () => {
+      await randomERC20.mint(recovery.address, amount)
+    })
+
+    context("when called not by the owner", () => {
+      it("reverts", async () => {
+        await expect(
+          recovery
+            .connect(thirdParty)
+            .recoverERC20(randomERC20.address, thirdParty.address, amount)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      it("transfers tokens to the recipient", async () => {
+        await recovery
+          .connect(recoveryOwner)
+          .recoverERC20(randomERC20.address, thirdParty.address, amount)
+        expect(await randomERC20.balanceOf(thirdParty.address)).to.equal(amount)
+      })
+    })
+  })
+
+  describe("recoverERC721", () => {
+    const tokenId = 19112
+
+    beforeEach(async () => {
+      await randomERC721.mint(recovery.address, tokenId)
+    })
+
+    context("when called not by the owner", () => {
+      it("reverts", async () => {
+        await expect(
+          recovery.recoverERC721(
+            randomERC721.address,
+            thirdParty.address,
+            tokenId,
+            []
+          )
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      it("transfers token to the recipient", async () => {
+        await recovery
+          .connect(recoveryOwner)
+          .recoverERC721(randomERC721.address, thirdParty.address, tokenId, [])
+        expect(await randomERC721.ownerOf(tokenId)).to.equal(thirdParty.address)
+      })
+    })
+  })
+})


### PR DESCRIPTION
In case someone sends tokens to TBTC token contract address, these
tokens can be recovered by the governance. We observed such cases of
misfunds for tBTC v1 so to become more user-friendly, we are giving
rescue tools to tBTC v2 governance.

In practice, recovery functions will have to be proxied through the
vending machine because the vending machine will be the owner of TBTC
token contract.