### PR TITLE
Assemble sweep transaction btc

### DIFF
--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -3,8 +3,6 @@ import bcoin from "bcoin"
 // @ts-ignore
 import hash160 from "bcrypto/lib/hash160"
 // @ts-ignore
-import hash256 from "bcrypto/lib/hash256"
-// @ts-ignore
 import { opcodes } from "bcoin/lib/script/common"
 // @ts-ignore
 import wif from "wif"
@@ -228,7 +226,7 @@ export async function createDepositScriptHash(
   const parsedScript = bcoin.Script.fromRaw(Buffer.from(script, "hex"))
   // If witness script hash should be produced, HASH256 should be used.
   // Legacy script hash needs HASH160.
-  return witness ? hash256.digest(parsedScript.toRaw()) : parsedScript.hash160()
+  return witness ? parsedScript.sha256() : parsedScript.hash160()
 }
 
 /**

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -24,7 +24,7 @@ export interface DepositData {
   ethereumAddress: string
 
   /**
-   * Deposit amount in sathoshis.
+   * Deposit amount in satoshis.
    */
   amount: BigNumber
 

--- a/tbtc-ts/src/deposit.ts
+++ b/tbtc-ts/src/deposit.ts
@@ -250,7 +250,8 @@ export async function createDepositAddress(
   return address.toString(network)
 }
 
