### PR TITLE
Verify contracts on Etherscan

### DIFF
--- a/.github/annotations.json
+++ b/.github/annotations.json
@@ -1,0 +1,12 @@
+[
+  {
+    "path": "./.github/workflows/contracts.yml",
+    "start_line": 1,
+    "end_line": 1,
+    "start_column": 1,
+    "end_column": 1,
+    "title": "Failed contract verification",
+    "message": "Verification of contracts on Etherscan has failed.",
+    "annotation_level": "warning"
+  }
+]

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -148,6 +148,29 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --tag ${{ github.event.inputs.environment }} --network=${{ github.event.inputs.environment }}
 
+      # If we don't remove the `tbtc` contracts from `node-modules`, the
+      # `etherscan-verify` plugins tries to verify them, which is not desired.
+      - name: Prepare for verification on Etherscan
+        run: rm -rf ./node_modules/@keep-network/tbtc
+
+      - name: Verify contracts on Etherscan
+        continue-on-error: true
+        id: verify-contracts
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
+        run: yarn run hardhat --network ${{ github.event.inputs.environment }} etherscan-verify --license MIT
+
+      - name: Annotate in case of verification failure
+        if: steps.verify-contracts.outcome == 'failure'
+        continue-on-error: true
+        uses: thesis/github-action-create-annotations@v0.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          json-file-path: "./.github/annotations.json"
+          fail-on-error: false
+          check-name: "contracts-deployment-testnet"
+
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:


### PR DESCRIPTION
We're adding a step verifying the migrated contracts on Etherscan. We're
using `etherscan-verify` plugin. In order for the plugin not to pick up
wrong files for verification we have to remove contracts of the
dependent projects stored in the `node_modules`.
We're also adding a step which executes in case of failures during the
contracts verifications. The step adds a warning annotation to the
GitHub page with the workflow run details.
Some info regarding configuration of `annotations.json` and
`github-action-create-annotations` action:
1. Values of `paths`, `start_line`, `end_line`, `start_column` and
   `end_column` don't seem to have much effect on how the annotation is
   displayed for workflows triggered by the `workflow_dispatch` event
   (they matter more for workflows triggered by `pull_request`, but we
   only annotate for `workflow_dispatch`).
2. We were getting errors when `end_line` was configured to different
   value than `start_line`.
3. The value of the `check-name` parameter of the action needs to be the
   same as the name of the job we want to annotate. Otherwise the
   annotation may get assigned to the random job (even in different
   workflow).

Refs:
https://github.com/keep-network/tbtc-v2/pull/29

https://github.com/keep-network/keep-core/pull/2598
https://github.com/keep-network/keep-ecdsa/pull/913
https://github.com/keep-network/tbtc/pull/834