### PR TITLE
Assemble P2SH deposit transaction

### DIFF
--- a/tbtc-ts/.eslintrc.js
+++ b/tbtc-ts/.eslintrc.js
@@ -3,4 +3,14 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
+  rules: {
+    "valid-jsdoc": [
+      "error",
+      {
+        prefer: { return: "returns" },
+        requireParamType: false,
+        requireReturnType: false,
+      },
+    ],
+  },
 }

--- a/tbtc-ts/package.json
+++ b/tbtc-ts/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#semver:~2.2.0",
+    "ethers": "^5.5.2",
     "wif": "2.0.6"
   },
   "devDependencies": {

--- a/tbtc-ts/package.json
+++ b/tbtc-ts/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --ext .js,.ts --fix",
     "test": "mocha --exit --recursive 'test/**/*.test.ts'",
     "build": "tsc",
-    "prepare": "yarn run build"
+    "postinstall": "npm rebuild"
   },
   "files": [
     "dist/src/",
@@ -19,7 +19,7 @@
     "README.md"
   ],
   "dependencies": {
-    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#acdeb84",
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#semver:~2.2.0",
     "wif": "2.0.6"
   },
   "devDependencies": {

--- a/tbtc-ts/package.json
+++ b/tbtc-ts/package.json
@@ -16,9 +16,12 @@
   "files": [
     "dist/src/",
     "src/",
-    "LICENSE",
     "README.md"
   ],
+  "dependencies": {
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#acdeb84",
+    "wif": "2.0.6"
+  },
   "devDependencies": {
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep",
     "@types/chai": "^4.2.21",

--- a/tbtc-ts/src/bitcoin.ts
+++ b/tbtc-ts/src/bitcoin.ts
@@ -95,3 +95,12 @@ export interface Client {
 
   broadcast(transaction: RawTransaction): Promise<void>
 }
+
+// TODO: Documentation.
+export function isCompressedPublicKey(publicKey: string): boolean {
+  // Must have 33 bytes and 02 or 03 prefix.
+  return (
+    publicKey.length == 66 &&
+    (publicKey.substring(0, 2) == "02" || publicKey.substring(0, 2) == "03")
+  )
+}

--- a/tbtc-ts/src/bitcoin.ts
+++ b/tbtc-ts/src/bitcoin.ts
@@ -1,0 +1,97 @@
+/**
+ * Represents a raw transaction.
+ */
+export interface RawTransaction {
+  /**
+   * The full transaction payload as an un-prefixed hex string.
+   */
+  transactionHex: string
+}
+
+/**
+ * Data about a transaction.
+ */
+export interface Transaction {
+  /**
+   * The transaction hash (or transaction ID) as an un-prefixed hex string.
+   */
+  transactionHash: string
+
+  /**
+   * The vector of transaction inputs.
+   */
+  inputs: TransactionInput[]
+
+  /**
+   * The vector of transaction outputs.
+   */
+  outputs: TransactionOutput[]
+}
+
+/**
+ * Data about a transaction outpoint.
+ */
+export interface TransactionOutpoint {
+  /**
+   * The hash of the transaction the outpoint belongs to.
+   */
+  transactionHash: string
+
+  /**
+   * The zero-based index of the output from the specified transaction.
+   */
+  outputIndex: number
+}
+
+/**
+ * Data about a transaction input.
+ */
+export type TransactionInput = TransactionOutpoint & {
+  /**
+   * The scriptSig that unlocks the specified outpoint for spending.
+   */
+  scriptSig: any
+}
+
+/**
+ * Data about a transaction output.
+ */
+export interface TransactionOutput {
+  /**
+   * The 0-based index of the output.
+   */
+  outputIndex: number
+
+  /**
+   * The value of the output in satoshis.
+   */
+  value: number
+
+  /**
+   * The receiving scriptPubKey.
+   */
+  scriptPubKey: any
+}
+
+/**
+ * Data about an unspent transaction output.
+ */
+export type UnspentTransactionOutput = TransactionOutpoint & {
+  /**
+   * The unspent value in satoshis.
+   */
+  value: number
+}
+
+// TODO: Documentation.
+export interface Client {
+  findAllUnspentTransactionOutputs(
+    address: string
+  ): Promise<UnspentTransactionOutput[]>
+
+  getTransaction(transactionHash: string): Promise<Transaction>
+
+  getRawTransaction(transactionHash: string): Promise<RawTransaction>
+
+  broadcast(transaction: RawTransaction): Promise<void>
+}

--- a/tbtc-ts/src/bitcoin.ts
+++ b/tbtc-ts/src/bitcoin.ts
@@ -83,20 +83,45 @@ export type UnspentTransactionOutput = TransactionOutpoint & {
   value: number
 }
 
-// TODO: Documentation.
+/**
+ * Represents a Bitcoin client.
+ */
 export interface Client {
+  /**
+   * Finds all unspent transaction outputs (UTXOs) for given Bitcoin address.
+   * @param address - Bitcoin address UTXOs should be determined for.
+   * @returns List of UTXOs.
+   */
   findAllUnspentTransactionOutputs(
     address: string
   ): Promise<UnspentTransactionOutput[]>
 
+  /**
+   * Gets the full transaction object for given transaction hash.
+   * @param transactionHash - Hash of the transaction.
+   * @returns Transaction object.
+   */
   getTransaction(transactionHash: string): Promise<Transaction>
 
+  /**
+   * Gets the raw transaction data for given transaction hash.
+   * @param transactionHash - Hash of the transaction.
+   * @returns Raw transaction.
+   */
   getRawTransaction(transactionHash: string): Promise<RawTransaction>
 
+  /**
+   * Broadcasts the given transaction over the network.
+   * @param transaction - Transaction to broadcast.
+   */
   broadcast(transaction: RawTransaction): Promise<void>
 }
 
-// TODO: Documentation.
+/**
+ * Checks whether given public key is a compressed Bitcoin public key.
+ * @param publicKey - Public key that should be checked.
+ * @returns True if the key is a compressed Bitcoin public key, false otherwise.
+ */
 export function isCompressedPublicKey(publicKey: string): boolean {
   // Must have 33 bytes and 02 or 03 prefix.
   return (

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -1,5 +1,99 @@
-export async function createDeposit(): Promise<void> {
-  // TODO: Implementation.
+import bcoin from "bcoin"
+import wif from "wif"
+import {
+  Client as BitcoinClient,
+  RawTransaction,
+  UnspentTransactionOutput,
+} from "./bitcoin"
+
+// TODO: Documentation
+export interface DepositData {
+  ethereumAddress: string
+  amount: number
+  refundPublicKey: string
+}
+
+// TODO: Documentation
+export async function createDeposit(
+  bitcoinClient: BitcoinClient,
+  depositorPrivateKey: string,
+  depositData: DepositData
+): Promise<void> {
+  const decodedDepositorPrivateKey = wif.decode(depositorPrivateKey)
+
+  const depositorKeyRing = new bcoin.KeyRing({
+    witness: true,
+    privateKey: decodedDepositorPrivateKey.privateKey,
+    compressed: decodedDepositorPrivateKey.compressed,
+  })
+
+  const depositorAddress = depositorKeyRing.getAddress("string")
+
+  const utxos = await bitcoinClient.findAllUnspentTransactionOutputs(
+    depositorAddress
+  )
+
+  const utxosWithRaw: (UnspentTransactionOutput & RawTransaction)[] = []
+  for (const utxo of utxos) {
+    const rawTransaction = await bitcoinClient.getRawTransaction(
+      utxo.transactionHash
+    )
+
+    utxosWithRaw.push({
+      ...utxo,
+      transactionHex: rawTransaction.transactionHex,
+    })
+  }
+
+  const rawUnsignedTransaction = await assembleDepositTransaction(
+    utxosWithRaw,
+    depositorAddress,
+    depositData
+  )
+
+  const unsignedTransaction = bcoin.MTX.fromRaw(
+    rawUnsignedTransaction.transactionHex,
+    "hex"
+  )
+  const signedTransaction = unsignedTransaction.sign(depositorKeyRing)
+
+  await bitcoinClient.broadcast({
+    transactionHex: signedTransaction.toRaw().toString("hex"),
+  })
+}
+
+// TODO: Documentation
+export async function assembleDepositTransaction(
+  utxos: (UnspentTransactionOutput & RawTransaction)[],
+  changeAddress: string,
+  depositData: DepositData
+): Promise<RawTransaction> {
+  const inputCoins = utxos.map((utxo) =>
+    bcoin.Coin.fromTX(
+      bcoin.MTX.fromRaw(utxo.transactionHex, "hex"),
+      utxo.outputIndex,
+      -1
+    )
+  )
+
+  // TODO: Fail fast if input coins sum is less than deposit amount.
+
+  const transaction = new bcoin.MTX()
+
+  transaction.addOutput({
+    script: {}, // TODO: Construct the script
+    value: depositData.amount,
+  })
+
+  await transaction.fund(inputCoins, {
+    rate: null, // set null explicitly to always use the default value
+    changeAddress: changeAddress,
+    subtractFee: false, // do not subtract the fee from outputs
+  })
+
+  return {
+    transactionHex: transaction.toRaw().toString("hex"),
+  }
 }
 
 export async function revealDeposit(): Promise<void> {

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -1,4 +1,6 @@
+// @ts-ignore
 import bcoin from "bcoin"
+// @ts-ignore
 import wif from "wif"
 import {
   Client as BitcoinClient,

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -44,7 +44,14 @@ export interface DepositData {
   createdAt: number
 }
 
-// TODO: Documentation
+/**
+ * Makes a deposit by creating and broadcasting a Bitcoin P2SH
+ * deposit transaction.
+ * @param depositData - Details of the deposit.
+ * @param depositorPrivateKey - Bitcoin private key of the depositor.
+ * @param bitcoinClient - Bitcoin client used to interact with the network.
+ * @returns Empty promise.
+ */
 export async function makeDeposit(
   depositData: DepositData,
   depositorPrivateKey: string,
@@ -78,7 +85,13 @@ export async function makeDeposit(
   await bitcoinClient.broadcast(transaction)
 }
 
-// TODO: Documentation
+/**
+ * Creates a Bitcoin P2SH deposit transaction.
+ * @param depositData - Details of the deposit.
+ * @param utxos - UTXOs that should be used as transaction inputs.
+ * @param depositorPrivateKey - Bitcoin private key of the depositor.
+ * @returns Bitcoin P2SH deposit transaction in raw format.
+ */
 export async function createDepositTransaction(
   depositData: DepositData,
   utxos: (UnspentTransactionOutput & RawTransaction)[],
@@ -117,7 +130,11 @@ export async function createDepositTransaction(
   }
 }
 
-// TODO: Documentation
+/**
+ * Creates a Bitcoin locking script for P2SH deposit transaction.
+ * @param depositData - Details of the deposit.
+ * @returns Script as an un-prefixed hex string.
+ */
 export async function createDepositScript(
   depositData: DepositData
 ): Promise<string> {
@@ -178,7 +195,11 @@ export async function createDepositScript(
   return script.toRaw().toString("hex")
 }
 
-// TODO: Documentation
+/**
+ * Creates a Bitcoin locking script hash for P2SH deposit transaction.
+ * @param depositData - Details of the deposit.
+ * @returns Buffer with script hash.
+ */
 export async function createDepositScriptHash(
   depositData: DepositData
 ): Promise<Buffer> {
@@ -187,7 +208,13 @@ export async function createDepositScriptHash(
   return bcoin.Script.fromRaw(Buffer.from(script, "hex")).hash160()
 }
 
-// TODO: Documentation
+/**
+ * Creates a Bitcoin target address for P2SH deposit transaction.
+ * @param depositData - Details of the deposit.
+ * @param network - Network that the address should be created for.
+ *        For example, `main` or `testnet`.
+ * @returns Address as string.
+ */
 export async function createDepositAddress(
   depositData: DepositData,
   network: string
@@ -197,12 +224,16 @@ export async function createDepositAddress(
   return address.toString(network)
 }
 
-// TODO: Implementation and documentation. Dummy key is returned for now,
+// TODO: Implementation and documentation. Dummy key is returned for now.
 export async function getActiveWalletPublicKey(): Promise<string> {
   return "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9"
 }
 
-// TODO: Documentation.
+/**
+ * Creates a Bitcoin key ring based on given private key.
+ * @param privateKey Private key that should be used to create the key ring.
+ * @returns Bitcoin key ring.
+ */
 function createKeyRing(privateKey: string): bcoin.KeyRing {
   const decodedPrivateKey = wif.decode(privateKey)
 
@@ -213,6 +244,5 @@ function createKeyRing(privateKey: string): bcoin.KeyRing {
   })
 }
 
-export async function revealDeposit(): Promise<void> {
-  // TODO: Implementation.
-}
+// TODO: Implementation and documentation.
+export async function revealDeposit(): Promise<void> {}

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -37,6 +37,11 @@ export interface DepositData {
    * public key and refund public key.
    */
   blindingFactor: BigNumber
+
+  /**
+   * Unix timestamp in seconds determining the moment of deposit creation.
+   */
+  createdAt: number
 }
 
 // TODO: Documentation
@@ -150,8 +155,9 @@ export async function createDepositScript(
     throw new Error("Refund public key must be compressed")
   }
 
-  // Locktime is an Unix timestamp in seconds, computed as now + 30 days.
-  const locktime = BigNumber.from(Math.floor(Date.now() / 1000) + 2592000)
+  // Locktime is an Unix timestamp in seconds, computed as deposit
+  // creation timestamp + 30 days.
+  const locktime = BigNumber.from(depositData.createdAt + 2592000)
 
   // All HEXes pushed to the script must be un-prefixed.
   const script = new bcoin.Script()

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -198,7 +198,7 @@ export async function createDepositAddress(
 }
 
 // TODO: Implementation and documentation. Dummy key is returned for now,
-async function getActiveWalletPublicKey(): Promise<string> {
+export async function getActiveWalletPublicKey(): Promise<string> {
   return "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9"
 }
 

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -24,7 +24,7 @@ export interface TBTC {
   createDepositTransaction(
     depositData: DepositData,
     utxos: (UnspentTransactionOutput & RawTransaction)[],
-    changeAddress: string
+    depositorPrivateKey: string
   ): Promise<RawTransaction>
 
   createDepositScript(depositData: DepositData): Promise<string>

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -1,6 +1,7 @@
 import {
   createDepositAddress,
   createDepositScript,
+  createDepositScriptHash,
   createDepositTransaction,
   DepositData,
   makeDeposit,
@@ -28,6 +29,8 @@ export interface TBTC {
 
   createDepositScript(depositData: DepositData): Promise<string>
 
+  createDepositScriptHash(depositData: DepositData): Promise<Buffer>
+
   createDepositAddress(
     depositData: DepositData,
     network: string
@@ -40,6 +43,7 @@ const tbtc: TBTC = {
   makeDeposit,
   createDepositTransaction,
   createDepositScript,
+  createDepositScriptHash,
   createDepositAddress,
   revealDeposit,
 }

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -26,9 +26,12 @@ export interface TBTC {
     changeAddress: string
   ): Promise<RawTransaction>
 
-  createDepositScript(depositData: DepositData): string
+  createDepositScript(depositData: DepositData): Promise<string>
 
-  createDepositAddress(depositData: DepositData, network: string): string
+  createDepositAddress(
+    depositData: DepositData,
+    network: string
+  ): Promise<string>
 
   revealDeposit(): Promise<void>
 }

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -3,6 +3,7 @@ import {
   createDepositScript,
   createDepositScriptHash,
   createDepositTransaction,
+  getActiveWalletPublicKey,
   DepositData,
   makeDeposit,
   revealDeposit,
@@ -36,6 +37,8 @@ export interface TBTC {
     network: string
   ): Promise<string>
 
+  getActiveWalletPublicKey(): Promise<string>
+
   revealDeposit(): Promise<void>
 }
 
@@ -45,6 +48,7 @@ const tbtc: TBTC = {
   createDepositScript,
   createDepositScriptHash,
   createDepositAddress,
+  getActiveWalletPublicKey,
   revealDeposit,
 }
 

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -14,31 +14,67 @@ import {
   UnspentTransactionOutput,
 } from "./bitcoin"
 
-// TODO: Documentation
+/**
+ * TBTC interface.
+ */
 export interface TBTC {
+  /**
+   * Makes a deposit by creating and broadcasting a Bitcoin P2SH
+   * deposit transaction.
+   * @param depositData - Details of the deposit.
+   * @param depositorPrivateKey - Bitcoin private key of the depositor.
+   * @param bitcoinClient - Bitcoin client used to interact with the network.
+   * @returns Empty promise.
+   */
   makeDeposit(
     depositData: DepositData,
     depositorPrivateKey: string,
     bitcoinClient: BitcoinClient
   ): Promise<void>
 
+  /**
+   * Creates a Bitcoin P2SH deposit transaction.
+   * @param depositData - Details of the deposit.
+   * @param utxos - UTXOs that should be used as transaction inputs.
+   * @param depositorPrivateKey - Bitcoin private key of the depositor.
+   * @returns Bitcoin P2SH deposit transaction in raw format.
+   */
   createDepositTransaction(
     depositData: DepositData,
     utxos: (UnspentTransactionOutput & RawTransaction)[],
     depositorPrivateKey: string
   ): Promise<RawTransaction>
 
+  /**
+   * Creates a Bitcoin locking script for P2SH deposit transaction.
+   * @param depositData - Details of the deposit.
+   * @returns Script as an un-prefixed hex string.
+   */
   createDepositScript(depositData: DepositData): Promise<string>
 
+  /**
+   * Creates a Bitcoin locking script hash for P2SH deposit transaction.
+   * @param depositData - Details of the deposit.
+   * @returns Buffer with script hash.
+   */
   createDepositScriptHash(depositData: DepositData): Promise<Buffer>
 
+  /**
+   * Creates a Bitcoin target address for P2SH deposit transaction.
+   * @param depositData - Details of the deposit.
+   * @param network - Network that the address should be created for.
+   *        For example, `main` or `testnet`.
+   * @returns Address as string.
+   */
   createDepositAddress(
     depositData: DepositData,
     network: string
   ): Promise<string>
 
+  // TODO: Implementation and documentation.
   getActiveWalletPublicKey(): Promise<string>
 
+  // TODO: Implementation and documentation.
   revealDeposit(): Promise<void>
 }
 

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -1,12 +1,43 @@
-import { createDeposit, revealDeposit } from "./deposit"
+import {
+  createDepositAddress,
+  createDepositScript,
+  createDepositTransaction,
+  DepositData,
+  makeDeposit,
+  revealDeposit,
+} from "./deposit"
+import {
+  Client as BitcoinClient,
+  RawTransaction,
+  UnspentTransactionOutput,
+} from "./bitcoin"
 
+// TODO: Documentation
 export interface TBTC {
-  createDeposit(): Promise<void>
+  makeDeposit(
+    depositData: DepositData,
+    depositorPrivateKey: string,
+    bitcoinClient: BitcoinClient
+  ): Promise<void>
+
+  createDepositTransaction(
+    depositData: DepositData,
+    utxos: (UnspentTransactionOutput & RawTransaction)[],
+    changeAddress: string
+  ): Promise<RawTransaction>
+
+  createDepositScript(depositData: DepositData): string
+
+  createDepositAddress(depositData: DepositData, network: string): string
+
   revealDeposit(): Promise<void>
 }
 
 const tbtc: TBTC = {
-  createDeposit,
+  makeDeposit,
+  createDepositTransaction,
+  createDepositScript,
+  createDepositAddress,
   revealDeposit,
 }
 

--- a/tbtc-ts/test/data/bitcoin.ts
+++ b/tbtc-ts/test/data/bitcoin.ts
@@ -1,0 +1,38 @@
+import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
+
+/**
+ * An example address taken from the BTC testnet and having a non-zero balance.
+ */
+export const testnetAddress = "mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk"
+
+/**
+ * Transaction c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028
+ * made by testnetAddress. It can be decoded, for example, with:
+ * https://live.blockcypher.com/btc-testnet/decodetx
+ */
+export const testnetTransaction: RawTransaction = {
+  transactionHex:
+    "0100000001e855ac190e3946a139ad47f8fcdf6ea6dfbc4b0255841d66a591b61bc622" +
+    "baaf030000006b483045022100c56843f5e26b1b556313b0897bb6254391946e2bc333" +
+    "52a18f220c08699fb61b02203b9e05d0d996e1a1f0edfe2669ce6a1701f14e1e6948e9" +
+    "d32ba88d751d51829a0121037435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f" +
+    "17021980d777691f1dfdffffff047c15000000000000536a4c5054325b18282567a11e" +
+    "ea42b5de940f957fd40d896a226f20705724cc1cddda1b59a9c5003832bff2d69d6763" +
+    "cc20b5647076059605ee0c99caa73330615984cf830a0300208b980006002021770009" +
+    "2be8230000000000001976a914000000000000000000000000000000000000000088ac" +
+    "e8230000000000001976a914000000000000000000000000000000000000000088ac5e" +
+    "b76733000000001976a914ba27f99e007c7f605a8305e318c1abde3cd220ac88ac0000" +
+    "0000",
+}
+
+/**
+ * An UTXO from the c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028
+ * transaction.
+ */
+export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
+  transactionHash:
+    "c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028",
+  outputIndex: 3,
+  value: 862435166,
+  ...testnetTransaction,
+}

--- a/tbtc-ts/test/data/bitcoin.ts
+++ b/tbtc-ts/test/data/bitcoin.ts
@@ -3,36 +3,37 @@ import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
 /**
  * An example address taken from the BTC testnet and having a non-zero balance.
  */
-export const testnetAddress = "mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk"
+export const testnetAddress = "tb1q0tpdjdu2r3r7tzwlhqy4e2276g2q6fexsz4j0m"
 
 /**
- * Transaction c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028
+ * Private key corresponding to the testnetAddress.
+ */
+export const testnetPrivateKey =
+  "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
+
+/**
+ * Transaction 2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883
  * made by testnetAddress. It can be decoded, for example, with:
  * https://live.blockcypher.com/btc-testnet/decodetx
  */
 export const testnetTransaction: RawTransaction = {
   transactionHex:
-    "0100000001e855ac190e3946a139ad47f8fcdf6ea6dfbc4b0255841d66a591b61bc622" +
-    "baaf030000006b483045022100c56843f5e26b1b556313b0897bb6254391946e2bc333" +
-    "52a18f220c08699fb61b02203b9e05d0d996e1a1f0edfe2669ce6a1701f14e1e6948e9" +
-    "d32ba88d751d51829a0121037435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f" +
-    "17021980d777691f1dfdffffff047c15000000000000536a4c5054325b18282567a11e" +
-    "ea42b5de940f957fd40d896a226f20705724cc1cddda1b59a9c5003832bff2d69d6763" +
-    "cc20b5647076059605ee0c99caa73330615984cf830a0300208b980006002021770009" +
-    "2be8230000000000001976a914000000000000000000000000000000000000000088ac" +
-    "e8230000000000001976a914000000000000000000000000000000000000000088ac5e" +
-    "b76733000000001976a914ba27f99e007c7f605a8305e318c1abde3cd220ac88ac0000" +
-    "0000",
+    "0100000000010162cae24e74ad64f9f0493b09f3964908b3b3038f4924882d3dbd853b" +
+    "4c9bc7390100000000ffffffff02102700000000000017a914867120d5480a9cc0c11c" +
+    "1193fa59b3a92e852da78710043c00000000001600147ac2d9378a1c47e589dfb8095c" +
+    "a95ed2140d272602483045022100b70bd9b7f5d230444a542c7971bea79786b4ebde67" +
+    "03cee7b6ee8cd16e115ebf02204d50ea9d1ee08de9741498c2cc64266e40d52c4adb9e" +
+    "f68e65aa2727cd4208b5012102ee067a0273f2e3ba88d23140a24fdb290f27bbcd0f94" +
+    "117a9c65be3911c5c04e00000000",
 }
 
 /**
- * An UTXO from the c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028
- * transaction.
+ * An UTXO from the testnetTransaction.
  */
 export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
   transactionHash:
-    "c842fda444ffa2e90fbe652c3bc1797b57cceaf63ed2d432fe53ee06701af028",
-  outputIndex: 3,
-  value: 862435166,
+    "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883",
+  outputIndex: 1,
+  value: 3933200,
   ...testnetTransaction,
 }

--- a/tbtc-ts/test/data/bitcoin.ts
+++ b/tbtc-ts/test/data/bitcoin.ts
@@ -2,6 +2,7 @@ import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
 
 /**
  * An example address taken from the BTC testnet and having a non-zero balance.
+ * This address and its transaction data can be used to make deposits during tests.
  */
 export const testnetAddress = "tb1q0tpdjdu2r3r7tzwlhqy4e2276g2q6fexsz4j0m"
 
@@ -12,8 +13,14 @@ export const testnetPrivateKey =
   "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
 
 /**
- * Transaction 2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883
- * made by testnetAddress. It can be decoded, for example, with:
+ * Hash of one of the transactions originating from testnetAddress.
+ */
+export const testnetTransactionHash =
+  "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883"
+
+/**
+ * Transaction corresponding to testnetTransactionHash and originating
+ * from testnetAddress. It can be decoded, for example, with:
  * https://live.blockcypher.com/btc-testnet/decodetx
  */
 export const testnetTransaction: RawTransaction = {
@@ -31,8 +38,7 @@ export const testnetTransaction: RawTransaction = {
  * An UTXO from the testnetTransaction.
  */
 export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
-  transactionHash:
-    "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883",
+  transactionHash: testnetTransactionHash,
   outputIndex: 1,
   value: 3933200,
   ...testnetTransaction,

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -1,16 +1,31 @@
 import TBTC from "./../src"
 import { expect } from "chai"
 import { BigNumber } from "ethers"
+import { testnetAddress, testnetUTXO } from "./data/bitcoin"
 
 describe("Deposit", () => {
+  const depositData = {
+    ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+    amount: BigNumber.from(120000000), // 1.2 BTC
+    refundPublicKey:
+      "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
+  }
+
+  describe("createDepositTransaction", () => {
+    it("should work", async () => {
+      const rawTransaction = await TBTC.createDepositTransaction(
+        depositData,
+        [testnetUTXO],
+        testnetAddress
+      )
+
+      expect(rawTransaction.transactionHex.length).to.be.equal(234)
+    })
+  })
+
   describe("createDepositScript", () => {
     it("should work", async () => {
-      const rawScript = await TBTC.createDepositScript({
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-        amount: BigNumber.from(120000000), // 1.2 BTC
-        refundPublicKey:
-          "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
-      })
+      const rawScript = await TBTC.createDepositScript(depositData)
 
       expect(rawScript.length).to.be.equal(236)
     })

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -1,7 +1,10 @@
 import TBTC from "./../src"
 import { expect } from "chai"
 import { BigNumber } from "ethers"
-import { testnetPrivateKey, testnetUTXO } from "./data/bitcoin"
+import { testnetAddress, testnetPrivateKey, testnetUTXO } from "./data/bitcoin"
+import { RawTransaction } from "../src/bitcoin"
+// @ts-ignore
+import bcoin from "bcoin"
 
 describe("Deposit", () => {
   const depositData = {
@@ -14,22 +17,232 @@ describe("Deposit", () => {
   }
 
   describe("createDepositTransaction", () => {
-    it("should work", async () => {
-      const rawTransaction = await TBTC.createDepositTransaction(
+    let transaction: RawTransaction
+
+    beforeEach(async () => {
+      transaction = await TBTC.createDepositTransaction(
         depositData,
         [testnetUTXO],
         testnetPrivateKey
       )
+    })
 
-      expect(rawTransaction.transactionHex.length).to.be.equal(446)
+    it("should return transaction with proper structure", async () => {
+      // Convert raw transaction to JSON.
+      bcoin.set("testnet")
+      const buffer = Buffer.from(transaction.transactionHex, "hex")
+      const txJSON = bcoin.TX.fromRaw(buffer).toJSON()
+
+      expect(txJSON.hash).to.be.equal(
+        "c219f45cb5c883161a064e3574c6206d64e5ac67bc349ce4687843202c8d2701"
+      )
+      expect(txJSON.version).to.be.equal(1)
+
+      // Validate inputs.
+      expect(txJSON.inputs.length).to.be.equal(1)
+
+      const input = txJSON.inputs[0]
+
+      expect(input.prevout.hash).to.be.equal(testnetUTXO.transactionHash)
+      expect(input.prevout.index).to.be.equal(testnetUTXO.outputIndex)
+      // Transaction should be signed but this is SegWit input so the `script`
+      // field should be empty and the `witness` field should be filled instead.
+      expect(input.script.length).to.be.equal(0)
+      expect(input.witness.length).to.be.greaterThan(0)
+      expect(input.address).to.be.equal(testnetAddress)
+
+      // Validate outputs.
+      expect(txJSON.outputs.length).to.be.equal(2)
+
+      const depositOutput = txJSON.outputs[0]
+      const changeOutput = txJSON.outputs[1]
+
+      // Value should correspond to the deposit amount.
+      expect(depositOutput.value).to.be.equal(depositData.amount.toNumber())
+      // Should be OP_HASH160 <script-hash> OP_EQUAL. The script hash is
+      // 867120d5480a9cc0c11c1193fa59b3a92e852da7 (see createDepositScriptHash
+      // scenario) and it should be prefixed with its byte length: 0x14.
+      // The OP_HASH160 opcode is 0xa9 and OP_EQUAL is 0x87. So, the final
+      // form should be: a914867120d5480a9cc0c11c1193fa59b3a92e852da787.
+      expect(depositOutput.script).to.be.equal(
+        "a914867120d5480a9cc0c11c1193fa59b3a92e852da787"
+      )
+      // The address should correspond to the script hash
+      // 867120d5480a9cc0c11c1193fa59b3a92e852da7 on testnet so it should be
+      // 2N5W64H5wBX8iGhWQdNP4DLP7TtnLh26PAa (see createDepositAddress scenario).
+      expect(depositOutput.address).to.be.equal(
+        "2N5W64H5wBX8iGhWQdNP4DLP7TtnLh26PAa"
+      )
+
+      // Change value should be equal to: inputValue - depositAmount - fee.
+      expect(changeOutput.value).to.be.equal(3921790)
+      // Should be OP_0 <public-key-hash>. Public key corresponds to
+      // depositor BTC address.
+      expect(changeOutput.script).to.be.equal(
+        "00147ac2d9378a1c47e589dfb8095ca95ed2140d2726"
+      )
+      // Should return the change to depositor BTC address.
+      expect(changeOutput.address).to.be.equal(testnetAddress)
     })
   })
 
   describe("createDepositScript", () => {
-    it("should work", async () => {
-      const rawScript = await TBTC.createDepositScript(depositData)
+    let script: string
 
-      expect(rawScript.length).to.be.equal(236)
+    beforeEach(async () => {
+      script = await TBTC.createDepositScript(depositData)
+    })
+
+    it("should return script with proper structure", async () => {
+      expect(script.length).to.be.equal(236) // 118 bytes
+
+      // Assert the Ethereum address is encoded correctly.
+      // According the Bitcoin script format, the first byte before arbitrary
+      // data must determine the length of those data. In this case the first
+      // byte is 0x14 which is 20 in decimal, and this is correct because we
+      // have a 20 bytes Ethereum address as subsequent data.
+      expect(script.substring(0, 2)).to.be.equal("14")
+      expect(script.substring(2, 42)).to.be.equal(
+        depositData.ethereumAddress.substring(2).toLowerCase()
+      )
+
+      // According to https://en.bitcoin.it/wiki/Script#Constants, the
+      // OP_DROP opcode is 0x75.
+      expect(script.substring(42, 44)).to.be.equal("75")
+
+      // Assert the blinding factor is encoded correctly.
+      // The first byte (0x08) before the blinding factor is this byte length.
+      // In this case it's 8 bytes.
+      expect(script.substring(44, 46)).to.be.equal("08")
+      expect(script.substring(46, 62)).to.be.equal(
+        depositData.blindingFactor.toHexString().substring(2)
+      )
+
+      // OP_DROP opcode is 0x75.
+      expect(script.substring(62, 64)).to.be.equal("75")
+
+      // OP_DUP opcode is 0x76.
+      expect(script.substring(64, 66)).to.be.equal("76")
+
+      // OP_HASH160 opcode is 0xa9.
+      expect(script.substring(66, 68)).to.be.equal("a9")
+
+      // Assert the signing group public key is encoded correctly.
+      // The first byte (0x21) before the public key is this byte length.
+      // In this case it's 33 bytes which is a correct length for a compressed
+      // Bitcoin public key.
+      expect(script.substring(68, 70)).to.be.equal("21")
+      expect(script.substring(70, 136)).to.be.equal(
+        await TBTC.getActiveWalletPublicKey()
+      )
+
+      // OP_EQUAL opcode is 0x87.
+      expect(script.substring(136, 138)).to.be.equal("87")
+
+      // OP_IF opcode is 0x63.
+      expect(script.substring(138, 140)).to.be.equal("63")
+
+      // OP_CHECKSIG opcode is 0xac.
+      expect(script.substring(140, 142)).to.be.equal("ac")
+
+      // OP_ELSE opcode is 0x67.
+      expect(script.substring(142, 144)).to.be.equal("67")
+
+      // OP_DUP opcode is 0x76.
+      expect(script.substring(144, 146)).to.be.equal("76")
+
+      // OP_HASH160 opcode is 0xa9.
+      expect(script.substring(146, 148)).to.be.equal("a9")
+
+      // Assert the refund public key is encoded correctly.
+      // The first byte (0x21) before the public key is this byte length.
+      // In this case it's 33 bytes which is a correct length for a compressed
+      // Bitcoin public key.
+      expect(script.substring(148, 150)).to.be.equal("21")
+      expect(script.substring(150, 216)).to.be.equal(
+        depositData.refundPublicKey
+      )
+
+      // OP_EQUALVERIFY opcode is 0x88.
+      expect(script.substring(216, 218)).to.be.equal("88")
+
+      // Assert the locktime is encoded correctly.
+      // The first byte (0x04) before the locktime is this byte length.
+      // In this case it's 4 bytes.
+      expect(script.substring(218, 220)).to.be.equal("04")
+      expect(script.substring(220, 228)).to.be.equal(
+        BigNumber.from(depositData.createdAt + 2592000)
+          .toHexString()
+          .substring(2)
+      )
+
+      // OP_CHECKLOCKTIMEVERIFY opcode is 0xb1.
+      expect(script.substring(228, 230)).to.be.equal("b1")
+
+      // OP_DROP opcode is 0x75.
+      expect(script.substring(230, 232)).to.be.equal("75")
+
+      // OP_CHECKSIG opcode is 0xac.
+      expect(script.substring(232, 234)).to.be.equal("ac")
+
+      // OP_ENDIF opcode is 0x68.
+      expect(script.substring(234, 236)).to.be.equal("68")
+    })
+  })
+
+  describe("createDepositScriptHash", () => {
+    let scriptHash: Buffer
+
+    beforeEach(async () => {
+      scriptHash = await TBTC.createDepositScriptHash(depositData)
+    })
+
+    it("should return proper script hash", async () => {
+      // The script for given depositData should be the same as in
+      // createDepositScript test scenario:
+      // 14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a921
+      // 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d98763
+      // ac6776a9210300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d9
+      // 7763a9880461eabc60b175ac68. The hash of this script should correspond
+      // to the OP_HASH160 opcode which applies SHA-256 and then RIPEMD-160
+      // on the input. In this case the hash is 867120d5480a9cc0c11c1193fa59b3a92e852da7
+      // and it can be verified with the following command:
+      // echo -n $SCRIPT | xxd -r -p | openssl dgst -sha256 -binary | openssl dgst -rmd160
+      expect(scriptHash.toString("hex")).to.be.equal(
+        "867120d5480a9cc0c11c1193fa59b3a92e852da7"
+      )
+    })
+  })
+
+  describe("createDepositAddress", () => {
+    let address: string
+
+    context("when network is main", () => {
+      beforeEach(async () => {
+        address = await TBTC.createDepositAddress(depositData, "main")
+      })
+
+      it("should return proper address with prefix 3", async () => {
+        // Address is created from same script hash as presented in the
+        // createDepositScriptHash scenario: 867120d5480a9cc0c11c1193fa59b3a92e852da7.
+        // According to https://en.bitcoin.it/wiki/List_of_address_prefixes
+        // the P2SH address prefix for mainnet is 3.
+        expect(address).to.be.equal("3DwszY9ua4dN4usrxEmBbPPrFYaArCvB47")
+      })
+    })
+
+    context("when network is testnet", () => {
+      beforeEach(async () => {
+        address = await TBTC.createDepositAddress(depositData, "testnet")
+      })
+
+      it("should return proper address with prefix 2", async () => {
+        // Address is created from same script hash as presented in the
+        // createDepositScriptHash scenario: 867120d5480a9cc0c11c1193fa59b3a92e852da7.
+        // According to https://en.bitcoin.it/wiki/List_of_address_prefixes
+        // the P2SH address prefix for testnet is 2.
+        expect(address).to.be.equal("2N5W64H5wBX8iGhWQdNP4DLP7TtnLh26PAa")
+      })
     })
   })
 })

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -1,12 +1,12 @@
 import TBTC from "./../src"
 import { expect } from "chai"
 import { BigNumber } from "ethers"
-import { testnetAddress, testnetUTXO } from "./data/bitcoin"
+import { testnetPrivateKey, testnetUTXO } from "./data/bitcoin"
 
 describe("Deposit", () => {
   const depositData = {
     ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-    amount: BigNumber.from(120000000), // 1.2 BTC
+    amount: BigNumber.from(10000), // 0.0001 BTC
     refundPublicKey:
       "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
     blindingFactor: BigNumber.from("0xf9f0c90d00039523"), // 18010115967526606115
@@ -18,10 +18,10 @@ describe("Deposit", () => {
       const rawTransaction = await TBTC.createDepositTransaction(
         depositData,
         [testnetUTXO],
-        testnetAddress
+        testnetPrivateKey
       )
 
-      expect(rawTransaction.transactionHex.length).to.be.equal(234)
+      expect(rawTransaction.transactionHex.length).to.be.equal(446)
     })
   })
 

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -1,0 +1,18 @@
+import TBTC from "./../src"
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+
+describe("Deposit", () => {
+  describe("createDepositScript", () => {
+    it("should work", async () => {
+      const rawScript = await TBTC.createDepositScript({
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(120000000), // 1.2 BTC
+        refundPublicKey:
+          "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
+      })
+
+      expect(rawScript.length).to.be.equal(236)
+    })
+  })
+})

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -10,6 +10,7 @@ describe("Deposit", () => {
     refundPublicKey:
       "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
     blindingFactor: BigNumber.from("0xf9f0c90d00039523"), // 18010115967526606115
+    createdAt: 1640181600, // 22-12-2021 14:00:00 UTC
   }
 
   describe("createDepositTransaction", () => {

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -9,6 +9,7 @@ describe("Deposit", () => {
     amount: BigNumber.from(120000000), // 1.2 BTC
     refundPublicKey:
       "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
+    blindingFactor: BigNumber.from("0xf9f0c90d00039523"), // 18010115967526606115
   }
 
   describe("createDepositTransaction", () => {

--- a/tbtc-ts/yarn.lock
+++ b/tbtc-ts/yarn.lock
@@ -333,7 +333,7 @@ base-x@^3.0.2:
   dependencies:
     bsert "~0.0.10"
 
-"bcoin@git+https://github.com/bcoin-org/bcoin.git#acdeb84":
+"bcoin@git+https://github.com/bcoin-org/bcoin.git#semver:~2.2.0":
   version "2.2.0"
   resolved "git+https://github.com/bcoin-org/bcoin.git#acdeb84767f3ceb82b4a75931fe353229c3bc7b5"
   dependencies:
@@ -1237,14 +1237,9 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1":
+"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1", loady@~0.0.1, loady@~0.0.5:
   version "0.0.5"
   resolved "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
-
-loady@~0.0.1, loady@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
-  integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
 
 locate-path@^6.0.0:
   version "6.0.0"

--- a/tbtc-ts/yarn.lock
+++ b/tbtc-ts/yarn.lock
@@ -50,6 +50,346 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
+  integrity sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
+  integrity sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
+
+"@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
+  integrity sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/address@5.5.0", "@ethersproject/address@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
+  integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+
+"@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
+  integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+
+"@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
+  integrity sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
+  integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bytes@5.5.0", "@ethersproject/bytes@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
+  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/constants@5.5.0", "@ethersproject/constants@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
+  integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/contracts@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.5.0.tgz#b735260d4bd61283a670a82d5275e2a38892c197"
+  integrity sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==
+  dependencies:
+    "@ethersproject/abi" "^5.5.0"
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+
+"@ethersproject/hash@5.5.0", "@ethersproject/hash@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
+  integrity sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.5.0.tgz#4a04e28f41c546f7c978528ea1575206a200ddf6"
+  integrity sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/pbkdf2" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/wordlists" "^5.5.0"
+
+"@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz#dd522d4297e15bccc8e1427d247ec8376b60e325"
+  integrity sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hdnode" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/pbkdf2" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
+  integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/logger@5.5.0", "@ethersproject/logger@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
+  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/networks@5.5.1", "@ethersproject/networks@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.1.tgz#b7f7b9fb88dec1ea48f739b7fb9621311aa8ce6c"
+  integrity sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz#e25032cdf02f31505d47afbf9c3e000d95c4a050"
+  integrity sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+
+"@ethersproject/properties@5.5.0", "@ethersproject/properties@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
+  integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/providers@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.1.tgz#ba87e3c93219bbd2e2edf8b369873aee774abf04"
+  integrity sha512-2zdD5sltACDWhjUE12Kucg2PcgM6V2q9JMyVvObtVGnzJu+QSmibbP+BHQyLWZUBfLApx2942+7DC5D+n4wBQQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.5.0", "@ethersproject/random@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.0.tgz#305ed9e033ca537735365ac12eed88580b0f81f9"
+  integrity sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
+  integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
+  integrity sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
+  integrity sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.5.0.tgz#2662eb3e5da471b85a20531e420054278362f93f"
+  integrity sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/strings@5.5.0", "@ethersproject/strings@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
+  integrity sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
+  integrity sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+
+"@ethersproject/units@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
+  integrity sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/wallet@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.5.0.tgz#322a10527a440ece593980dca6182f17d54eae75"
+  integrity sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/hdnode" "^5.5.0"
+    "@ethersproject/json-wallets" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/wordlists" "^5.5.0"
+
+"@ethersproject/web@5.5.1", "@ethersproject/web@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.1.tgz#cfcc4a074a6936c657878ac58917a61341681316"
+  integrity sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==
+  dependencies:
+    "@ethersproject/base64" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
+  integrity sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -231,6 +571,11 @@ acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
   integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -394,6 +739,11 @@ base-x@^3.0.2:
   dependencies:
     bsert "~0.0.10"
 
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
 "bevent@git+https://github.com/bcoin-org/bevent.git#semver:~0.1.5":
   version "0.1.5"
   resolved "git+https://github.com/bcoin-org/bevent.git#60fb503de3ea1292d29ce438bfba80f0bc5ccb60"
@@ -455,6 +805,11 @@ binary-extensions@^2.0.0:
   dependencies:
     bsert "~0.0.10"
 
+bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -469,6 +824,11 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+brorand@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -745,6 +1105,19 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+elliptic@6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -926,6 +1299,42 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+ethers@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.2.tgz#cd2e508c7342c44fa70392f722e8de8f2416489f"
+  integrity sha512-EF5W+6Wwcu6BqVwpgmyR5U2+L4c1FQzlM/02dkZOugN3KF0cG9bzHZP+TDJglmPm2/IzCEJDT7KBxzayk7SAHw==
+  dependencies:
+    "@ethersproject/abi" "5.5.0"
+    "@ethersproject/abstract-provider" "5.5.1"
+    "@ethersproject/abstract-signer" "5.5.0"
+    "@ethersproject/address" "5.5.0"
+    "@ethersproject/base64" "5.5.0"
+    "@ethersproject/basex" "5.5.0"
+    "@ethersproject/bignumber" "5.5.0"
+    "@ethersproject/bytes" "5.5.0"
+    "@ethersproject/constants" "5.5.0"
+    "@ethersproject/contracts" "5.5.0"
+    "@ethersproject/hash" "5.5.0"
+    "@ethersproject/hdnode" "5.5.0"
+    "@ethersproject/json-wallets" "5.5.0"
+    "@ethersproject/keccak256" "5.5.0"
+    "@ethersproject/logger" "5.5.0"
+    "@ethersproject/networks" "5.5.1"
+    "@ethersproject/pbkdf2" "5.5.0"
+    "@ethersproject/properties" "5.5.0"
+    "@ethersproject/providers" "5.5.1"
+    "@ethersproject/random" "5.5.0"
+    "@ethersproject/rlp" "5.5.0"
+    "@ethersproject/sha2" "5.5.0"
+    "@ethersproject/signing-key" "5.5.0"
+    "@ethersproject/solidity" "5.5.0"
+    "@ethersproject/strings" "5.5.0"
+    "@ethersproject/transactions" "5.5.0"
+    "@ethersproject/units" "5.5.0"
+    "@ethersproject/wallet" "5.5.0"
+    "@ethersproject/web" "5.5.1"
+    "@ethersproject/wordlists" "5.5.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -1109,10 +1518,27 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hmac-drbg@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1193,6 +1619,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1299,6 +1730,16 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
@@ -1547,6 +1988,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, 
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
@@ -1778,6 +2224,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/tbtc-ts/yarn.lock
+++ b/tbtc-ts/yarn.lock
@@ -320,10 +320,140 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+"bcfg@git+https://github.com/bcoin-org/bcfg.git#semver:~0.1.7":
+  version "0.1.7"
+  resolved "git+https://github.com/bcoin-org/bcfg.git#05122154b35baa82cd01dc9478ebee7346386ba1"
+  dependencies:
+    bsert "~0.0.10"
+
+"bcoin@git+https://github.com/bcoin-org/bcoin.git#acdeb84":
+  version "2.2.0"
+  resolved "git+https://github.com/bcoin-org/bcoin.git#acdeb84767f3ceb82b4a75931fe353229c3bc7b5"
+  dependencies:
+    bcfg "git+https://github.com/bcoin-org/bcfg.git#semver:~0.1.7"
+    bcrypto "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0"
+    bcurl "git+https://github.com/bcoin-org/bcurl.git#semver:^0.1.6"
+    bdb "git+https://github.com/bcoin-org/bdb.git#semver:~1.2.1"
+    bdns "git+https://github.com/bcoin-org/bdns.git#semver:~0.1.5"
+    bevent "git+https://github.com/bcoin-org/bevent.git#semver:~0.1.5"
+    bfile "git+https://github.com/bcoin-org/bfile.git#semver:~0.2.1"
+    bfilter "git+https://github.com/bcoin-org/bfilter.git#semver:~2.3.0"
+    bheep "git+https://github.com/bcoin-org/bheep.git#semver:~0.1.5"
+    binet "git+https://github.com/bcoin-org/binet.git#semver:~0.3.5"
+    blgr "git+https://github.com/bcoin-org/blgr.git#semver:~0.2.0"
+    blru "git+https://github.com/bcoin-org/blru.git#semver:~0.1.6"
+    blst "git+https://github.com/bcoin-org/blst.git#semver:~0.1.5"
+    bmutex "git+https://github.com/bcoin-org/bmutex.git#semver:~0.1.6"
+    brq "git+https://github.com/bcoin-org/brq.git#semver:~0.1.7"
+    bs32 "git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6"
+    bsert "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
+    bsock "git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9"
+    bsocks "git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6"
+    btcp "git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5"
+    buffer-map "git+https://github.com/chjj/buffer-map.git#semver:~0.0.7"
+    bufio "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6"
+    bupnp "git+https://github.com/bcoin-org/bupnp.git#semver:~0.2.6"
+    bval "git+https://github.com/bcoin-org/bval.git#semver:~0.1.6"
+    bweb "git+https://github.com/bcoin-org/bweb.git#semver:=0.1.9"
+    loady "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+    n64 "git+https://github.com/chjj/n64.git#semver:~0.2.10"
+    nan "git+https://github.com/braydonf/nan.git#semver:=2.14.0"
+
+"bcrypto@git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0":
+  version "5.5.0"
+  resolved "git+https://github.com/bcoin-org/bcrypto.git#34738cf15033e3bce91a4f6f41ec1ebee3c2fdc8"
+  dependencies:
+    bufio "~1.0.7"
+    loady "~0.0.5"
+
+"bcurl@git+https://github.com/bcoin-org/bcurl.git#semver:^0.1.6":
+  version "0.1.10"
+  resolved "git+https://github.com/bcoin-org/bcurl.git#d7e088fad4c284fb5d6fd7205c6b903bd3e6bf83"
+  dependencies:
+    brq "~0.1.8"
+    bsert "~0.0.10"
+    bsock "~0.1.9"
+
+"bdb@git+https://github.com/bcoin-org/bdb.git#semver:~1.2.1":
+  version "1.2.2"
+  resolved "git+https://github.com/bcoin-org/bdb.git#2c8d48c8adca4b11260263472766cd4b7ae74ef7"
+  dependencies:
+    bsert "~0.0.10"
+    loady "~0.0.1"
+
+"bdns@git+https://github.com/bcoin-org/bdns.git#semver:~0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/bcoin-org/bdns.git#cb0b62a0075f7e1259fc50fa723ba644e9a07d14"
+  dependencies:
+    bsert "~0.0.10"
+
+"bevent@git+https://github.com/bcoin-org/bevent.git#semver:~0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/bcoin-org/bevent.git#60fb503de3ea1292d29ce438bfba80f0bc5ccb60"
+  dependencies:
+    bsert "~0.0.10"
+
+"bfile@git+https://github.com/bcoin-org/bfile.git#semver:~0.2.1":
+  version "0.2.2"
+  resolved "git+https://github.com/bcoin-org/bfile.git#c3075133a02830dc384f8353d8275d4499b8bff9"
+
+"bfilter@git+https://github.com/bcoin-org/bfilter.git#semver:~2.3.0":
+  version "2.3.0"
+  resolved "git+https://github.com/bcoin-org/bfilter.git#70e42125f877191d340e8838a1a90fabb750e680"
+  dependencies:
+    bcrypto "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0"
+    bsert "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
+    bufio "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6"
+    loady "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+
+"bheep@git+https://github.com/bcoin-org/bheep.git#semver:~0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/bcoin-org/bheep.git#e59329d0a776ae71b2fb7a2876ee5b9fd3030fa2"
+  dependencies:
+    bsert "~0.0.10"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+"binet@git+https://github.com/bcoin-org/binet.git#semver:~0.3.5", binet@~0.3.5:
+  version "0.3.6"
+  resolved "git+https://github.com/bcoin-org/binet.git#d3decfb7a7257abdfb03c3a9c091499b2ebff0e1"
+  dependencies:
+    bs32 "~0.1.5"
+    bsert "~0.0.10"
+
+"blgr@git+https://github.com/bcoin-org/blgr.git#semver:~0.2.0":
+  version "0.2.0"
+  resolved "git+https://github.com/bcoin-org/blgr.git#050cbb587a1654a078468dbb92606330fdc4d120"
+  dependencies:
+    bsert "~0.0.10"
+
+"blru@git+https://github.com/bcoin-org/blru.git#semver:~0.1.6":
+  version "0.1.6"
+  resolved "git+https://github.com/bcoin-org/blru.git#c2c093e9475439333dfb87bfb2fdc3be6c98b080"
+  dependencies:
+    bsert "~0.0.10"
+
+"blst@git+https://github.com/bcoin-org/blst.git#semver:~0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/bcoin-org/blst.git#d588403edb18e628899e05aeba8c3a98a5cdedff"
+  dependencies:
+    bsert "~0.0.10"
+
+"bmutex@git+https://github.com/bcoin-org/bmutex.git#semver:~0.1.6":
+  version "0.1.6"
+  resolved "git+https://github.com/bcoin-org/bmutex.git#e50782323932a4946ecc05a74c6d45861adc2c25"
+  dependencies:
+    bsert "~0.0.10"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -344,6 +474,84 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+"brq@git+https://github.com/bcoin-org/brq.git#semver:~0.1.7", brq@~0.1.7, brq@~0.1.8:
+  version "0.1.8"
+  resolved "git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294"
+  dependencies:
+    bsert "~0.0.10"
+
+"bs32@git+https://github.com/bcoin-org/bs32.git#semver:=0.1.6", bs32@~0.1.5:
+  version "0.1.6"
+  resolved "git+https://github.com/bcoin-org/bs32.git#21cf9c724659dc15df722d2410548828c142f265"
+  dependencies:
+    bsert "~0.0.10"
+
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@<3.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
+
+"bsert@git+https://github.com/chjj/bsert.git#semver:~0.0.10", bsert@~0.0.10:
+  version "0.0.10"
+  resolved "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc"
+
+"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9", bsock@~0.1.8, bsock@~0.1.9:
+  version "0.1.9"
+  resolved "git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528"
+  dependencies:
+    bsert "~0.0.10"
+
+"bsocks@git+https://github.com/bcoin-org/bsocks.git#semver:~0.2.6":
+  version "0.2.6"
+  resolved "git+https://github.com/bcoin-org/bsocks.git#6a8eb764dc4408e7f47da4f84e1afb1b393117e8"
+  dependencies:
+    binet "~0.3.5"
+    bsert "~0.0.10"
+
+"btcp@git+https://github.com/bcoin-org/btcp.git#semver:~0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/bcoin-org/btcp.git#4ea7e1ce5a43cd5348152c007aff76a419190a3a"
+
+"buffer-map@git+https://github.com/chjj/buffer-map.git#semver:~0.0.7":
+  version "0.0.7"
+  resolved "git+https://github.com/chjj/buffer-map.git#bad5863af9a520701937a17fc8fa2bd8ca8e73f3"
+
+"bufio@git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6", bufio@~1.0.7:
+  version "1.0.7"
+  resolved "git+https://github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984"
+
+"bupnp@git+https://github.com/bcoin-org/bupnp.git#semver:~0.2.6":
+  version "0.2.6"
+  resolved "git+https://github.com/bcoin-org/bupnp.git#c44fa7356aa297c9de96e8ad094a6816939cd688"
+  dependencies:
+    binet "~0.3.5"
+    brq "~0.1.7"
+    bsert "~0.0.10"
+
+"bval@git+https://github.com/bcoin-org/bval.git#semver:~0.1.6":
+  version "0.1.6"
+  resolved "git+https://github.com/bcoin-org/bval.git#c8cd14419ca46f63610dc48b797b076835e86f48"
+  dependencies:
+    bsert "~0.0.10"
+
+"bweb@git+https://github.com/bcoin-org/bweb.git#semver:=0.1.9":
+  version "0.1.9"
+  resolved "git+https://github.com/bcoin-org/bweb.git#31ae94ec9e97079610394e91928fe070d312c39d"
+  dependencies:
+    bsert "~0.0.10"
+    bsock "~0.1.8"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -411,6 +619,14 @@ chokidar@3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+cipher-base@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -448,6 +664,17 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+create-hash@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -873,6 +1100,15 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -909,7 +1145,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1001,6 +1237,15 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1":
+  version "0.0.5"
+  resolved "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
+
+loady@~0.0.1, loady@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
+  integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -1037,6 +1282,15 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 merge2@^1.3.0:
   version "1.4.1"
@@ -1097,6 +1351,14 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+"n64@git+https://github.com/chjj/n64.git#semver:~0.2.10":
+  version "0.2.10"
+  resolved "git+https://github.com/chjj/n64.git#34f981f1441f569821d97a31f8cf21a3fc11b8f6"
+
+"nan@git+https://github.com/braydonf/nan.git#semver:=2.14.0":
+  version "2.14.0"
+  resolved "git+https://github.com/braydonf/nan.git#1dcc61bd06d84e389bfd5311b2b1492a14c74201"
 
 nanoid@3.1.25:
   version "3.1.25"
@@ -1222,6 +1484,15 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -1261,6 +1532,14 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -1268,7 +1547,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1286,6 +1565,14 @@ serialize-javascript@6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+sha.js@^2.4.0:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -1326,6 +1613,13 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -1442,6 +1736,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -1453,6 +1752,13 @@ which@2.0.2, which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wif@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
+  integrity sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=
+  dependencies:
+    bs58check "<3.0.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/79

This pull request introduces tooling meant to be used for assembling and broadcasting Bitcoin P2SH deposit transactions. Specifically, it extends the `TBTC` interface by adding the following methods:
- `makeDeposit`: Function which can be used to perform an end-to-end deposit flow. Takes deposit parameters, depositor private key, and Bitcoin client as arguments. It scans the depositor account for UTXOs, constructs the P2SH transaction according to given parameters, and broadcasts the transaction over the network. The main purpose of that function are future e2e tests of the whole system.
- `createDepositTransaction`: Function which assembles the P2SH transaction based on given deposit parameters, depositor private key, and UTXOs. It returns the transaction in a raw format. Such a transaction can be used for testing or can be broadcast out-of-band.
- `createDepositScript`: Creates the Bitcoin script used as a lock of the P2SH deposit transaction output. It implements the script described in [RFC-1](https://github.com/keep-network/tbtc-v2/blob/main/docs/rfc/rfc-1.adoc#23-depositing). Returns the serialized script in a raw format for further processing.
- `createDepositScriptHash`:  Function that computes the hash of the script returned by `createDepositScript`. This hash has several use cases. It is used during P2SH transaction creation and while deriving deposit target address.
- `createDepositAddress`: Function that computes the deposit target address for the given Bitcoin network using the output of `createDepositScriptHash`. That address can be passed to the depositor who wants to perform the Bitcoin P2SH transaction on their own.