### PR TITLE
Initial draft of Bank, Vault, and Bridge

### DIFF
--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./IVault.sol";
+import "../bridge/IBridge.sol";
+
+contract Bank is Ownable {
+    mapping(address => uint256) public balance;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    IBridge public bridge;
+
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    modifier onlyBridge() {
+        require(msg.sender == address(bridge), "Caller is not the bridge");
+        _;
+    }
+
+    function setBridge(IBridge newBridge) external onlyOwner {
+        bridge = newBridge;
+    }
+
+    function increaseBalance(address owner, uint256 amount)
+        external
+        onlyBridge
+    {
+        balance[owner] += amount;
+    }
+
+    function quickLock(
+        address owner,
+        uint256 amount,
+        address vault
+    ) external onlyBridge {
+        balance[owner] += amount;
+        _approve(owner, vault, amount);
+        IQuickLock(vault).quickLock(owner, amount);
+    }
+
+    function decreaseBalance(address owner, uint256 amount)
+        external
+        onlyBridge
+    {
+        balance[owner] -= amount;
+    }
+
+    function approve(address spender, uint256 amount) external {
+        _approve(msg.sender, spender, amount);
+    }
+
+    // TODO: approveAndCall?
+    // TODO: EIP2612 approval?
+
+    function transfer(address recipient, uint256 amount) external {
+        _transfer(msg.sender, recipient, amount);
+    }
+
+    function transferFrom(
+        address spender,
+        address recipient,
+        uint256 amount
+    ) external {
+        uint256 currentAllowance = allowance[spender][msg.sender];
+        if (currentAllowance != type(uint256).max) {
+            require(
+                currentAllowance >= amount,
+                "Transfer amount exceeds allowance"
+            );
+
+            _approve(spender, msg.sender, currentAllowance - amount);
+        }
+
+        _transfer(spender, recipient, amount);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) private {
+        require(owner != address(0), "Approve from the zero address");
+        require(spender != address(0), "Approve to the zero address");
+
+        allowance[owner][spender] = amount;
+
+        emit Approval(owner, spender, amount);
+    }
+
+    function _transfer(
+        address spender,
+        address recipient,
+        uint256 amount
+    ) private {
+        require(spender != address(0), "Transfer from the zero address");
+        require(recipient != address(0), "Transfer to the zero address");
+        require(recipient != address(this), "Transfer to bank not allowed");
+
+        uint256 spenderBalance = balance[spender];
+        require(
+            spenderBalance >= amount,
+            "Transfer amount exceeds swept balance"
+        );
+
+        balance[spender] -= amount;
+        balance[recipient] += amount;
+
+        emit Transfer(spender, recipient, amount);
+    }
+}

--- a/solidity/contracts/bank/IVault.sol
+++ b/solidity/contracts/bank/IVault.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+interface IQuickLock {
+    function quickLock(address owner, uint256 amount) external;
+}

--- a/solidity/contracts/bank/Vault.sol
+++ b/solidity/contracts/bank/Vault.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "./Bank.sol";
+
+contract Vault {
+    Bank public bank;
+    mapping(address => uint256) public lockedBalance;
+
+    constructor(Bank _bank) {
+        require(
+            address(_bank) != address(0),
+            "Bank can not be the zero address"
+        );
+        bank = _bank;
+    }
+
+    function lockBalance(address owner, uint256 amount) internal {
+        bank.transferFrom(owner, address(this), amount);
+        lockedBalance[owner] += amount;
+    }
+
+    function unlockBalance(address owner, uint256 amount) internal {
+        bank.transferFrom(address(this), owner, amount);
+        lockedBalance[owner] -= amount;
+    }
+
+    function redeemBalance(
+        address owner,
+        uint256 amount,
+        bytes8 outputValueBytes,
+        bytes memory redeemerOutputScript
+    ) internal {
+        require(
+            lockedBalance[owner] >= amount,
+            "Redeem amount exceeds balance"
+        );
+        bank.bridge().redeem(amount, outputValueBytes, redeemerOutputScript);
+    }
+}

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "../bank/Bank.sol";
+
+contract Bridge {
+    struct UTXO {
+        uint256 digest;
+        uint256 amount;
+        address owner;
+        address vault; // optional
+    }
+
+    Bank public bank;
+    mapping(uint256 => UTXO) public unswept;
+
+    event Revealed(
+        address indexed owner,
+        uint256 utxoDigest,
+        uint256 amount,
+        address vault
+    );
+
+    event Swept(address indexed owner, uint256 utxoDigest, uint256 amount);
+
+    event Redemeed(
+        address indexed owner,
+        uint256 amount,
+        bytes8 outputValueBytes,
+        bytes redeemerOutputScript
+    );
+
+    constructor(Bank _bank) {
+        require(
+            address(_bank) != address(0),
+            "Bank can not be the zero address"
+        );
+
+        bank = _bank;
+    }
+
+    function reveal(UTXO calldata utxo) external {
+        unswept[utxo.digest] = utxo;
+    }
+
+    function sweep(uint256 utxoDigest, uint256 amount) external {
+        UTXO memory utxo = unswept[utxoDigest];
+        bank.increaseBalance(utxo.owner, amount);
+
+        emit Swept(utxo.owner, utxoDigest, amount);
+
+        delete unswept[utxoDigest];
+    }
+
+    function redeem(
+        uint256 amount,
+        bytes8 outputValueBytes,
+        bytes memory redeemerOutputScript
+    ) external {
+        bank.decreaseBalance(msg.sender, amount);
+        emit Redemeed(
+            msg.sender,
+            amount,
+            outputValueBytes,
+            redeemerOutputScript
+        );
+    }
+}

