### PR TITLE
Migrate contracts and publish package

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -120,7 +120,7 @@ jobs:
           query: tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 
       - name: Resolve latest contracts
-        run: yarn add @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
+        run: yarn upgrade @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
 
       - name: Configure tenderly
         if: github.event.inputs.environment == 'ropsten'

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }}
+        run: npm publish --access=public --tag ${{ github.event.inputs.environment }} --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -149,10 +149,10 @@ jobs:
           github-project-name: tbtc-v2
           version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Publish to npm # TODO: remove `--dry-run` before merge to main
+      - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --dry-run
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -122,6 +122,12 @@ jobs:
       - name: Resolve latest contracts
         run: yarn add @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
 
+      - name: Configure tenderly
+        if: github.event.inputs.environment == 'ropsten'
+        env:
+          TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
+        run: ./config_tenderly.sh
+
       - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
@@ -136,18 +142,6 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
-
-      - name: Push contracts to Tenderly
-        if: github.event.inputs.environment == 'ropsten'
-        uses: keep-network/tenderly-push-action@v1
-        continue-on-error: true
-        with:
-          working-directory: solidity
-          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
-          tenderly-project: thesis/keep-test
-          eth-network-id: ${{ env.NETWORK_ID }}
-          github-project-name: tbtc-v2
-          version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
         env:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -8,6 +8,18 @@ on:
       - "solidity/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment for workflow execution"
+        required: false
+        default: "dev"
+      upstream_builds:
+        description: "Upstream builds"
+        required: false
+      upstream_ref:
+        description: "Git reference to checkout (e.g. branch name)"
+        required: false
+        default: "main"
 
 jobs:
   contracts-detect-changes:
@@ -25,6 +37,7 @@ jobs:
           filters: |
             path-filter:
               - './solidity/**'
+
   contracts-build-and-test:
     needs: contracts-detect-changes
     if: |
@@ -51,6 +64,107 @@ jobs:
 
       - name: Run tests
         run: yarn test
+
+  contracts-deployment-dry-run:
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Deploy contracts
+        run: yarn deploy
+
+  contracts-deployment-testnet:
+    needs: [contracts-detect-changes, contracts-build-and-test]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Load environment variables
+        uses: keep-network/ci/actions/load-env-variables@v1
+        with:
+          environment: ${{ github.event.inputs.environment }}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Get upstream packages versions
+        uses: keep-network/ci/actions/upstream-builds-query@v1
+        id: upstream-builds-query
+        with:
+          upstream-builds: ${{ github.event.inputs.upstream_builds }}
+          query: tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
+
+      - name: Resolve latest contracts
+        run: yarn add @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
+
+      - name: Deploy contracts
+        env:
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: yarn deploy --network ${{ github.event.inputs.environment }}
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          work-dir: solidity
+          environment: ${{ github.event.inputs.environment }}
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
+
+      - name: Push contracts to Tenderly
+        if: github.event.inputs.environment == 'ropsten'
+        uses: keep-network/tenderly-push-action@v1
+        continue-on-error: true
+        with:
+          working-directory: solidity
+          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
+          tenderly-project: thesis/keep-test
+          eth-network-id: ${{ env.NETWORK_ID }}
+          github-project-name: tbtc-v2
+          version-tag: ${{ steps.npm-version-bump.outputs.version }}
+
+      - name: Publish to npm # TODO: remove `--dry-run` before merge to main
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
+          npm publish --access=public --network=${{ github.event.inputs.environment }} --dry-run
+
+      - name: Notify CI about completion of the workflow
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/keep-network/tbtc-v2/solidity"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          upstream_ref: ${{ github.event.inputs.upstream_ref }}
+          version: ${{ steps.npm-version-bump.outputs.version }}
 
   contracts-format:
     needs: contracts-detect-changes

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
 
       - name: Install dependencies
         run: yarn install
@@ -67,6 +68,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
 
       # Below step is a workaround. Eslint executed in `solidity` directory
       # finds `.prettierrc.js` config in the root directory and fails if
