### PR TITLE
Prepare NPM package structure for package publication

### DIFF
--- a/solidity/.prettierignore
+++ b/solidity/.prettierignore
@@ -1,2 +1,5 @@
 artifacts/
+build/
 cache/
+deployments/
+export.json

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@keep-network/tbtc-v2",
   "license": "MIT",
+  "files": [
+    "artifacts/",
+    "build/contracts/",
+    "contracts/",
+    "!**/test/",
+    "deploy/",
+    "export.json"
+  ],
   "scripts": {
     "build": "hardhat compile",
     "deploy": "hardhat deploy --export export.json",
@@ -12,7 +20,8 @@
     "lint:fix": "npm run lint:fix:js && npm run lint:fix:sol",
     "lint:fix:js": "eslint . --fix",
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
-    "test": "hardhat test"
+    "test": "hardhat test",
+    "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network"
   },
   "dependencies": {
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",

--- a/solidity/scripts/prepare-artifacts.sh
+++ b/solidity/scripts/prepare-artifacts.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eo pipefail
+
+help() {
+  echo -e "\nUsage: $0 --network <network>"
+
+  echo -e "\nCommand line arguments:\n"
+  echo -e "\t--network: Ethereum network." \
+    "Available networks and settings are specified in 'hardhat.config.ts'"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--network") set -- "$@" "-n" ;;
+    "--help") set -- "$@" "-h" ;;
+    *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "n:h" opt; do
+  case "$opt" in
+    n) NETWORK="$OPTARG" ;;
+    h) help ;;
+    ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+[ -z "$NETWORK" ] && {
+  echo "--network option not provided" >&2
+  help
+  exit 1
+}
+
+echo "Copying deployments artifacts for network: $NETWORK"
+
+ROOT_DIR="$(realpath "$(dirname "$0")/..")"
+SOURCE_DEPLOYMENT_DIR="$(realpath "$ROOT_DIR/deployments/$NETWORK")"
+DESTINATION_ARTIFACTS_DIR="$(realpath "$ROOT_DIR/artifacts")"
+
+[ ! -d "${SOURCE_DEPLOYMENT_DIR}" ] && {
+  echo "$SOURCE_DEPLOYMENT_DIR does not exist" >&2
+  exit 1
+}
+
+rm -rf $DESTINATION_ARTIFACTS_DIR
+cp -r deployments/$NETWORK $DESTINATION_ARTIFACTS_DIR
+
+echo "Deployment artifacts copied to: $DESTINATION_ARTIFACTS_DIR"


### PR DESCRIPTION
This PR implements what was previously described in https://github.com/keep-network/coverage-pools/issues/159.

## Structure

The package will have the following structure:
```
artifacts/               # copy of deployments/<network>/
build/contracts/         # build artifacts
contracts/               # source code
export.json              # single-file deployment export
```

- `artifacts/` - is a directory containing deployed contracts artifacts for the network the package is being created. It is assumed that a package is published for each supported network separately as per the [RFC-18](https://github.com/keep-network/keep-core/blob/main/docs/rfc/rfc-18-release-management.adoc), so we don't need to create separate directories per network.
- `build/contracts/` - is a directory containing compiled contracts artifacts in the Hardhat format.
- `contracts/` - is a directory containing contracts source code.
- `export.json` - lightweight deployment data in a single file.


## Scripts

There was a script created to prepare the `artifacts/` directory. The script can be executed with:
```
./scripts/prepare-artifacts.sh --network <network>
```

In `package.json` we defined a `prepublishOnly` entry that will execute before the package is packed and published if `npm publish` command is run. It expects the network option to be provided like in the following example:
```
npm publish --dry-run --network=ropsten
```
or
```
npm_config_network=development yarn publish
```

The command can be also executed separately with:
```
npm run prepublishOnly --network=ropsten
```
or
```
npm_config_network=development yarn prepublishOnly
```

Closes: https://github.com/keep-network/coverage-pools/issues/159