### PR TITLE
RFC 1: Update Unswept Balances With Refunds Too

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -254,7 +254,9 @@ When the transaction clears, and the information has made its way
 over the relay maintainer, then another transaction needs to be created to on
 the ethereum side to update the account balances. The users unswept balances
 are decreased, and their swept balances are increased (after paying their share
-of the <<bitcoin-sweeping-fee,bitcoin sweeping fee>>).
+of the <<bitcoin-sweeping-fee,bitcoin sweeping fee>>). Additionally, we also
+include any `unsweptBalances` that should be *decreased* due to not being swept
+before the 30-day refund period (from not having a high enough bitcoin fee).
 
 This transaction will be expensive gas-wise, and can be submitted by anyone
 with the motivation to do so. For more details on transaction incentives,


### PR DESCRIPTION
Previously, the transaction that updates the ethereum account balances only collected information about the most recent sweep. Now, we *also* lump in the deposits that have expired due to nearing their refund time (and thus should have their associated account's unswept balance decrease).

Tagging @pdyraga for review.