@@ -98,6 +100,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -150,9 +150,9 @@ jobs:
           version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm # TODO: remove `--dry-run` before merge to main
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --network=${{ github.event.inputs.environment }} --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --dry-run
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,53 @@
+name: NPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "solidity/contracts/**"
+      - "solidity/package.json"
+      - "solidity/yarn.lock"
+  pull_request: #TODO: remove before merging
+
+jobs:
+  npm-compile-publish-contracts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
+
+      - name: Resolve latest contracts
+        run: |
+          yarn add @keep-network/tbtc
+
+      - name: Compile contracts
+        run: yarn build
+
+      - name: Copy artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r build/contracts/* artifacts/
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          work-dir: ./solidity
+          environment: dev
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
+
+      - name: Publish package # TODO: remove `--dry-run` before merge to main
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --network=development --dry-run

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat
+        run: npm publish --access=public --tag=dev --network=hardhat

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn add @keep-network/tbtc
+          yarn upgrade @keep-network/tbtc
 
       # Deploy contracts to a local network to generate deployment artifacts that
       # are required by dashboard compilation.

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,13 +31,10 @@ jobs:
         run: |
           yarn add @keep-network/tbtc
 
-      - name: Compile contracts
-        run: yarn build
-
-      - name: Copy artifacts
-        run: |
-          mkdir -p artifacts
-          cp -r build/contracts/* artifacts/
+      # Deploy contracts to a local network to generate deployment artifacts that
+      # are required by dashboard compilation.
+      - name: Deploy contracts
+        run: yarn deploy --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump
@@ -51,4 +48,4 @@ jobs:
       - name: Publish package # TODO: remove `--dry-run` before merge to main
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=development --dry-run
+        run: npm publish --access=public --network=hardhat --dry-run

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,7 +8,6 @@ on:
       - "solidity/contracts/**"
       - "solidity/package.json"
       - "solidity/yarn.lock"
-  pull_request: #TODO: remove before merging
   workflow_dispatch:
 
 jobs:
@@ -45,7 +44,7 @@ jobs:
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
 
-      - name: Publish package # TODO: remove `--dry-run` before merge to main
+      - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat --dry-run
+        run: npm publish --access=public --network=hardhat

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -9,6 +9,7 @@ on:
       - "solidity/package.json"
       - "solidity/yarn.lock"
   pull_request: #TODO: remove before merging
+  workflow_dispatch:
 
 jobs:
   npm-compile-publish-contracts:

--- a/solidity/.hardhat/networks_TEMPLATE.ts
+++ b/solidity/.hardhat/networks_TEMPLATE.ts
@@ -11,11 +11,13 @@ const config: LocalNetworksConfig = {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
+      tags: ["tenderly"],
     },
     mainnet: {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
+      tags: ["tenderly"],
     },
   },
 }

--- a/solidity/config_tenderly.sh
+++ b/solidity/config_tenderly.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m'      # new line + reset color
+
+printf "${LOG_START}Configuring Tenderly...${LOG_END}"
+
+mkdir $HOME/.tenderly && touch $HOME/.tenderly/config.yaml
+
+echo access_key: ${TENDERLY_TOKEN} > $HOME/.tenderly/config.yaml

--- a/solidity/deploy/01_deploy_tbtc_v2_token.ts
+++ b/solidity/deploy/01_deploy_tbtc_v2_token.ts
@@ -6,10 +6,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
-  await deploy("TBTC", {
+  const TBTC = await deploy("TBTC", {
     from: deployer,
     log: true,
   })
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "TBTC",
+      address: TBTC.address,
+    })
+  }
 }
 
 export default func

--- a/solidity/deploy/02_deploy_vending_machine.ts
+++ b/solidity/deploy/02_deploy_vending_machine.ts
@@ -17,18 +17,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
+  await helpers.ownable.transferOwnership(
+    "TBTC",
+    VendingMachine.address,
+    deployer
+  )
+
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "VendingMachine",
       address: VendingMachine.address,
     })
   }
-
-  await helpers.ownable.transferOwnership(
-    "TBTC",
-    VendingMachine.address,
-    deployer
-  )
 }
 
 export default func

--- a/solidity/deploy/02_deploy_vending_machine.ts
+++ b/solidity/deploy/02_deploy_vending_machine.ts
@@ -17,6 +17,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "VendingMachine",
+      address: VendingMachine.address,
+    })
+  }
+
   await helpers.ownable.transferOwnership(
     "TBTC",
     VendingMachine.address,

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomiclabs/hardhat-waffle"
 import "@nomiclabs/hardhat-etherscan"
 import "hardhat-gas-reporter"
 import "hardhat-deploy"
+import "@tenderly/hardhat-tenderly"
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -44,7 +45,13 @@ const config: HardhatUserConfig = {
       accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
         ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
         : undefined,
+      tags: ["tenderly"],
     },
+  },
+
+  tenderly: {
+    username: "thesis",
+    project: "",
   },
 
   // Define local networks configuration file path to load networks from file.

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -37,6 +37,13 @@ const config: HardhatUserConfig = {
       chainId: 1101,
       tags: ["local"],
     },
+    ropsten: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 3,
+      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
+        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        : undefined,
+    },
   },
 
   // Define local networks configuration file path to load networks from file.

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "0.0.1-dev",
+  "version": "0.1.1-dev",
   "license": "MIT",
   "files": [
     "artifacts/",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
+  "version": "0.0.1-dev",
   "license": "MIT",
   "scripts": {
     "build": "hardhat compile",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
     "@openzeppelin/contracts": "^4.1.0",
+    "@tenderly/hardhat-tenderly": "^1.0.12",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#507c647"
   },
   "devDependencies": {

--- a/solidity/scripts/prepare-artifacts.sh
+++ b/solidity/scripts/prepare-artifacts.sh
@@ -37,15 +37,6 @@ shift $(expr $OPTIND - 1) # remove options from positional parameters
   exit 1
 }
 
-# For `development` network we don't expect the deployment artifacts to be published.
-# We want to gracefully exit the script, so the package publication can be
-# completed. This is a solution we use to publish a NPM package that can be used
-# in other projects.
-[[ $NETWORK == "development" ]] && {
-  echo "Skipping execution for network: $NETWORK"
-  exit 0
-}
-
 echo "Copying deployments artifacts for network: $NETWORK"
 
 ROOT_DIR="$(realpath "$(dirname "$0")/..")"

--- a/solidity/scripts/prepare-artifacts.sh
+++ b/solidity/scripts/prepare-artifacts.sh
@@ -37,6 +37,15 @@ shift $(expr $OPTIND - 1) # remove options from positional parameters
   exit 1
 }
 
+# For `development` network we don't expect the deployment artifacts to be published.
+# We want to gracefully exit the script, so the package publication can be
+# completed. This is a solution we use to publish a NPM package that can be used
+# in other projects.
+[[ $NETWORK == "development" ]] && {
+  echo "Skipping execution for network: $NETWORK"
+  exit 0
+}
+
 echo "Copying deployments artifacts for network: $NETWORK"
 
 ROOT_DIR="$(realpath "$(dirname "$0")/..")"

--- a/solidity/tenderly.yaml
+++ b/solidity/tenderly.yaml
@@ -1,0 +1,8 @@
+account_id: d9a948cf-8667-43df-acb0-ce194f6dda7a
+projects:
+  thesis/keep:
+    networks:
+      - "1" # mainnet
+  thesis/keep-test:
+    networks:
+      - "3" # ropsten

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1065,6 +1065,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
+"@keep-network/prettier-config-keep@github:keep-network/prettier-config-keep":
+  version "0.0.1"
+  resolved "https://codeload.github.com/keep-network/prettier-config-keep/tar.gz/a1a333e7ac49928a0f6ed39421906dd1e46ab0f3"
+
 "@keep-network/sortition-pools@>1.2.0-pre <1.2.0-rc":
   version "1.2.0-pre.6"
   resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz#d526c0c8cde16bd4f027805b93d993028dbfcf98"
@@ -1429,6 +1433,15 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@tenderly/hardhat-tenderly@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.0.12.tgz#fa64da2bf2f6d35a1c131ac9ccaf2f7e8b189a50"
+  integrity sha512-zx2zVpbBxGWVp+aLgf59sZR5lxdqfq/PjqUhga6+iazukQNu/Y6pLfVnCcF1ggvLsf7gnMjwLe3YEx/GxCAykQ==
+  dependencies:
+    axios "^0.21.1"
+    fs-extra "^9.0.1"
+    js-yaml "^3.14.0"
 
 "@thesis/solidity-contracts@github:thesis/solidity-contracts#507c647":
   version "0.0.1"
@@ -2068,6 +2081,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -4176,7 +4194,7 @@ eslint-config-google@^0.13.0:
     eslint-plugin-no-only-tests "^2.3.1"
     eslint-plugin-prettier "^3.1.2"
 
-eslint-config-prettier@^6.10.0:
+eslint-config-prettier@^6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
   integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
@@ -5437,6 +5455,16 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.1:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -6515,7 +6543,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==


### PR DESCRIPTION
We're adding jobs which will deploy and publish `tbtc-v2` contracts.
Published artifacts will be used in the Continuous Integration proccess.
`NPM` workflow will build & publish contracts every time there is a
change in contracts or in the files describing package dependencies.
The `-dev` suffix will be used in the name of the published package.
`Solidity` workflow will deploy and publish contracts every time
worklfow is triggered by the `workflow_dispatch` event. Published
package name will point to name of the environment on which the
contracts were deployed.

TODO:

- [x] remove `--dry-run` from jobs configuration
- [x] prepare PR modifying `config.json` in the `ci` project (https://github.com/keep-network/ci/pull/16)
- [x] fix problem with the `prepare-artifacts.sh` script not allowing for publish of contracts built on `development` env (https://github.com/keep-network/tbtc-v2/pull/29/commits/943ce01eb2cf5ad79ace7707b9af806416a22833)

TODO **after** merging and publishing new NPM package:
- [ ] Update PR https://github.com/keep-network/keep-core/pull/2609 (update `yarn.lock` to contain dependency to the right NPM package with `tbtc-v2` contracts)

Refs:
https://github.com/keep-network/ci/pull/16