### PR TITLE
Bank.approveBalanceAndCall

### DIFF
--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -301,7 +301,7 @@ contract Bank is Ownable {
             totalAmount += depositedAmounts[i];
         }
         _increaseBalance(vault, totalAmount);
-        IVault(vault).onBalanceIncreased(depositors, depositedAmounts);
+        IVault(vault).receiveBalanceIncrease(depositors, depositedAmounts);
     }
 
     /// @notice Decreases caller's balance by the provided `amount`. There is no

--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -114,6 +114,21 @@ contract Bank is Ownable {
         _approveBalance(msg.sender, spender, amount);
     }
 
+    /// @notice Sets `amount` as the allowance of a smart contract `vault` over
+    ///         the caller's balance and calls the vault via
+    ///         `receiveBalanceApproval`.
+    /// @dev If the `amount` is set to `type(uint256).max` then the logic in
+    ///     `receiveBalanceApproval` or later call to `transferBalanceFrom` by
+    ///      the vault will not reduce an allowance. Beware that changing an
+    ///      allowance with this function brings the risk that vault may use
+    ///      both the old and the new allowance by unfortunate transaction
+    ///      ordering. Please use `increaseBalanceAllowance` and
+    ///      `decreaseBalanceAllowance` to eliminate the risk.
+    function approveBalanceAndCall(address vault, uint256 amount) external {
+        _approveBalance(msg.sender, vault, amount);
+        IVault(vault).receiveBalanceApproval(msg.sender, amount);
+    }
+
     /// @notice Atomically increases the balance allowance granted to `spender`
     ///         by the caller by the given `addedValue`.
     function increaseBalanceAllowance(address spender, uint256 addedValue)

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -122,8 +122,9 @@ contract Bridge is Ownable {
     /// @notice Allows the Governance to mark the given vault address as trusted
     ///         or no longer trusted. Vaults are not trusted by default.
     ///         Trusted vault must meet the following criteria:
-    ///         - `IVault.onBalanceIncreased` must have a known, low gas cost.
-    ///         - `IVault.onBalanceIncreased` must never revert.
+    ///         - `IVault.receiveBalanceIncrease` must have a known, low gas
+    ///           cost.
+    ///         - `IVault.receiveBalanceIncrease` must never revert.
     /// @dev Without restricting reveal only to trusted vaults, malicious
     ///      vaults not meeting the criteria would be able to nuke sweep proof
     ///      transactions executed by ECDSA wallet with  deposits routed to

--- a/solidity/contracts/vault/IVault.sol
+++ b/solidity/contracts/vault/IVault.sol
@@ -53,9 +53,7 @@ interface IVault {
     ///      by the Bank. The Bank guarantees that the vault's balance was
     ///      increased by the sum of all deposited amounts before this function
     ///      is called, in the same transaction.
-    // TODO rename to `receiveBalanceIncrease` to keep it aligned with
-    // TODO `receiveBalanceApproval`?
-    function onBalanceIncreased(
+    function receiveBalanceIncrease(
         address[] calldata depositors,
         uint256[] calldata depositedAmounts
     ) external;

--- a/solidity/contracts/vault/IVault.sol
+++ b/solidity/contracts/vault/IVault.sol
@@ -17,20 +17,44 @@ pragma solidity 0.8.4;
 
 /// @title Bank Vault interface
 /// @notice `IVault` is an interface for a smart contract consuming Bank
-///         balances allowing the smart contract to receive Bank balances right
-///         after sweeping the deposit by the Bridge. This method allows the
-///         depositor to route their deposit revealed to the Bridge to the
-///         particular smart contract in the same transaction the deposit is
-///         revealed. This way, the depositor does not have to execute
-///         additional transaction after the deposit gets swept by the Bridge.
+///         balances of other contracts or externally owned accounts (EOA).
 interface IVault {
+    /// @notice Called by the Bank in `approveBalanceAndCall` function after
+    ///         the balance `owner` approved `amount` of their balance in the
+    ///         Bank for the vault. This way, the depositor can approve balance
+    ///         and call the vault to use the approved balance in a single
+    ///         transaction.
+    /// @param owner Address of the Bank balance owner who approved their
+    ///        balance to be used by the vault
+    /// @param amount The amount of the Bank balance approved by the owner
+    ///        to be used by the vault
+    // @dev The implementation must ensure this function can only be called
+    ///      by the Bank. The Bank does _not_ guarantee that the `amount`
+    ///      approved by the `owner` currently exists on their balance. That is,
+    ///      the `owner` could approve more balance than they currently have.
+    ///      This works the same as `Bank.approve` function. The vault must
+    ///      ensure the actual balance is checked before performing any action
+    ///      based on it.
+    function receiveBalanceApproval(address owner, uint256 amount) external;
+
     /// @notice Called by the Bank in `increaseBalanceAndCall` function after
-    ///         increasing the balance in the Bank for the vault.
+    ///         increasing the balance in the Bank for the vault. It happens in
+    ///         the same transaction in which deposits were swept by the Bridge.
+    ///         This allows the depositor to route their deposit revealed to the
+    ///         Bridge to the particular smart contract (vault) in the same
+    ///         transaction in which the deposit is revealed. This way, the
+    ///         depositor does not have to execute additional transaction after
+    ///         the deposit gets swept by the Bridge to approve and transfer
+    ///         their balance to the vault.
     /// @param depositors Addresses of depositors whose deposits have been swept
     /// @param depositedAmounts Amounts deposited by individual depositors and
     ///        swept
     /// @dev The implementation must ensure this function can only be called
-    ///      by the Bank.
+    ///      by the Bank. The Bank guarantees that the vault's balance was
+    ///      increased by the sum of all deposited amounts before this function
+    ///      is called, in the same transaction.
+    // TODO rename to `receiveBalanceIncrease` to keep it aligned with
+    // TODO `receiveBalanceApproval`?
     function onBalanceIncreased(
         address[] calldata depositors,
         uint256[] calldata depositedAmounts

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -70,6 +70,24 @@ contract TBTCVault is IVault {
         bank.transferBalanceFrom(minter, address(this), amount);
     }
 
+    /// @notice Transfers the given `amount` of the Bank balance from the caller
+    ///         to TBTC Vault and mints `amount` of TBTC to the caller.
+    /// @dev Can only be called by the Bank via `approveBalanceAndCall`.
+    /// @param owner The owner who approved their Bank balance
+    /// @param amount Amount of TBTC to mint
+    function receiveBalanceApproval(address owner, uint256 amount)
+        external
+        override
+        onlyBank
+    {
+        require(
+            bank.balanceOf(owner) >= amount,
+            "Amount exceeds balance in the bank"
+        );
+        _mint(owner, amount);
+        bank.transferBalanceFrom(owner, address(this), amount);
+    }
+
     /// @notice Mints the same amount of TBTC as the deposited amount for each
     ///         depositor in the array. Can only be called by the Bank after the
     ///         Bridge swept deposits and Bank increased balance for the

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -94,7 +94,7 @@ contract TBTCVault is IVault {
     ///         vault.
     /// @dev Fails if `depositors` array is empty. Expects the length of
     ///      `depositors` and `depositedAmounts` is the same.
-    function onBalanceIncreased(
+    function receiveBalanceIncrease(
         address[] calldata depositors,
         uint256[] calldata depositedAmounts
     ) external override onlyBank {

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -1,4 +1,4 @@
-import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import { artifacts, ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
 
@@ -7,6 +7,8 @@ import type { Bank } from "../../typechain"
 
 const { to1e18 } = helpers.number
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+const IVaultJSON = artifacts.readArtifactSync("IVault")
 
 const ZERO_ADDRESS = ethers.constants.AddressZero
 const MAX_UINT256 = ethers.constants.MaxUint256
@@ -264,6 +266,91 @@ describe("Bank", () => {
     })
   })
 
+  describe("approveBalanceAndCall", () => {
+    const amount = to1e18(11)
+
+    let owner: SignerWithAddress
+
+    let mockVault
+
+    before(async () => {
+      const accounts = await getUnnamedAccounts()
+      owner = await ethers.getSigner(accounts[0])
+      mockVault = await waffle.deployMockContract(deployer, IVaultJSON.abi)
+    })
+
+    context("when the vault is the zero address", () => {
+      it("should revert", async () => {
+        await expect(
+          bank.connect(owner).approveBalanceAndCall(ZERO_ADDRESS, amount)
+        ).to.be.revertedWith("Can not approve to the zero address")
+      })
+    })
+
+    context("when the vault callback reverted", () => {
+      it("should revert", async () => {
+        await mockVault.mock.receiveBalanceApproval.revertsWithReason("brrrr")
+        await expect(
+          bank.connect(owner).approveBalanceAndCall(mockVault.address, amount)
+        ).to.be.revertedWith("brrrr")
+      })
+    })
+
+    context("when the vault had no approved balance before", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        await mockVault.mock.receiveBalanceApproval.returns()
+        tx = await bank
+          .connect(owner)
+          .approveBalanceAndCall(mockVault.address, amount)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should approve the requested amount", async () => {
+        expect(await bank.allowance(owner.address, mockVault.address)).to.equal(
+          amount
+        )
+      })
+
+      it("should emit the BalanceApproved event", async () => {
+        await expect(tx)
+          .to.emit(bank, "BalanceApproved")
+          .withArgs(owner.address, mockVault.address, amount)
+      })
+    })
+
+    context("when the vault had an approved balance before", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await mockVault.mock.receiveBalanceApproval.returns()
+
+        await bank
+          .connect(owner)
+          .approveBalance(mockVault.address, to1e18(1337))
+        await bank
+          .connect(owner)
+          .approveBalanceAndCall(mockVault.address, amount)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should replace the previous allowance", async () => {
+        expect(await bank.allowance(owner.address, mockVault.address)).to.equal(
+          amount
+        )
+      })
+    })
+  })
+
   describe("approveBalance", () => {
     const amount = to1e18(10)
 
@@ -271,16 +358,10 @@ describe("Bank", () => {
     let spender: string
 
     before(async () => {
-      await createSnapshot()
-
       const accounts = await getUnnamedAccounts()
       owner = await ethers.getSigner(accounts[0])
       // eslint-disable-next-line prefer-destructuring
       spender = accounts[1]
-    })
-
-    after(async () => {
-      await restoreSnapshot()
     })
 
     context("when the spender is the zero address", () => {

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -113,7 +113,7 @@ describe("TBTCVault", () => {
       })
     })
 
-    context("when there is a single minter", async () => {
+    context("when there is a single minter", () => {
       const amount = to1e18(13) // 3 + 1 + 9 = 13
 
       const transactions: ContractTransaction[] = []
@@ -155,7 +155,7 @@ describe("TBTCVault", () => {
       })
     })
 
-    context("when there are multiple minters", async () => {
+    context("when there are multiple minters", () => {
       const amount1 = to1e18(13) // 3 + 1 + 9 = 13
       const amount2 = to1e18(3) // 1 + 2 = 3
 
@@ -440,6 +440,164 @@ describe("TBTCVault", () => {
     })
   })
 
+  describe("receiveBalanceApproval", () => {
+    context("when called not by the bank", () => {
+      const amount = initialBalance
+
+      it("should revert", async () => {
+        await expect(
+          vault.connect(bridge).receiveBalanceApproval(account1.address, amount)
+        ).to.be.revertedWith("Caller is not the Bank")
+        await expect(
+          vault
+            .connect(account1)
+            .receiveBalanceApproval(account1.address, amount)
+        ).to.be.revertedWith("Caller is not the Bank")
+      })
+    })
+
+    context("when caller has not enough balance in the bank", () => {
+      const amount = initialBalance.add(1)
+
+      it("should revert", async () => {
+        await expect(
+          bank.connect(account1).approveBalanceAndCall(vault.address, amount)
+        ).to.be.revertedWith("Amount exceeds balance in the bank")
+      })
+    })
+
+    context("when there is a single caller", () => {
+      const amount = to1e18(19) // 4 + 10 + 5
+
+      const transactions: ContractTransaction[] = []
+
+      before(async () => {
+        await createSnapshot()
+
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(4))
+        )
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(10))
+        )
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(5))
+        )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should transfer balance to the vault", async () => {
+        expect(await bank.balanceOf(vault.address)).to.equal(amount)
+        expect(await bank.balanceOf(account1.address)).to.equal(
+          initialBalance.sub(amount)
+        )
+      })
+
+      it("should mint TBTC", async () => {
+        expect(await tbtc.balanceOf(account1.address)).to.equal(amount)
+        expect(await tbtc.totalSupply()).to.equal(amount)
+      })
+
+      it("should emit Minted event", async () => {
+        await expect(transactions[0])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(4))
+        await expect(transactions[1])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(10))
+        await expect(transactions[2])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(5))
+      })
+    })
+
+    context("when there are multiple callers", () => {
+      const amount1 = to1e18(4) // 2 + 1 + 1 = 4
+      const amount2 = to1e18(5) // 4 + 1 = 5
+
+      const transactions: ContractTransaction[] = []
+
+      before(async () => {
+        await createSnapshot()
+
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(2))
+        )
+        transactions.push(
+          await bank
+            .connect(account2)
+            .approveBalanceAndCall(vault.address, to1e18(4))
+        )
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(1))
+        )
+        transactions.push(
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, to1e18(1))
+        )
+        transactions.push(
+          await bank
+            .connect(account2)
+            .approveBalanceAndCall(vault.address, to1e18(1))
+        )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should transfer balances to the vault", async () => {
+        expect(await bank.balanceOf(vault.address)).to.equal(
+          amount1.add(amount2)
+        )
+        expect(await bank.balanceOf(account1.address)).to.equal(
+          initialBalance.sub(amount1)
+        )
+        expect(await bank.balanceOf(account2.address)).to.equal(
+          initialBalance.sub(amount2)
+        )
+      })
+
+      it("should mint TBTC", async () => {
+        expect(await tbtc.balanceOf(account1.address)).to.equal(amount1)
+        expect(await tbtc.balanceOf(account2.address)).to.equal(amount2)
+        expect(await tbtc.totalSupply()).to.equal(amount1.add(amount2))
+      })
+
+      it("should emit Minted event", async () => {
+        await expect(transactions[0])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(2))
+        await expect(transactions[1])
+          .to.emit(vault, "Minted")
+          .withArgs(account2.address, to1e18(4))
+        await expect(transactions[2])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(1))
+        await expect(transactions[3])
+          .to.emit(vault, "Minted")
+          .withArgs(account1.address, to1e18(1))
+        await expect(transactions[4])
+          .to.emit(vault, "Minted")
+          .withArgs(account2.address, to1e18(1))
+      })
+    })
+  })
+
   describe("onBalanceIncreased", () => {
     const depositor1 = "0x30c371E0651B2Ff6062158ca1D95b07C7531c719"
     const depositor2 = "0xb3464806d680722dBc678996F1670D19A42eA3e9"
@@ -459,7 +617,7 @@ describe("TBTCVault", () => {
       await restoreSnapshot()
     })
 
-    context("when called not by the Bank", () => {
+    context("when called not by the bank", () => {
       it("should revert", async () => {
         await expect(
           vault

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -598,7 +598,7 @@ describe("TBTCVault", () => {
     })
   })
 
-  describe("onBalanceIncreased", () => {
+  describe("receiveBalanceIncrease", () => {
     const depositor1 = "0x30c371E0651B2Ff6062158ca1D95b07C7531c719"
     const depositor2 = "0xb3464806d680722dBc678996F1670D19A42eA3e9"
     const depositor3 = "0x6B9925e04bc46569d1F7362eD7f11539234f0aEc"
@@ -622,7 +622,7 @@ describe("TBTCVault", () => {
         await expect(
           vault
             .connect(bridge)
-            .onBalanceIncreased([depositor1], [depositedAmount1])
+            .receiveBalanceIncrease([depositor1], [depositedAmount1])
         ).to.be.revertedWith("Caller is not the Bank")
       })
     })


### PR DESCRIPTION
Closes #99 

```
function approveBalanceAndCall(address vault, uint256 amount) external 
```

The function sets `amount` as the allowance of a smart contract `vault` over the caller's balance and calls the vault via `receiveBalanceApproval`. TBTC Vault implements this function by minting TBTC.

This way, the Bank balance owner can mint TBTC in one transaction instead of having to execute two separate transactions: `Bank.approve` and `TBTC.mint`.

I have also renamed `IVault.onBalanceIncreased` to `receiveBalanceIncrease`. Now the naming is aligned with `IVault.receiveBalanceApproval`.