### PR TITLE
Moar Bitcoin details: documentation improvements

### DIFF
--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.4;
+
+/// @title Bitcoin transaction
+/// @notice Allows to reference Bitcoin raw transaction in Solidity.
+/// @dev See https://developer.bitcoin.org/reference/transactions.html#raw-transaction-format
+///
+///      Raw Bitcon transaction data:
+///
+///      | Bytes  |     Name     |        BTC type        |        Description        |
+///      |--------|--------------|------------------------|---------------------------|
+///      | 4      | version      | int32_t (LE)           | TX version number         |
+///      | varies | tx_in_count  | compactSize uint (LE)  | Number of TX inputs       |
+///      | varies | tx_in        | txIn[]                 | TX inputs                 |
+///      | varies | tx_out count | compactSize uint (LE)  | Number of TX outputs      |
+///      | varies | tx_out       | txOut[]                | TX outputs                |
+///      | 4      | lock_time    | uint32_t (LE)          | Unix time or block number |
+///
+//
+///      Non-coinbase transaction input (txIn):
+///
+///      | Bytes  |       Name       |        BTC type        |                 Description                 |
+///      |--------|------------------|------------------------|---------------------------------------------|
+///      | 36     | previous_output  | outpoint               | The previous outpoint being spent           |
+///      | varies | script bytes     | compactSize uint (LE)  | The number of bytes in the signature script |
+///      | varies | signature script | char[]                 | The signature script, not present for P2WSH |
+///      | 4      | sequence         | uint32_t (LE)          | Sequence number                             |
+///
+///
+///      The reference to transaction being spent (outpoint):
+///
+///      | Bytes | Name  |   BTC type    |               Description                |
+///      |-------|-------|---------------|------------------------------------------|
+///      |    32 | hash  | char[32]      | Hash of the transaction to spend         |
+///      |    4  | index | uint32_t (LE) | Index of the specific output from the TX |
+///
+///
+///      Transaction output (txOut):
+///
+///      | Bytes  |      Name       |     BTC type          |             Description              |
+///      |--------|-----------------|-----------------------|--------------------------------------|
+///      | 8      | value           | int64_t (LE)          | Number of satoshis to spend          |
+///      | 1+     | pk_script_bytes | compactSize uint (LE) | Number of bytes in the pubkey script |
+///      | varies | pk_script       | char[]                | Pubkey script                        |
+///
+library BitcoinTx {
+    /// @notice Represents Bitcoin transaction data for funding BTC deposit
+    ///         P2(W)SH transaction.
+    struct Info {
+        /// @notice Bitcoin transaction version
+        /// @dev `version` from raw Bitcon transaction data.
+        ///      Encoded as 4-bytes signed integer, little endian.
+        bytes4 version;
+        /// @notice All Bitcoin transaction inputs, prepended by the number of
+        ///         transaction inputs.
+        /// @dev `tx_in_count | tx_in` from raw Bitcon transaction data.
+        ///
+        ///      The number of transaction inputs encoded as compactSize
+        ///      unsigned integer, little-endian.
+        ///
+        ///      Note that some popular block explorers reverse the order of
+        ///      bytes from `outpoint`'s `hash` and display it as big-endian.
+        ///      Solidity code of Bridge expects hashes in little-endian, just
+        ///      like they are represented in a raw Bitcoin transaction.
+        bytes inputVector;
+        /// @notice All Bitcoin transaction outputs prepended by the number of
+        ///         transaction outputs.
+        /// @dev `tx_out_count | tx_out` from raw Bitcoin transaction data.
+        ///
+        ///       The number of transaction outputs encoded as a compactSize
+        ///       unsigned integer, little-endian.
+        bytes outputVector;
+        /// @notice Bitcoin transaction locktime.
+        ///
+        /// @dev `lock_time` from raw Bitcoin transaction data.
+        ///      Encoded as 4-bytes unsigned integer, little endian.
+        bytes4 locktime;
+    }
+}

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -57,6 +57,17 @@ pragma solidity 0.8.4;
 ///      | 1+     | pk_script_bytes | compactSize uint (LE) | Number of bytes in the pubkey script |
 ///      | varies | pk_script       | char[]                | Pubkey script                        |
 ///
