### PR TITLE
RFC 1: make the heartbeat approach more concrete

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -281,15 +281,22 @@ it.
 [[heartbeat]]
 === Heartbeats
 
-To make sure that older wallets are still accessible for redemption, we need to
-perform heartbeats. The signing group signs each bitcoin block and then does _not_
-publish the result. If a signer suspects other signers are not online, they can
-issue an on-chain challenge to publish a specified signed bitcoin block (with a
-maximum block age). Since publishing this information costs the signers gas, the
-challenger must pay a deposit to be distributed to the signers if they pass.
+Governable Parameters:
 
-Any signer unable to publish the signed block within a specified amount of time
-will begin to be slashed and the challenger will be rewarded.
+- `failed_heartbeat_sortition_timeout`: The amount of time an operator is
+  removed from the sortition pool after failing a heartbeat.
+- `heartbeat`: The number of group members required for a heartbeat to successful.
+
+To make sure that older wallets are still accessible for redemption, we need to
+perform heartbeats. The signing group signs every 40th ethereum block and then
+does _not_ publish the result. If there are ever less than `heartbeat`
+operators that participate in the heartbeat, the ones that did can create and
+sign a new transaction that lists the _inactive_ operators. Once this
+transaction is posted to the ethereum chain, we can iterate through the
+inactive operators, remove them from the sortition pool for
+`failed_heartbeat_sortition_timeout` amount of time (which disables their `T`
+rewards), transfer the from the wallet to another random wallet and close this
+wallet.
 
 [[transaction-incentives]]
 ===


### PR DESCRIPTION
This PR re-writes the heartbeat approach. Previously, there wasn't a great way for the signers to read bitcoin blocks and slashing was too harsh.

The new approach signs ethereum blocks, collects which operators aren't around if a heartbeat fails, and then submits that on chain. This opens us up to an attack where the wallet is controlled by the adversary and now they can kick honest operators out of the sortition pool for a few weeks, but honestly that's not the worst they can do 🤷 

tagging @pdyraga for review

open questions for a different PR:

* who submits the transaction to the chain? (an unlucky alive operator?)
* who submits the (very expensive) transaction to remove the inactive operators from the sortition pool? I think I heard something about a gas station idea