### PR TITLE
Single deposit proof

### DIFF
--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -19,7 +19,7 @@ pragma solidity 0.8.4;
 /// @notice Allows to reference Bitcoin raw transaction in Solidity.
 /// @dev See https://developer.bitcoin.org/reference/transactions.html#raw-transaction-format
 ///
-///      Raw Bitcon transaction data:
+///      Raw Bitcoin transaction data:
 ///
 ///      | Bytes  |     Name     |        BTC type        |        Description        |
 ///      |--------|--------------|------------------------|---------------------------|
@@ -73,12 +73,12 @@ library BitcoinTx {
     ///         P2(W)SH transaction.
     struct Info {
         /// @notice Bitcoin transaction version
-        /// @dev `version` from raw Bitcon transaction data.
+        /// @dev `version` from raw Bitcoin transaction data.
         ///      Encoded as 4-bytes signed integer, little endian.
         bytes4 version;
         /// @notice All Bitcoin transaction inputs, prepended by the number of
         ///         transaction inputs.
-        /// @dev `tx_in_count | tx_in` from raw Bitcon transaction data.
+        /// @dev `tx_in_count | tx_in` from raw Bitcoin transaction data.
         ///
         ///      The number of transaction inputs encoded as compactSize
         ///      unsigned integer, little-endian.

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -8,12 +8,18 @@ import "hardhat-gas-reporter"
 import "hardhat-deploy"
 import "@tenderly/hardhat-tenderly"
 import "@typechain/hardhat"
+import "hardhat-contract-sizer"
 
 const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
         version: "0.8.4", // TODO: Revisit solidity version before deploying on mainnet!
+        settings: {
+          optimizer: {
+            enabled: true,
+          },
+        },
       },
     ],
   },
@@ -86,6 +92,13 @@ const config: HardhatUserConfig = {
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,
+  },
+
+  contractSizer: {
+    alphaSort: true,
+    disambiguatePaths: false,
+    runOnCompile: true,
+    strict: true,
   },
 }
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -51,6 +51,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.7",
     "hardhat": "^2.6.4",
+    "hardhat-contract-sizer": "^2.1.1",
     "hardhat-deploy": "^0.8.11",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.3.0",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -3928,6 +3928,15 @@ cli-table3@^0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -4000,7 +4009,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -6634,6 +6643,14 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-contract-sizer@^2.1.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.4.0.tgz#3cc125937aa3d773283851085de99c9bd31a7828"
+  integrity sha512-ww+Fw5Fq+q6gkVxB8KFvicqZFH5pH9HGZwV4ZSTxd0QrxA162qzLdbScJseUP30VvIBPYN9wpdj0cWlz6M9j6g==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
 
 hardhat-deploy@^0.8.11:
   version "0.8.11"


### PR DESCRIPTION
It can be useful to prove a single deposit when a wallet made a sweep transaction on Bitcoin, but cannot prove the whole batch of deposits.

Depends on https://github.com/keep-network/tbtc-v2/pull/106.

