### PR TITLE
Transfer roles in tBTC v2 deployment script

### DIFF
--- a/solidity/deploy/02_deploy_vending_machine.ts
+++ b/solidity/deploy/02_deploy_vending_machine.ts
@@ -9,7 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const TBTCToken = await deployments.get("TBTCToken")
   const TBTC = await deployments.get("TBTC") // tBTC v2
 
-  const unmintFee = 1000000000000000 // 0.001 of the amount being unminted
+  const unmintFee = 0
 
   await deploy("VendingMachine", {
     from: deployer,

--- a/solidity/deploy/03_transfer_roles.ts
+++ b/solidity/deploy/03_transfer_roles.ts
@@ -1,0 +1,46 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers, deployments } = hre
+  const { execute, log } = deployments
+  const { deployer, keepTechnicalWalletTeam, keepCommunityMultiSig } =
+    await getNamedAccounts()
+
+  log(
+    `transferring vendingMachineUpgradeInitiator role to ${keepTechnicalWalletTeam}`
+  )
+
+  await execute(
+    "VendingMachine",
+    { from: deployer },
+    "transferVendingMachineUpgradeInitiatorRole",
+    keepTechnicalWalletTeam
+  )
+
+  log(
+    `transferring unmintFeeUpdateInitiator role to ${keepTechnicalWalletTeam}`
+  )
+
+  await execute(
+    "VendingMachine",
+    { from: deployer },
+    "transferUnmintFeeUpdateInitiatorRole",
+    keepTechnicalWalletTeam
+  )
+
+  await helpers.ownable.transferOwnership(
+    "VendingMachine",
+    keepCommunityMultiSig,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["TransferRoles"]
+func.dependencies = ["TBTC", "VendingMachine"]
+func.runAtTheEnd = true
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name !== "mainnet"
+}

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -61,6 +61,12 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 0, // take the first account as deployer
     },
+    keepTechnicalWalletTeam: {
+      mainnet: "0xB3726E69Da808A689F2607939a2D9E958724FC2A",
+    },
+    keepCommunityMultiSig: {
+      mainnet: "0x19FcB32347ff4656E4E6746b4584192D185d640d",
+    },
   },
 }
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -20,7 +20,7 @@
     "@openzeppelin/contracts": "^4.1.0"
   },
   "devDependencies": {
-    "@keep-network/hardhat-helpers": "github:keep-network/hardhat-helpers#v0.1.0",
+    "@keep-network/hardhat-helpers": "^0.2.0-pre",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1034,9 +1034,10 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
-"@keep-network/hardhat-helpers@github:keep-network/hardhat-helpers#v0.1.0":
-  version "0.1.0"
-  resolved "https://codeload.github.com/keep-network/hardhat-helpers/tar.gz/f076fdb32ea6f1d4668347d68994f764fd55ace2"
+"@keep-network/hardhat-helpers@^0.2.0-pre":
+  version "0.2.0-pre"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.2.0-pre.tgz#f3c83b0798087408d791220437c6b70117aa80b8"
+  integrity sha512-HMOjve/0cGpXrbjw1VBeTBHe7dcOCk+Uz7C+hx7XsWFMCvzKJyGL57BjfLrsNSLaS1hPU3MlB8lbOJFQex4OHg==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.0":
   version "0.1.0-pre.0"


### PR DESCRIPTION
This change adds appropriate roles transfers defined by the deployment scenario. It also sets the initial `unmintFee` value to zero. Follow-up to https://github.com/keep-network/tbtc-v2/pull/17