### PR TITLE
Standardize Solidity version to 0.8.4

### DIFF
--- a/solidity/contracts/test/ReceiveApprovalStub.sol
+++ b/solidity/contracts/test/ReceiveApprovalStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../token/TBTCToken.sol";
 

--- a/solidity/contracts/test/TestERC20.sol
+++ b/solidity/contracts/test/TestERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../token/ERC20WithPermit.sol";
 

--- a/solidity/contracts/test/TestERC721.sol
+++ b/solidity/contracts/test/TestERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/solidity/contracts/token/IERC20WithPermit.sol
+++ b/solidity/contracts/token/IERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/solidity/contracts/token/MisfundRecovery.sol
+++ b/solidity/contracts/token/MisfundRecovery.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /// @title  MisfundRecovery

--- a/solidity/contracts/token/TBTCToken.sol
+++ b/solidity/contracts/token/TBTCToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./ERC20WithPermit.sol";
 import "./MisfundRecovery.sol";

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -3,6 +3,10 @@ require("hardhat-gas-reporter")
 
 module.exports = {
   solidity: {
-    version: "0.7.6",
+    compilers: [
+      {
+        version: "0.8.4",
+      },
+    ],
   },
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -2,7 +2,7 @@
     "name": "@keep-network/tbtc-v2",
     "license": "MIT",
     "dependencies": {
-      "@openzeppelin/contracts": "^3.3.0"
+      "@openzeppelin/contracts": "^4.1.0"
     },
     "devDependencies": {
       "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -551,10 +551,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^3.3.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"
-  integrity sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ==
+"@openzeppelin/contracts@^4.1.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.2.0.tgz#260d921d99356e48013d9d760caaa6cea35dc642"
+  integrity sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
Depends on #5 

This change required updating Open Zeppelin library to version 4.x which
supports Solidity 0.8. I have also cleaned up all usages of `SafeMath` as
Solidity 0.8 checks the arithmetics.

The same Solidity version is currently used in coverage pools.