### PR TITLE
Updated to global format configuration

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests
         run: yarn test
 
-  contracts-lint:
+  contracts-format:
     needs: contracts-detect-changes
     if: |
       github.event_name == 'push'
@@ -77,8 +77,8 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Lint
-        run: yarn lint
+      - name: Check formatting
+        run: yarn format
 
   contracts-slither:
     needs: contracts-detect-changes

--- a/.github/workflows/yearn.yml
+++ b/.github/workflows/yearn.yml
@@ -52,7 +52,7 @@ jobs:
           FORKING_URL: ${{ secrets.MAINNET_ETH_HOSTNAME }}
         run: yarn test:system
 
-  contracts-lint:
+  contracts-format:
     needs: contracts-detect-changes
     if: |
       github.event_name == 'push'
@@ -79,5 +79,5 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Lint
-        run: yarn lint
+      - name: Check formatting
+        run: yarn format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,21 @@ repos:
       - id: check-added-large-files
   - repo: local
     hooks:
-      - id: lint-js
-        name: "lint js"
-        entry: /usr/bin/env bash -c "npm run lint:js"
-        files: '\.js$'
+      - id: root-format
+        name: "Check root directory code formatting"
+        entry: /usr/bin/env bash -c "yarn format"
+        exclude: '^solidity\/|^yearn\/'
         language: script
-        description: "Checks JS code according to the package's linter configuration"
-      - id: lint-sol
-        name: "lint solidity"
-        entry: /usr/bin/env bash -c "npm run lint:sol"
-        files: '\.sol$'
+        description: "Checks root directory code according to the formatting configuration"
+      - id: solidity-format
+        name: "Check solidity directory code formatting"
+        entry: /usr/bin/env bash -c "cd solidity && yarn format"
+        files: "^solidity/"
         language: script
-        description: "Checks Solidity code according to the package's linter configuration"
-      - id: prettier
-        name: "prettier"
-        entry: /usr/bin/env bash -c "npx prettier --check ."
+        description: "Checks solidity directory code according to the formatting configuration"
+      - id: yearn-format
+        name: "Check yearn directory code formatting"
+        entry: /usr/bin/env bash -c "cd yearn && yarn format"
+        files: "^yearn/"
         language: script
-        description: "Checks code according to the package's formatting configuration"
+        description: "Checks yearn directory code according to the formatting configuration"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 # Following directories have their own formatting configuration:
 solidity/
+yearn/

--- a/solidity/.prettierignore
+++ b/solidity/.prettierignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -22,11 +22,14 @@
   },
   "scripts": {
     "build": "hardhat compile",
+    "format": "npm run lint && prettier --check .",
+    "format:fix": "npm run lint:fix && prettier --write .",
     "lint": "npm run lint:js && npm run lint:sol",
+    "lint:js": "eslint .",
+    "lint:sol": "solhint 'contracts/**/*.sol'",
+    "lint:fix": "npm run lint:fix:js && npm run lint:fix:sol",
     "lint:fix:js": "eslint . --fix",
-    "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix && prettier --write '**/*.sol'",
-    "lint:js": "eslint . ",
-    "lint:sol": "solhint 'contracts/**/*.sol' && prettier --check '**/*.sol'",
+    "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
     "test": "hardhat test"
   }
 }

--- a/yearn/.prettierignore
+++ b/yearn/.prettierignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/yearn/package.json
+++ b/yearn/package.json
@@ -24,11 +24,14 @@
   "name": "@keep-network/tbtc-v2-yearn",
   "scripts": {
     "build": "hardhat compile",
+    "format": "npm run lint && prettier --check .",
+    "format:fix": "npm run lint:fix && prettier --write .",
     "lint": "npm run lint:js && npm run lint:sol",
+    "lint:js": "eslint .",
+    "lint:sol": "solhint 'contracts/**/*.sol'",
+    "lint:fix": "npm run lint:fix:js && npm run lint:fix:sol",
     "lint:fix:js": "eslint . --fix",
-    "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix && prettier --write '**/*.sol'",
-    "lint:js": "eslint . ",
-    "lint:sol": "solhint 'contracts/**/*.sol' && prettier --check '**/*.sol'",
+    "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
     "size-contracts": "hardhat compile && hardhat size-contracts",
     "test": "hardhat test",
     "test:system": "NODE_ENV=system-test hardhat test ./test/system/*.test.js"


### PR DESCRIPTION
This PR enhances https://github.com/keep-network/tbtc-v2/pull/12 with additional updates to packages code formatting.
In `solidity` and `yearn` packages we add `format` script that will execute linting for both `js` and `sol` file types, but also will run `prettier` for all supported files (e.g. `json`).
