### PR TITLE
Transfer TBTC token ownership to VendingMachine

### DIFF
--- a/solidity/deploy/02_deploy_vending_machine.ts
+++ b/solidity/deploy/02_deploy_vending_machine.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, getNamedAccounts } = hre
+  const { deployments, helpers, getNamedAccounts } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
@@ -11,11 +11,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const unmintFee = 0
 
-  await deploy("VendingMachine", {
+  const VendingMachine = await deploy("VendingMachine", {
     from: deployer,
     args: [TBTCToken.address, TBTC.address, unmintFee],
     log: true,
   })
+
+  await helpers.ownable.transferOwnership(
+    "TBTC",
+    VendingMachine.address,
+    deployer
+  )
 }
 
 export default func


### PR DESCRIPTION
It is expected that VendingMachine becomes the owner of TBTC token to manage
minting of the token.

Refs https://github.com/keep-network/tbtc-v2/issues/26