### PR TITLE
Added `approveAndCall` to TBTC token

### DIFF
--- a/solidity/contracts/test/ReceiveApprovalStub.sol
+++ b/solidity/contracts/test/ReceiveApprovalStub.sol
@@ -2,8 +2,6 @@
 
 pragma solidity <0.9.0;
 
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-
 import "../token/TBTCToken.sol";
 
 contract ReceiveApprovalStub is IReceiveApproval {

--- a/solidity/contracts/test/ReceiveApprovalStub.sol
+++ b/solidity/contracts/test/ReceiveApprovalStub.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "../token/TBTCToken.sol";
+
+contract ReceiveApprovalStub is IReceiveApproval {
+    bool public shouldRevert;
+
+    event ApprovalReceived(
+        address from,
+        uint256 value,
+        address token,
+        bytes extraData
+    );
+
+    function receiveApproval(
+        address from,
+        uint256 value,
+        address token,
+        bytes calldata extraData
+    ) external override {
+        if (shouldRevert) {
+            revert("i am your father luke");
+        }
+
+        emit ApprovalReceived(from, value, token, extraData);
+    }
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+}

--- a/solidity/contracts/token/ERC20WithPermit.sol
+++ b/solidity/contracts/token/ERC20WithPermit.sol
@@ -76,15 +76,6 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
         return true;
     }
 
-    function approve(address spender, uint256 amount)
-        external
-        override
-        returns (bool)
-    {
-        _approve(msg.sender, spender, amount);
-        return true;
-    }
-
     function permit(
         address owner,
         address spender,
@@ -153,6 +144,15 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
             )
         );
         _burn(account, amount);
+    }
+
+    function approve(address spender, uint256 amount)
+        public
+        override
+        returns (bool)
+    {
+        _approve(msg.sender, spender, amount);
+        return true;
     }
 
     /* solhint-disable-next-line func-name-mixedcase */

--- a/solidity/contracts/token/TBTCToken.sol
+++ b/solidity/contracts/token/TBTCToken.sol
@@ -5,6 +5,37 @@ pragma solidity <0.9.0;
 import "./ERC20WithPermit.sol";
 import "./MisfundRecovery.sol";
 
+interface IReceiveApproval {
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes calldata _extraData
+    ) external;
+}
+
 contract TBTCToken is ERC20WithPermit, MisfundRecovery {
     constructor() ERC20WithPermit("TBTC v2 migration", "TBTC") {}
+
+    /// @notice Executes receiveApproval function on spender as specified in
+    ///         IReceiveApproval interface. Approves spender to withdraw from
+    ///         the caller multiple times, up to the value amount. If this
+    ///         function is called again, it overwrites the current allowance
+    ///         with value. Reverts if the approval reverted or if
+    ///         receiveApproval call on the spender reverted.
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) external returns (bool) {
+        if (approve(spender, value)) {
+            IReceiveApproval(spender).receiveApproval(
+                msg.sender,
+                value,
+                address(this),
+                extraData
+            );
+            return true;
+        }
+    }
 }

--- a/solidity/test/TBTCToken.test.js
+++ b/solidity/test/TBTCToken.test.js
@@ -1,7 +1,0 @@
-const { expect } = require("chai")
-
-describe("TBTCToken", () => {
-  it("works", async () => {
-    expect(1).is.equal(1)
-  })
-})

--- a/solidity/test/token/TBTCToken.test.js
+++ b/solidity/test/token/TBTCToken.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai")
+const { to1e18, ZERO_ADDRESS } = require("../helpers/contract-test-helpers")
+
+describe("TBTCToken", () => {
+  let approver
+
+  let approvalReceiver
+  let tbtc
+
+  beforeEach(async () => {
+    approver = await ethers.getSigner(1)
+
+    const ReceiveApprovalStub = await ethers.getContractFactory(
+      "ReceiveApprovalStub"
+    )
+    approvalReceiver = await ReceiveApprovalStub.deploy()
+    await approvalReceiver.deployed()
+
+    const TBTCToken = await ethers.getContractFactory("TBTCToken")
+    tbtc = await TBTCToken.deploy()
+    await tbtc.deployed()
+
+    tbtc.mint(approver.address, to1e18(1000000))
+  })
+
+  describe("approveAndCall", () => {
+    const amount = to1e18(200)
+
+    context("when approval fails", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtc.connect(approver).approveAndCall(ZERO_ADDRESS, amount, [])
+        ).to.be.reverted
+      })
+    })
+
+    context("when receiveApproval fails", () => {
+      beforeEach(async () => {
+        await approvalReceiver.setShouldRevert(true)
+      })
+
+      it("should revert", async () => {
+        await expect(
+          tbtc
+            .connect(approver)
+            .approveAndCall(approvalReceiver.address, amount, [])
+        ).to.be.revertedWith("i am your father luke")
+      })
+    })
+
+    it("approves the provided amount for transfer", async () => {
+      await tbtc
+        .connect(approver)
+        .approveAndCall(approvalReceiver.address, amount, [])
+      expect(
+        await tbtc.allowance(approver.address, approvalReceiver.address)
+      ).to.equal(amount)
+    })
+
+    it("calls approveAndCall with the provided parameters", async () => {
+      const tx = await tbtc
+        .connect(approver)
+        .approveAndCall(approvalReceiver.address, amount, "0xbeef")
+      await expect(tx)
+        .to.emit(approvalReceiver, "ApprovalReceived")
+        .withArgs(approver.address, amount, tbtc.address, "0xbeef")
+    })
+  })
+})


### PR DESCRIPTION
Depends on #4 

`approveAndCall` is not a part of ERC20 - it was specified in [ERC827](https://github.com/ethereum/eips/issues/827) and
slightly diverged for some implementations. This one is identical to
`approveAndCall` behavior of [KEEP token](https://github.com/keep-network/keep-core/blob/v1.0.1/solidity/contracts/KeepToken.sol#L29).

`approveAndCall` executes `receiveApproval` function on the spender as
specified in `IReceiveApproval` interface. Approves spender to withdraw
from the caller multiple times, up to the value amount. If this function
is called again, it overwrites the current allowance with the provided
value. Reverts if the approval operation reverted or if `receiveApproval`
call on the spender reverted.