### PR TITLE
Fix broken import in contract-test-helpers

### DIFF
--- a/solidity/test/helpers/contract-test-helpers.ts
+++ b/solidity/test/helpers/contract-test-helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "@ethersproject/units/node_modules/@ethersproject/bignumber"
+import { BigNumber } from "@ethersproject/bignumber"
 import { ethers } from "hardhat"
 
 export function to1ePrecision(n: number, precision: number): BigNumber {


### PR DESCRIPTION
The current import for `BigNumber` causes an error on a clean install. Changing it from `@ethersproject/units/node_modules/@ethersproject/bignumber` to just `@ethersproject/bignumber` fixes this.