### PR TITLE
Renamed TBTCToken contract to TBTC

### DIFF
--- a/solidity/contracts/bridge/VendingMachine.sol
+++ b/solidity/contracts/bridge/VendingMachine.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@thesis/solidity-contracts/contracts/token/IReceiveApproval.sol";
 
-import "../token/TBTCToken.sol";
+import "../token/TBTC.sol";
 import "../GovernanceUtils.sol";
 
 /// @title TBTC v2 Vending Machine
@@ -33,7 +33,7 @@ import "../GovernanceUtils.sol";
 ///         governance delay passes.
 contract VendingMachine is Ownable, IReceiveApproval {
     using SafeERC20 for IERC20;
-    using SafeERC20 for TBTCToken;
+    using SafeERC20 for TBTC;
 
     /// @notice The time delay that needs to pass between initializing and
     ///         finalizing update of any governable parameter in this contract.
@@ -44,7 +44,7 @@ contract VendingMachine is Ownable, IReceiveApproval {
     uint256 public constant FLOATING_POINT_DIVISOR = 1e18;
 
     IERC20 public immutable tbtcV1;
-    TBTCToken public immutable tbtcV2;
+    TBTC public immutable tbtcV2;
 
     /// @notice The fee for unminting TBTC v2 back into TBTC v1 represented as
     ///         1e18 precision fraction. The fee is proportional to the amount
@@ -94,7 +94,7 @@ contract VendingMachine is Ownable, IReceiveApproval {
 
     constructor(
         IERC20 _tbtcV1,
-        TBTCToken _tbtcV2,
+        TBTC _tbtcV2,
         uint256 _unmintFee
     ) {
         tbtcV1 = _tbtcV1;

--- a/solidity/contracts/test/ReceiveApprovalStub.sol
+++ b/solidity/contracts/test/ReceiveApprovalStub.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.4;
 
-import "../token/TBTCToken.sol";
+import "../token/TBTC.sol";
 
 contract ReceiveApprovalStub is IReceiveApproval {
     bool public shouldRevert;

--- a/solidity/contracts/token/TBTC.sol
+++ b/solidity/contracts/token/TBTC.sol
@@ -5,6 +5,6 @@ pragma solidity 0.8.4;
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 import "./MisfundRecovery.sol";
 
-contract TBTCToken is ERC20WithPermit, MisfundRecovery {
+contract TBTC is ERC20WithPermit, MisfundRecovery {
     constructor() ERC20WithPermit("tBTC v2", "tBTC") {}
 }

--- a/solidity/test/bridge/VendingMachine.test.js
+++ b/solidity/test/bridge/VendingMachine.test.js
@@ -33,8 +33,8 @@ describe("VendingMachine", () => {
     tbtcV1 = await TestERC20.deploy()
     await tbtcV1.deployed()
 
-    const TBTCToken = await ethers.getContractFactory("TBTCToken")
-    tbtcV2 = await TBTCToken.deploy()
+    const TBTC = await ethers.getContractFactory("TBTC")
+    tbtcV2 = await TBTC.deploy()
     await tbtcV2.deployed()
 
     await tbtcV1.mint(tokenHolder.address, initialBalance)


### PR DESCRIPTION
For simplicity and... it just looks better. Same approach as for just [`T`](https://github.com/threshold-network/solidity-contracts/blob/005339e6afa0af117fe9cff97b48f170e188c24b/contracts/token/T.sol) instead of `TToken`.