### PR TITLE
Sweep gas optimisation

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -285,8 +285,7 @@ contract Bridge is Ownable {
             // P2PKH and P2WPKH, it will fail on the output hash comparison with
             // the expected locking script hash.
             require(
-                keccak256(fundingOutputHash) ==
-                    keccak256(expectedScript.hash160()),
+                fundingOutputHash.slice20(0) == expectedScript.hash160View(),
                 "Wrong 20-byte script hash"
             );
         } else if (fundingOutputHash.length == 32) {
@@ -313,7 +312,7 @@ contract Bridge is Ownable {
                 fundingTx
                     .locktime
             )
-                .hash256();
+                .hash256View();
 
         DepositInfo storage deposit =
             deposits[
@@ -486,7 +485,7 @@ contract Bridge is Ownable {
             sweepTx
                 .locktime
         )
-            .hash256();
+            .hash256View();
 
         checkProofFromTxHash(sweepTxHash, sweepProof);
 

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -14,6 +14,12 @@ const config: HardhatUserConfig = {
     compilers: [
       {
         version: "0.8.4", // TODO: Revisit solidity version before deploying on mainnet!
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000,
+          },
+        },
       },
     ],
   },


### PR DESCRIPTION
Use the optimiser in tests, and use low-level hash functions where applicable. Further gas savings could be achieved by replacing all instances of `keccak256(abi.encodePacked(x, y))` with assembly code utilising the scratchpad memory, but the savings are negligible. Depends on https://github.com/keep-network/bitcoin-spv/pull/6 exposing `hash160View`.