+///      compactSize uint format:
+///
+///      |                  Value                  | Bytes |                    Format                    |
+///      |-----------------------------------------|-------|----------------------------------------------|
+///      | >= 0 && <= 252                          | 1     | uint8_t                                      |
+///      | >= 253 && <= 0xffff                     | 3     | 0xfd followed by the number as uint16_t (LE) |
+///      | >= 0x10000 && <= 0xffffffff             | 5     | 0xfe followed by the number as uint32_t (LE) |
+///      | >= 0x100000000 && <= 0xffffffffffffffff | 9     | 0xff followed by the number as uint64_t (LE) |
+///
+///      (*) compactSize uint is often references as VarInt)
+///
 library BitcoinTx {
     /// @notice Represents Bitcoin transaction data for funding BTC deposit
     ///         P2(W)SH transaction.

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -37,7 +37,7 @@ pragma solidity 0.8.4;
 ///      |--------|------------------|------------------------|---------------------------------------------|
 ///      | 36     | previous_output  | outpoint               | The previous outpoint being spent           |
 ///      | varies | script bytes     | compactSize uint (LE)  | The number of bytes in the signature script |
-///      | varies | signature script | char[]                 | The signature script, not present for P2WSH |
+///      | varies | signature script | char[]                 | The signature script, empty for P2WSH       |
 ///      | 4      | sequence         | uint32_t (LE)          | Sequence number                             |
 ///
 ///

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -15,6 +15,8 @@
 
 pragma solidity 0.8.4;
 
+import "./BitcoinTx.sol";
+
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 
@@ -39,25 +41,6 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 contract Bridge {
     using BTCUtils for bytes;
     using BytesLib for bytes;
-
-    /// @notice Represents Bitcoin transaction data as described in:
-    ///         https://developer.bitcoin.org/reference/transactions.html#raw-transaction-format
-    struct TxInfo {
-        // Transaction version number (4-byte LE).
-        bytes4 version;
-        // All transaction inputs prepended by the number of inputs encoded
-        // as a compactSize uint. Single vector item looks as follows:
-        // https://developer.bitcoin.org/reference/transactions.html#txin-a-transaction-input-non-coinbase
-        // though SegWit inputs don't contain the signature script (scriptSig).
-        // All encoded input transaction hashes are little-endian.
-        bytes inputVector;
-        // All transaction outputs prepended by the number of outputs encoded
-        // as a compactSize uint. Single vector item looks as follows:
-        // https://developer.bitcoin.org/reference/transactions.html#txout-a-transaction-output
-        bytes outputVector;
-        // Transaction locktime (4-byte LE).
-        bytes4 locktime;
-    }
 
     /// @notice Represents data which must be revealed by the depositor during
     ///         deposit reveal.
@@ -128,7 +111,7 @@ contract Bridge {
     ///         the Bitcoin chain. Worth noting, the gas cost of this function
     ///         scales with the number of P2(W)SH transaction inputs and
     ///         outputs.
-    /// @param fundingTx Bitcoin funding transaction data, see `TxInfo` struct
+    /// @param fundingTx Bitcoin funding transaction data, see `BitcoinTx.Info`
     /// @param reveal Deposit reveal data, see `RevealInfo struct
     /// @dev Requirements:
     ///      - `reveal.fundingOutputIndex` must point to the actual P2(W)SH
@@ -150,7 +133,7 @@ contract Bridge {
     ///      to sweep the deposit and the depositor has to wait until the
     ///      deposit script unlocks to receive their BTC back.
     function revealDeposit(
-        TxInfo calldata fundingTx,
+        BitcoinTx.Info calldata fundingTx,
         RevealInfo calldata reveal
     ) external {
         bytes memory expectedScript =
@@ -285,7 +268,7 @@ contract Bridge {
     /// @param bitcoinHeaders Single bytestring of 80-byte bitcoin headers,
     ///                       lowest height first.
     function sweep(
-        TxInfo calldata sweepTx,
+        BitcoinTx.Info calldata sweepTx,
         bytes memory merkleProof,
         uint256 txIndexInBlock,
         bytes memory bitcoinHeaders

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -18,22 +18,23 @@ pragma solidity 0.8.4;
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 
-/// @title BTC Bridge
-/// @notice Bridge manages BTC deposit and redemption and is increasing and
+/// @title Bitcoin Bridge
+/// @notice Bridge manages BTC deposit and redemption flow and is increasing and
 ///         decreasing balances in the Bank as a result of BTC deposit and
-///         redemption operations.
+///         redemption operations performed by depositors and redeemers.
 ///
 ///         Depositors send BTC funds to the most-recently-created-wallet of the
-///         bridge using pay-to-script-hash (P2SH) or
-///         pay-to-witness-script-hash (P2WSH) which contains hashed
-///         information about the depositor’s minting Ethereum address. Then,
-///         the depositor reveals their desired Ethereum minting address to the
-///         Ethereum chain. The Bridge listens for these sorts of messages and
-///         when it gets one, it checks the Bitcoin network to make sure the
-///         funds line up. If they do, the off-chain wallet may decide to pick
-///         this transaction for sweeping, and when the sweep operation is
-///         confirmed on the Bitcoin network, the wallet informs the Bridge
-///         about the sweep increasing appropriate balances in the Bank.
+///         bridge using pay-to-script-hash (P2SH) or pay-to-witness-script-hash
+///         (P2WSH) containing hashed information about the depositor’s Ethereum
+///         address. Then, the depositor reveals their desired Ethereum address
+///         along with their deposit blinding factor to the Bridge on Ethereum
+///         chain. The off-chain ECDSA wallet listens for these sorts of
+///         messages and when it gets one, it checks the Bitcoin network to make
+///         sure the deposit lines up. If it does, the off-chain ECDSA wallet
+///         may decide to pick the deposit transaction for sweeping, and when
+///         the sweep operation is confirmed on the Bitcoin network, the ECDSA
+///         wallet informs the Bridge about the sweep increasing appropriate
+///         balances in the Bank.
 /// @dev Bridge is an upgradeable component of the Bank.
 contract Bridge {
     using BTCUtils for bytes;
@@ -124,11 +125,11 @@ contract Bridge {
     ///         include the revealed deposit in the next executed sweep.
     ///         Information about the Bitcoin deposit can be revealed before or
     ///         after the Bitcoin transaction with P2(W)SH deposit is mined on
-    ///         the Bitcoin chain. Worth noting the gas cost of this function
+    ///         the Bitcoin chain. Worth noting, the gas cost of this function
     ///         scales with the number of P2(W)SH transaction inputs and
     ///         outputs.
-    /// @param fundingTx Bitcoin funding transaction data.
-    /// @param reveal Deposit reveal data.
+    /// @param fundingTx Bitcoin funding transaction data, see `TxInfo` struct
+    /// @param reveal Deposit reveal data, see `RevealInfo struct
     /// @dev Requirements:
     ///      - `reveal.fundingOutputIndex` must point to the actual P2(W)SH
     ///        output of the BTC deposit transaction

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -29,14 +29,15 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 ///         ECDSA wallet of the bridge using pay-to-script-hash (P2SH) or
 ///         pay-to-witness-script-hash (P2WSH) containing hashed information
 ///         about the depositor’s Ethereum address. Then, the depositor reveals
-///         their desired Ethereum address along with their deposit blinding
-///         factor to the Bridge on Ethereum chain. The off-chain ECDSA wallet
-///         listens for these sorts of messages and when it gets one, it checks
-///         the Bitcoin network to make sure the deposit lines up. If it does,
-///         the off-chain ECDSA wallet may decide to pick the deposit
-///         transaction for sweeping, and when the sweep operation is confirmed
-///         on the Bitcoin network, the ECDSA wallet informs the Bridge about
-///         the sweep increasing appropriate balances in the Bank.
+///         their Ethereum address along with their deposit blinding factor,
+///         refund public key hash and refund locktime to the Bridge on Ethereum
+///         chain. The off-chain ECDSA wallet listens for these sorts of
+///         messages and when it gets one, it checks the Bitcoin network to make
+///         sure the deposit lines up. If it does, the off-chain ECDSA wallet
+///         may decide to pick the deposit transaction for sweeping, and when
+///         the sweep operation is confirmed on the Bitcoin network, the ECDSA
+///         wallet informs the Bridge about the sweep increasing appropriate
+///         balances in the Bank.
 /// @dev Bridge is an upgradeable component of the Bank.
 contract Bridge {
     using BTCUtils for bytes;

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -25,18 +25,18 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 ///         decreasing balances in the Bank as a result of BTC deposit and
 ///         redemption operations performed by depositors and redeemers.
 ///
-///         Depositors send BTC funds to the most-recently-created-wallet of the
-///         bridge using pay-to-script-hash (P2SH) or pay-to-witness-script-hash
-///         (P2WSH) containing hashed information about the depositor’s Ethereum
-///         address. Then, the depositor reveals their desired Ethereum address
-///         along with their deposit blinding factor to the Bridge on Ethereum
-///         chain. The off-chain ECDSA wallet listens for these sorts of
-///         messages and when it gets one, it checks the Bitcoin network to make
-///         sure the deposit lines up. If it does, the off-chain ECDSA wallet
-///         may decide to pick the deposit transaction for sweeping, and when
-///         the sweep operation is confirmed on the Bitcoin network, the ECDSA
-///         wallet informs the Bridge about the sweep increasing appropriate
-///         balances in the Bank.
+///         Depositors send BTC funds to the most recently created off-chain
+///         ECDSA wallet of the bridge using pay-to-script-hash (P2SH) or
+///         pay-to-witness-script-hash (P2WSH) containing hashed information
+///         about the depositor’s Ethereum address. Then, the depositor reveals
+///         their desired Ethereum address along with their deposit blinding
+///         factor to the Bridge on Ethereum chain. The off-chain ECDSA wallet
+///         listens for these sorts of messages and when it gets one, it checks
+///         the Bitcoin network to make sure the deposit lines up. If it does,
+///         the off-chain ECDSA wallet may decide to pick the deposit
+///         transaction for sweeping, and when the sweep operation is confirmed
+///         on the Bitcoin network, the ECDSA wallet informs the Bridge about
+///         the sweep increasing appropriate balances in the Bank.
 /// @dev Bridge is an upgradeable component of the Bank.
 contract Bridge {
     using BTCUtils for bytes;


### PR DESCRIPTION
Improved documentation by adding tables explaining raw Bitcoin transaction format, transaction inputs, and outputs. Referenced these types from `BitcoinTx.Info` struct documentation.

I decided to extract `BitcoinTx.Info` to a separate file because the tables - although helpful to understand the format - were polluting `Bridge` contract code too much.