### PR TITLE
Specify registry during node setup

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -110,6 +110,7 @@ jobs:
           node-version: "14.x"
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
If we're using `NODE_AUTH_TOKEN` env variable in the `Publish to npm`
step, we need to specify the `registry-url` property in the step setting
up the node.
Otherwise publication of the package fails with error like this:
```
 '@keep-network/tbtc-v2@0.1.1-ropsten.0' is not in the npm registry
```

Workflow run showing successful publication:
https://github.com/keep-network/tbtc-v2/runs/3686753776?check_suite_focus=true