### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -100,11 +100,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@v1
-        with:
-          environment: ${{ github.event.inputs.environment }}
-
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -267,7 +267,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.8.4 # according to solidity.version in hardhat.config.js
+          SOLC_VERSION: 0.8.4 # according to solidity.version in hardhat.config.ts
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION

--- a/.github/workflows/yearn.yml
+++ b/.github/workflows/yearn.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
-          cache-dependency-path: yarn/yarn.lock
+          cache-dependency-path: yearn/yarn.lock
 
       - name: Install dependencies
         run: yarn install
@@ -73,7 +73,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
-          cache-dependency-path: yarn/yarn.lock
+          cache-dependency-path: yearn/yarn.lock
 
       # Below step is a workaround. Eslint executed in `yearn` directory
       # finds `.prettierrc.js` config in the root directory and fails if

--- a/.github/workflows/yearn.yml
+++ b/.github/workflows/yearn.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             path-filter:
               - './yearn/**'
+
   contracts-build-and-test:
     needs: contracts-detect-changes
     if: |
@@ -42,6 +43,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          cache: "yarn"
+          cache-dependency-path: yarn/yarn.lock
 
       - name: Install dependencies
         run: yarn install
@@ -69,6 +72,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          cache: "yarn"
+          cache-dependency-path: yarn/yarn.lock
 
       # Below step is a workaround. Eslint executed in `yearn` directory
       # finds `.prettierrc.js` config in the root directory and fails if


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/threshold-network/solidity-contracts/pull/59