### PR TITLE
RFC 1: CheckTimeLockVerify Race Condition Prevention

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -190,12 +190,12 @@ without a 30-day refund clause to same wallet. This has two main effects: it
 consolidates the UTXO set and it disables the refund.
 
 Caveat: We only include deposits in batches that have at least 8 remaining
-hours on their refund window. This prevents potential attacks or weird corner
-cases where we create a transaction with a valid, unspent input, but by the
-time we have signed that transaction, the depositor has already submitted a
-refund to the mining pool. Giving ourselves 8 hours of leeway stops this from
-happening. Once a deposit crosses that 8-hour threshold, the depositor should
-refund their deposit.
+hours on their refund window. This prevents potential attacks or corner cases
+where we create a transaction with a valid, unspent input, but by the time we
+have signed that transaction, the depositor has already submitted a refund to
+the mining pool. Giving ourselves 8 hours of leeway stops this from happening.
+Once a deposit crosses that 8-hour threshold, the depositor should refund their
+deposit.
 
 This process is called a "sweep", and occurs based on a governable frequency or
 if enough deposits have accumulated (also governable), whichever comes first.


### PR DESCRIPTION
This caveat adds a little bit of logic to the concept of "what makes a valid deposit for a batch", to filter out deposits that could be potentially redeemed *during* the signing/submitting process. Doing so reduces the chance that we have a transaction fail because one of our inputs is no longer valid because it has already been refunded.

Tagging @pdyraga and @eth-r for review

refs https://github.com/keep-network/tbtc-v2/pull/54