--- a/solidity/contracts/bridge/IBridge.sol
+++ b/solidity/contracts/bridge/IBridge.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+interface IBridge {
+    function redeem(
+        uint256 amount,
+        bytes8 outputValueBytes,
+        bytes memory redeemerOutputScript
+    ) external;
+}

--- a/solidity/contracts/tbtc/TBTCVault.sol
+++ b/solidity/contracts/tbtc/TBTCVault.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "../bank/IVault.sol";
+import "../bank/Vault.sol";
+import "../token/TBTC.sol";
+
+contract TBTCVault is Vault, IQuickLock {
+    TBTC public token;
+
+    constructor(Bank _bank) Vault(_bank) {}
+
+    function quickLock(address owner, uint256 amount) external override {
+        mint(owner, amount);
+    }
+
+    function redeem(
+        uint256 amount,
+        bytes8 outputValueBytes,
+        bytes memory redeemerOutputScript
+    ) external {
+        redeemBalance(
+            msg.sender,
+            amount,
+            outputValueBytes,
+            redeemerOutputScript
+        );
+        token.burnFrom(msg.sender, amount);
+    }
+
+    function mint(address owner, uint256 amount) public {
+        lockBalance(owner, amount);
+        token.mint(owner, amount);
+    }
+}


### PR DESCRIPTION
This is an attempt to draft the initial components of tBTC v2 and define how they will interact with each other.

This is not a final version by any means.

# Bank

`Bank` is a non-upgradeable contract holding BTC account balances. Balances can be transferred between holders just like ERC20 tokens, with `transfer` and `transferFrom` functions. One can give an approval to use their balance to someone else by calling `approve` function. In the future, we may also consider adding support for EIP2612 approvals.

The only contract allowed to increase or decrease balances in `Bank` is `Bridge`. `Bridge` is upgradeable by `Bank` contract owner which eventually should be the DAO. `Bank` is currently only interested in confirmed balances but we might want to add tracking of unconfirmed balances as well.

All components of the system except `TBTC` token and `Bank` will be upgradeable in the early days. Upgrading functionality is easy, upgrading state is difficult. `Bank` is just about the global state of balances and its functionality is reduced to an absolute minimum.

# Vault

`Vault` is a base contract for all applications (products of Bank) allowed to lock and unlock user's balances. Every `Vault` has its balance in `Bank`, just like any other account. To lock balance, `Vault` needs to have a balance `approve`d and transferred from holder's to `Vault`'s address. `Vault` base class allows keeping track of locked balances that can be later unlocked and transferred back to their original holders.

Anyone can deploy any `Vault` and anyone can approve any `Vault` to use their balances. This approach gives us extendability and draws a clear separation line between `Bank` and `Bridge` which manage balances and `Vault` that can use only balances it was `approve`d for. `Vault` can not change balances of other `Vault`s or print balances in `Bank`. Every `Vault` is clearly separated from the balances of other `Vault`s and holders in `Bank`.

One implementation of a `Vault` is `TBTCVault` minting and burning TBTC tokens based on locked balances.

# Bridge

Bridge manages BTC deposit and redemption and is the only component being able to increase and decrease the balance of the given holder (including `Vault`s) in `Bank` contract. `Bridge` has a shortcut path to `Vault` in case the depositor wants to lock their balance in the given `Vault` as soon as their UTXO gets swept. One example could be the auto-minting of TBTC token. Depositor can supply an optional `Vault` address when revealing their UTXO and then, once the given UTXO is swept, vault implementing `IQuickLock` interface can do whatever is needed, for example, mint TBTC.

# Open questions

We were considering allowing to ming TBTC based on yet unconfirmed balance. This option needs to be thought through and tracking of unconfirmed balances might need be added to `Bank`. This is nice functionality but complicates everything. For example, should unconfirmed balances be transferrable? What happens if they could not be swept etc. Right now, it's `Bridge`'s concern to keep track and manage them and `Bank` is only interested in confirmed balances that can be used right away. 