### PR TITLE
Deposits can be routed only to trusted vaults

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -100,7 +100,8 @@ contract Bridge {
         bytes8 blindingFactor,
         bytes20 walletPubKeyHash,
         bytes20 refundPubKeyHash,
-        bytes4 refundLocktime
+        bytes4 refundLocktime,
+        address vault
     );
 
     /// @notice Used by the depositor to reveal information about their P2(W)SH
@@ -248,7 +249,8 @@ contract Bridge {
             reveal.blindingFactor,
             reveal.walletPubKeyHash,
             reveal.refundPubKeyHash,
-            reveal.refundLocktime
+            reveal.refundLocktime,
+            reveal.vault
         );
     }
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -117,6 +117,8 @@ contract Bridge is Ownable {
         address vault
     );
 
+    event VaultStatusUpdated(address indexed vault, bool isTrusted);
+
     /// @notice Allows the Governance to mark the given vault address as trusted
     ///         or no longer trusted. Vaults are not trusted by default.
     ///         Trusted vault must meet the following criteria:
@@ -131,6 +133,7 @@ contract Bridge is Ownable {
     /// @dev Can only be called by the Governance.
     function setVaultStatus(address vault, bool isTrusted) external onlyOwner {
         isVaultTrusted[vault] = isTrusted;
+        emit VaultStatusUpdated(vault, isTrusted);
     }
 
     /// @notice Used by the depositor to reveal information about their P2(W)SH

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -15,10 +15,12 @@
 
 pragma solidity 0.8.4;
 
-import "./BitcoinTx.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
+
+import "./BitcoinTx.sol";
 
 /// @title Bitcoin Bridge
 /// @notice Bridge manages BTC deposit and redemption flow and is increasing and
@@ -39,7 +41,7 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 ///         wallet informs the Bridge about the sweep increasing appropriate
 ///         balances in the Bank.
 /// @dev Bridge is an upgradeable component of the Bank.
-contract Bridge {
+contract Bridge is Ownable {
     using BTCUtils for bytes;
     using BytesLib for bytes;
 
@@ -66,7 +68,8 @@ contract Bridge {
         // and used with OP_CHECKLOCKTIMEVERIFY opcode as described in:
         // https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
         bytes4 refundLocktime;
-        // Address of the tBTC vault.
+        // Address of the Bank vault to which the deposit is routed to.
+        // Optional, can be 0x0. The vault must be trusted by the Bridge.
         address vault;
     }
 
@@ -79,9 +82,19 @@ contract Bridge {
         bytes8 amount;
         // UNIX timestamp the deposit was revealed at.
         uint32 revealedAt;
-        // Address of the tBTC vault.
+        // Address of the Bank vault the deposit is routed to.
+        // Optional, can be 0x0.
         address vault;
     }
+
+    /// @notice Indicates if the vault with the given address is trusted or not.
+    ///         Depositors can route their revealed deposits only to trusted
+    ///         vaults and have trusted vaults notified about new deposits as
+    ///         soon as these deposits get swept. Vaults not trusted by the
+    ///         Bridge can still be used by Bank balance owners on their own
+    ///         responsibility - anyone can approve their Bank balance to any
+    ///         address.
+    mapping(address => bool) public isVaultTrusted;
 
     /// @notice Collection of all unswept deposits indexed by
     ///         keccak256(fundingTxHash | fundingOutputIndex).
@@ -104,6 +117,22 @@ contract Bridge {
         address vault
     );
 
+    /// @notice Allows the Governance to mark the given vault address as trusted
+    ///         or no longer trusted. Vaults are not trusted by default.
+    ///         Trusted vault must meet the following criteria:
+    ///         - `IVault.onBalanceIncreased` must have a known, low gas cost.
+    ///         - `IVault.onBalanceIncreased` must never revert.
+    /// @dev Without restricting reveal only to trusted vaults, malicious
+    ///      vaults not meeting the criteria would be able to nuke sweep proof
+    ///      transactions executed by ECDSA wallet with  deposits routed to
+    ///      them.
+    /// @param vault The address of the vault
+    /// @param isTrusted flag indicating whether the vault is trusted or not
+    /// @dev Can only be called by the Governance.
+    function setVaultStatus(address vault, bool isTrusted) external onlyOwner {
+        isVaultTrusted[vault] = isTrusted;
+    }
+
     /// @notice Used by the depositor to reveal information about their P2(W)SH
     ///         Bitcoin deposit to the Bridge on Ethereum chain. The off-chain
     ///         wallet listens for revealed deposit events and may decide to
@@ -112,10 +141,13 @@ contract Bridge {
     ///         after the Bitcoin transaction with P2(W)SH deposit is mined on
     ///         the Bitcoin chain. Worth noting, the gas cost of this function
     ///         scales with the number of P2(W)SH transaction inputs and
-    ///         outputs.
+    ///         outputs. The deposit may be routed to one of the trusted vaults.
+    ///         When a deposit is routed to a vault, vault gets notified when
+    ///         the deposit gets swept and it may execute the appropriate action.
     /// @param fundingTx Bitcoin funding transaction data, see `BitcoinTx.Info`
     /// @param reveal Deposit reveal data, see `RevealInfo struct
     /// @dev Requirements:
+    ///      - `reveal.vault` must be 0x0 or point to a trusted vault
     ///      - `reveal.fundingOutputIndex` must point to the actual P2(W)SH
     ///        output of the BTC deposit transaction
     ///      - `reveal.depositor` must be the Ethereum address used in the
@@ -138,6 +170,11 @@ contract Bridge {
         BitcoinTx.Info calldata fundingTx,
         RevealInfo calldata reveal
     ) external {
+        require(
+            reveal.vault == address(0) || isVaultTrusted[reveal.vault],
+            "Vault is not trusted"
+        );
+
         bytes memory expectedScript =
             abi.encodePacked(
                 hex"14", // Byte length of depositor Ethereum address.

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -126,7 +126,8 @@ describe("Bridge", () => {
                 "0xf9f0c90d00039523",
                 "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
                 "0x28e081f285138ccbe389c1eb8985716230129f89",
-                "0x60bcea61"
+                "0x60bcea61",
+                reveal.vault
               )
           })
         })
@@ -219,7 +220,8 @@ describe("Bridge", () => {
                 "0xf9f0c90d00039523",
                 "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
                 "0x28e081f285138ccbe389c1eb8985716230129f89",
-                "0x60bcea61"
+                "0x60bcea61",
+                reveal.vault
               )
           })
         })

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -58,10 +58,12 @@ describe("Bridge", () => {
     })
 
     describe("when called by the governance", () => {
+      let tx: ContractTransaction
+
       describe("when setting vault status as trusted", () => {
         before(async () => {
           await createSnapshot()
-          await bridge.connect(governance).setVaultStatus(vault, true)
+          tx = await bridge.connect(governance).setVaultStatus(vault, true)
         })
 
         after(async () => {
@@ -72,21 +74,34 @@ describe("Bridge", () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           expect(await bridge.isVaultTrusted(vault)).to.be.true
         })
+
+        it("should emit VaultStatusUpdated event", async () => {
+          await expect(tx)
+            .to.emit(bridge, "VaultStatusUpdated")
+            .withArgs(vault, true)
+        })
       })
 
       describe("when setting vault status as no longer trusted", () => {
         before(async () => {
           await createSnapshot()
           await bridge.connect(governance).setVaultStatus(vault, true)
-          await bridge.connect(governance).setVaultStatus(vault, false)
+          tx = await bridge.connect(governance).setVaultStatus(vault, false)
         })
 
         after(async () => {
           await restoreSnapshot()
         })
+
         it("should correctly update vault status", async () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           expect(await bridge.isVaultTrusted(vault)).to.be.false
+        })
+
+        it("should emit VaultStatusUpdated event", async () => {
+          await expect(tx)
+            .to.emit(bridge, "VaultStatusUpdated")
+            .withArgs(vault, false)
         })
       })
     })


### PR DESCRIPTION
Closes: #95 

Depositors can route their revealed deposits only to trusted vaults and have
trusted vaults notified about new deposits as soon as these deposits get swept.
Vaults not trusted by the Bridge can still be used by Bank balance owners on
their own responsibility - anyone can approve their Bank balance to any
address.

Governance can mark the given vault address as trusted or no longer trusted.
Vaults are not trusted by default.

Trusted vault must meet the following criteria:
- `IVault.onBalanceIncreased` must have a known, low gas cost.
- `IVault.onBalanceIncreased` must never revert.

Without restricting reveal only to trusted vaults, malicious vaults not meeting
the criteria would be able to nuke sweep proof transactions executed by ECDSA
wallet with deposits routed to them.

Additionally, `DepositRevealed` even holds now vault address.

Knowing the vault address, off-chain wallet can group deposits
in sweep batches by vault to minimize the cost of the sweep proof
transaction.

All changes in this PR increased the gas cost of reveal function by approximately
3500 gas units.