### PR TITLE
Updated @thesis/solidity-contracts dependency to the most recent version

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
-    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#657d210",
+    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#507c647",
     "@openzeppelin/contracts": "^4.1.0"
   },
   "devDependencies": {

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1417,9 +1417,9 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@thesis/solidity-contracts@github:thesis/solidity-contracts#657d210":
+"@thesis/solidity-contracts@github:thesis/solidity-contracts#507c647":
   version "0.0.1"
-  resolved "https://codeload.github.com/thesis/solidity-contracts/tar.gz/657d21018a52af8d7374fa1698b386029a796746"
+  resolved "https://codeload.github.com/thesis/solidity-contracts/tar.gz/507c64759a2783196b505365e0cb4bf13c1ad1fa"
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 


### PR DESCRIPTION
Updated the dependency after merging the change about replacing assembly
`chainid()` call with `block.chainid` in `ERC20WithPermit.sol`.

See https://github.com/thesis/solidity-contracts/pull/10