### PR TITLE
RFC 1: Align RFC 1 Transaction Incentives With RFC 6

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -515,10 +515,9 @@ Operator-Only transactions are where only the operators have access to the
 information required to assemble the transaction with the right input
 parameters.
 
-In order to avoid all operators racing to submit the
-transaction at the same time, we have an off-chain gentleman's agreement to
-submit based on the operator's position in the group (can use the hash of the
-group's pubkey).
+In order to avoid all operators racing to submit the transaction at the same
+time, we have an off-chain informal agreement to submit based on the operator's
+position in the group (can use the hash of the group's pubkey).
 
 If the designated operator does not submit their transaction before a timeout
 expires, the duty moves to the next operator and the group can sign a
@@ -535,7 +534,7 @@ Public-Knowledge transactions are where anyone has access to the information
 required to assemble the transaction.
 
 In order to prevent wasting gas on racing to submit, we can either use an
-off-chain gentleman's agreement for the operators like in
+off-chain informal agreement for the operators like in
 <<operator-only,Operator-Only>> transactions, or we can delegate the
 transactions to a network like https://www.gelato.network/[Gelato]. We can't
 cost-effectively stop members of the public from trying to race to submit.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -504,7 +504,7 @@ this transaction.
 [[transaction-incentives]]
 === Transaction Incentives
 
-Governable Parameters
+Governable Parameters:
 - `max_gas_refund_price`: The highest amount of gwei that the gas refund
   contract will pay out per gas for a refund transaction.
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -503,6 +503,11 @@ this transaction.
 
 [[transaction-incentives]]
 === Transaction Incentives
+
+Governable Parameters
+- `max_gas_refund_price`: The highest amount of gwei that the gas refund
+  contract will pay out per gas for a refund transaction.
+
 Transaction incentives are more deeply explored in link:rfc-6.adoc[RFC 6:
 Transaction Incentives]. Summarized:
 
@@ -526,8 +531,8 @@ reward, and since this transaction can only be submitted by an operator, this
 transaction is also Operator-Only.
 
 In order to compensate the operator for posting the transaction, the gas spent
-will be reimbursed by a DAO-funded eth pool in the same transaction with
-governable limits on how much eth can be spent on gas.
+will be reimbursed by a DAO-funded eth pool in the same transaction, limited by
+`max_gas_refund_price`.
 
 [[public-knowledge]]
 ==== Public-Knowledge
@@ -541,8 +546,8 @@ transactions to a network like https://www.gelato.network/[Gelato]. We can't
 cost-effectively stop members of the public from trying to race to submit.
 
 To compensate these transactions, whoever posts them will have the gas spent
-reimbursed by a DAO-funded eth pool in the same transaction, with governable
-limits on how much eth can be spent on gas.
+reimbursed by a DAO-funded eth pool in the same transaction, limited by
+`max_gas_refund_price`.
 
 [[punishment]]
 ==== Punishment

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -503,37 +503,58 @@ this transaction.
 
 [[transaction-incentives]]
 === Transaction Incentives
+Transaction incentives are more deeply explored in link:rfc-6.adoc[RFC 6:
+Transaction Incentives]. Summarized:
 
-Governable Parameters:
+There are three different types of transactions: <<operator-only,Operator-Only>>,
+<<public-knowledge,Public-Knowledge>>, and <<punishment,Punishment>>.
 
-- `max_gas_refund_price`: The highest amount of gwei that the gas refund
-  contract will pay out per gas for a refund transaction.
+[[operator-only]]
+==== Operator-Only
+Operator-Only transactions are where only the operators have access to the
+information required to assemble the transaction with the right input
+parameters.
 
-There are 7 main transactions that require incentives:
+In order to avoid all operators racing to submit the
+transaction at the same time, we have an off-chain gentleman's agreement to
+submit based on the operator's position in the group (can use the hash of the
+group's pubkey).
 
-==== Transactions That Must Be Submitted By Operators
-- Submit distributed key generation results for new wallet creation (weekly).
-- Signal that funds need to be moved between wallets if a <<heartbeat,heartbeat>> fails.
-- Signal that a staker is not performing their duty and should be marked as
-ineligible for rewards (as in the case that they were inactive during
-heartbeats).
+If the designated operator does not submit their transaction before a timeout
+expires, the duty moves to the next operator and the group can sign a
+transaction to mark that operator as inactive. Such a transaction would be a
+<<punishment,Punishment>>.
 
-==== Transactions That Can Be Submitted By Anyone
-- Begin distributed key generation for new wallet creation (weekly).
-- Provide the proof for a <<sweeping,sweep>> transaction.
-- Provide the proof for a <<redemption,redemption>> transaction.
-- Provide the proof that funds have moved between wallets.
+In order to compensate the operator for posting the transaction, the gas spent
+will be reimbursed by a DAO-funded eth pool in the same transaction with
+governable limits on how much eth can be spent on gas.
 
-To make sure that these transactions get posted, we need the DAO to fund an ETH
-pool that provides gas refunds for anyone submitting these transactions. We
-know the amount of gas spent, and we know the gas price used, and so can
-reimburse the operator.
+[[public-knowledge]]
+==== Public-Knowledge
+Public-Knowledge transactions are where anyone has access to the information
+required to assemble the transaction.
 
-To prevent abuse, we need to let governance set caps (`max_gas_refund_price`)
-on how much eth can be reimbursed (so that a miner can't drain the pool).
+In order to prevent wasting gas on racing to submit, we can either use an
+off-chain gentleman's agreement for the operators like in
+<<operator-only,Operator-Only>> transactions, or we can delegate the
+transactions to a network like https://www.gelato.network/[Gelato]. We can't
+cost-effectively stop members of the public from trying to race to submit.
 
-Further ideas are to run bots like those provided by https://www.gelato.network/[Gelato]
-in order to prevent problems like operators front-running each other.
+To compensate these transactions, whoever posts them will have the gas spent
+reimbursed by a DAO-funded eth pool in the same transaction, with governable
+limits on how much eth can be spent on gas.
+
+[[punishment]]
+==== Punishment
+Punishment transactions are where anyone has access to the information required
+to assemble the transaction (like <<public-knowledge,Public-Knowledge>>) and
+the transaction leads to the potential for punishment (reward ineligibility or
+slashing).
+
+In these transactions, maintaining system health is more important than
+optimizing gas via preventing racing, so we offer up bounties in the form of
+potentially slashed tokens to whichever submitter submits first. We do not
+compensate gas.
 
 [[bitcoin-sweeping-fee]]
 === Bitcoin Sweeping Fee

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -521,8 +521,9 @@ position in the group (can use the hash of the group's pubkey).
 
 If the designated operator does not submit their transaction before a timeout
 expires, the duty moves to the next operator and the group can sign a
-transaction to mark that operator as inactive. Such a transaction would be a
-<<punishment,Punishment>>.
+transaction to mark that operator as inactive. Since there is no slashing
+reward, and since this transaction can only be submitted by an operator, this
+transaction is also Operator-Only.
 
 In order to compensate the operator for posting the transaction, the gas spent
 will be reimbursed by a DAO-funded eth pool in the same transaction with


### PR DESCRIPTION
This PR rewrites the transaction incentives section to summarize and point to RFC 6 so that internal to RFC 1, the concepts can still be referenced but can be followed for more information.

Tagging @pdyraga and @michalinacienciala for review

marking as a draft until #115 gets merged