-// TODO: Implementation and documentation. Dummy key is returned for now.
+// TODO: Dummy key is returned for now. Remove this function and add
+// `walletPublicKey` to `DepositData`.
 export async function getActiveWalletPublicKey(): Promise<string> {
   return "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9"
 }

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -95,14 +95,17 @@ export interface TBTC {
 
   /**
    * Creates a Bitcoin P2WPKH sweep transaction.
+   * @dev The caller is responsible for ensuring the provided UTXOs are correctly
+   *      formed, can be spent by the wallet and their combined value is greater
+   *      then the fee.
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
-   * @param walletPrivateKey - Bitcoin private key of the wallet.
+   * @param walletPrivateKey - Bitcoin private key of the wallet in WIF format.
    * @param utxos - UTXOs from new deposit transactions. Must be P2(W)SH.
-   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
-   *                      number of UTXOs and deposit data elements must equal.
-   * @param previousUtxo - UTXO from the previous sweep transaction (optional).
-   *                       Must be P2WPKH.
+   * @param depositData - data on deposits. Each element corresponds to UTXO.
+   *                      The number of UTXOs and deposit data elements must equal.
+   * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
+   *                   from the previous sweep transaction (optional).
    * @returns Bitcoin sweep transaction in raw format.
    */
   createSweepTransaction(
@@ -110,25 +113,26 @@ export interface TBTC {
     walletPrivateKey: string,
     utxos: (UnspentTransactionOutput & RawTransaction)[],
     depositData: DepositData[],
-    previousUtxo?: UnspentTransactionOutput & RawTransaction
+    mainUtxo?: UnspentTransactionOutput & RawTransaction
   ): Promise<RawTransaction>
 
   /**
-   * Sweeps UTXOs by combining all the provided UTXOs and broadcasting a Bitcoin
-   * P2WPKH sweep transaction.
+   * Sweeps P2(W)SH UTXOs by combining all the provided UTXOs and broadcasting
+   * a Bitcoin P2WPKH sweep transaction.
    * @dev The caller is responsible for ensuring the provided UTXOs are correctly
    *      formed, can be spent by the wallet and their combined value is greater
-   *      then the fee.
+   *      then the fee. Note that broadcasting transaction may fail silently (e.g.
+   *      when the provided UTXOs are not spendable) and no error will be returned.
    * @param bitcoinClient - Bitcoin client used to interact with the network.
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
-   * @param walletPrivateKey - Bitcoin private key of the wallet.
+   * @param walletPrivateKey - Bitcoin private key of the wallet in WIF format.
    * @param utxos - P2(W)SH UTXOs to be combined into one output.
-   * @param depositData - data on deposits. Each elements corresponds to UTXO.
+   * @param depositData - data on deposits. Each element corresponds to UTXO.
    *                      The number of UTXOs and deposit data elements must
    *                      equal.
-   * @param previousSweepUtxo - P2WKH UTXO from the previous sweep transaction
-   *                            (optional).
+   * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
+   *                   from the previous sweep transaction (optional).
    * @returns Empty promise.
    */
   sweepDeposits(
@@ -137,7 +141,7 @@ export interface TBTC {
     walletPrivateKey: string,
     utxos: UnspentTransactionOutput[],
     depositData: DepositData[],
-    previousSweepUtxo?: UnspentTransactionOutput
+    mainUtxo?: UnspentTransactionOutput
   ): Promise<void>
 }
 

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -95,19 +95,21 @@ export interface TBTC {
 
   /**
    * Creates a Bitcoin P2WPKH sweep transaction.
-   * @param utxos - UTXOs that should be used as transaction inputs.
-   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
-   *                      number of UTXOs and deposit data elements must equal.
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
    * @param walletPrivateKey - Bitcoin private key of the wallet.
+   * @param utxos - UTXOs from new deposit transactions.
+   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
+   *                      number of UTXOs and deposit data elements must equal.
+   * @param previousSweepUtxo - UTXO from the previous sweep transaction (optional).
    * @returns Bitcoin sweep transaction in raw format.
    */
   createSweepTransaction(
+    fee: BigNumber,
+    walletPrivateKey: string,
     utxos: (UnspentTransactionOutput & RawTransaction)[],
     depositData: DepositData[],
-    fee: BigNumber,
-    walletPrivateKey: string
+    previousUtxo?: UnspentTransactionOutput & RawTransaction
   ): Promise<RawTransaction>
 
   /**
@@ -116,21 +118,25 @@ export interface TBTC {
    * @dev The caller is responsible for ensuring the provided UTXOs are correctly
    *      formed, can be spent by the wallet and their combined value is greater
    *      then the fee.
-   * @param utxos - UTXOs to be combined into one output.
-   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
-   *                      number of UTXOs and deposit data elements must equal.
+   * @param bitcoinClient - Bitcoin client used to interact with the network.
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
    * @param walletPrivateKey - Bitcoin private key of the wallet.
-   * @param bitcoinClient - Bitcoin client used to interact with the network.
+   * @param utxos - UTXOs to be combined into one output.
+   * @param depositData - data on deposits. Each elements corresponds to UTXO.
+   *                      The number of UTXOs and deposit data elements must
+   *                      equal.
+   * @param previousSweepUtxo - UTXO from the previous sweep transaction
+   *                            (optional).
    * @returns Empty promise.
    */
   sweepDeposits(
-    utxos: UnspentTransactionOutput[],
-    depositData: DepositData[],
+    bitcoinClient: BitcoinClient,
     fee: BigNumber,
     walletPrivateKey: string,
-    bitcoinClient: BitcoinClient
+    utxos: UnspentTransactionOutput[],
+    depositData: DepositData[],
+    previousSweepUtxo?: UnspentTransactionOutput
   ): Promise<void>
 }
 

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -8,11 +8,13 @@ import {
   makeDeposit,
   revealDeposit,
 } from "./deposit"
+import { createSweepTransaction, sweepDeposits } from "./sweep"
 import {
   Client as BitcoinClient,
   RawTransaction,
   UnspentTransactionOutput,
 } from "./bitcoin"
+import { BigNumber } from "ethers"
 
 /**
  * TBTC interface.
@@ -90,6 +92,46 @@ export interface TBTC {
 
   // TODO: Implementation and documentation.
   revealDeposit(): Promise<void>
+
+  /**
+   * Creates a Bitcoin P2WPKH sweep transaction.
+   * @param utxos - UTXOs that should be used as transaction inputs.
+   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
+   *                      number of UTXOs and deposit data elements must equal.
+   * @param fee - the value that should be subtracted from the sum of the UTXOs
+   *              values and used as the transaction fee.
+   * @param walletPrivateKey - Bitcoin private key of the wallet.
+   * @returns Bitcoin sweep transaction in raw format.
+   */
+  createSweepTransaction(
+    utxos: (UnspentTransactionOutput & RawTransaction)[],
+    depositData: DepositData[],
+    fee: BigNumber,
+    walletPrivateKey: string
+  ): Promise<RawTransaction>
+
+  /**
+   * Sweeps UTXOs by combining all the provided UTXOs and broadcasting a Bitcoin
+   * P2WPKH sweep transaction.
+   * @dev The caller is responsible for ensuring the provided UTXOs are correctly
+   *      formed, can be spent by the wallet and their combined value is greater
+   *      then the fee.
+   * @param utxos - UTXOs to be combined into one output.
+   * @param depositData - data on deposits. Each elements corresponds to UTXO. The
+   *                      number of UTXOs and deposit data elements must equal.
+   * @param fee - the value that should be subtracted from the sum of the UTXOs
+   *              values and used as the transaction fee.
+   * @param walletPrivateKey - Bitcoin private key of the wallet.
+   * @param bitcoinClient - Bitcoin client used to interact with the network.
+   * @returns Empty promise.
+   */
+  sweepDeposits(
+    utxos: UnspentTransactionOutput[],
+    depositData: DepositData[],
+    fee: BigNumber,
+    walletPrivateKey: string,
+    bitcoinClient: BitcoinClient
+  ): Promise<void>
 }
 
 const tbtc: TBTC = {
@@ -100,6 +142,8 @@ const tbtc: TBTC = {
   createDepositAddress,
   getActiveWalletPublicKey,
   revealDeposit,
+  createSweepTransaction,
+  sweepDeposits,
 }
 
 export default tbtc

--- a/tbtc-ts/src/index.ts
+++ b/tbtc-ts/src/index.ts
@@ -98,10 +98,11 @@ export interface TBTC {
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
    * @param walletPrivateKey - Bitcoin private key of the wallet.
-   * @param utxos - UTXOs from new deposit transactions.
+   * @param utxos - UTXOs from new deposit transactions. Must be P2(W)SH.
    * @param depositData - data on deposits. Each elements corresponds to UTXO. The
    *                      number of UTXOs and deposit data elements must equal.
-   * @param previousSweepUtxo - UTXO from the previous sweep transaction (optional).
+   * @param previousUtxo - UTXO from the previous sweep transaction (optional).
+   *                       Must be P2WPKH.
    * @returns Bitcoin sweep transaction in raw format.
    */
   createSweepTransaction(
@@ -122,11 +123,11 @@ export interface TBTC {
    * @param fee - the value that should be subtracted from the sum of the UTXOs
    *              values and used as the transaction fee.
    * @param walletPrivateKey - Bitcoin private key of the wallet.
-   * @param utxos - UTXOs to be combined into one output.
+   * @param utxos - P2(W)SH UTXOs to be combined into one output.
    * @param depositData - data on deposits. Each elements corresponds to UTXO.
    *                      The number of UTXOs and deposit data elements must
    *                      equal.
-   * @param previousSweepUtxo - UTXO from the previous sweep transaction
+   * @param previousSweepUtxo - P2WKH UTXO from the previous sweep transaction
    *                            (optional).
    * @returns Empty promise.
    */

--- a/tbtc-ts/src/sweep.ts
+++ b/tbtc-ts/src/sweep.ts
@@ -159,6 +159,10 @@ export async function createSweepTransaction(
     subtractFee: true,
   })
 
+  if (transaction.outputs.length != 1) {
+    throw new Error("Sweep transaction must have one output")
+  }
+
   // UTXOs must be mapped to deposit data, as `fund` may arrange inputs in any
   // order
   const utxosWithDepositData: (UnspentTransactionOutput &

--- a/tbtc-ts/src/sweep.ts
+++ b/tbtc-ts/src/sweep.ts
@@ -1,0 +1,161 @@
+// @ts-ignore
+import bcoin from "bcoin"
+// @ts-ignore
+import wif from "wif"
+import { BigNumber } from "ethers"
+import {
+  RawTransaction,
+  UnspentTransactionOutput,
+  Client as BitcoinClient,
+  isCompressedPublicKey,
+} from "./bitcoin"
+import {
+  createDepositScript,
+  getActiveWalletPublicKey,
+  DepositData,
+} from "./deposit"
+
+// TODO: Add description
+export async function createScriptSig(
+  signature: Buffer,
+  depositScript: Buffer
+): Promise<bcoin.Script> {
+  // Get the active wallet public key and use it as signing group public key.
+  const signingGroupPublicKey = await getActiveWalletPublicKey()
+  if (!isCompressedPublicKey(signingGroupPublicKey)) {
+    throw new Error("Signing group public key must be compressed")
+  }
+  const scriptSig = new bcoin.Script()
+  scriptSig.clear()
+  scriptSig.pushData(signature)
+  scriptSig.pushData(Buffer.from(signingGroupPublicKey, "hex"))
+  scriptSig.pushData(depositScript)
+  scriptSig.compile()
+  return scriptSig
+}
+
+/**
+ * Sweeps UTXOs by combining all the provided UTXOs and broadcasting a Bitcoin
+ * P2WPKH sweep transaction.
+ * @dev The caller is responsible for ensuring the provided UTXOs are correctly
+ *      formed, can be spent by the wallet and their combined value is greater
+ *      then the fee.
+ * @param utxos - UTXOs to be combined into one output.
+ * @param depositData - data on deposits. Each elements corresponds to UTXO. The
+ *                      number of UTXOs and deposit data elements must equal.
+ * @param fee - the value that should be subtracted from the sum of the UTXOs
+ *              values and used as the transaction fee.
+ * @param walletPrivateKey - Bitcoin private key of the wallet.
+ * @param bitcoinClient - Bitcoin client used to interact with the network.
+ * @returns Empty promise.
+ */
+export async function sweepDeposits(
+  utxos: UnspentTransactionOutput[],
+  depositData: DepositData[],
+  fee: BigNumber,
+  walletPrivateKey: string,
+  bitcoinClient: BitcoinClient
+): Promise<void> {
+  if (utxos.length != depositData.length) {
+    throw new Error(
+      "Number of UTXOs must equal the number of deposit data elements"
+    )
+  }
+
+  const utxosWithRaw: (UnspentTransactionOutput & RawTransaction)[] = []
+  for (const utxo of utxos) {
+    const rawTransaction = await bitcoinClient.getRawTransaction(
+      utxo.transactionHash
+    )
+
+    utxosWithRaw.push({
+      ...utxo,
+      transactionHex: rawTransaction.transactionHex,
+    })
+  }
+
+  const transaction = await createSweepTransaction(
+    utxosWithRaw,
+    depositData,
+    fee,
+    walletPrivateKey
+  )
+
+  await bitcoinClient.broadcast(transaction)
+}
+
+/**
+ * Creates a Bitcoin P2WPKH sweep transaction.
+ * @param utxos - UTXOs that should be used as transaction inputs.
+ * @param depositData - data on deposits. Each elements corresponds to UTXO. The
+ *                      number of UTXOs and deposit data elements must equal.
+ * @param fee - the value that should be subtracted from the sum of the UTXOs
+ *              values and used as the transaction fee.
+ * @param walletPrivateKey - Bitcoin private key of the wallet.
+ * @returns Bitcoin sweep transaction in raw format.
+ */
+export async function createSweepTransaction(
+  utxos: (UnspentTransactionOutput & RawTransaction)[],
+  depositData: DepositData[],
+  fee: BigNumber,
+  walletPrivateKey: string
+): Promise<RawTransaction> {
+  const decodedWalletPrivateKey = wif.decode(walletPrivateKey)
+
+  const walletKeyRing = new bcoin.KeyRing({
+    witness: true,
+    privateKey: decodedWalletPrivateKey.privateKey,
+    compressed: decodedWalletPrivateKey.compressed,
+  })
+
+  const walletAddress = walletKeyRing.getAddress("string")
+
+  const inputCoins = []
+  let totalInputValue = BigNumber.from(0)
+
+  for (const utxo of utxos) {
+    inputCoins.push(
+      bcoin.Coin.fromTX(
+        bcoin.MTX.fromRaw(utxo.transactionHex, "hex"),
+        utxo.outputIndex,
+        -1
+      )
+    )
+    totalInputValue = totalInputValue.add(utxo.value)
+  }
+
+  const transaction = new bcoin.MTX()
+
+  transaction.addOutput({
+    script: bcoin.Script.fromAddress(walletAddress),
+    value: totalInputValue.toNumber(),
+  })
+
+  await transaction.fund(inputCoins, {
+    changeAddress: walletAddress,
+    hardFee: fee.toNumber(),
+    subtractFee: true,
+  })
+
+  for (let i = 0; i < transaction.inputs.length; i++) {
+    const previousOutpoint = transaction.inputs[i].prevout
+    const previousOutput = transaction.view.getOutput(previousOutpoint)
+    const depositScript = bcoin.Script.fromRaw(
+      Buffer.from(await createDepositScript(depositData[i]), "hex")
+    )
+    const signature: Buffer = transaction.signature(
+      i,
+      depositScript,
+      previousOutput.value,
+      walletKeyRing.privateKey,
+      null,
+      0
+    )
+    const scriptSig = await createScriptSig(signature, depositScript)
+    transaction.inputs[i].script = scriptSig
+  }
+
+  return {
+    transactionHex: transaction.toRaw().toString("hex"),
+  }
+}

--- a/tbtc-ts/test/data/bitcoin.ts
+++ b/tbtc-ts/test/data/bitcoin.ts
@@ -1,4 +1,6 @@
 import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
+import { DepositData } from "../deposit"
+import { BigNumber } from "ethers"
 
 /**
  * An example address taken from the BTC testnet and having a non-zero balance.
@@ -42,4 +44,231 @@ export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
   outputIndex: 1,
   value: 3933200,
   ...testnetTransaction,
+}
+
+/**
+ * Private key of the wallet on testnet.
+ */
+export const testnetWalletPrivateKey =
+  "cRk1zdau3jp2X3XsrRKDdviYLuC32fHfyU186wLBEbZWx4uQWW3v"
+
+/**
+ * Address corresponding to testnetWalletPrivateKey.
+ */
+export const testnetWalletAddress = "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
+
+/**
+ * Address generated from deposit script hash during deposit creation
+ */
+export const testnetDepositScripthashAddress =
+  "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+
+/**
+ * Address generated from deposit witness script hash during deposit creation
+ */
+export const testnetDepositWitnessScripthashAddress =
+  "tb1qs63s8nwjut4tr5t8nudgzwp4m3dpkefjzpmumn90pruce0cye2tq2jkq0y"
+
+export const NO_PREVIOUS_SWEEP = {
+  transactionHash: "",
+  outputIndex: 0,
+  value: 0,
+}
+
+/**
+ * Represents data for tests of assembling sweep transactions.
+ */
+export interface SweepDepositsTestData {
+  utxoData: {
+    hash: string
+    rawTx: RawTransaction
+    utxo: UnspentTransactionOutput
+    depositData: DepositData
+  }[]
+  previousSweepUtxo: UnspentTransactionOutput
+  sweepResult: {
+    transactionHash: string
+    transaction: RawTransaction
+  }
+}
+
+export const sweepWithNoPreviousSweep: SweepDepositsTestData = {
+  utxoData: [
+    {
+      // P2SH deposit
+      hash: "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+      rawTx: {
+        transactionHex:
+          "01000000000101d9fdf44eb0874a31a462dc0aedce55c0b5be6d20956b4cdfbe1c16" +
+          "761f7c4aa60100000000ffffffff02a86100000000000017a9143ec459d0f3c29286" +
+          "ae5df5fcc421e2786024277e8716a1110000000000160014e257eccafbc07c381642" +
+          "ce6e7e55120fb077fbed0247304402204e779706c5134032f6be73633a4d32de0841" +
+          "54a7fd16c82810325584eea6406a022068bf855004476b8776f5a902a4d518a486ff" +
+          "7ebc6dc12fc31cd94e3e9b4220bb0121039d61d62dcd048d3f8550d22eb90b4af908" +
+          "db60231d117aeede04e7bc11907bfa00000000",
+      },
+      utxo: {
+        transactionHash:
+          "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+        outputIndex: 0,
+        value: 25000,
+      },
+      depositData: {
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(25000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    },
+    {
+      // P2WSH deposit
+      hash: "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+      rawTx: {
+        transactionHex:
+          "01000000000101a0367a0790e3dfc199df34ca9ce5c35591510b6525d2d586916672" +
+          "8a5ed554be0100000000ffffffff02e02e00000000000022002086a303cdd2e2eab1" +
+          "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962c2c1100000000001600" +
+          "14e257eccafbc07c381642ce6e7e55120fb077fbed0247304402206dafd502aac9d4" +
+          "d542416664063533b1fed1d16877f0295740e1b09ec2abe05102200be28d9dd76863" +
+          "796addef4b9595aad23b2e9363ac2d64f75c21beb0e2ade5df0121039d61d62dcd04" +
+          "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
+      },
+      utxo: {
+        transactionHash:
+          "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+        outputIndex: 0,
+        value: 12000,
+      },
+      depositData: {
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(12000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    },
+  ],
+  previousSweepUtxo: NO_PREVIOUS_SWEEP,
+  sweepResult: {
+    transactionHash:
+      "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+    transaction: {
+      transactionHex:
+        "01000000000102bc187be612bc3db8cfcdec56b75e9bc0262ab6eacfe27cc1a699" +
+        "bacd53e3d07400000000c948304502210089a89aaf3fec97ac9ffa91cdff59829f" +
+        "0cb3ef852a468153e2c0e2b473466d2e022072902bb923ef016ac52e941ced78f8" +
+        "16bf27991c2b73211e227db27ec200bc0a012103989d253b17a6a0f41838b84ff0" +
+        "d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98637ca318a4d6e7ca" +
+        "6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3" +
+        "eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120f" +
+        "b077fbed8804e0250162b175ac68ffffffffdc557e737b6688c5712649b86f7757" +
+        "a722dc3d42786f23b2fa826394dfec545c0000000000ffffffff01488a00000000" +
+        "00001600148db50eb52063ea9d98b3eac91489a90f738986f60003473044022037" +
+        "47f5ee31334b11ebac6a2a156b1584605de8d91a654cd703f9c843863499740220" +
+        "2059d680211776f93c25636266b02e059ed9fcc6209f7d3d9926c49a0d8750ed01" +
+        "2103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581" +
+        "d95c14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d00039523" +
+        "7576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257" +
+        "eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac6800000000",
+    },
+  },
+}
+
+export const sweepWithPreviousSweep: SweepDepositsTestData = {
+  utxoData: [
+    {
+      // P2SH deposit
+      hash: "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+      rawTx: {
+        transactionHex:
+          "01000000000101e37f552fc23fa0032bfd00c8eef5f5c22bf85fe4c6e735857719ff" +
+          "8a4ff66eb80100000000ffffffff02684200000000000017a9143ec459d0f3c29286" +
+          "ae5df5fcc421e2786024277e8742b7100000000000160014e257eccafbc07c381642" +
+          "ce6e7e55120fb077fbed0248304502210084eb60347b9aa48d9a53c6ab0fc2c2357a" +
+          "0df430d193507facfb2238e46f034502202a29d11e128dba3ff3a8ad9a1e820a3b58" +
+          "e89e37fa90d1cc2b3f05207599fef00121039d61d62dcd048d3f8550d22eb90b4af9" +
+          "08db60231d117aeede04e7bc11907bfa00000000",
+      },
+      utxo: {
+        transactionHash:
+          "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+        outputIndex: 0,
+        value: 17000,
+      },
+      depositData: {
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(17000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    },
+    {
+      // P2WSH deposit
+      hash: "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+      rawTx: {
+        transactionHex:
+          "01000000000101dc557e737b6688c5712649b86f7757a722dc3d42786f23b2fa8263" +
+          "94dfec545c0100000000ffffffff02102700000000000022002086a303cdd2e2eab1" +
+          "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962cff1000000000001600" +
+          "14e257eccafbc07c381642ce6e7e55120fb077fbed02473044022050759dde2c84bc" +
+          "cf3c1502b0e33a6acb570117fd27a982c0c2991c9f9737508e02201fcba5d6f6c0ab" +
+          "780042138a9110418b3f589d8d09a900f20ee28cfcdb14d2970121039d61d62dcd04" +
+          "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
+      },
+      utxo: {
+        transactionHash:
+          "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+        outputIndex: 0,
+        value: 10000,
+      },
+      depositData: {
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(10000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    },
+  ],
+  previousSweepUtxo: {
+    // P2WKH
+    transactionHash:
+      "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+    outputIndex: 0,
+    value: 35400,
+  },
+  sweepResult: {
+    transactionHash:
+      "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e",
+    transaction: {
+      transactionHex:
+        "010000000001036896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea1" +
+        "5ea542f2eaf80000000000ffffffffed0ae94da996c6f3b89dfe967675d4808251" +
+        "db93e81022ae9e038d06f92efed400000000c948304502210092327ddff69a2b8c" +
+        "7ae787c5d590a2f14586089e6339e942d56e82aa42052cd902204c0d1700ba1ac6" +
+        "17da27fee032a57937c9607f0187199ed3c46954df845643d7012103989d253b17" +
+        "a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98" +
+        "637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a9148db5" +
+        "0eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257eccafbc07c38" +
+        "1642ce6e7e55120fb077fbed8804e0250162b175ac68ffffffffe37f552fc23fa0" +
+        "032bfd00c8eef5f5c22bf85fe4c6e735857719ff8a4ff66eb80000000000ffffff" +
+        "ff0180ed0000000000001600148db50eb52063ea9d98b3eac91489a90f738986f6" +
+        "02483045022100baf754252d0d6a49aceba7eb0ec40b4cc568e8c659e168b96598" +
+        "a11cf56dc078022051117466ee998a3fc72221006817e8cfe9c2e71ad622ff811a" +
+        "0bf100d888d49c012103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f25" +
+        "64da4cc29dcf8581d90003473044022014a535eb334656665ac69a678dbf7c019c" +
+        "4f13262e9ea4d195c61a00cd5f698d022023c0062913c4614bdff07f94475ceb4c" +
+        "585df53f71611776c3521ed8f8785913012103989d253b17a6a0f41838b84ff0d2" +
+        "0e8898f9d7b1a98f2564da4cc29dcf8581d95c14934b98637ca318a4d6e7ca6ffd" +
+        "1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3eac9" +
+        "1489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120fb077" +
+        "fbed8804e0250162b175ac6800000000",
+    },
+  },
 }

--- a/tbtc-ts/test/data/bitcoin.ts
+++ b/tbtc-ts/test/data/bitcoin.ts
@@ -69,7 +69,7 @@ export const testnetDepositScripthashAddress =
 export const testnetDepositWitnessScripthashAddress =
   "tb1qs63s8nwjut4tr5t8nudgzwp4m3dpkefjzpmumn90pruce0cye2tq2jkq0y"
 
-export const NO_PREVIOUS_SWEEP = {
+export const NO_MAIN_UTXO = {
   transactionHash: "",
   outputIndex: 0,
   value: 0,
@@ -78,21 +78,21 @@ export const NO_PREVIOUS_SWEEP = {
 /**
  * Represents data for tests of assembling sweep transactions.
  */
-export interface SweepDepositsTestData {
+export interface SweepTestData {
   utxoData: {
     hash: string
     rawTx: RawTransaction
     utxo: UnspentTransactionOutput
     depositData: DepositData
   }[]
-  previousSweepUtxo: UnspentTransactionOutput
+  mainUtxo: UnspentTransactionOutput
   sweepResult: {
     transactionHash: string
     transaction: RawTransaction
   }
 }
 
-export const sweepWithNoPreviousSweep: SweepDepositsTestData = {
+export const sweepWithNoPreviousSweep: SweepTestData = {
   utxoData: [
     {
       // P2SH deposit
@@ -151,7 +151,7 @@ export const sweepWithNoPreviousSweep: SweepDepositsTestData = {
       },
     },
   ],
-  previousSweepUtxo: NO_PREVIOUS_SWEEP,
+  mainUtxo: NO_MAIN_UTXO,
   sweepResult: {
     transactionHash:
       "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
@@ -177,7 +177,7 @@ export const sweepWithNoPreviousSweep: SweepDepositsTestData = {
   },
 }
 
-export const sweepWithPreviousSweep: SweepDepositsTestData = {
+export const sweepWithPreviousSweep: SweepTestData = {
   utxoData: [
     {
       // P2SH deposit
@@ -236,7 +236,7 @@ export const sweepWithPreviousSweep: SweepDepositsTestData = {
       },
     },
   ],
-  previousSweepUtxo: {
+  mainUtxo: {
     // P2WKH
     transactionHash:
       "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",

--- a/tbtc-ts/test/data/deposit.ts
+++ b/tbtc-ts/test/data/deposit.ts
@@ -1,0 +1,68 @@
+import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
+
+/**
+ * An example address taken from the BTC testnet and having a non-zero balance.
+ * This address and its transaction data can be used to make deposits during tests.
+ */
+export const testnetAddress = "tb1q0tpdjdu2r3r7tzwlhqy4e2276g2q6fexsz4j0m"
+
+/**
+ * Private key corresponding to the testnetAddress.
+ */
+export const testnetPrivateKey =
+  "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
+
+/**
+ * Hash of one of the transactions originating from testnetAddress.
+ */
+export const testnetTransactionHash =
+  "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883"
+
+/**
+ * Transaction corresponding to testnetTransactionHash and originating
+ * from testnetAddress. It can be decoded, for example, with:
+ * https://live.blockcypher.com/btc-testnet/decodetx
+ */
+export const testnetTransaction: RawTransaction = {
+  transactionHex:
+    "0100000000010162cae24e74ad64f9f0493b09f3964908b3b3038f4924882d3dbd853b" +
+    "4c9bc7390100000000ffffffff02102700000000000017a914867120d5480a9cc0c11c" +
+    "1193fa59b3a92e852da78710043c00000000001600147ac2d9378a1c47e589dfb8095c" +
+    "a95ed2140d272602483045022100b70bd9b7f5d230444a542c7971bea79786b4ebde67" +
+    "03cee7b6ee8cd16e115ebf02204d50ea9d1ee08de9741498c2cc64266e40d52c4adb9e" +
+    "f68e65aa2727cd4208b5012102ee067a0273f2e3ba88d23140a24fdb290f27bbcd0f94" +
+    "117a9c65be3911c5c04e00000000",
+}
+
+/**
+ * An UTXO from the testnetTransaction.
+ */
+export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
+  transactionHash: testnetTransactionHash,
+  outputIndex: 1,
+  value: 3933200,
+  ...testnetTransaction,
+}
+
+/**
+ * Private key of the wallet on testnet.
+ */
+export const testnetWalletPrivateKey =
+  "cRk1zdau3jp2X3XsrRKDdviYLuC32fHfyU186wLBEbZWx4uQWW3v"
+
+/**
+ * Address corresponding to testnetWalletPrivateKey.
+ */
+export const testnetWalletAddress = "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
+
+/**
+ * Address generated from deposit script hash during deposit creation
+ */
+export const testnetDepositScripthashAddress =
+  "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+
+/**
+ * Address generated from deposit witness script hash during deposit creation
+ */
+export const testnetDepositWitnessScripthashAddress =
+  "tb1qs63s8nwjut4tr5t8nudgzwp4m3dpkefjzpmumn90pruce0cye2tq2jkq0y"

--- a/tbtc-ts/test/data/sweep.ts
+++ b/tbtc-ts/test/data/sweep.ts
@@ -2,102 +2,36 @@ import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
 import { DepositData } from "../deposit"
 import { BigNumber } from "ethers"
 
-/**
- * An example address taken from the BTC testnet and having a non-zero balance.
- * This address and its transaction data can be used to make deposits during tests.
- */
-export const testnetAddress = "tb1q0tpdjdu2r3r7tzwlhqy4e2276g2q6fexsz4j0m"
-
-/**
- * Private key corresponding to the testnetAddress.
- */
-export const testnetPrivateKey =
-  "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
-
-/**
- * Hash of one of the transactions originating from testnetAddress.
- */
-export const testnetTransactionHash =
-  "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883"
-
-/**
- * Transaction corresponding to testnetTransactionHash and originating
- * from testnetAddress. It can be decoded, for example, with:
- * https://live.blockcypher.com/btc-testnet/decodetx
- */
-export const testnetTransaction: RawTransaction = {
-  transactionHex:
-    "0100000000010162cae24e74ad64f9f0493b09f3964908b3b3038f4924882d3dbd853b" +
-    "4c9bc7390100000000ffffffff02102700000000000017a914867120d5480a9cc0c11c" +
-    "1193fa59b3a92e852da78710043c00000000001600147ac2d9378a1c47e589dfb8095c" +
-    "a95ed2140d272602483045022100b70bd9b7f5d230444a542c7971bea79786b4ebde67" +
-    "03cee7b6ee8cd16e115ebf02204d50ea9d1ee08de9741498c2cc64266e40d52c4adb9e" +
-    "f68e65aa2727cd4208b5012102ee067a0273f2e3ba88d23140a24fdb290f27bbcd0f94" +
-    "117a9c65be3911c5c04e00000000",
-}
-
-/**
- * An UTXO from the testnetTransaction.
- */
-export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
-  transactionHash: testnetTransactionHash,
-  outputIndex: 1,
-  value: 3933200,
-  ...testnetTransaction,
-}
-
-/**
- * Private key of the wallet on testnet.
- */
-export const testnetWalletPrivateKey =
-  "cRk1zdau3jp2X3XsrRKDdviYLuC32fHfyU186wLBEbZWx4uQWW3v"
-
-/**
- * Address corresponding to testnetWalletPrivateKey.
- */
-export const testnetWalletAddress = "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
-
-/**
- * Address generated from deposit script hash during deposit creation
- */
-export const testnetDepositScripthashAddress =
-  "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
-
-/**
- * Address generated from deposit witness script hash during deposit creation
- */
-export const testnetDepositWitnessScripthashAddress =
-  "tb1qs63s8nwjut4tr5t8nudgzwp4m3dpkefjzpmumn90pruce0cye2tq2jkq0y"
-
 export const NO_MAIN_UTXO = {
   transactionHash: "",
   outputIndex: 0,
   value: 0,
+  transactionHex: "",
 }
 
 /**
  * Represents data for tests of assembling sweep transactions.
  */
 export interface SweepTestData {
-  utxoData: {
-    hash: string
-    rawTx: RawTransaction
-    utxo: UnspentTransactionOutput
-    depositData: DepositData
+  deposits: {
+    utxo: UnspentTransactionOutput & RawTransaction
+    data: DepositData
   }[]
-  mainUtxo: UnspentTransactionOutput
-  sweepResult: {
+  mainUtxo: UnspentTransactionOutput & RawTransaction
+  expectedSweep: {
     transactionHash: string
     transaction: RawTransaction
   }
 }
 
-export const sweepWithNoPreviousSweep: SweepTestData = {
-  utxoData: [
+export const sweepWithNoMainUtxo: SweepTestData = {
+  deposits: [
     {
-      // P2SH deposit
-      hash: "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
-      rawTx: {
+      utxo: {
+        transactionHash:
+          "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+        outputIndex: 0,
+        value: 25000,
         transactionHex:
           "01000000000101d9fdf44eb0874a31a462dc0aedce55c0b5be6d20956b4cdfbe1c16" +
           "761f7c4aa60100000000ffffffff02a86100000000000017a9143ec459d0f3c29286" +
@@ -107,13 +41,7 @@ export const sweepWithNoPreviousSweep: SweepTestData = {
           "7ebc6dc12fc31cd94e3e9b4220bb0121039d61d62dcd048d3f8550d22eb90b4af908" +
           "db60231d117aeede04e7bc11907bfa00000000",
       },
-      utxo: {
-        transactionHash:
-          "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
-        outputIndex: 0,
-        value: 25000,
-      },
-      depositData: {
+      data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(25000),
         refundPublicKey:
@@ -123,9 +51,11 @@ export const sweepWithNoPreviousSweep: SweepTestData = {
       },
     },
     {
-      // P2WSH deposit
-      hash: "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
-      rawTx: {
+      utxo: {
+        transactionHash:
+          "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+        outputIndex: 0,
+        value: 12000,
         transactionHex:
           "01000000000101a0367a0790e3dfc199df34ca9ce5c35591510b6525d2d586916672" +
           "8a5ed554be0100000000ffffffff02e02e00000000000022002086a303cdd2e2eab1" +
@@ -135,13 +65,7 @@ export const sweepWithNoPreviousSweep: SweepTestData = {
           "796addef4b9595aad23b2e9363ac2d64f75c21beb0e2ade5df0121039d61d62dcd04" +
           "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
       },
-      utxo: {
-        transactionHash:
-          "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
-        outputIndex: 0,
-        value: 12000,
-      },
-      depositData: {
+      data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(12000),
         refundPublicKey:
@@ -152,7 +76,7 @@ export const sweepWithNoPreviousSweep: SweepTestData = {
     },
   ],
   mainUtxo: NO_MAIN_UTXO,
-  sweepResult: {
+  expectedSweep: {
     transactionHash:
       "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
     transaction: {
@@ -177,12 +101,15 @@ export const sweepWithNoPreviousSweep: SweepTestData = {
   },
 }
 
-export const sweepWithPreviousSweep: SweepTestData = {
-  utxoData: [
+export const sweepWithMainUtxo: SweepTestData = {
+  deposits: [
     {
       // P2SH deposit
-      hash: "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
-      rawTx: {
+      utxo: {
+        transactionHash:
+          "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+        outputIndex: 0,
+        value: 17000,
         transactionHex:
           "01000000000101e37f552fc23fa0032bfd00c8eef5f5c22bf85fe4c6e735857719ff" +
           "8a4ff66eb80100000000ffffffff02684200000000000017a9143ec459d0f3c29286" +
@@ -192,13 +119,7 @@ export const sweepWithPreviousSweep: SweepTestData = {
           "e89e37fa90d1cc2b3f05207599fef00121039d61d62dcd048d3f8550d22eb90b4af9" +
           "08db60231d117aeede04e7bc11907bfa00000000",
       },
-      utxo: {
-        transactionHash:
-          "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
-        outputIndex: 0,
-        value: 17000,
-      },
-      depositData: {
+      data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(17000),
         refundPublicKey:
@@ -209,8 +130,11 @@ export const sweepWithPreviousSweep: SweepTestData = {
     },
     {
       // P2WSH deposit
-      hash: "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
-      rawTx: {
+      utxo: {
+        transactionHash:
+          "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+        outputIndex: 0,
+        value: 10000,
         transactionHex:
           "01000000000101dc557e737b6688c5712649b86f7757a722dc3d42786f23b2fa8263" +
           "94dfec545c0100000000ffffffff02102700000000000022002086a303cdd2e2eab1" +
@@ -220,13 +144,7 @@ export const sweepWithPreviousSweep: SweepTestData = {
           "780042138a9110418b3f589d8d09a900f20ee28cfcdb14d2970121039d61d62dcd04" +
           "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
       },
-      utxo: {
-        transactionHash:
-          "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
-        outputIndex: 0,
-        value: 10000,
-      },
-      depositData: {
+      data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(10000),
         refundPublicKey:
@@ -242,8 +160,25 @@ export const sweepWithPreviousSweep: SweepTestData = {
       "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
     outputIndex: 0,
     value: 35400,
+    transactionHex:
+      "01000000000102bc187be612bc3db8cfcdec56b75e9bc0262ab6eacfe27cc1a699" +
+      "bacd53e3d07400000000c948304502210089a89aaf3fec97ac9ffa91cdff59829f" +
+      "0cb3ef852a468153e2c0e2b473466d2e022072902bb923ef016ac52e941ced78f8" +
+      "16bf27991c2b73211e227db27ec200bc0a012103989d253b17a6a0f41838b84ff0" +
+      "d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98637ca318a4d6e7ca" +
+      "6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3" +
+      "eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120f" +
+      "b077fbed8804e0250162b175ac68ffffffffdc557e737b6688c5712649b86f7757" +
+      "a722dc3d42786f23b2fa826394dfec545c0000000000ffffffff01488a00000000" +
+      "00001600148db50eb52063ea9d98b3eac91489a90f738986f60003473044022037" +
+      "47f5ee31334b11ebac6a2a156b1584605de8d91a654cd703f9c843863499740220" +
+      "2059d680211776f93c25636266b02e059ed9fcc6209f7d3d9926c49a0d8750ed01" +
+      "2103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581" +
+      "d95c14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d00039523" +
+      "7576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257" +
+      "eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac6800000000",
   },
-  sweepResult: {
+  expectedSweep: {
     transactionHash:
       "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e",
     transaction: {

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -7,7 +7,7 @@ import {
   testnetTransaction,
   testnetTransactionHash,
   testnetUTXO,
-} from "./data/bitcoin"
+} from "./data/deposit"
 import { RawTransaction, UnspentTransactionOutput } from "../src/bitcoin"
 import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
 // @ts-ignore

--- a/tbtc-ts/test/deposit.test.ts
+++ b/tbtc-ts/test/deposit.test.ts
@@ -8,12 +8,8 @@ import {
   testnetTransactionHash,
   testnetUTXO,
 } from "./data/bitcoin"
-import {
-  RawTransaction,
-  Client as BitcoinClient,
-  UnspentTransactionOutput,
-  Transaction,
-} from "../src/bitcoin"
+import { RawTransaction, UnspentTransactionOutput } from "../src/bitcoin"
+import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
 // @ts-ignore
 import bcoin from "bcoin"
 // @ts-ignore
@@ -524,58 +520,3 @@ describe("Deposit", () => {
     })
   })
 })
-
-class MockBitcoinClient implements BitcoinClient {
-  private _unspentTransactionOutputs = new Map<
-    string,
-    UnspentTransactionOutput[]
-  >()
-
-  private _rawTransactions = new Map<string, RawTransaction>()
-
-  private _broadcastLog: RawTransaction[] = []
-
-  set unspentTransactionOutputs(
-    value: Map<string, UnspentTransactionOutput[]>
-  ) {
-    this._unspentTransactionOutputs = value
-  }
-
-  set rawTransactions(value: Map<string, RawTransaction>) {
-    this._rawTransactions = value
-  }
-
-  get broadcastLog(): RawTransaction[] {
-    return this._broadcastLog
-  }
-
-  findAllUnspentTransactionOutputs(
-    address: string
-  ): Promise<UnspentTransactionOutput[]> {
-    return new Promise<UnspentTransactionOutput[]>((resolve, _) => {
-      resolve(
-        this._unspentTransactionOutputs.get(
-          address
-        ) as UnspentTransactionOutput[]
-      )
-    })
-  }
-
-  getTransaction(transactionHash: string): Promise<Transaction> {
-    // Not implemented.
-    return new Promise<Transaction>((resolve, _) => {})
-  }
-
-  getRawTransaction(transactionHash: string): Promise<RawTransaction> {
-    return new Promise<RawTransaction>((resolve, _) => {
-      resolve(this._rawTransactions.get(transactionHash) as RawTransaction)
-    })
-  }
-
-  broadcast(transaction: RawTransaction): Promise<void> {
-    this._broadcastLog.push(transaction)
-    return new Promise<void>((resolve, _) => {
-      resolve()
-    })
-  }
-}

--- a/tbtc-ts/test/sweep.test.ts
+++ b/tbtc-ts/test/sweep.test.ts
@@ -91,7 +91,7 @@ describe("Sweep", () => {
           testnetWalletPrivateKey,
           utxos,
           depositData,
-          secondSweepData.previousSweepUtxo
+          secondSweepData.mainUtxo
         )
       })
 
@@ -208,8 +208,8 @@ describe("Sweep", () => {
       })
 
       // P2WKH
-      const previousUtxoWithRaw = {
-        ...secondSweepData.previousSweepUtxo,
+      const mainUtxoWithRaw = {
+        ...secondSweepData.mainUtxo,
         ...firstSweepData.sweepResult.transaction,
       }
 
@@ -219,7 +219,7 @@ describe("Sweep", () => {
           testnetWalletPrivateKey,
           utxosWithRaw,
           depositData,
-          previousUtxoWithRaw
+          mainUtxoWithRaw
         )
       })
 
@@ -241,10 +241,10 @@ describe("Sweep", () => {
 
         const p2wkhInput = txJSON.inputs[0]
         expect(p2wkhInput.prevout.hash).to.be.equal(
-          secondSweepData.previousSweepUtxo.transactionHash
+          secondSweepData.mainUtxo.transactionHash
         )
         expect(p2wkhInput.prevout.index).to.be.equal(
-          secondSweepData.previousSweepUtxo.outputIndex
+          secondSweepData.mainUtxo.outputIndex
         )
         // Transaction should be signed. As it's a SegWit input, the `witness`
         // field should be filled, while the `script` field should be empty.
@@ -375,7 +375,7 @@ describe("Sweep", () => {
         const depositData = firstSweepData.utxoData[0].depositData
 
         // The UTXO below does not belong to the wallet
-        const previousSweepUtxoWithRaw = {
+        const mainUtxoWithRaw = {
           transactionHash:
             "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883",
           outputIndex: 1,
@@ -397,7 +397,7 @@ describe("Sweep", () => {
               testnetWalletPrivateKey,
               [utxoWithRaw],
               [depositData],
-              previousSweepUtxoWithRaw
+              mainUtxoWithRaw
             )
           ).to.be.rejectedWith("UTXO does not belong to the wallet")
         })

--- a/tbtc-ts/test/sweep.test.ts
+++ b/tbtc-ts/test/sweep.test.ts
@@ -1,0 +1,470 @@
+import TBTC from "./../src"
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+import { RawTransaction } from "../src/bitcoin"
+import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
+// @ts-ignore
+import bcoin from "bcoin"
+
+describe("Sweep", () => {
+  const fee = BigNumber.from(1600)
+  const walletPrivateKey =
+    "cRk1zdau3jp2X3XsrRKDdviYLuC32fHfyU186wLBEbZWx4uQWW3v"
+
+  const firstSweepData = {
+    txHashP2SH:
+      "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+    rawTxP2SH: {
+      transactionHex:
+        "01000000000101d9fdf44eb0874a31a462dc0aedce55c0b5be6d20956b4cdfbe1c16" +
+        "761f7c4aa60100000000ffffffff02a86100000000000017a9143ec459d0f3c29286" +
+        "ae5df5fcc421e2786024277e8716a1110000000000160014e257eccafbc07c381642" +
+        "ce6e7e55120fb077fbed0247304402204e779706c5134032f6be73633a4d32de0841" +
+        "54a7fd16c82810325584eea6406a022068bf855004476b8776f5a902a4d518a486ff" +
+        "7ebc6dc12fc31cd94e3e9b4220bb0121039d61d62dcd048d3f8550d22eb90b4af908" +
+        "db60231d117aeede04e7bc11907bfa00000000",
+    },
+    txHashP2WSH:
+      "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+    rawTxP2WSH: {
+      transactionHex:
+        "01000000000101a0367a0790e3dfc199df34ca9ce5c35591510b6525d2d586916672" +
+        "8a5ed554be0100000000ffffffff02e02e00000000000022002086a303cdd2e2eab1" +
+        "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962c2c1100000000001600" +
+        "14e257eccafbc07c381642ce6e7e55120fb077fbed0247304402206dafd502aac9d4" +
+        "d542416664063533b1fed1d16877f0295740e1b09ec2abe05102200be28d9dd76863" +
+        "796addef4b9595aad23b2e9363ac2d64f75c21beb0e2ade5df0121039d61d62dcd04" +
+        "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
+    },
+    utxos: [
+      {
+        // P2SH
+        transactionHash:
+          "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+        outputIndex: 0,
+        value: 25000,
+      },
+      {
+        // P2WSH
+        transactionHash:
+          "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+        outputIndex: 0,
+        value: 12000,
+      },
+    ],
+    depositData: [
+      {
+        // P2SH
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(25000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+      {
+        // P2WSH
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(12000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    ],
+    sweepResult: {
+      transactionHash:
+        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+      transaction: {
+        transactionHex:
+          "01000000000102bc187be612bc3db8cfcdec56b75e9bc0262ab6eacfe27cc1a699" +
+          "bacd53e3d07400000000c948304502210089a89aaf3fec97ac9ffa91cdff59829f" +
+          "0cb3ef852a468153e2c0e2b473466d2e022072902bb923ef016ac52e941ced78f8" +
+          "16bf27991c2b73211e227db27ec200bc0a012103989d253b17a6a0f41838b84ff0" +
+          "d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98637ca318a4d6e7ca" +
+          "6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3" +
+          "eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120f" +
+          "b077fbed8804e0250162b175ac68ffffffffdc557e737b6688c5712649b86f7757" +
+          "a722dc3d42786f23b2fa826394dfec545c0000000000ffffffff01488a00000000" +
+          "00001600148db50eb52063ea9d98b3eac91489a90f738986f60003473044022037" +
+          "47f5ee31334b11ebac6a2a156b1584605de8d91a654cd703f9c843863499740220" +
+          "2059d680211776f93c25636266b02e059ed9fcc6209f7d3d9926c49a0d8750ed01" +
+          "2103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581" +
+          "d95c14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d00039523" +
+          "7576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257" +
+          "eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac6800000000",
+      },
+    },
+  }
+
+  const secondSweepData = {
+    txHashP2SH:
+      "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+    rawTxP2SH: {
+      transactionHex:
+        "01000000000101e37f552fc23fa0032bfd00c8eef5f5c22bf85fe4c6e735857719ff" +
+        "8a4ff66eb80100000000ffffffff02684200000000000017a9143ec459d0f3c29286" +
+        "ae5df5fcc421e2786024277e8742b7100000000000160014e257eccafbc07c381642" +
+        "ce6e7e55120fb077fbed0248304502210084eb60347b9aa48d9a53c6ab0fc2c2357a" +
+        "0df430d193507facfb2238e46f034502202a29d11e128dba3ff3a8ad9a1e820a3b58" +
+        "e89e37fa90d1cc2b3f05207599fef00121039d61d62dcd048d3f8550d22eb90b4af9" +
+        "08db60231d117aeede04e7bc11907bfa00000000",
+    },
+    txHashP2WSH:
+      "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+    rawTxP2WSH: {
+      transactionHex:
+        "01000000000101dc557e737b6688c5712649b86f7757a722dc3d42786f23b2fa8263" +
+        "94dfec545c0100000000ffffffff02102700000000000022002086a303cdd2e2eab1" +
+        "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962cff1000000000001600" +
+        "14e257eccafbc07c381642ce6e7e55120fb077fbed02473044022050759dde2c84bc" +
+        "cf3c1502b0e33a6acb570117fd27a982c0c2991c9f9737508e02201fcba5d6f6c0ab" +
+        "780042138a9110418b3f589d8d09a900f20ee28cfcdb14d2970121039d61d62dcd04" +
+        "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
+    },
+    utxos: [
+      {
+        // P2SH
+        transactionHash:
+          "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+        outputIndex: 0,
+        value: 17000,
+      },
+      {
+        // P2WSH
+        transactionHash:
+          "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+        outputIndex: 0,
+        value: 10000,
+      },
+    ],
+    depositData: [
+      {
+        // P2SH
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(17000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+      {
+        // P2WSH
+        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        amount: BigNumber.from(10000),
+        refundPublicKey:
+          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
+        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
+        createdAt: 1641650400,
+      },
+    ],
+    previousSweepUtxo: {
+      // P2WKH
+      transactionHash: firstSweepData.sweepResult.transactionHash,
+      outputIndex: 0,
+      value: 35400,
+    },
+    sweepResult: {
+      transactionHash:
+        "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e",
+      transaction: {
+        transactionHex:
+          "010000000001036896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea1" +
+          "5ea542f2eaf80000000000ffffffffed0ae94da996c6f3b89dfe967675d4808251" +
+          "db93e81022ae9e038d06f92efed400000000c948304502210092327ddff69a2b8c" +
+          "7ae787c5d590a2f14586089e6339e942d56e82aa42052cd902204c0d1700ba1ac6" +
+          "17da27fee032a57937c9607f0187199ed3c46954df845643d7012103989d253b17" +
+          "a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98" +
+          "637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a9148db5" +
+          "0eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257eccafbc07c38" +
+          "1642ce6e7e55120fb077fbed8804e0250162b175ac68ffffffffe37f552fc23fa0" +
+          "032bfd00c8eef5f5c22bf85fe4c6e735857719ff8a4ff66eb80000000000ffffff" +
+          "ff0180ed0000000000001600148db50eb52063ea9d98b3eac91489a90f738986f6" +
+          "02483045022100baf754252d0d6a49aceba7eb0ec40b4cc568e8c659e168b96598" +
+          "a11cf56dc078022051117466ee998a3fc72221006817e8cfe9c2e71ad622ff811a" +
+          "0bf100d888d49c012103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f25" +
+          "64da4cc29dcf8581d90003473044022014a535eb334656665ac69a678dbf7c019c" +
+          "4f13262e9ea4d195c61a00cd5f698d022023c0062913c4614bdff07f94475ceb4c" +
+          "585df53f71611776c3521ed8f8785913012103989d253b17a6a0f41838b84ff0d2" +
+          "0e8898f9d7b1a98f2564da4cc29dcf8581d95c14934b98637ca318a4d6e7ca6ffd" +
+          "1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3eac9" +
+          "1489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120fb077" +
+          "fbed8804e0250162b175ac6800000000",
+      },
+    },
+  }
+
+  describe("sweepDeposits", () => {
+    let bitcoinClient: MockBitcoinClient
+
+    beforeEach(async () => {
+      bcoin.set("testnet")
+      bitcoinClient = new MockBitcoinClient()
+
+      const rawTransactions = new Map<string, RawTransaction>()
+      rawTransactions.set(firstSweepData.txHashP2SH, firstSweepData.rawTxP2SH)
+      rawTransactions.set(firstSweepData.txHashP2WSH, firstSweepData.rawTxP2WSH)
+      rawTransactions.set(secondSweepData.txHashP2SH, secondSweepData.rawTxP2SH)
+      rawTransactions.set(
+        secondSweepData.txHashP2WSH,
+        secondSweepData.rawTxP2WSH
+      )
+      rawTransactions.set(
+        firstSweepData.sweepResult.transactionHash,
+        firstSweepData.sweepResult.transaction
+      )
+      bitcoinClient.rawTransactions = rawTransactions
+    })
+
+    context("when there was no previous sweep", () => {
+      beforeEach(async () => {
+        await TBTC.sweepDeposits(
+          bitcoinClient,
+          fee,
+          walletPrivateKey,
+          firstSweepData.utxos,
+          firstSweepData.depositData
+        )
+      })
+
+      it("should broadcast sweep transaction with proper structure", async () => {
+        expect(bitcoinClient.broadcastLog.length).to.be.equal(1)
+        expect(bitcoinClient.broadcastLog[0]).to.be.eql(
+          firstSweepData.sweepResult.transaction
+        )
+      })
+    })
+
+    context("when there was previous sweep", () => {
+      beforeEach(async () => {
+        await TBTC.sweepDeposits(
+          bitcoinClient,
+          fee,
+          walletPrivateKey,
+          secondSweepData.utxos,
+          secondSweepData.depositData,
+          secondSweepData.previousSweepUtxo
+        )
+      })
+
+      it("should broadcast sweep transaction with proper structure", async () => {
+        expect(bitcoinClient.broadcastLog.length).to.be.equal(1)
+        expect(bitcoinClient.broadcastLog[0]).to.be.eql(
+          secondSweepData.sweepResult.transaction
+        )
+      })
+    })
+  })
+
+  describe("createSweepTransaction", () => {
+    context("when there was no previous sweep transaction", () => {
+      let transaction: RawTransaction
+
+      const utxosWithRaw = [
+        {
+          // P2SH
+          transactionHash: firstSweepData.utxos[0].transactionHash,
+          outputIndex: firstSweepData.utxos[0].outputIndex,
+          value: firstSweepData.utxos[0].value,
+          transactionHex: firstSweepData.rawTxP2SH.transactionHex,
+        },
+        {
+          // P2WSH
+          transactionHash: firstSweepData.utxos[1].transactionHash,
+          outputIndex: firstSweepData.utxos[1].outputIndex,
+          value: firstSweepData.utxos[1].value,
+          transactionHex: firstSweepData.rawTxP2WSH.transactionHex,
+        },
+      ]
+
+      beforeEach(async () => {
+        transaction = await TBTC.createSweepTransaction(
+          fee,
+          walletPrivateKey,
+          utxosWithRaw,
+          firstSweepData.depositData
+        )
+      })
+
+      it("should return sweep transaction with proper structure", () => {
+        // Compare HEXes.
+        expect(transaction).to.be.eql(firstSweepData.sweepResult.transaction)
+
+        // Convert raw transaction to JSON to make detailed comparison.
+        const buffer = Buffer.from(transaction.transactionHex, "hex")
+        const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
+
+        expect(txJSON.hash).to.be.equal(
+          firstSweepData.sweepResult.transactionHash
+        )
+        expect(txJSON.version).to.be.equal(1)
+
+        // Validate inputs.
+        expect(txJSON.inputs.length).to.be.equal(2)
+
+        const p2shInput = txJSON.inputs[0]
+        expect(p2shInput.prevout.hash).to.be.equal(
+          firstSweepData.utxos[0].transactionHash
+        )
+        expect(p2shInput.prevout.index).to.be.equal(
+          firstSweepData.utxos[0].outputIndex
+        )
+        // Transaction should be signed. As it's not SegWit input, the `witness`
+        // field should be empty, while the `script` field should be filled.
+        // TODO: Add description
+        expect(p2shInput.witness).to.be.equal("00")
+        expect(p2shInput.script.length).to.be.greaterThan(0)
+        // TODO: Add description
+        expect(p2shInput.address).to.be.equal(
+          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        )
+
+        const p2wshInput = txJSON.inputs[1]
+        expect(p2wshInput.prevout.hash).to.be.equal(
+          firstSweepData.utxos[1].transactionHash
+        )
+        expect(p2wshInput.prevout.index).to.be.equal(
+          firstSweepData.utxos[1].outputIndex
+        )
+        // Transaction should be signed. As it's a SegWit input, the `witness`
+        // field should be filled, while the `script` field should be empty.
+        expect(p2wshInput.witness.length).to.be.greaterThan(0)
+        expect(p2wshInput.script.length).to.be.equal(0)
+        // TODO: Add description
+        expect(p2shInput.address).to.be.equal(
+          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        )
+
+        // Validate outputs.
+        expect(txJSON.outputs.length).to.be.equal(1)
+        const sweepOutput = txJSON.outputs[0]
+
+        // TODO: Add description
+        expect(sweepOutput.script).to.be.equal(
+          "00148db50eb52063ea9d98b3eac91489a90f738986f6"
+        )
+        // TODO: Add description
+        expect(sweepOutput.address).to.be.equal(
+          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
+        )
+      })
+    })
+    context("when there was previous sweep transaction", () => {
+      let transaction: RawTransaction
+
+      const utxosWithRaw = [
+        {
+          // P2SH
+          transactionHash: secondSweepData.utxos[0].transactionHash,
+          outputIndex: secondSweepData.utxos[0].outputIndex,
+          value: secondSweepData.utxos[0].value,
+          transactionHex: secondSweepData.rawTxP2SH.transactionHex,
+        },
+        {
+          // P2WSH
+          transactionHash: secondSweepData.utxos[1].transactionHash,
+          outputIndex: secondSweepData.utxos[1].outputIndex,
+          value: secondSweepData.utxos[1].value,
+          transactionHex: secondSweepData.rawTxP2WSH.transactionHex,
+        },
+      ]
+
+      // P2WKH
+      const previousUtxoWithRaw = {
+        transactionHash: secondSweepData.previousSweepUtxo.transactionHash,
+        outputIndex: secondSweepData.previousSweepUtxo.outputIndex,
+        value: secondSweepData.previousSweepUtxo.value,
+        transactionHex: firstSweepData.sweepResult.transaction.transactionHex,
+      }
+
+      beforeEach(async () => {
+        transaction = await TBTC.createSweepTransaction(
+          fee,
+          walletPrivateKey,
+          utxosWithRaw,
+          secondSweepData.depositData,
+          previousUtxoWithRaw
+        )
+      })
+
+      it("should return sweep transaction with proper structure", () => {
+        // Compare HEXes.
+        expect(transaction).to.be.eql(secondSweepData.sweepResult.transaction)
+
+        // Convert raw transaction to JSON to make detailed comparison.
+        const buffer = Buffer.from(transaction.transactionHex, "hex")
+        const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
+
+        expect(txJSON.hash).to.be.equal(
+          secondSweepData.sweepResult.transactionHash
+        )
+        expect(txJSON.version).to.be.equal(1)
+
+        // Validate inputs.
+        expect(txJSON.inputs.length).to.be.equal(3)
+
+        const p2wkhInput = txJSON.inputs[0]
+        expect(p2wkhInput.prevout.hash).to.be.equal(
+          secondSweepData.previousSweepUtxo.transactionHash
+        )
+        expect(p2wkhInput.prevout.index).to.be.equal(
+          secondSweepData.previousSweepUtxo.outputIndex
+        )
+        // Transaction should be signed. As it's a SegWit input, the `witness`
+        // field should be filled, while the `script` field should be empty.
+        expect(p2wkhInput.witness.length).to.be.greaterThan(0)
+        expect(p2wkhInput.script.length).to.be.equal(0)
+        // TODO: Add description
+        expect(p2wkhInput.address).to.be.equal(
+          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
+        )
+
+        const p2shInput = txJSON.inputs[1]
+        expect(p2shInput.prevout.hash).to.be.equal(
+          secondSweepData.utxos[0].transactionHash
+        )
+        expect(p2shInput.prevout.index).to.be.equal(
+          secondSweepData.utxos[0].outputIndex
+        )
+        // Transaction should be signed. As it's not SegWit input, the `witness`
+        // field should be empty, while the `script` field should be filled.
+        // TODO: check why "00" is set here
+        expect(p2shInput.witness).to.be.equal("00")
+        expect(p2shInput.script.length).to.be.greaterThan(0)
+        // TODO: Add description
+        expect(p2shInput.address).to.be.equal(
+          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        )
+
+        const p2wshInput = txJSON.inputs[2]
+        expect(p2wshInput.prevout.hash).to.be.equal(
+          secondSweepData.utxos[1].transactionHash
+        )
+        expect(p2wshInput.prevout.index).to.be.equal(
+          secondSweepData.utxos[1].outputIndex
+        )
+        // Transaction should be signed. As it's a SegWit input, the `witness`
+        // field should be filled, while the `script` field should be empty.
+        expect(p2wshInput.witness.length).to.be.greaterThan(0)
+        expect(p2wshInput.script.length).to.be.equal(0)
+        // TODO: Add description
+        expect(p2shInput.address).to.be.equal(
+          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        )
+
+        // Validate outputs.
+        expect(txJSON.outputs.length).to.be.equal(1)
+        const sweepOutput = txJSON.outputs[0]
+
+        // TODO: Add description
+        expect(sweepOutput.script).to.be.equal(
+          "00148db50eb52063ea9d98b3eac91489a90f738986f6"
+        )
+        // TODO: Add description
+        expect(sweepOutput.address).to.be.equal(
+          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
+        )
+      })
+    })
+  })
+})

--- a/tbtc-ts/test/sweep.test.ts
+++ b/tbtc-ts/test/sweep.test.ts
@@ -1,198 +1,26 @@
 import TBTC from "./../src"
-import { expect } from "chai"
 import { BigNumber } from "ethers"
-import { RawTransaction } from "../src/bitcoin"
+import { RawTransaction, UnspentTransactionOutput } from "../src/bitcoin"
+import {
+  sweepWithPreviousSweep,
+  sweepWithNoPreviousSweep,
+  testnetDepositScripthashAddress,
+  testnetDepositWitnessScripthashAddress,
+  testnetWalletAddress,
+  testnetWalletPrivateKey,
+} from "./data/bitcoin"
 import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
 // @ts-ignore
 import bcoin from "bcoin"
+import * as chai from "chai"
+import chaiAsPromised from "chai-as-promised"
+chai.use(chaiAsPromised)
+import { expect } from "chai"
 
 describe("Sweep", () => {
   const fee = BigNumber.from(1600)
-  const walletPrivateKey =
-    "cRk1zdau3jp2X3XsrRKDdviYLuC32fHfyU186wLBEbZWx4uQWW3v"
-
-  const firstSweepData = {
-    txHashP2SH:
-      "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
-    rawTxP2SH: {
-      transactionHex:
-        "01000000000101d9fdf44eb0874a31a462dc0aedce55c0b5be6d20956b4cdfbe1c16" +
-        "761f7c4aa60100000000ffffffff02a86100000000000017a9143ec459d0f3c29286" +
-        "ae5df5fcc421e2786024277e8716a1110000000000160014e257eccafbc07c381642" +
-        "ce6e7e55120fb077fbed0247304402204e779706c5134032f6be73633a4d32de0841" +
-        "54a7fd16c82810325584eea6406a022068bf855004476b8776f5a902a4d518a486ff" +
-        "7ebc6dc12fc31cd94e3e9b4220bb0121039d61d62dcd048d3f8550d22eb90b4af908" +
-        "db60231d117aeede04e7bc11907bfa00000000",
-    },
-    txHashP2WSH:
-      "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
-    rawTxP2WSH: {
-      transactionHex:
-        "01000000000101a0367a0790e3dfc199df34ca9ce5c35591510b6525d2d586916672" +
-        "8a5ed554be0100000000ffffffff02e02e00000000000022002086a303cdd2e2eab1" +
-        "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962c2c1100000000001600" +
-        "14e257eccafbc07c381642ce6e7e55120fb077fbed0247304402206dafd502aac9d4" +
-        "d542416664063533b1fed1d16877f0295740e1b09ec2abe05102200be28d9dd76863" +
-        "796addef4b9595aad23b2e9363ac2d64f75c21beb0e2ade5df0121039d61d62dcd04" +
-        "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
-    },
-    utxos: [
-      {
-        // P2SH
-        transactionHash:
-          "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
-        outputIndex: 0,
-        value: 25000,
-      },
-      {
-        // P2WSH
-        transactionHash:
-          "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
-        outputIndex: 0,
-        value: 12000,
-      },
-    ],
-    depositData: [
-      {
-        // P2SH
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-        amount: BigNumber.from(25000),
-        refundPublicKey:
-          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
-        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
-        createdAt: 1641650400,
-      },
-      {
-        // P2WSH
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-        amount: BigNumber.from(12000),
-        refundPublicKey:
-          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
-        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
-        createdAt: 1641650400,
-      },
-    ],
-    sweepResult: {
-      transactionHash:
-        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
-      transaction: {
-        transactionHex:
-          "01000000000102bc187be612bc3db8cfcdec56b75e9bc0262ab6eacfe27cc1a699" +
-          "bacd53e3d07400000000c948304502210089a89aaf3fec97ac9ffa91cdff59829f" +
-          "0cb3ef852a468153e2c0e2b473466d2e022072902bb923ef016ac52e941ced78f8" +
-          "16bf27991c2b73211e227db27ec200bc0a012103989d253b17a6a0f41838b84ff0" +
-          "d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98637ca318a4d6e7ca" +
-          "6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3" +
-          "eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120f" +
-          "b077fbed8804e0250162b175ac68ffffffffdc557e737b6688c5712649b86f7757" +
-          "a722dc3d42786f23b2fa826394dfec545c0000000000ffffffff01488a00000000" +
-          "00001600148db50eb52063ea9d98b3eac91489a90f738986f60003473044022037" +
-          "47f5ee31334b11ebac6a2a156b1584605de8d91a654cd703f9c843863499740220" +
-          "2059d680211776f93c25636266b02e059ed9fcc6209f7d3d9926c49a0d8750ed01" +
-          "2103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581" +
-          "d95c14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d00039523" +
-          "7576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257" +
-          "eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac6800000000",
-      },
-    },
-  }
-
-  const secondSweepData = {
-    txHashP2SH:
-      "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
-    rawTxP2SH: {
-      transactionHex:
-        "01000000000101e37f552fc23fa0032bfd00c8eef5f5c22bf85fe4c6e735857719ff" +
-        "8a4ff66eb80100000000ffffffff02684200000000000017a9143ec459d0f3c29286" +
-        "ae5df5fcc421e2786024277e8742b7100000000000160014e257eccafbc07c381642" +
-        "ce6e7e55120fb077fbed0248304502210084eb60347b9aa48d9a53c6ab0fc2c2357a" +
-        "0df430d193507facfb2238e46f034502202a29d11e128dba3ff3a8ad9a1e820a3b58" +
-        "e89e37fa90d1cc2b3f05207599fef00121039d61d62dcd048d3f8550d22eb90b4af9" +
-        "08db60231d117aeede04e7bc11907bfa00000000",
-    },
-    txHashP2WSH:
-      "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
-    rawTxP2WSH: {
-      transactionHex:
-        "01000000000101dc557e737b6688c5712649b86f7757a722dc3d42786f23b2fa8263" +
-        "94dfec545c0100000000ffffffff02102700000000000022002086a303cdd2e2eab1" +
-        "d1679f1a813835dc5a1b65321077cdccaf08f98cbf04ca962cff1000000000001600" +
-        "14e257eccafbc07c381642ce6e7e55120fb077fbed02473044022050759dde2c84bc" +
-        "cf3c1502b0e33a6acb570117fd27a982c0c2991c9f9737508e02201fcba5d6f6c0ab" +
-        "780042138a9110418b3f589d8d09a900f20ee28cfcdb14d2970121039d61d62dcd04" +
-        "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
-    },
-    utxos: [
-      {
-        // P2SH
-        transactionHash:
-          "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
-        outputIndex: 0,
-        value: 17000,
-      },
-      {
-        // P2WSH
-        transactionHash:
-          "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
-        outputIndex: 0,
-        value: 10000,
-      },
-    ],
-    depositData: [
-      {
-        // P2SH
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-        amount: BigNumber.from(17000),
-        refundPublicKey:
-          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
-        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
-        createdAt: 1641650400,
-      },
-      {
-        // P2WSH
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-        amount: BigNumber.from(10000),
-        refundPublicKey:
-          "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
-        blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
-        createdAt: 1641650400,
-      },
-    ],
-    previousSweepUtxo: {
-      // P2WKH
-      transactionHash: firstSweepData.sweepResult.transactionHash,
-      outputIndex: 0,
-      value: 35400,
-    },
-    sweepResult: {
-      transactionHash:
-        "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e",
-      transaction: {
-        transactionHex:
-          "010000000001036896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea1" +
-          "5ea542f2eaf80000000000ffffffffed0ae94da996c6f3b89dfe967675d4808251" +
-          "db93e81022ae9e038d06f92efed400000000c948304502210092327ddff69a2b8c" +
-          "7ae787c5d590a2f14586089e6339e942d56e82aa42052cd902204c0d1700ba1ac6" +
-          "17da27fee032a57937c9607f0187199ed3c46954df845643d7012103989d253b17" +
-          "a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98" +
-          "637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a9148db5" +
-          "0eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257eccafbc07c38" +
-          "1642ce6e7e55120fb077fbed8804e0250162b175ac68ffffffffe37f552fc23fa0" +
-          "032bfd00c8eef5f5c22bf85fe4c6e735857719ff8a4ff66eb80000000000ffffff" +
-          "ff0180ed0000000000001600148db50eb52063ea9d98b3eac91489a90f738986f6" +
-          "02483045022100baf754252d0d6a49aceba7eb0ec40b4cc568e8c659e168b96598" +
-          "a11cf56dc078022051117466ee998a3fc72221006817e8cfe9c2e71ad622ff811a" +
-          "0bf100d888d49c012103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f25" +
-          "64da4cc29dcf8581d90003473044022014a535eb334656665ac69a678dbf7c019c" +
-          "4f13262e9ea4d195c61a00cd5f698d022023c0062913c4614bdff07f94475ceb4c" +
-          "585df53f71611776c3521ed8f8785913012103989d253b17a6a0f41838b84ff0d2" +
-          "0e8898f9d7b1a98f2564da4cc29dcf8581d95c14934b98637ca318a4d6e7ca6ffd" +
-          "1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3eac9" +
-          "1489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120fb077" +
-          "fbed8804e0250162b175ac6800000000",
-      },
-    },
-  }
+  const firstSweepData = sweepWithNoPreviousSweep
+  const secondSweepData = sweepWithPreviousSweep
 
   describe("sweepDeposits", () => {
     let bitcoinClient: MockBitcoinClient
@@ -202,28 +30,38 @@ describe("Sweep", () => {
       bitcoinClient = new MockBitcoinClient()
 
       const rawTransactions = new Map<string, RawTransaction>()
-      rawTransactions.set(firstSweepData.txHashP2SH, firstSweepData.rawTxP2SH)
-      rawTransactions.set(firstSweepData.txHashP2WSH, firstSweepData.rawTxP2WSH)
-      rawTransactions.set(secondSweepData.txHashP2SH, secondSweepData.rawTxP2SH)
-      rawTransactions.set(
-        secondSweepData.txHashP2WSH,
-        secondSweepData.rawTxP2WSH
-      )
+      for (const utxoData of firstSweepData.utxoData) {
+        rawTransactions.set(utxoData.hash, utxoData.rawTx)
+      }
+      for (const utxoData of secondSweepData.utxoData) {
+        rawTransactions.set(utxoData.hash, utxoData.rawTx)
+      }
       rawTransactions.set(
         firstSweepData.sweepResult.transactionHash,
         firstSweepData.sweepResult.transaction
       )
+
       bitcoinClient.rawTransactions = rawTransactions
     })
 
     context("when there was no previous sweep", () => {
       beforeEach(async () => {
+        const utxos: UnspentTransactionOutput[] = firstSweepData.utxoData.map(
+          (data) => {
+            return data.utxo
+          }
+        )
+
+        const depositData = firstSweepData.utxoData.map((data) => {
+          return data.depositData
+        })
+
         await TBTC.sweepDeposits(
           bitcoinClient,
           fee,
-          walletPrivateKey,
-          firstSweepData.utxos,
-          firstSweepData.depositData
+          testnetWalletPrivateKey,
+          utxos,
+          depositData
         )
       })
 
@@ -237,12 +75,22 @@ describe("Sweep", () => {
 
     context("when there was previous sweep", () => {
       beforeEach(async () => {
+        const utxos: UnspentTransactionOutput[] = secondSweepData.utxoData.map(
+          (data) => {
+            return data.utxo
+          }
+        )
+
+        const depositData = secondSweepData.utxoData.map((data) => {
+          return data.depositData
+        })
+
         await TBTC.sweepDeposits(
           bitcoinClient,
           fee,
-          walletPrivateKey,
-          secondSweepData.utxos,
-          secondSweepData.depositData,
+          testnetWalletPrivateKey,
+          utxos,
+          depositData,
           secondSweepData.previousSweepUtxo
         )
       })
@@ -260,29 +108,23 @@ describe("Sweep", () => {
     context("when there was no previous sweep transaction", () => {
       let transaction: RawTransaction
 
-      const utxosWithRaw = [
-        {
-          // P2SH
-          transactionHash: firstSweepData.utxos[0].transactionHash,
-          outputIndex: firstSweepData.utxos[0].outputIndex,
-          value: firstSweepData.utxos[0].value,
-          transactionHex: firstSweepData.rawTxP2SH.transactionHex,
-        },
-        {
-          // P2WSH
-          transactionHash: firstSweepData.utxos[1].transactionHash,
-          outputIndex: firstSweepData.utxos[1].outputIndex,
-          value: firstSweepData.utxos[1].value,
-          transactionHex: firstSweepData.rawTxP2WSH.transactionHex,
-        },
-      ]
+      const utxosWithRaw = firstSweepData.utxoData.map((data) => {
+        return {
+          ...data.utxo,
+          ...data.rawTx,
+        }
+      })
+
+      const depositData = firstSweepData.utxoData.map((data) => {
+        return data.depositData
+      })
 
       beforeEach(async () => {
         transaction = await TBTC.createSweepTransaction(
           fee,
-          walletPrivateKey,
+          testnetWalletPrivateKey,
           utxosWithRaw,
-          firstSweepData.depositData
+          depositData
         )
       })
 
@@ -304,85 +146,79 @@ describe("Sweep", () => {
 
         const p2shInput = txJSON.inputs[0]
         expect(p2shInput.prevout.hash).to.be.equal(
-          firstSweepData.utxos[0].transactionHash
+          firstSweepData.utxoData[0].hash
         )
         expect(p2shInput.prevout.index).to.be.equal(
-          firstSweepData.utxos[0].outputIndex
+          firstSweepData.utxoData[0].utxo.outputIndex
         )
         // Transaction should be signed. As it's not SegWit input, the `witness`
         // field should be empty, while the `script` field should be filled.
-        // TODO: Add description
         expect(p2shInput.witness).to.be.equal("00")
         expect(p2shInput.script.length).to.be.greaterThan(0)
-        // TODO: Add description
-        expect(p2shInput.address).to.be.equal(
-          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
-        )
+        // Input's address should be set to the address generated from deposit
+        // script hash
+        expect(p2shInput.address).to.be.equal(testnetDepositScripthashAddress)
 
         const p2wshInput = txJSON.inputs[1]
         expect(p2wshInput.prevout.hash).to.be.equal(
-          firstSweepData.utxos[1].transactionHash
+          firstSweepData.utxoData[1].hash
         )
         expect(p2wshInput.prevout.index).to.be.equal(
-          firstSweepData.utxos[1].outputIndex
+          firstSweepData.utxoData[1].utxo.outputIndex
         )
         // Transaction should be signed. As it's a SegWit input, the `witness`
         // field should be filled, while the `script` field should be empty.
         expect(p2wshInput.witness.length).to.be.greaterThan(0)
         expect(p2wshInput.script.length).to.be.equal(0)
-        // TODO: Add description
-        expect(p2shInput.address).to.be.equal(
-          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        // Input's address should be set to the address generated from deposit
+        // witness script hash
+        expect(p2wshInput.address).to.be.equal(
+          testnetDepositWitnessScripthashAddress
         )
 
         // Validate outputs.
         expect(txJSON.outputs.length).to.be.equal(1)
         const sweepOutput = txJSON.outputs[0]
 
-        // TODO: Add description
+        // Should be OP_0 <public-key-hash>. Public key corresponds to the
+        // wallet BTC address.
         expect(sweepOutput.script).to.be.equal(
           "00148db50eb52063ea9d98b3eac91489a90f738986f6"
         )
-        // TODO: Add description
-        expect(sweepOutput.address).to.be.equal(
-          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
-        )
+        // The output's address should be the wallet's address
+        expect(sweepOutput.address).to.be.equal(testnetWalletAddress)
+        // The output's value should be equal to the sum of all input values
+        // minus fee (25000 + 12000 - 1600)
+        expect(sweepOutput.value).to.be.equal(35400)
       })
     })
+
     context("when there was previous sweep transaction", () => {
       let transaction: RawTransaction
 
-      const utxosWithRaw = [
-        {
-          // P2SH
-          transactionHash: secondSweepData.utxos[0].transactionHash,
-          outputIndex: secondSweepData.utxos[0].outputIndex,
-          value: secondSweepData.utxos[0].value,
-          transactionHex: secondSweepData.rawTxP2SH.transactionHex,
-        },
-        {
-          // P2WSH
-          transactionHash: secondSweepData.utxos[1].transactionHash,
-          outputIndex: secondSweepData.utxos[1].outputIndex,
-          value: secondSweepData.utxos[1].value,
-          transactionHex: secondSweepData.rawTxP2WSH.transactionHex,
-        },
-      ]
+      const utxosWithRaw = secondSweepData.utxoData.map((data) => {
+        return {
+          ...data.utxo,
+          ...data.rawTx,
+        }
+      })
+
+      const depositData = secondSweepData.utxoData.map((data) => {
+        return data.depositData
+      })
 
       // P2WKH
       const previousUtxoWithRaw = {
-        transactionHash: secondSweepData.previousSweepUtxo.transactionHash,
-        outputIndex: secondSweepData.previousSweepUtxo.outputIndex,
-        value: secondSweepData.previousSweepUtxo.value,
-        transactionHex: firstSweepData.sweepResult.transaction.transactionHex,
+        ...secondSweepData.previousSweepUtxo,
+        ...firstSweepData.sweepResult.transaction,
       }
 
       beforeEach(async () => {
         transaction = await TBTC.createSweepTransaction(
           fee,
-          walletPrivateKey,
+          testnetWalletPrivateKey,
           utxosWithRaw,
-          secondSweepData.depositData,
+          depositData,
           previousUtxoWithRaw
         )
       })
@@ -414,56 +250,210 @@ describe("Sweep", () => {
         // field should be filled, while the `script` field should be empty.
         expect(p2wkhInput.witness.length).to.be.greaterThan(0)
         expect(p2wkhInput.script.length).to.be.equal(0)
-        // TODO: Add description
-        expect(p2wkhInput.address).to.be.equal(
-          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
-        )
+        // The input is the result of the previous sweep so the input should be
+        // the wallet's address
+        expect(p2wkhInput.address).to.be.equal(testnetWalletAddress)
 
         const p2shInput = txJSON.inputs[1]
         expect(p2shInput.prevout.hash).to.be.equal(
-          secondSweepData.utxos[0].transactionHash
+          secondSweepData.utxoData[0].hash
         )
         expect(p2shInput.prevout.index).to.be.equal(
-          secondSweepData.utxos[0].outputIndex
+          secondSweepData.utxoData[0].utxo.outputIndex
         )
         // Transaction should be signed. As it's not SegWit input, the `witness`
         // field should be empty, while the `script` field should be filled.
-        // TODO: check why "00" is set here
         expect(p2shInput.witness).to.be.equal("00")
         expect(p2shInput.script.length).to.be.greaterThan(0)
-        // TODO: Add description
-        expect(p2shInput.address).to.be.equal(
-          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
-        )
+        // Input's address should be set to the address generated from deposit
+        // script hash
+        expect(p2shInput.address).to.be.equal(testnetDepositScripthashAddress)
 
         const p2wshInput = txJSON.inputs[2]
         expect(p2wshInput.prevout.hash).to.be.equal(
-          secondSweepData.utxos[1].transactionHash
+          secondSweepData.utxoData[1].hash
         )
         expect(p2wshInput.prevout.index).to.be.equal(
-          secondSweepData.utxos[1].outputIndex
+          secondSweepData.utxoData[1].utxo.outputIndex
         )
         // Transaction should be signed. As it's a SegWit input, the `witness`
         // field should be filled, while the `script` field should be empty.
         expect(p2wshInput.witness.length).to.be.greaterThan(0)
         expect(p2wshInput.script.length).to.be.equal(0)
-        // TODO: Add description
-        expect(p2shInput.address).to.be.equal(
-          "2Mxy76sc1qAxiJ1fXMXDXqHvVcPLh6Lf12C"
+        // Input's address should be set to the address generated from deposit
+        // witness script hash
+        expect(p2wshInput.address).to.be.equal(
+          testnetDepositWitnessScripthashAddress
         )
 
         // Validate outputs.
         expect(txJSON.outputs.length).to.be.equal(1)
-        const sweepOutput = txJSON.outputs[0]
 
-        // TODO: Add description
+        const sweepOutput = txJSON.outputs[0]
+        // Should be OP_0 <public-key-hash>. Public key corresponds to the
+        // wallet BTC address.
         expect(sweepOutput.script).to.be.equal(
           "00148db50eb52063ea9d98b3eac91489a90f738986f6"
         )
-        // TODO: Add description
-        expect(sweepOutput.address).to.be.equal(
-          "tb1q3k6sadfqv04fmx9naty3fzdfpaecnphkfm3cf3"
-        )
+        // The output's address should be the wallet's address
+        expect(sweepOutput.address).to.be.equal(testnetWalletAddress)
+        // The output's value should be equal to the sum of all input values
+        // minus fee (17000 + 10000 + 35400 - 1600)
+        expect(sweepOutput.value).to.be.equal(60800)
+      })
+    })
+
+    context("when there are no UTXOs", () => {
+      it("should revert", async () => {
+        await expect(
+          TBTC.createSweepTransaction(fee, testnetWalletPrivateKey, [], [])
+        ).to.be.rejectedWith("There must be at least one deposit UTXO to sweep")
+      })
+    })
+
+    context(
+      "when the numbers of UTXOs and deposit data elements are not equal",
+      () => {
+        const utxosWithRaw = firstSweepData.utxoData.map((data) => {
+          return {
+            ...data.utxo,
+            ...data.rawTx,
+          }
+        })
+
+        // Add only one element to deposit data
+        const depositData = [firstSweepData.utxoData[0].depositData]
+
+        it("should revert", async () => {
+          await expect(
+            TBTC.createSweepTransaction(
+              fee,
+              testnetWalletPrivateKey,
+              utxosWithRaw,
+              depositData
+            )
+          ).to.be.rejectedWith(
+            "Number of UTXOs must equal the number of deposit data elements"
+          )
+        })
+      }
+    )
+
+    context(
+      "when there is a mismatch between the UTXO's value and amount in deposit data",
+      () => {
+        const utxoWithRaw = {
+          ...firstSweepData.utxoData[0].utxo,
+          ...firstSweepData.utxoData[0].rawTx,
+        }
+
+        // Use a deposit data that does not match the UTXO
+        const depositData = firstSweepData.utxoData[1].depositData
+
+        it("should revert", async () => {
+          await expect(
+            TBTC.createSweepTransaction(
+              fee,
+              testnetWalletPrivateKey,
+              [utxoWithRaw],
+              [depositData]
+            )
+          ).to.be.rejectedWith(
+            "Mismatch between amount in deposit data and deposit tx"
+          )
+        })
+      }
+    )
+
+    context(
+      "when the previous sweep output does not belong to the wallet",
+      () => {
+        const utxoWithRaw = {
+          ...firstSweepData.utxoData[0].utxo,
+          ...firstSweepData.utxoData[0].rawTx,
+        }
+        const depositData = firstSweepData.utxoData[0].depositData
+
+        // The UTXO below does not belong to the wallet
+        const previousSweepUtxoWithRaw = {
+          transactionHash:
+            "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883",
+          outputIndex: 1,
+          value: 3933200,
+          transactionHex:
+            "0100000000010162cae24e74ad64f9f0493b09f3964908b3b3038f4924882d3d" +
+            "bd853b4c9bc7390100000000ffffffff02102700000000000017a914867120d5" +
+            "480a9cc0c11c1193fa59b3a92e852da78710043c00000000001600147ac2d937" +
+            "8a1c47e589dfb8095ca95ed2140d272602483045022100b70bd9b7f5d230444a" +
+            "542c7971bea79786b4ebde6703cee7b6ee8cd16e115ebf02204d50ea9d1ee08d" +
+            "e9741498c2cc64266e40d52c4adb9ef68e65aa2727cd4208b5012102ee067a02" +
+            "73f2e3ba88d23140a24fdb290f27bbcd0f94117a9c65be3911c5c04e00000000",
+        }
+
+        it("should revert", async () => {
+          await expect(
+            TBTC.createSweepTransaction(
+              fee,
+              testnetWalletPrivateKey,
+              [utxoWithRaw],
+              [depositData],
+              previousSweepUtxoWithRaw
+            )
+          ).to.be.rejectedWith("UTXO does not belong to the wallet")
+        })
+      }
+    )
+
+    context(
+      "when the wallet private does not correspond to the signing group public key",
+      () => {
+        const utxoWithRaw = {
+          ...firstSweepData.utxoData[0].utxo,
+          ...firstSweepData.utxoData[0].rawTx,
+        }
+        const depositData = firstSweepData.utxoData[0].depositData
+        const anotherPrivateKey =
+          "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
+
+        it("should revert", async () => {
+          await expect(
+            TBTC.createSweepTransaction(
+              fee,
+              anotherPrivateKey,
+              [utxoWithRaw],
+              [depositData]
+            )
+          ).to.be.rejectedWith(
+            "Signing group public key does not correspond to wallet private key"
+          )
+        })
+      }
+    )
+
+    context("when the type of UTXO is unsupported", () => {
+      // Use coinbase transaction of some block
+      const utxoWithRaw = {
+        transactionHash:
+          "025de155e6f2ffbbf4851493e0d28dad54020db221a3f38bf63c1f65e3d3595b",
+        outputIndex: 0,
+        value: 5000000000,
+        transactionHex:
+          "010000000100000000000000000000000000000000000000000000000000000000" +
+          "00000000ffffffff0e04db07c34f0103062f503253482fffffffff0100f2052a01" +
+          "000000232102db6a0f2ef2e970eb1d2a84eabb5337f9cac0d85b49f209bffc4ec6" +
+          "805802e6a5ac00000000",
+      }
+      const depositData = firstSweepData.utxoData[0].depositData
+
+      it("should revert", async () => {
+        await expect(
+          TBTC.createSweepTransaction(
+            fee,
+            testnetWalletPrivateKey,
+            [utxoWithRaw],
+            [depositData]
+          )
+        ).to.be.rejectedWith("Unsupported UTXO script type")
       })
     })
   })

--- a/tbtc-ts/test/utils/mock-bitcoin-client.ts
+++ b/tbtc-ts/test/utils/mock-bitcoin-client.ts
@@ -1,0 +1,64 @@
+import {
+  Client,
+  UnspentTransactionOutput,
+  RawTransaction,
+  Transaction,
+} from "../../src/bitcoin"
+
+/**
+ * Mock Bitcoin client used for test purposes.
+ */
+export class MockBitcoinClient implements Client {
+  private _unspentTransactionOutputs = new Map<
+    string,
+    UnspentTransactionOutput[]
+  >()
+
+  private _rawTransactions = new Map<string, RawTransaction>()
+
+  private _broadcastLog: RawTransaction[] = []
+
+  set unspentTransactionOutputs(
+    value: Map<string, UnspentTransactionOutput[]>
+  ) {
+    this._unspentTransactionOutputs = value
+  }
+
+  set rawTransactions(value: Map<string, RawTransaction>) {
+    this._rawTransactions = value
+  }
+
+  get broadcastLog(): RawTransaction[] {
+    return this._broadcastLog
+  }
+
+  findAllUnspentTransactionOutputs(
+    address: string
+  ): Promise<UnspentTransactionOutput[]> {
+    return new Promise<UnspentTransactionOutput[]>((resolve, _) => {
+      resolve(
+        this._unspentTransactionOutputs.get(
+          address
+        ) as UnspentTransactionOutput[]
+      )
+    })
+  }
+
+  getTransaction(transactionHash: string): Promise<Transaction> {
+    // Not implemented.
+    return new Promise<Transaction>((resolve, _) => {})
+  }
+
+  getRawTransaction(transactionHash: string): Promise<RawTransaction> {
+    return new Promise<RawTransaction>((resolve, _) => {
+      resolve(this._rawTransactions.get(transactionHash) as RawTransaction)
+    })
+  }
+
+  broadcast(transaction: RawTransaction): Promise<void> {
+    this._broadcastLog.push(transaction)
+    return new Promise<void>((resolve, _) => {
+      resolve()
+    })
+  }
+}


### PR DESCRIPTION
Refs: #79

This pull request introduces tooling meant to be used for assembling and broadcasting Bitcoin P2WPKH sweep transactions. Specifically, it extends the TBTC interface by adding the following methods:

* `sweepDeposits`: Function that can be used to perform the end-to-end sweep transaction. It combines the provided UTXOs (must be either P2SH or P2WSH, may optionally include UTXO from the previous sweep function), creates a transaction with one output with value equal to the sum of all UTXOs values minus fee. The recipient of the created output is the wallet itself. NOTE: The caller must ensure the provided UTXOs are correctly formed, the wallet can spend them and their total value is bigger than the provided fee. The main purpose of that function are future e2e tests of the whole system.
* `createSweepTransaction`: Function that assembles the P2WPKH sweep transaction based on the provided UTXOs, fee and the private key of the wallet. It returns the transaction in a raw format. Such a transaction can be used for testing or can be broadcast out-of-band.