### PR TITLE
Yearn: Convex strategy

### DIFF
--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -549,15 +549,14 @@ contract ConvexStrategy is BaseStrategy {
             );
         }
 
-        // Calculate the profit after obtaining new vault's underlying tokens.
-        profit = want.balanceOf(address(this)).sub(initialWantBalance);
-
         // Check the profit and loss in the context of strategy debt.
         uint256 totalAssets = estimatedTotalAssets();
         uint256 totalDebt = vault.strategies(address(this)).totalDebt;
         if (totalAssets < totalDebt) {
             loss = totalDebt - totalAssets;
             profit = 0;
+        } else {
+            profit = want.balanceOf(address(this)).sub(initialWantBalance);
         }
 
         // Repay some vault debt if needed.

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@keep-network/yearn-vaults/contracts/BaseStrategy.sol";
+
+contract ConvexStrategy is BaseStrategy {
+}

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -481,7 +481,7 @@ contract ConvexStrategy is BaseStrategy {
 
             IUniswapV2Router(uniswap).swapExactTokensForTokens(
                 crvBalance,
-                uint256(0),
+                0,
                 path,
                 address(this),
                 now
@@ -501,7 +501,7 @@ contract ConvexStrategy is BaseStrategy {
 
             IUniswapV2Router(sushiswap).swapExactTokensForTokens(
                 cvxBalance,
-                uint256(0),
+                0,
                 path,
                 address(this),
                 now
@@ -525,7 +525,7 @@ contract ConvexStrategy is BaseStrategy {
 
                 IUniswapV2Router(uniswap).swapExactTokensForTokens(
                     extraRewardBalance,
-                    uint256(0),
+                    0,
                     path,
                     address(this),
                     now

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -96,7 +96,32 @@ interface IERC20Metadata {
 }
 
 /// @title ConvexStrategy
-/// @notice TODO: Detailed strategy description.
+/// @notice This strategy is meant to be used with the Curve tBTC v2 pool vault.
+///         The vault's underlying token (a.k.a. want token) should be the LP
+///         token of the Curve tBTC v2 pool. This strategy borrows the vault's
+///         underlying token up to the debt limit configured for this strategy
+///         in the vault. In order to make the profit, the strategy deposits
+///         the borrowed tokens into the Convex reward pool via the Convex
+///         booster contract. Depositing tokens in the reward pool generates
+///         regular CRV and CVX rewards. It can also provide extra rewards
+///         (denominated in another token) if the Convex reward pool works on
+///         top of a Curve pool gauge which stakes its deposits into the
+///         Synthetix staking rewards contract. The financial outcome is settled
+///         upon a call of the `harvest` method (BaseStrategy.sol). Once that
+///         call is made, the strategy gets the CRV and CVX rewards from Convex
+///         reward pool, and claims extra rewards if applicable. Then, it takes
+///         a small portion of CRV (defined by keepCRV param) and locks it
+///         into the Curve vote escrow (via CurveYCRVVoter contract) to gain
+///         CRV boost and increase future gains. Remaining CRV, CVX, and
+///         optional extra reward tokens are used to buy wBTC via a
+///         decentralized exchange. At the end, the strategy takes acquired wBTC
+///         and deposits them to the Curve tBTC v2 pool. This way it obtains new
+///         LP tokens the vault is interested for, and makes the profit in
+///         result. At this stage, the strategy may repay some debt back to the
+///         vault, if needed. The entire cycle repeats for the strategy lifetime
+///         so all gains are constantly reinvested. Worth to flag that current
+///         implementation uses wBTC as the intermediary token because
+///         of its liquidity and ubiquity in BTC-based Curve pools.
 /// @dev Implementation is based on:
 ///      - General Yearn strategy template
 ///        https://github.com/yearn/brownie-strategy-mix

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -288,8 +288,7 @@ contract ConvexStrategy is BaseStrategy {
     function adjustPosition(uint256 debtOutstanding) internal override {
         uint256 wantBalance = balanceOfWant();
         if (wantBalance > 0) {
-            want.safeApprove(booster, 0);
-            want.safeApprove(booster, wantBalance);
+            want.safeIncreaseAllowance(booster, wantBalance);
 
             IConvexBooster(booster).deposit(
                 tbtcConvexRewardPoolId,
@@ -473,8 +472,7 @@ contract ConvexStrategy is BaseStrategy {
             // Deposit a portion of CRV to the voter to gain CRV boost.
             crvBalance = adjustCRV(crvBalance);
 
-            IERC20(crv).safeApprove(uniswap, 0);
-            IERC20(crv).safeApprove(uniswap, crvBalance);
+            IERC20(crv).safeIncreaseAllowance(uniswap, crvBalance);
 
             address[] memory path = new address[](3);
             path[0] = crv;
@@ -494,8 +492,7 @@ contract ConvexStrategy is BaseStrategy {
         // supported by UniSwap.
         uint256 cvxBalance = IERC20(cvx).balanceOf(address(this));
         if (cvxBalance > 0) {
-            IERC20(cvx).safeApprove(sushiswap, 0);
-            IERC20(cvx).safeApprove(sushiswap, cvxBalance);
+            IERC20(cvx).safeIncreaseAllowance(sushiswap, cvxBalance);
 
             address[] memory path = new address[](3);
             path[0] = cvx;
@@ -516,8 +513,7 @@ contract ConvexStrategy is BaseStrategy {
             uint256 extraRewardBalance = IERC20(tbtcConvexExtraReward)
             .balanceOf(address(this));
             if (extraRewardBalance > extraRewardSwapThreshold) {
-                IERC20(tbtcConvexExtraReward).safeApprove(uniswap, 0);
-                IERC20(tbtcConvexExtraReward).safeApprove(
+                IERC20(tbtcConvexExtraReward).safeIncreaseAllowance(
                     uniswap,
                     extraRewardBalance
                 );
@@ -541,8 +537,11 @@ contract ConvexStrategy is BaseStrategy {
         // vault's underlying tokens.
         uint256 wbtcBalance = IERC20(wbtc).balanceOf(address(this));
         if (wbtcBalance > 0) {
-            IERC20(wbtc).safeApprove(tbtcCurvePoolDepositor, 0);
-            IERC20(wbtc).safeApprove(tbtcCurvePoolDepositor, wbtcBalance);
+            IERC20(wbtc).safeIncreaseAllowance(
+                tbtcCurvePoolDepositor,
+                wbtcBalance
+            );
+
             ICurvePool(tbtcCurvePoolDepositor).add_liquidity(
                 [0, 0, wbtcBalance, 0],
                 0

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -4,6 +4,351 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@keep-network/yearn-vaults/contracts/BaseStrategy.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/Math.sol";
 
+/// @notice Interface for the Convex booster.
+/// @dev This is an interface with just a few function signatures of the booster.
+///      For more info and function description please see:
+///      https://github.com/convex-eth/platform/blob/main/contracts/contracts/Booster.sol
+interface IConvexBooster {
+    function poolInfo(uint256)
+        external
+        view
+        returns (
+            address,
+            address,
+            address,
+            address,
+            address,
+            bool
+        );
+
+    function deposit(
+        uint256 poolId,
+        uint256 amount,
+        bool stake
+    ) external returns (bool);
+}
+
+/// @notice Interface for the Convex reward pool.
+/// @dev This is an interface with just a few function signatures of the reward pool.
+///      For more info and function description please see:
+///      https://github.com/convex-eth/platform/blob/main/contracts/contracts/BaseRewardPool.sol
+interface IConvexRewardPool {
+    function balanceOf(address account) external view returns (uint256);
+
+    function withdrawAndUnwrap(uint256 amount, bool claim)
+        external
+        returns (bool);
+
+    function withdrawAllAndUnwrap(bool claim) external;
+}
+
+/// @notice Interface for the optional metadata functions from the ERC20 standard.
+interface IERC20Metadata {
+    function symbol() external view returns (string memory);
+}
+
+/// @title ConvexStrategy
+/// @notice TODO: Detailed strategy description.
+/// @dev Implementation is based on:
+///      - General Yearn strategy template
+///        https://github.com/yearn/brownie-strategy-mix
+///      - Convex implementation for tBTC v1 vault
+///        https://github.com/orbxball/btc-curve-convex
 contract ConvexStrategy is BaseStrategy {
+    using SafeERC20 for IERC20;
+    using Address for address;
+    using SafeMath for uint256;
+
+    uint256 public constant DENOMINATOR = 10000;
+
+    // Address of the CurveYCRVVoter contract.
+    address public constant voter =
+        address(0xF147b8125d2ef93FB6965Db97D6746952a133934);
+    // Address of the Convex Booster contract.
+    address public constant booster =
+        address(0xF403C135812408BFbE8713b5A23a04b3D48AAE31);
+    // Address of the CRV token contract.
+    address public constant crv =
+        address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    // Address of the Convex CVX token contract.
+    address public constant cvx =
+        address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    // Address of the WETH token contract.
+    address public constant weth =
+        address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    // Address of the WBTC token contract.
+    address public constant wbtc =
+        address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    // Address of the Uniswap V2 router contract.
+    address public constant uniswap =
+        address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+
+    // Address of the depositor contract for the tBTC v2 Curve pool.
+    address public tbtcCurvePoolDepositor;
+    // ID of the Convex reward pool paired with the tBTC v2 Curve pool.
+    uint256 public tbtcConvexRewardPoolId;
+    // Address of the Convex reward pool contract paired with the
+    // tBTC v2 Curve pool.
+    address public tbtcConvexRewardPool;
+    // Address of the DEX used to swap reward tokens back to the vault's
+    // underlying token. This can be Uniswap or other Uni-like DEX.
+    address public dex;
+    // Determines the portion of CRV tokens which should be locked in the
+    // Curve vote escrow to gain a CRV boost. This is the counter of a fraction
+    // denominated by the DENOMINATOR constant. For example, if the value
+    // is `1000`, that means 10% of tokens will be locked because
+    // 1000/10000 = 0.1
+    uint256 public keepCRV;
+
+    constructor(
+        address _vault,
+        address _tbtcCurvePoolDepositor,
+        address _tbtcConvexRewardPoolId
+    ) public BaseStrategy(_vault) {
+        // Strategy settings.
+        minReportDelay = 12 hours;
+        maxReportDelay = 3 days;
+        profitFactor = 1000;
+        debtThreshold = 1e21;
+        dex = uniswap;
+        keepCRV = 1000;
+
+        // tBTC-related settings.
+        tbtcCurvePoolDepositor = _tbtcCurvePoolDepositor;
+        tbtcConvexRewardPoolId = _tbtcConvexRewardPoolId;
+        (address lpToken, , , address rewardPool, , ) = IConvexBooster(booster)
+        .poolInfo(_tbtcConvexRewardPoolId);
+        require(lpToken == address(want), "Incorrect reward pool LP token");
+        tbtcConvexRewardPool = rewardPool;
+    }
+
+    /// @notice Sets the portion of CRV tokens which should be locked in
+    ///         the Curve vote escrow to gain CRV boost.
+    /// @dev Can be called only by the strategist and governance.
+    /// @param _keepCRV Portion as counter of a fraction denominated by the
+    ///        DENOMINATOR constant.
+    function setKeepCRV(uint256 _keepCRV) external onlyAuthorized {
+        keepCRV = _keepCRV;
+    }
+
+    /// @return Name of the Yearn vault strategy.
+    function name() external view override returns (string memory) {
+        return
+            string(
+                abi.encodePacked(
+                    "Convex",
+                    IERC20Metadata(address(want)).symbol()
+                )
+            );
+    }
+
+    /// @return Balance of the vault's underlying token under management.
+    function balanceOfWant() public view returns (uint256) {
+        return want.balanceOf(address(this));
+    }
+
+    /// @return Balance of the vault's underlying token staked into the Convex
+    ///         reward pool.
+    function balanceOfPool() public view returns (uint256) {
+        return IConvexRewardPool(tbtcConvexRewardPool).balanceOf(address(this));
+    }
+
+    /// @return Sum of balanceOfWant and balanceOfPool.
+    function estimatedTotalAssets() public view override returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is
+    ///         meant to perform any adjustments to the core position(s) of this
+    ///         strategy, given what change the vault made in the investable
+    ///         capital available to the strategy. All free capital in the
+    ///         strategy after the report was made is available for reinvestment.
+    ///         This strategy implements the aforementioned behavior by taking
+    ///         its balance of the vault's underlying token and depositing it to
+    ///         the Convex Booster contract.
+    /// @param debtOutstanding Will be 0 if the strategy is not past the
+    ///        configured debt limit, otherwise its value will be how far past
+    ///        the debt limit the strategy is. The strategy's debt limit is
+    ///        configured in the vault.
+    function adjustPosition(uint256 _debtOutstanding) internal override {
+        uint256 wantBalance = want.balanceOf(address(this));
+        if (wantBalance > 0) {
+            want.safeApprove(booster, 0);
+            want.safeApprove(booster, wantBalance);
+
+            IConvexBooster(booster).deposit(id, wantBalance, true);
+        }
+    }
+
+    /// @notice Withdraws a portion of the vault's underlying token from
+    ///         the Convex reward pool.
+    /// @param amount Amount to withdraw.
+    /// @return Amount withdrawn.
+    function withdrawSome(uint256 amount) internal returns (uint256) {
+        amount = Math.min(amount, balanceOfPool());
+        uint256 initialWantBalance = balanceOfWant();
+        // Withdraw some vault's underlying tokens but do not claim the rewards
+        // accumulated so far.
+        IConvexRewardPool(tbtcConvexRewardPool).withdrawAndUnwrap(
+            amount,
+            false
+        );
+        return balanceOfWant().sub(initialWantBalance);
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is meant
+    ///         to liquidate up to amountNeeded of want token of this strategy's
+    ///         positions, irregardless of slippage. Any excess will be
+    ///         re-invested with adjustPosition. This function should return
+    ///         the amount of want tokens made available by the liquidation.
+    ///         If there is a difference between them, loss indicates whether
+    ///         the difference is due to a realized loss, or if there is some
+    ///         other situation at play (e.g. locked funds). This function is
+    ///         used during emergency exit instead of prepareReturn to
+    ///         liquidate all of the strategy's positions back to the vault.
+    ///         This strategy implements the aforementioned behavior by
+    ///         withdrawing a portion of the vault's underlying token
+    ///         (want token) from the Convex reward pool.
+    /// @dev The invariant `liquidatedAmount + loss <= amountNeeded` should
+    ///      always be maintained.
+    /// @param amountNeeded Amount of the vault's underlying tokens needed by
+    ///        the liquidation process.
+    /// @return liquidatedAmount Amount of vault's underlying tokens made
+    ///         available by the liquidation.
+    /// @return loss Amount of the loss.
+    function liquidatePosition(uint256 amountNeeded)
+        internal
+        override
+        returns (uint256 liquidatedAmount, uint256 loss)
+    {
+        uint256 wantBalance = want.balanceOf(address(this));
+        if (wantBalance < amountNeeded) {
+            liquidatedAmount = withdrawSome(amountNeeded.sub(wantBalance));
+            liquidatedAmount = liquidatedAmount.add(wantBalance);
+            loss = amountNeeded.sub(liquidatedAmount);
+        } else {
+            liquidatedAmount = amountNeeded;
+        }
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is meant
+    ///         to liquidate everything and return the amount that got freed.
+    ///         This strategy implements the aforementioned behavior by withdrawing
+    ///         all vault's underlying tokens from the Convex reward pool.
+    /// @dev This function is used during emergency exit instead of prepareReturn
+    ///      to liquidate all of the strategy's positions back to the vault.
+    /// @return amountFreed Amount that got freed.
+    function liquidateAllPositions()
+        internal
+        override
+        returns (uint256 amountFreed)
+    {
+        // Withdraw all vault's underlying tokens from the Convex reward pool.
+        // However, do not claim the rewards accumulated so far because this is
+        // an emergency action and we just focus on recovering all principle
+        // funds, without trying to realize potential gains.
+        IConvexRewardPool(tbtcConvexRewardPool).withdrawAllAndUnwrap(false);
+
+        // Yearn docs doesn't specify clear enough what exactly should be
+        // returned here. It may be either the total balance after
+        // withdrawAllAndUnwrap or just the amount withdrawn. Currently opting
+        // for the former because of
+        // https://github.com/yearn/yearn-vaults/pull/311#discussion_r625588313.
+        // Also, usage of this result in the harvest method in the BaseStrategy
+        // seems to confirm that.
+        return want.balanceOf(address(this));
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is meant
+    ///         to do anything necessary to prepare this strategy for migration,
+    ///         such as transferring any reserve or LP tokens, CDPs, or other
+    ///         tokens or stores of value. This strategy implements the
+    ///         aforementioned behavior by withdrawing all vault's underlying
+    ///         tokens from the Convex reward pool, claiming all rewards
+    ///         accumulated so far, and transferring those rewards to the new
+    ///         strategy.
+    /// @param newStrategy Address of the new strategy meant to replace the
+    ///        current one.
+    function prepareMigration(address newStrategy) internal override {
+        // Just withdraw the vault's underlying token from the Convex reward pool.
+        // There is no need to transfer those tokens to the new strategy
+        // right here as this is done in the BaseStrategy's migrate() method.
+        // This call also claims the rewards accumulated so far but they
+        // must be transferred to the new strategy manually.
+        IConvexRewardPool(tbtcConvexRewardPool).withdrawAllAndUnwrap(true);
+
+        // Transfer all claimed rewards to the new strategy manually.
+        IERC20(crv).safeTransfer(
+            newStrategy,
+            IERC20(crv).balanceOf(address(this))
+        );
+        IERC20(cvx).safeTransfer(
+            newStrategy,
+            IERC20(cvx).balanceOf(address(this))
+        );
+        // TODO: Transfer gauge additional rewards too (KEEP token).
+    }
+
+    /// @notice Takes the keepCRV portion of the CRV balance and transfers
+    ///         it to the CurveYCRVVoter contract in order to gain CRV boost.
+    /// @param crvBalance Balance of CRV tokens under management.
+    /// @return Amount of CRV tokens remaining under management after the
+    ///         transfer.
+    function adjustCRV(uint256 crvBalance) internal returns (uint256) {
+        uint256 crvTransfer = crvBalance.mul(keepCRV).div(DENOMINATOR);
+        IERC20(crv).safeTransfer(voter, crvTransfer);
+        return crvBalance.sub(crvTransfer);
+    }
+
+    // TODO: Documentation.
+    function prepareReturn(uint256 debtOutstanding)
+        internal
+        override
+        returns (
+            uint256 profit,
+            uint256 loss,
+            uint256 debtPayment
+        )
+    {
+        // TODO: Implementation.
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is meant
+    ///         to define all tokens/tokenized positions this contract manages
+    ///         on a persistent basis (e.g. not just for swapping back to
+    ///         the want token ephemerally).
+    /// @dev Should not include want token, already included in the base contract.
+    /// @return Addresses of protected tokens
+    function protectedTokens()
+        internal
+        view
+        override
+        returns (address[] memory)
+    {
+        address[] memory protected = new address[](2);
+        protected[0] = crv;
+        protected[1] = cvx;
+        // TODO: Gauge additional rewards token (KEEP token).
+        return protected;
+    }
+
+    /// @notice This method is defined in the BaseStrategy contract and is meant
+    ///         to provide an accurate conversion from amtInWei (denominated in wei)
+    ///         to want token (using the native decimal characteristics of want token).
+    /// @param amtInWei The amount (in wei/1e-18 ETH) to convert to want tokens.
+    /// @return The amount in want tokens.
+    function ethToWant(uint256 amtInWei)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        // TODO: Create an accurate price oracle.
+        return amtInWei;
+    }
 }

--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -556,7 +556,7 @@ contract ConvexStrategy is BaseStrategy {
             loss = totalDebt - totalAssets;
             profit = 0;
         } else {
-            profit = want.balanceOf(address(this)).sub(initialWantBalance);
+            profit = balanceOfWant().sub(initialWantBalance);
         }
 
         // Repay some vault debt if needed.

--- a/yearn/test/system/constants.js
+++ b/yearn/test/system/constants.js
@@ -40,3 +40,5 @@ module.exports.tbtc = {
   synthetixCurveRewardsOwnerAddress:
     "0xb3726e69da808a689f2607939a2d9e958724fc2a",
 }
+
+module.exports.forkBlockNumber = 12786839

--- a/yearn/test/system/constants.js
+++ b/yearn/test/system/constants.js
@@ -1,3 +1,6 @@
+// Block to which the mainnet fork should be resetted at the beginning of test.
+module.exports.forkBlockNumber = 12786839
+
 // Constants related with Yearn.
 module.exports.yearn = {
   // Address of the Yearn registry contract.
@@ -40,5 +43,3 @@ module.exports.tbtc = {
   synthetixCurveRewardsOwnerAddress:
     "0xb3726e69da808a689f2607939a2d9e958724fc2a",
 }
-
-module.exports.forkBlockNumber = 12786839

--- a/yearn/test/system/constants.js
+++ b/yearn/test/system/constants.js
@@ -1,0 +1,42 @@
+// Constants related with Yearn.
+module.exports.yearn = {
+  // Address of the Yearn registry contract.
+  registryAddress: "0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804",
+  // Address of the governance managing the StrategyProxy contract.
+  strategyProxyGovernanceAddress: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52",
+}
+
+// Constants related with Convex.
+module.exports.convex = {
+  // Address of the Convex booster contract.
+  boosterAddress: "0xF403C135812408BFbE8713b5A23a04b3D48AAE31",
+}
+
+// Constants related with tBTC token and liquidity pools (Curve, Saddle, etc.).
+// TODO: The tBTC v2 token and their liquidity pools are not deployed yet. Those
+//       addresses are related with tBTC v1 token and liquidity pool temporarily.
+//       Once the new token and pools land, those addresses must be changed.
+module.exports.tbtc = {
+  // Address of the tBTC v2 Curve pool LP token.
+  curvePoolLPTokenAddress: "0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd",
+  // Example address which holds an amount of the tBTC v2 Curve pool LP token.
+  curvePoolLPTokenHolderAddress: "0x26fcbd3afebbe28d0a8684f790c48368d21665b5",
+  // Address of the tBTC v2 Curve pool depositor contract.
+  curvePoolDepositorAddress: "0xaa82ca713D94bBA7A89CEAB55314F9EfFEdDc78c",
+  // Address of the tBTC v2 Curve pool gauge contract.
+  curvePoolGaugeAddress: "0x6828bcF74279eE32f2723eC536c22c51Eed383C6",
+  // Address of the tBTC v2 Curve pool gauge additional reward token.
+  curvePoolGaugeRewardAddress: "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+  // Example address which holds an amount of the tBTC v2 Curve pool gauge
+  // additional reward token and can act as its distributor.
+  curvePoolGaugeRewardDistributorAddress:
+    "0x5203aeaaee721195707b01e613b6c3259b3a5cf6",
+  // ID of the Convex reward pool paired with the tBTC v2 Curve pool.
+  convexRewardPoolId: 16,
+  // Address of the Synthetix Curve rewards contract used by the tBTC v2 Curve
+  // pool gauge.
+  synthetixCurveRewardsAddress: "0xAF379f0228ad0d46bB7B4f38f9dc9bCC1ad0360c",
+  // Address of the Synthetix Curve rewards contract owner.
+  synthetixCurveRewardsOwnerAddress:
+    "0xb3726e69da808a689f2607939a2d9e958724fc2a",
+}

--- a/yearn/test/system/convex-strategy.test.js
+++ b/yearn/test/system/convex-strategy.test.js
@@ -1,4 +1,255 @@
+const { expect } = require("chai")
+const { BigNumber } = ethers
+const {
+  resetFork,
+  to1ePrecision,
+  impersonateAccount,
+  increaseTime,
+  to1e18,
+} = require("../helpers/contract-test-helpers.js")
+
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
 
-describeFn("System -- convex strategy", () => {})
+// TODO: The tBTC v2 token and their Curve pool are not deployed yet.
+//       This test uses tBTC v1 token and Curve pool temporarily.
+//       Once the new token and pool land, those addresses must be changed.
+// TODO: Refactor this test and extract common parts shared with other tests.
+describeFn("System -- convex strategy", () => {
+  // Address of the Yearn registry contract.
+  const registryAddress = "0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804"
+  // Address of the tBTC v2 Curve pool LP token.
+  const tbtcCurvePoolLPTokenAddress =
+    "0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd"
+  // Example address which holds an amount of the tBTC v2 Curve pool LP token.
+  const tbtcCurvePoolLPTokenHolderAddress =
+    "0x26fcbd3afebbe28d0a8684f790c48368d21665b5"
+  // Address of the tBTC v2 Curve pool depositor contract.
+  const tbtcCurvePoolDepositorAddress =
+    "0xaa82ca713D94bBA7A89CEAB55314F9EfFEdDc78c"
+  // ID of the Convex reward pool paired with the tBTC v2 Curve pool.
+  const tbtcConvexRewardPoolId = 16
+  // Address of the tBTC v2 Curve pool gauge additional reward token.
+  const tbtcCurvePoolGaugeRewardAddress =
+    "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+  // Example address which holds an amount of the tBTC v2 Curve pool gauge
+  // additional reward token and can act as its distributor.
+  const tbtcCurvePoolGaugeRewardDistributorAddress =
+    "0x5203aeaaee721195707b01e613b6c3259b3a5cf6"
+  // Address of the Synthetix Curve rewards contract used by the tBTC v2 Curve
+  // pool gauge.
+  const synthetixCurveRewardsAddress =
+    "0xAF379f0228ad0d46bB7B4f38f9dc9bCC1ad0360c"
+  // Address of the Synthetix Curve rewards contract owner.
+  const synthetixCurveRewardsOwnerAddress =
+    "0xb3726e69da808a689f2607939a2d9e958724fc2a"
+  // Address of the Convex booster contract.
+  const boosterAddress = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31"
+
+  // Name of the vault for tBTCv2 Curve pool.
+  const vaultName = "Curve tBTCv2 Pool yVault"
+  // Symbol of the vault for tBTCv2 Curve pool.
+  const vaultSymbol = "yvCurve-tBTCv2"
+  // Total deposit limit of the vault for tBTCv2 Curve pool.
+  const vaultDepositLimit = to1ePrecision(300, 15)
+  // Amount of the deposit made by the depositor.
+  const vaultDepositAmount = to1ePrecision(300, 15)
+
+  let vaultGovernance
+  let tbtcCurvePoolLPToken
+  let vaultDepositor
+  let tbtcCurvePoolGaugeReward
+  let tbtcCurvePoolGaugeRewardDistributor
+  let synthetixCurveRewards
+  let synthetixCurveRewardsOwner
+  let booster
+  let vault
+  let strategy
+
+  before(async () => {
+    await resetFork(12786839)
+
+    // Setup roles.
+    vaultGovernance = await ethers.getSigner(0)
+    vaultDepositor = await impersonateAccount(
+      tbtcCurvePoolLPTokenHolderAddress,
+      vaultGovernance
+    )
+    tbtcCurvePoolGaugeRewardDistributor = await impersonateAccount(
+      tbtcCurvePoolGaugeRewardDistributorAddress,
+      vaultGovernance
+    )
+    synthetixCurveRewardsOwner = await impersonateAccount(
+      synthetixCurveRewardsOwnerAddress,
+      vaultGovernance
+    )
+
+    // Get tBTC v2 Curve pool LP token handle.
+    tbtcCurvePoolLPToken = await ethers.getContractAt(
+      "IERC20",
+      tbtcCurvePoolLPTokenAddress
+    )
+
+    // Setup Synthetix staking rewards to provide Curve pool's gauge additional
+    // rewards.
+    await setupSynthetixRewards()
+
+    // Get Convex booster handle.
+    booster = await ethers.getContractAt("IConvexBooster", boosterAddress)
+
+    // Get a handle to the Yearn registry.
+    const registry = await ethers.getContractAt(
+      "IYearnRegistry",
+      registryAddress
+    )
+
+    // Always use the same vault release to avoid test failures in the future.
+    // Target release index is taken from the deployed Yearn registry contract.
+    // We aim for version 0.4.2 (see BaseStrategy.apiVersion()) whose index is 9.
+    const targetReleaseIndex = 9
+    const releaseDelta = (await registry.numReleases()) - 1 - targetReleaseIndex
+
+    // Deploy a new experimental vault accepting tBTC v2 Curve pool LP tokens.
+    const tx = await registry.newExperimentalVault(
+      tbtcCurvePoolLPToken.address,
+      vaultGovernance.address,
+      vaultGovernance.address, // set governance to be the guardian as well
+      vaultGovernance.address, // set governance to be the rewards target as well
+      vaultName,
+      vaultSymbol,
+      releaseDelta
+    )
+
+    // Get a handle to the experimental Yearn vault.
+    vault = await ethers.getContractAt(
+      "IYearnVault",
+      extractVaultAddress(await tx.wait())
+    )
+
+    // Just make sure the vault has been created properly.
+    expect(await vault.name()).to.be.equal(vaultName)
+
+    // Deploy the ConvexStrategy contract.
+    const ConvexStrategy = await ethers.getContractFactory("ConvexStrategy")
+    strategy = await ConvexStrategy.deploy(
+      vault.address,
+      tbtcCurvePoolDepositorAddress,
+      tbtcConvexRewardPoolId
+    )
+    await strategy.deployed()
+
+    // Add ConvexStrategy to the vault.
+    await vault.addStrategy(
+      strategy.address,
+      10000, // 100% debt ratio
+      0, // zero min debt per harvest
+      BigNumber.from(2).pow(256).sub(1), // infinite max debt per harvest
+      1000 // 10% performance fee
+    )
+
+    // Set a deposit limit.
+    await vault.setDepositLimit(vaultDepositLimit)
+  })
+
+  describe("when depositor deposits to the vault", () => {
+    before(async () => {
+      await tbtcCurvePoolLPToken
+        .connect(vaultDepositor)
+        .approve(vault.address, vaultDepositAmount)
+      await vault.connect(vaultDepositor).deposit(vaultDepositAmount)
+    })
+
+    it("should correctly handle the deposit", async () => {
+      expect(await vault.totalAssets()).to.be.equal(vaultDepositAmount)
+    })
+  })
+
+  describe("when harvesting occurs", () => {
+    before(async () => {
+      // First harvest just allocates funds for the first time.
+      await strategy.harvest()
+
+      // Simulate 7 harvests occurring each day.
+      for (let i = 0; i < 7; i++) {
+        await increaseTime(86400) // ~1 day
+        await strategy.harvest()
+        // Move accumulated rewards from Curve gauge to Convex reward pool.
+        await booster.earmarkRewards(tbtcConvexRewardPoolId)
+      }
+    })
+
+    it("should make a profit", async () => {
+      // TODO: Implementation.
+      expect(
+        (await vault.strategies(strategy.address)).totalGain
+      ).to.be.greaterThan(0)
+    })
+  })
+
+  describe("when depositor withdraws from the vault", () => {
+    let amountWithdrawn
+
+    before(async () => {
+      const initialBalance = await tbtcCurvePoolLPToken.balanceOf(
+        vaultDepositor.address
+      )
+      await vault.connect(vaultDepositor).withdraw() // withdraw all shares
+      const currentBalance = await tbtcCurvePoolLPToken.balanceOf(
+        vaultDepositor.address
+      )
+      amountWithdrawn = currentBalance.sub(initialBalance)
+    })
+
+    it("should correctly handle the withdrawal", async () => {
+      // TODO: Implementation.
+      expect(amountWithdrawn.gt(vaultDepositAmount)).to.be.true
+    })
+  })
+  async function setupSynthetixRewards() {
+    // Get a handle to the tBTC v2 Curve pool gauge additional reward token.
+    tbtcCurvePoolGaugeReward = await ethers.getContractAt(
+      "IERC20",
+      tbtcCurvePoolGaugeRewardAddress
+    )
+
+    // Get a handle to the Synthetix Curve rewards contract used by the
+    // tBTC v2 Curve pool gauge.
+    synthetixCurveRewards = await ethers.getContractAt(
+      "ICurveRewards",
+      synthetixCurveRewardsAddress
+    )
+
+    // Allocate 100k.
+    const rewardsAllocation = to1e18(100000)
+
+    // Set a new reward distributor. It's just a holder of the reward tokens.
+    await synthetixCurveRewards
+      .connect(synthetixCurveRewardsOwner)
+      .setRewardDistribution(tbtcCurvePoolGaugeRewardDistributor.address)
+
+    // Allow distributor's tokens to be taken by the Curve rewards contract.
+    await tbtcCurvePoolGaugeReward
+      .connect(tbtcCurvePoolGaugeRewardDistributor)
+      .approve(synthetixCurveRewards.address, rewardsAllocation)
+
+    // Deposit reward tokens.
+    await synthetixCurveRewards
+      .connect(tbtcCurvePoolGaugeRewardDistributor)
+      .notifyRewardAmount(rewardsAllocation)
+  }
+
+  function extractVaultAddress(receipt) {
+    // Find the NewExperimentalVaultEvent using their hex.
+    // See: https://etherscan.io/address/0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804#events
+    const newExperimentalVaultEvent = receipt.events.find(
+      (e) =>
+        e.topics[0] ===
+        "0x57a9cdc2a05e05f66e76769bdbe88e21ec45d9ee0f97d4cb60395d4c75dcbcda"
+    )
+    // Event data consist of vault address and API version string.
+    return ethers.utils.defaultAbiCoder.decode(
+      ["address", "string"],
+      newExperimentalVaultEvent.data
+    )[0]
+  }
+})

--- a/yearn/test/system/convex-strategy.test.js
+++ b/yearn/test/system/convex-strategy.test.js
@@ -1,0 +1,4 @@
+const describeFn =
+  process.env.NODE_ENV === "system-test" ? describe : describe.skip
+
+describeFn("System -- convex strategy", () => {})

--- a/yearn/test/system/convex-strategy.test.js
+++ b/yearn/test/system/convex-strategy.test.js
@@ -171,9 +171,12 @@ describeFn("System -- convex strategy", () => {
       // wBTC bought: 4501
       // LP tokens profit: 44591140717357
       //
-      // Sum of LP tokens profits: 413743570737460
-      expect((await vault.strategies(strategy.address)).totalGain).to.be.equal(
-        413743570737460
+      // Sum of LP tokens profits: 413743570737460 (15 digits)
+      expect(
+        (await vault.strategies(strategy.address)).totalGain
+      ).to.be.closeTo(
+        to1ePrecision(4137, 11),
+        to1ePrecision(1, 11) // 0.0001 precision because there are 15 digits.
       )
     })
   })

--- a/yearn/test/system/curve-voter-proxy-strategy.test.js
+++ b/yearn/test/system/curve-voter-proxy-strategy.test.js
@@ -8,7 +8,7 @@ const {
   to1e18,
 } = require("../helpers/contract-test-helpers.js")
 const { yearn, tbtc, forkBlockNumber } = require("./constants.js")
-const { allocateSynthetixRewards } = require("./functions.js")
+const { allocateSynthetixRewards, deployYearnVault } = require("./functions.js")
 
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
@@ -45,11 +45,9 @@ describeFn("System -- curve voter proxy strategy", () => {
       yearn.strategyProxyGovernanceAddress
     )
 
-    await allocateSynthetixRewards(
-      tbtc,
-      synthetixRewardsAllocation,
-      vaultGovernance
-    )
+    // Allocate Synthetix rewards to obtain additional rewards (KEEP tokens)
+    // from the Curve pool's gauge.
+    await allocateSynthetixRewards(tbtc, synthetixRewardsAllocation)
 
     // Get tBTC v2 Curve pool LP token handle.
     tbtcCurvePoolLPToken = await ethers.getContractAt(
@@ -57,37 +55,15 @@ describeFn("System -- curve voter proxy strategy", () => {
       tbtc.curvePoolLPTokenAddress
     )
 
-    // Get a handle to the Yearn registry.
-    const registry = await ethers.getContractAt(
-      "IYearnRegistry",
-      yearn.registryAddress
-    )
-
-    // Always use the same vault release to avoid test failures in the future.
-    // Target release index is taken from the deployed Yearn registry contract.
-    // We aim for version 0.4.2 (see BaseStrategy.apiVersion()) whose index is 9.
-    const targetReleaseIndex = 9
-    const releaseDelta = (await registry.numReleases()) - 1 - targetReleaseIndex
-
     // Deploy a new experimental vault accepting tBTC v2 Curve pool LP tokens.
-    const tx = await registry.newExperimentalVault(
-      tbtcCurvePoolLPToken.address,
-      vaultGovernance.address,
-      vaultGovernance.address, // set governance to be the guardian as well
-      vaultGovernance.address, // set governance to be the rewards target as well
+    vault = await deployYearnVault(
+      yearn,
       vaultName,
       vaultSymbol,
-      releaseDelta
+      tbtcCurvePoolLPToken,
+      vaultGovernance,
+      vaultDepositLimit
     )
-
-    // Get a handle to the experimental Yearn vault.
-    vault = await ethers.getContractAt(
-      "IYearnVault",
-      extractVaultAddress(await tx.wait())
-    )
-
-    // Just make sure the vault has been created properly.
-    expect(await vault.name()).to.be.equal(vaultName)
 
     // Deploy the CurveVoterProxyStrategy contract.
     const CurveVoterProxyStrategy = await ethers.getContractFactory(
@@ -118,9 +94,6 @@ describeFn("System -- curve voter proxy strategy", () => {
       BigNumber.from(2).pow(256).sub(1), // infinite max debt per harvest
       1000 // 10% performance fee
     )
-
-    // Set a deposit limit.
-    await vault.setDepositLimit(vaultDepositLimit)
   })
 
   describe("when depositor deposits to the vault", () => {
@@ -246,19 +219,4 @@ describeFn("System -- curve voter proxy strategy", () => {
       expect(amountWithdrawn.gt(vaultDepositAmount)).to.be.true
     })
   })
-
-  function extractVaultAddress(receipt) {
-    // Find the NewExperimentalVaultEvent using their hex.
-    // See: https://etherscan.io/address/0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804#events
-    const newExperimentalVaultEvent = receipt.events.find(
-      (e) =>
-        e.topics[0] ===
-        "0x57a9cdc2a05e05f66e76769bdbe88e21ec45d9ee0f97d4cb60395d4c75dcbcda"
-    )
-    // Event data consist of vault address and API version string.
-    return ethers.utils.defaultAbiCoder.decode(
-      ["address", "string"],
-      newExperimentalVaultEvent.data
-    )[0]
-  }
 })

--- a/yearn/test/system/curve-voter-proxy-strategy.test.js
+++ b/yearn/test/system/curve-voter-proxy-strategy.test.js
@@ -7,7 +7,8 @@ const {
   increaseTime,
   to1e18,
 } = require("../helpers/contract-test-helpers.js")
-const { yearn, tbtc } = require("./constants.js")
+const { yearn, tbtc, forkBlockNumber } = require("./constants.js")
+const { allocateSynthetixRewards } = require("./functions.js")
 
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
@@ -21,20 +22,18 @@ describeFn("System -- curve voter proxy strategy", () => {
   const vaultDepositLimit = to1ePrecision(300, 15)
   // Amount of the deposit made by the depositor.
   const vaultDepositAmount = to1ePrecision(300, 15)
+  // Amount of Synthetix staking rewards which should be allocated.
+  const synthetixRewardsAllocation = to1e18(100000)
 
   let vaultGovernance
   let tbtcCurvePoolLPToken
   let vaultDepositor
-  let tbtcCurvePoolGaugeReward
-  let tbtcCurvePoolGaugeRewardDistributor
-  let synthetixCurveRewards
-  let synthetixCurveRewardsOwner
   let strategyProxyGovernance
   let vault
   let strategy
 
   before(async () => {
-    await resetFork(12786839)
+    await resetFork(forkBlockNumber)
 
     // Setup roles.
     vaultGovernance = await ethers.getSigner(0)
@@ -45,12 +44,10 @@ describeFn("System -- curve voter proxy strategy", () => {
     strategyProxyGovernance = await impersonateAccount(
       yearn.strategyProxyGovernanceAddress
     )
-    tbtcCurvePoolGaugeRewardDistributor = await impersonateAccount(
-      tbtc.curvePoolGaugeRewardDistributorAddress,
-      vaultGovernance
-    )
-    synthetixCurveRewardsOwner = await impersonateAccount(
-      tbtc.synthetixCurveRewardsOwnerAddress,
+
+    await allocateSynthetixRewards(
+      tbtc,
+      synthetixRewardsAllocation,
       vaultGovernance
     )
 
@@ -59,10 +56,6 @@ describeFn("System -- curve voter proxy strategy", () => {
       "IERC20",
       tbtc.curvePoolLPTokenAddress
     )
-
-    // Setup Synthetix staking rewards to provide Curve pool's gauge additional
-    // rewards.
-    await setupSynthetixRewards()
 
     // Get a handle to the Yearn registry.
     const registry = await ethers.getContractAt(
@@ -253,38 +246,6 @@ describeFn("System -- curve voter proxy strategy", () => {
       expect(amountWithdrawn.gt(vaultDepositAmount)).to.be.true
     })
   })
-  async function setupSynthetixRewards() {
-    // Get a handle to the tBTC v2 Curve pool gauge additional reward token.
-    tbtcCurvePoolGaugeReward = await ethers.getContractAt(
-      "IERC20",
-      tbtc.curvePoolGaugeRewardAddress
-    )
-
-    // Get a handle to the Synthetix Curve rewards contract used by the
-    // tBTC v2 Curve pool gauge.
-    synthetixCurveRewards = await ethers.getContractAt(
-      "ICurveRewards",
-      tbtc.synthetixCurveRewardsAddress
-    )
-
-    // Allocate 100k.
-    const rewardsAllocation = to1e18(100000)
-
-    // Set a new reward distributor. It's just a holder of the reward tokens.
-    await synthetixCurveRewards
-      .connect(synthetixCurveRewardsOwner)
-      .setRewardDistribution(tbtcCurvePoolGaugeRewardDistributor.address)
-
-    // Allow distributor's tokens to be taken by the Curve rewards contract.
-    await tbtcCurvePoolGaugeReward
-      .connect(tbtcCurvePoolGaugeRewardDistributor)
-      .approve(synthetixCurveRewards.address, rewardsAllocation)
-
-    // Deposit reward tokens.
-    await synthetixCurveRewards
-      .connect(tbtcCurvePoolGaugeRewardDistributor)
-      .notifyRewardAmount(rewardsAllocation)
-  }
 
   function extractVaultAddress(receipt) {
     // Find the NewExperimentalVaultEvent using their hex.

--- a/yearn/test/system/fixtures.js
+++ b/yearn/test/system/fixtures.js
@@ -1,0 +1,23 @@
+const { to1e18, to1ePrecision } = require("../helpers/contract-test-helpers.js")
+const { BigNumber } = ethers
+
+module.exports.curveStrategyFixture = {
+  // Name of the vault for tBTCv2 Curve pool.
+  vaultName: "Curve tBTCv2 Pool yVault",
+  // Symbol of the vault for tBTCv2 Curve pool.
+  vaultSymbol: "yvCurve-tBTCv2",
+  // Total deposit limit of the vault for tBTCv2 Curve pool.
+  vaultDepositLimit: to1ePrecision(300, 15), // 0.3
+  // Amount of the deposit made by the depositor.
+  vaultDepositAmount: to1ePrecision(300, 15), // 0.3
+  // Amount of Synthetix staking rewards which should be allocated.
+  synthetixRewardsAllocation: to1e18(100000), // 100k
+  // The share of the total assets in the vault that the strategy has access to.
+  strategyDebtRatio: 10000, // 100%
+  // Lower limit on the increase of debt since last harvest.
+  strategyMinDebtPerHarvest: 0,
+  // Upper limit on the increase of debt since last harvest.
+  strategyMaxDebtPerHarvest: BigNumber.from(2).pow(256).sub(1), // infinite
+  // The fee the strategist will receive based on this Vault's performance.
+  strategyPerformanceFee: 1000, // 10%
+}

--- a/yearn/test/system/functions.js
+++ b/yearn/test/system/functions.js
@@ -1,0 +1,45 @@
+const { impersonateAccount } = require("../helpers/contract-test-helpers.js")
+
+// Allocates Synthetix staking rewards to provide Curve pool's gauge additional
+// rewards.
+async function allocateSynthetixRewards(tbtc, rewardsAllocation, purseSigner) {
+  const tbtcCurvePoolGaugeRewardDistributor = await impersonateAccount(
+    tbtc.curvePoolGaugeRewardDistributorAddress,
+    purseSigner
+  )
+
+  const synthetixCurveRewardsOwner = await impersonateAccount(
+    tbtc.synthetixCurveRewardsOwnerAddress,
+    purseSigner
+  )
+
+  // Get a handle to the tBTC v2 Curve pool gauge additional reward token.
+  const tbtcCurvePoolGaugeReward = await ethers.getContractAt(
+    "IERC20",
+    tbtc.curvePoolGaugeRewardAddress
+  )
+
+  // Get a handle to the Synthetix Curve rewards contract used by the
+  // tBTC v2 Curve pool gauge.
+  const synthetixCurveRewards = await ethers.getContractAt(
+    "ICurveRewards",
+    tbtc.synthetixCurveRewardsAddress
+  )
+
+  // Set a new reward distributor. It's just a holder of the reward tokens.
+  await synthetixCurveRewards
+    .connect(synthetixCurveRewardsOwner)
+    .setRewardDistribution(tbtcCurvePoolGaugeRewardDistributor.address)
+
+  // Allow distributor's tokens to be taken by the Curve rewards contract.
+  await tbtcCurvePoolGaugeReward
+    .connect(tbtcCurvePoolGaugeRewardDistributor)
+    .approve(synthetixCurveRewards.address, rewardsAllocation)
+
+  // Deposit reward tokens.
+  await synthetixCurveRewards
+    .connect(tbtcCurvePoolGaugeRewardDistributor)
+    .notifyRewardAmount(rewardsAllocation)
+}
+
+module.exports.allocateSynthetixRewards = allocateSynthetixRewards

--- a/yearn/test/system/functions.js
+++ b/yearn/test/system/functions.js
@@ -2,15 +2,15 @@ const { impersonateAccount } = require("../helpers/contract-test-helpers.js")
 
 // Allocates Synthetix staking rewards to provide Curve pool's gauge additional
 // rewards.
-async function allocateSynthetixRewards(tbtc, rewardsAllocation, purseSigner) {
+async function allocateSynthetixRewards(tbtc, rewardsAllocation) {
   const tbtcCurvePoolGaugeRewardDistributor = await impersonateAccount(
     tbtc.curvePoolGaugeRewardDistributorAddress,
-    purseSigner
+    await ethers.getSigner(0)
   )
 
   const synthetixCurveRewardsOwner = await impersonateAccount(
     tbtc.synthetixCurveRewardsOwnerAddress,
-    purseSigner
+    await ethers.getSigner(0)
   )
 
   // Get a handle to the tBTC v2 Curve pool gauge additional reward token.
@@ -42,4 +42,69 @@ async function allocateSynthetixRewards(tbtc, rewardsAllocation, purseSigner) {
     .notifyRewardAmount(rewardsAllocation)
 }
 
+// Deploys a new experimental Yearn vault for given parameters.
+async function deployYearnVault(
+  yearn,
+  name,
+  symbol,
+  token,
+  governance,
+  depositLimit
+) {
+  // Get a handle to the Yearn registry.
+  const registry = await ethers.getContractAt(
+    "IYearnRegistry",
+    yearn.registryAddress
+  )
+
+  // Always use the same vault release to avoid test failures in the future.
+  // Target release index is taken from the deployed Yearn registry contract.
+  // We aim for version 0.4.2 (see BaseStrategy.apiVersion()) whose index is 9.
+  const targetReleaseIndex = 9
+  const releaseDelta = (await registry.numReleases()) - 1 - targetReleaseIndex
+
+  // Deploy a new experimental vault accepting the given token.
+  const tx = await registry.newExperimentalVault(
+    token.address,
+    governance.address,
+    governance.address, // set governance to be the guardian as well
+    governance.address, // set governance to be the rewards target as well
+    name,
+    symbol,
+    releaseDelta
+  )
+
+  // Get a handle to the experimental Yearn vault.
+  const vault = await ethers.getContractAt(
+    "IYearnVault",
+    extractVaultAddress(await tx.wait())
+  )
+
+  // Just make sure the vault has been created properly.
+  if ((await vault.name()) !== name) {
+    throw new Error("Invalid vault name")
+  }
+
+  // Set the deposit limit.
+  await vault.setDepositLimit(depositLimit)
+
+  return vault
+}
+
+function extractVaultAddress(receipt) {
+  // Find the NewExperimentalVaultEvent using their hex.
+  // See: https://etherscan.io/address/0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804#events
+  const newExperimentalVaultEvent = receipt.events.find(
+    (e) =>
+      e.topics[0] ===
+      "0x57a9cdc2a05e05f66e76769bdbe88e21ec45d9ee0f97d4cb60395d4c75dcbcda"
+  )
+  // Event data consist of vault address and API version string.
+  return ethers.utils.defaultAbiCoder.decode(
+    ["address", "string"],
+    newExperimentalVaultEvent.data
+  )[0]
+}
+
 module.exports.allocateSynthetixRewards = allocateSynthetixRewards
+module.exports.deployYearnVault = deployYearnVault


### PR DESCRIPTION
Refs: #7
Depends on: #8 

**Introduction**

This pull request introduces another Yearn strategy named `ConvexStrategy`, meant to be used with the Yearn vault for tBTC v2. It follows all conventions introduced in the previous PR (#8) and is quite similar to the first `CurveVoterProxyStrategy` but uses [Convex Finance](https://www.convexfinance.com/) to generate yield.

**The `ConvexStrategy` strategy contract**

This strategy is used in the existing vault for tBTC v1 ([Curve tBTC pool yVault](https://yearn.watch/vault/0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f)). The current implementation for tBTC v2 is based on the following repositories, especially on the last one:

- [General Yearn strategy template](https://github.com/yearn/brownie-strategy-mix)
- [Convex implementation for tBTC v1 vault](https://github.com/orbxball/btc-curve-convex)

Basically, the current implementation for tBTC v2 vault uses the same logic as the strategy for [tBTC v1 vault](https://github.com/orbxball/btc-curve-convex/blob/master/archived/tbtc.sol). However, it tries to simplify the contract structure and attempts to achieve better readability and documentation. It also uses a newer version of the `yearn-vault` base contract. Last but not least, it introduces support for extra rewards provided by Convex reward pools sitting on top of Curve gauges which stake their deposits into the Synthetix staker rewards contract. To read a detailed description about how this strategy works in details, please see the [documentation of the `ConvexStrategy` contract](https://github.com/keep-network/tbtc-v2/blob/aacc3130ca68a22fb245016262723c0d2a9188c0/yearn/contracts/ConvexStrategy.sol#L99)
