### PR TITLE
RFC 1: Fix Bitcoin Script Forgotten Hash

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -148,11 +148,11 @@ unique to each depositor and will look like:
 ```
 <eth-address> DROP
 <blinding-factor> DROP
-DUP HASH160 <signingGroupPubkey> EQUAL
+DUP HASH160 <signingGroupPubkeyHash> EQUAL
 IF
   CHECKSIG
 ELSE
-  DUP HASH160 <refundPubkey> EQUALVERIFY
+  DUP HASH160 <refundPubkeyHash> EQUALVERIFY
   <locktime> CHECKLOCKTIMEVERIFY DROP
   CHECKSIG
 ENDIF


### PR DESCRIPTION
This PR fixes a bug in the sample bitcoin script where the naming of the parameters was misleading.

The `DUP HASH160 <signingGroupPubkey> EQUAL` and `DUP HASH160 <refundPubkey> EQUALVERIFY` sections are modeled after the normal [P2PKH](https://learnmeabitcoin.com/technical/p2pkh) script, which goes `DUP HASH160 <hash160(public key)> EQUALVERIFY CHECKSIG`

When I named the parameters, it would have made **much** more sense to name those parameters `signingGroupPubkeyHash` and `refundPubkeyHash` respectively, since they are hashes rather than the raw data.

Tagging @pdyraga for review