### PR TITLE
Validate `_keepCRV` parameter

### DIFF
--- a/yearn/contracts/ConvexStrategy.sol
+++ b/yearn/contracts/ConvexStrategy.sol
@@ -243,6 +243,7 @@ contract ConvexStrategy is BaseStrategy {
     /// @param _keepCRV Portion as counter of a fraction denominated by the
     ///        DENOMINATOR constant.
     function setKeepCRV(uint256 _keepCRV) external onlyAuthorized {
+        require(_keepCRV <= DENOMINATOR, "Max value is 10000");
         keepCRV = _keepCRV;
     }
 

--- a/yearn/contracts/CurveVoterProxyStrategy.sol
+++ b/yearn/contracts/CurveVoterProxyStrategy.sol
@@ -189,6 +189,7 @@ contract CurveVoterProxyStrategy is BaseStrategy {
     /// @param _keepCRV Portion as counter of a fraction denominated by the
     ///        DENOMINATOR constant.
     function setKeepCRV(uint256 _keepCRV) external onlyAuthorized {
+        require(_keepCRV <= DENOMINATOR, "Max value is 10000");
         keepCRV = _keepCRV;
     }
 


### PR DESCRIPTION
Method `setKeepCRV` should validate their input parameter to be less or equal to the `DENOMINATOR` value.