### PR TITLE
Bridge.revealDeposit implementation

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -112,6 +112,8 @@ contract Bridge {
     ///         divided evenly between all swept deposits. Each depositor
     ///         receives a balance in the bank equal to the amount they have
     ///         declared during the reveal transaction, minus their fee share.
+    ///
+    ///         It is possible to prove the given sweep only one time.
     /// @param txVersion Transaction version number (4-byte LE)
     /// @param txInputVector All transaction inputs prepended by the number of
     ///                      inputs encoded as a VarInt, max 0xFC(252) inputs
@@ -144,6 +146,11 @@ contract Bridge {
         // TODO We need to validate txOutput to see if the balance was not
         //      transferred away from the wallet before increasing balances in
         //      the bank.
+        //
+        // TODO Delete deposit from unswept mapping or mark it as swept
+        //      depending on the gas costs. Alternativly, do not allow to
+        //      use the same TX input vector twice. Sweep should be provable
+        //      only one time.
     }
 
     // TODO It is possible a malicious wallet can sweep deposits that can not

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1,0 +1,154 @@
+pragma solidity 0.8.4;
+
+/// @title BTC Bridge
+/// @notice Bridge manages BTC deposit and redemption and is increasing and
+///         decreasing balances in the Bank as a result of BTC deposit and
+///         redemption operations.
+///
+///         Depositors send BTC funds to the most-recently-created-wallet of the
+///         bridge using pay-to-script-hash (P2SH) which contains hashed
+///         information about the depositor’s minting Ethereum address. Then,
+///         the depositor reveals their desired Ethereum minting address to the
+///         Ethereum chain. The Bridge listens for these sorts of messages and
+///         when it gets one, it checks the Bitcoin network to make sure the
+///         funds line up. If they do, the off-chain wallet may decide to pick
+///         this transaction for sweeping, and when the sweep operation is
+///         confirmed on the Bitcoin network, the wallet informs the Bridge
+///         about the sweep increasing appropriate balances in the Bank.
+/// @dev Bridge is an upgradeable component of the Bank.
+contract Bridge {
+    struct DepositInfo {
+        uint64 amount;
+        address vault;
+        uint32 revealedAt;
+    }
+
+    /// @notice Collection of all unswept deposits indexed by
+    ///         keccak256(fundingTxHash | fundingOutputIndex | depositorAddress).
+    ///         This mapping may contain valid and invalid deposits and the
+    ///         wallet is responsible for validating them before attempting to
+    ///         execute a sweep.
+    mapping(uint256 => DepositInfo) public unswept;
+
+    event DepositRevealed(
+        uint256 depositId,
+        bytes32 fundingTxHash,
+        uint8 fundingOutputIndex,
+        address depositor,
+        uint64 blindingFactor,
+        bytes refundPubKey,
+        uint64 amount,
+        address vault
+    );
+
+    /// @notice Used by the depositor to reveal information about their P2SH
+    ///         Bitcoin deposit to the Bridge on Ethereum chain. The off-chain
+    ///         wallet listens for revealed deposit events and may decide to
+    ///         include the revealed deposit in the next executed sweep.
+    ///         Information about the Bitcoin deposit can be revealed before or
+    ///         after the Bitcoin transaction with P2SH deposit is mined on the
+    ///         Bitcoin chain.
+    /// @param fundingTxHash The BTC transaction hash containing BTC P2SH
+    ///        deposit funding transaction
+    /// @param fundingOutputIndex The index of the transaction output in the
+    ///        funding TX with P2SH deposit, max 256
+    /// @param blindingFactor The blinding factor used in the BTC P2SH deposit,
+    ///        max 2^64
+    /// @param refundPubKey The refund pub key used in the BTC P2SH deposit
+    /// @param amount The amount locked in the BTC P2SH deposit
+    /// @param vault Bank vault to which the swept deposit should be routed
+    /// @dev Requirements:
+    ///      - `msg.sender` must be the Ethereum address used in the P2SH BTC deposit,
+    ///      - `blindingFactor` must be the blinding factor used in the P2SH BTC deposit,
+    ///      - `refundPubKey` must be the refund pub key used in the P2SH BTC deposit,
+    ///      - `amount` must be the same as locked in the P2SH BTC deposit,
+    ///      - BTC deposit for the given `fundingTxHash`, `fundingOutputIndex`
+    ///        can be revealed by `msg.sender` only one time.
+    ///
+    ///      If any of these requirements is not met, the wallet _must_ refuse
+    ///      to sweep the deposit and the depositor has to wait until the
+    ///      deposit script unlocks to receive their BTC back.
+    function revealDeposit(
+        bytes32 fundingTxHash,
+        uint8 fundingOutputIndex,
+        uint64 blindingFactor,
+        bytes calldata refundPubKey,
+        uint64 amount,
+        address vault
+    ) external {
+        uint256 depositId =
+            uint256(
+                keccak256(
+                    abi.encode(fundingTxHash, fundingOutputIndex, msg.sender)
+                )
+            );
+
+        DepositInfo storage deposit = unswept[depositId];
+        require(deposit.revealedAt == 0, "Deposit already revealed");
+
+        deposit.amount = amount;
+        deposit.vault = vault;
+        /* solhint-disable-next-line not-rely-on-time */
+        deposit.revealedAt = uint32(block.timestamp);
+
+        emit DepositRevealed(
+            depositId,
+            fundingTxHash,
+            fundingOutputIndex,
+            msg.sender,
+            blindingFactor,
+            refundPubKey,
+            amount,
+            vault
+        );
+    }
+
+    /// @notice Used by the wallet to prove the BTC deposit sweep transaction
+    ///         and to update Bank balances accordingly. Sweep is only accepted
+    ///         if it satisfies SPV proof.
+    ///
+    ///         The function is performing Bank balance updates by first
+    ///         computing the Bitcoin fee for the sweep transaction. The fee is
+    ///         divided evenly between all swept deposits. Each depositor
+    ///         receives a balance in the bank equal to the amount they have
+    ///         declared during the reveal transaction, minus their fee share.
+    /// @param txVersion Transaction version number (4-byte LE)
+    /// @param txInputVector All transaction inputs prepended by the number of
+    ///                      inputs encoded as a VarInt, max 0xFC(252) inputs
+    /// @param txOutput Single sweep transaction output
+    /// @param txLocktime Final 4 bytes of the transaction
+    /// @param merkleProof The merkle proof of transaction inclusion in a block
+    /// @param txIndexInBlock Transaction index in the block (0-indexed)
+    /// @param bitcoinHeaders Single bytestring of 80-byte bitcoin headers,
+    ///                       lowest height first
+    function sweep(
+        bytes4 txVersion,
+        bytes memory txInputVector,
+        bytes memory txOutput,
+        bytes4 txLocktime,
+        bytes memory merkleProof,
+        uint256 txIndexInBlock,
+        bytes memory bitcoinHeaders
+    ) external {
+        // TODO We need to read `fundingTxHash`, `fundingOutputIndex` and
+        //      P2SH script depositor address from `txInputVector`.
+        //      We then hash them to obtain deposit identifier and read
+        //      DepositInfo. From DepositInfo we know what amount was declared
+        //      by the depositor in their reveal transaction and we use that
+        //      amount to update their Bank balance, minus fee.
+        //
+        // TODO We need to validate if the sum in the output minus the
+        //      amount from the previous wallet balance input minus fees is
+        //      equal to the amount by which Bank balances were increased.
+        //
+        // TODO We need to validate txOutput to see if the balance was not
+        //      transferred away from the wallet before increasing balances in
+        //      the bank.
+    }
+
+    // TODO It is possible a malicious wallet can sweep deposits that can not
+    //      be later proved on Ethereum. For example, a deposit with
+    //      an incorrect amount revealed. We need to provide a function for honest
+    //      depositors, next to sweep, to prove their swept balances on Ethereum
+    //      selectively, based on deposits they have earlier received.
+}


### PR DESCRIPTION
Refs https://github.com/keep-network/tbtc-v2/issues/79

# Overview

Bridge manages BTC deposit and redemption and is increasing and decreasing balances in the Bank as a result of BTC deposit and redemption operations.

Depositors send BTC funds to the most-recently-created-wallet of the bridge using pay-to-script-hash (P2SH) which contains hashed information about the depositor’s minting Ethereum address. Then, the depositor reveals their desired Ethereum minting address to the Ethereum chain. The Bridge listens for these sorts of messages and when it gets one, it checks the Bitcoin network to make sure the funds line up. If they do, the off-chain wallet may decide to pick this transaction for sweeping, and when the sweep operation is confirmed on the Bitcoin network, the wallet informs the Bridge about the sweep increasing appropriate balances in the Bank.

This change adds a full implementation of `Bridge.revealDeposit` function and a draft implementation of `Bridge.sweep` function with just documentation and TODOs describing what kind of validation needs to be implemented to keep the mechanism secure. Tests are not included given that @lukasz-zimnoch is working on a TypeScript code for assembling transaction data and a full suite of tests needs to be implemented once we have that piece ready.

# The mechanism

## Depositor experience

The depositor is generating P2SH address in tBTC v2 dApp. To generate the address, they need to provide a refund public key and amount. The dApp is generating a blinding factor for the user.  The user receives P2SH address and uses any Bitcoin wallet they want - assuming the wallet supports P2SH transactions - to send the given amount of BTC to the provided address. Once BTC is sent, the user reveals information about their Bitcoin deposit to Ethereum chain using tBTC v2 dApp. The user does not need to wait for the Bitcoin transaction to be mined. The reveal transaction is cheap and consumes ~53k of gas.  

Once the sweep is performed - and it may take a couple of hours for this to happen - the user will have their Bitcoin bank balance increased by the amount of their deposit, minus fees. Optionally, the user may select an option in the dApp to mint TBTC token, instead of increasing their Bitcoin bank balance.

In the future we may add an additional option for the user to reveal their deposit and request a sweep, paying an additional fee for the wallet to execute the sweep faster.

## Wallet

The wallet needs to monitor `DepositRevealed` events and for each sufficiently confirmed deposit, validates information revealed by the user via `Bridge.revealDeposit` function with the one available on Bitcoin chain. The following requirements need to be met:
- `msg.sender` of `Bridge.revealDeposit` must be the Ethereum address used in the P2SH BTC deposit,
- `blindingFactor` must be the blinding factor used in the P2SH BTC deposit,
- `refundPubKey` must be the refund pub key used in the P2SH BTC deposit,
- `amount` must be the same as locked in the P2SH BTC deposit.

If any of these requirements is not met, the wallet **must refuse** to sweep the deposit and the depositor has to wait until the deposit script unlocks to receive their BTC back.

It is possible that someone can use `Bridge.revealDeposit` to inform about deposit that does not exist, a deposit with a dust, a non-P2SH deposit, or a deposit that has other parameter values used in P2SH script. The wallet needs to be able to filter out such deposits and refuse to sweep them.

Once the wallet executed a sweep and the sweep transaction was sufficiently confirmed, the wallet needs to call `Bridge.sweep` function that updates bank balances and validates SPV proof.

 The function is performing Bank balance updates by first computing the Bitcoin fee for the sweep transaction. The fee is divided evenly between all swept deposits. Each depositor receives a balance in the bank equal to the amount they have declared during the reveal transaction, minus their fee share.

# Attacks

## Malicious depositor

- The depositor reveals a deposit that does not exist.

  The Wallet needs to filter out such deposits and refuse to sweep them. Even if the wallet is malicious, this deposit does not exist on Bitcoin.

- The depositor reveals a deposit with incorrect P2SH script parameters.

  The Wallet needs to filter out such deposits and refuse to sweep them. Even if the wallet is malicious, it can not unlock such a deposit on Bitcoin.

- The depositor reveals a deposit with an amount higher than the BTC amount sent to P2SH address.

  The Wallet needs to filter out such deposits and refuse to sweep them. If the wallet is malicious, it can not prove such a sweep and modify bank balances (see Malicious Wallet section).

- Malicious player reveals information about someone else's P2SH deposit on Bitcoin chain.
  
  The Wallet needs to filter out such deposits and refuse to sweep them. Even if the wallet is malicious, we require `msg.sender` in the reveal transaction to be the Ethereum address used in P2SH deposit, so without a valid Ethereum address, P2SH deposit can not be unlocked.

  
## Malicious wallet

- The malicious wallet reveals info about a deposit with an amount higher than the actual deposited into P2SH address.

  Reveal transaction fails and no Bank balances are updated if the sweep transaction output amount minus the amount from the previous wallet balance input is lower than the planned balance updates in the bank. The fact Bitcoin transaction is valid is guaranteed by SPV proof.

- The malicious wallet tries to use someone else's deposit to increase its own balance.

  We read read `fundingTxHash`, `fundingOutputIndex` and P2SH script depositor address from `txInputVector`.  We then hash them to obtain deposit identifier and read `DepositInfo`. From `DepositInfo` we know what amount was declared by the depositor in their reveal transaction and we use that amount to update their `Bank` balance, minus fee. The wallet can not set arbitrary balances in the bank.

- Malicious wallet sweeps a deposit that can not be proved on Ethereum.

  It is possible a malicious wallet can sweep deposits that can not be later proved on Ethereum. For example, a deposit with an incorrect amount revealed. We need to provide a function for honest depositors, next to `sweep`, to prove their swept balances on Ethereum selectively, based on deposits they have earlier received. This was captured in a TODO in `Bridge.sol` and is also captured on a TODO list of https://github.com/keep-network/tbtc-v2/issues/79.


