### PR TITLE
RFC 1: Spec out details of redemption

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -382,6 +382,17 @@ key than the same `signingGroupPubkey` is fraud.
 
 Governable Parameters:
 
+- `redemption_request_timeout`: The amount of time the wallet has to provide
+  redemption proof.
+- `redemption_request_timeout_slashing_amount`: The amount of stake slashed from
+  each member of a wallet for a timed-out redemption request.
+- `redemption_request_timeout_redemeer_bonus_multiplier`: The percentage of the
+  notifier reward from the staking contract the redeemer receives in case of a
+  redemption timeout.
+- `redemption_fraud_slashing_amount`: The amount or stake slashed from each
+  member of a wallet for a redemption fraud.
+- `redempton_fraud_notifier_reward_multiplier`: The percentage of the notifier
+  reward from the staking contract the notifier of redemption fraud receives.
 - `wallet_min_btc`: The smallest amount of BTC a wallet can hold before we
   attempt to close the wallet and transfer the funds to a randomly selected
   wallet.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -457,6 +457,38 @@ not disincentivize it for waiting for enough redemption requests to accumulate,
 the redemption timeout should be long enough, for example, 72 hours and ideally
 even longer in the early days of the system.
 
+==== Redemption proof
+
+Based on the information provided in the submitted redemption proof, pending
+redemption requests possibly satisfied by the proof should be retrieved and each
+of them should be validated separately. 
+
+If a pending redemption request exists for every UTXO of the redemption
+transaction but the main wallet UTXO, and BTC value of each UTXO is within the
+expected range, redemption proof is accepted and redeemed Bitcoin balances in
+the Bridge are cleared out. It is important to note that timeout is not
+validated in this function. That is, if the timeout was not reported, the wallet
+can process the entire redemption proof successfully even though the timeout for
+the oldest redemption request already passed.
+
+If a pending redemption request for the given UTXO does not exist, and that
+redemption request was not earlier reported as timed-out or fraudulent because
+of the UTXO value not being within the expected range, the entire redemption
+proof transaction should revert.
+
+If the value of the given UTXO matching pending redemption request is not in the
+expected range, this is a fraud, and the entire redemption proof transactions
+should revert unless that fraud was already reported. 
+
+If a pending redemption request for the given UTXO does not exist but that
+redemption request was earlier reported as timed-out or fraudulent because of
+the UTXO value not being within the expected range, that UTXO is skipped, and
+the redemption proof transaction gets accepted, assuming there are more UTXOs in
+the redemption transaction.
+
+Submit redemption proof function updates the main wallet UTXO. Bitcoin balances
+in the bridge are cleared out for successfully processed redemption requests.
+
 ==== Fraud Proof
 
 When a redemption is requested, the redeeming bitcoin public key and amount are

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -733,12 +733,12 @@ advantage of manipulating btc fee consensus I would be very surprised.
 Alphabetized list of Governable Parameters with additional notes.
 
 - `base_btc_fee_max`: The highest amount of BTC that operators can
-  initially propose as a fee for miners for Bitcoin transaction.
+  initially propose as a fee for miners of Bitcoin transaction.
 - `btc_fee_broadcast_timeout`: The amount of time an operator has to provide a
   suggested BTC fee before the other operators give up and try the next
   operator.
 - `btc_fee_max`: The highest amount of BTC that operators can eventually
-  propose as a fee for miners for Bitcoin transaction.
+  propose as a fee for miners of Bitcoin transaction.
 - `consecutive_failed_heartbeats`: The number of times a heartbeat can fail in
   a row that triggers a move to close the wallet.
 - `dust_threshold`: The minimum bitcoin deposit amount for the transaction to

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -517,6 +517,36 @@ unblocking the wallet for future redemptions.
 The transaction must revert if the given redemption request was already reported
 as timed out.
 
+===== Redemption fraud
+
+Redemption proof containing UTXO identified as fraud is reverting the redemption
+proof submit transaction. Such a fraud must first be reported by calling a
+dedicated function.
+
+There are two possible fraudulent scenarios.
+
+First, there is no redemption requested for the given UTXO. In this scenario,
+each wallet member is slashed for `redemption_fraud_slashing_amount` and the
+notifier receives a reward as specified by
+`redempton_fraud_notifier_reward_multiplier`. The fraudulent output information
+is stored on-chain.
+
+Second, there was a redemption request for the given UTXO but the UTXO value is
+not within the expected range. In this case, the value difference is returned to
+the redemeer as their balance. Each wallet member is slashed for
+`redemption_fraud_slashing_amount` and the notifier receives a reward as
+specified by `redempton_fraud_notifier_reward_multiplier`. The fraudulent output
+information is stored on-chain.
+
+The transaction must revert if the given fraud was already reported. 
+
+If the wallet has still some BTC or if there is a redemption transaction with
+some part of outputs fraudulent and some part of outputs valid, it should be
+possible to submit redemption proof. Because information about fraudulent
+outputs is stored on-chain, these outputs can be skipped by the Bridge and the
+main wallet UTXO can be updated. This mechanism allows proving whatever can
+still be proved and unblocking the wallet for future redemptions.
+
 === Wallet Lifecycle
 
 Governable Parameters:

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -640,6 +640,18 @@ disabled (after the active operators sign this). See
 <<transaction-incentives,transaction incentives>> for more on how to encourage
 this transaction.
 
+=== Bridge donate
+
+If a wallet committed fraud, there has to be a function allowing to "donate" BTC
+to the Bridge without increasing anyone's balances. This function needs to
+validate SPV proof of the donate transaction and update the main wallet UTXO.
+This function should also be used to donate the Bridge to compensate for Bitcoin
+fees burned on moving funds between wallets that failed a heartbeat.
+
+The BTC to donate needs to come from the coverage pool funds. The DAO - or some
+delegate of the DAO - should be able to claim the coverage from the pool and
+manually liquidate tokens to acquire BTC and donate it to the Bridge.
+
 [[transaction-incentives]]
 === Transaction Incentives
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -737,6 +737,13 @@ Alphabetized list of Governable Parameters with additional notes.
 - `sweeping_refund_safety_time`: The amount of time prior to when a UTXO
   becomes eligible for a refund where we will not include it in a sweeping
   transaction.
+- `redemption_request_timeout`: The amount of time the wallet has to provide
+  redemption proof.
+- `redemption_request_timeout_slashing_amount`: The amount of stake slashed from
+  each member of a wallet for a timed-out redemption request.
+- `redemption_request_timeout_redemeer_bonus_multiplier`: The percentage of the
+  notifier reward from the staking contract the redeemer receives in case of a
+  redemption timeout.
 - `wallet_creation_period`: How frequently we attempt to create new wallets.
 - `wallet_max_age`: The oldest we allow a wallet to become before we transfer the funds
   to a randomly selected wallet.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -412,6 +412,51 @@ to submit multiple redemptions. After a redemption, if the wallet has under
 `wallet_min_btc` remaining, it transfers that BTC to a randomly selected wallet
 and closes.
 
+Each redemption request is identified by a concatenation of the wallet's pubkey
+hash and redeemer's output hash (redeemer's BTC address). Such an identifier
+allows retrieving pending redemption requests in a gas-efficient way based on
+information provided in the redemption proof. A consequence of this approach is
+that the redeemer can not use the same redemption BTC address when there is
+already one redemption request pending from the given wallet. User experience
+can be improved by the dApp by selecting the previous-oldest wallet without a
+pending redemption request to the given BTC address in case a new redemption is
+requested before the pending one gets cleared out.
+
+At a minimum, pending redemption request needs to capture the following
+information:
+- Expected range of value for redemption UTXO: needed to validate the amount
+  released by the system when processing the redemption proof. Fees are
+  governable and the expected amount redeemed needs to be captured at the moment
+  of the redemption request.
+- Ethereum address of the redeemer: in case anything goes wrong with the
+  redemption, this address will be used to return the unprocessed balance.
+- UNIX timestamp at which the redemption was requested: needed to validate
+  redemption timeout.
+
+There is a governable redemption request timeout value,
+`redemption_request_timeout`. If redemption request proof was not submitted and
+timeout is exceeded, the wallet is slashed and balances are returned back to the
+redeemer, no matter if Bitcoin was released or not. The system is as
+decentralized as the least decentralized element of it. Redeemers need to have
+certain guarantees provided by the smart contract and no external body should
+judge if the Bitcoin was spent or not. It is the wallet's responsibility to
+process redemption requests in time.
+
+Just like in the case of sweeps, off-chain clients should wait for enough
+redemption requests from the given wallet to accumulate and process them in
+batches in order to minimize gas expenditure of redemption proofs. At the same
+time, the redeemer does not care about the underlying mechanism and they want to
+have their particular redemption request processed in time. Given that it is the
+individual redemption request that is timing out and not the entire batch of
+redemption requests, the wallet takes a certain risk on itself by waiting and
+not processing individual redemption requests immediately. At the same time, in
+case of a high number of redemption requests, the wallet is incentivized to
+process them in batches to minimize the wait time for Bitcoin and Ethereum chain
+confirmations between redemptions. To minimize the risk for the wallet and to do
+not disincentivize it for waiting for enough redemption requests to accumulate,
+the redemption timeout should be long enough, for example, 72 hours and ideally
+even longer in the early days of the system.
+
 ==== Fraud Proof
 
 When a redemption is requested, the redeeming bitcoin public key and amount are

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -398,9 +398,10 @@ Governable Parameters:
   wallet.
 
 To initiate a redemption, a user with a swept balance > `x` supplies a bitcoin
-address. Then, the system calculates the redemption fee `fee`, and releases an
-amount of bitcoin `y` such that `x = y + fee` to the supplied bitcoin address.
-The remaining `fee` is sold by the system to buy back `T` tokens (more about this
+address. Then, the system calculates the redemption fee `redemption_treasury_fee`,
+and releases an amount of bitcoin `y` such that `x = y + redemption_treasury_fee`
+to the supplied bitcoin address. The remaining `redemption_treasury_fee` is sold
+by the system to buy back `T` tokens (more about this
 process in the <<continuous-fees,fee section>>) to pay to the operators.
 
 In the MVP version of the system, a redemption is capped at the amount of

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -398,7 +398,7 @@ Governable Parameters:
 To initiate a redemption, a user with a swept balance > `x` supplies a bitcoin
 address. Then, the system calculates the redemption fee `fee`, and releases an
 amount of bitcoin `y` such that `x = y + fee` to the supplied bitcoin address.
-The remaining `fee` sold by the system to buy back `T` tokens (more about this
+The remaining `fee` is sold by the system to buy back `T` tokens (more about this
 process in the <<continuous-fees,fee section>>) to pay to the operators.
 
 In the MVP version of the system, a redemption is capped at the amount of

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -389,10 +389,6 @@ Governable Parameters:
 - `redemption_request_timeout_redemeer_bonus_multiplier`: The percentage of the
   notifier reward from the staking contract the redeemer receives in case of a
   redemption timeout.
-- `redemption_fraud_slashing_amount`: The amount or stake slashed from each
-  member of a wallet for a redemption fraud.
-- `redempton_fraud_notifier_reward_multiplier`: The percentage of the notifier
-  reward from the staking contract the notifier of redemption fraud receives.
 - `wallet_min_btc`: The smallest amount of BTC a wallet can hold before we
   attempt to close the wallet and transfer the funds to a randomly selected
   wallet.
@@ -485,11 +481,10 @@ proof transaction should revert.
 
 If the value of the given UTXO matching pending redemption request is not in the
 expected range, this is a fraud, and the entire redemption proof transactions
-should revert unless that fraud was already reported. 
+should revert.
 
 If a pending redemption request for the given UTXO does not exist but that
-redemption request was earlier reported as timed-out or fraudulent because of
-the UTXO value not being within the expected range, that UTXO is skipped, and
+redemption request was earlier reported as timed-out, that UTXO is skipped, and
 the redemption proof transaction gets accepted, assuming there are more UTXOs in
 the redemption transaction.
 
@@ -525,37 +520,6 @@ When a redemption is requested, the redeeming bitcoin public key and amount are
 known on the ethereum chain. Any bitcoin transactions with the main wallet
 wallet UTXO as the input must have outputs that match those known redemption
 requests, otherwise the transaction was fraudulent.
-
-Redemption proof containing UTXO identified as fraud is reverting the redemption
-proof submit transaction. Such a fraud must first be reported by calling a
-dedicated function.
-
-There are two possible fraudulent scenarios.
-
-First, there is no redemption requested for the given UTXO. In this scenario,
-each wallet member is slashed for `redemption_fraud_slashing_amount` and the
-notifier receives a reward as specified by
-`redempton_fraud_notifier_reward_multiplier`. The fraudulent output information
-is stored on-chain.
-
-Second, there was a redemption request for the given UTXO but the UTXO value is
-not within the expected range. In this case, the value difference is returned to
-the redemeer as their balance. Each wallet member is slashed for
-`redemption_fraud_slashing_amount` and the notifier receives a reward as
-specified by `redempton_fraud_notifier_reward_multiplier`. The fraudulent output
-information is stored on-chain.
-
-The transaction must revert if the given fraud was already reported. 
-
-If the wallet has still some BTC or if there is a redemption transaction with
-some part of outputs fraudulent and some part of outputs valid, it should be
-possible to submit redemption proof. Because information about fraudulent
-outputs is stored on-chain, these outputs can be skipped by the Bridge and the
-main wallet UTXO can be updated. This mechanism allows proving whatever can
-still be proved and unblocking the wallet by updating its main UTXO.
-
-The wallet is ordered to move the BTC to another random wallet and is no longer
-accepting redemption requests.
 
 === Wallet Lifecycle
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -494,7 +494,28 @@ in the bridge are cleared out for successfully processed redemption requests.
 When a redemption is requested, the redeeming bitcoin public key and amount are
 known on the ethereum chain. Any bitcoin transactions with the main wallet
 wallet UTXO as the input must have outputs that match those known redemption
-requests, otherwise the transaction was fraudulent.
+requests, otherwise the transaction was fraudulent. Redemption request timeout
+is also considered a fraud.
+
+===== Redemption timeout
+
+Redemption proof for the given timed-out redemption request is accepted and
+processed unless that redemption request was reported as timed out. Anyone can
+report redemption timeout but there is no reward or gas cost reimbursement for
+doing it so only the redeemer is incentivized to report the timeout.
+
+When redemption request timeout is reported, the redeemer receives their balance
+back, no matter if the underlying Bitcoin was redeemed or not. Each wallet
+member is slashed for `redemption_request_timeout_slashing_amount` and redeemer
+receives a percentage of a misbehavior notifier reward, as specified in
+`redemption_request_timeout_redemeer_bonus`. Redemption request is removed from
+the list of pending redemption requests and it is marked as timed-out. This way,
+when redemption proof gets submitted, the timed-out redemption request will be
+skipped. This mechanism allows proving whatever can still be proved and
+unblocking the wallet for future redemptions.
+
+The transaction must revert if the given redemption request was already reported
+as timed out.
 
 === Wallet Lifecycle
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -215,7 +215,7 @@ Governable Parameters
   will trigger an early sweep on a wallet.
 - `dust_threshold`: The minimum bitcoin deposit amount for the transaction to
   be considered for a sweep.
-- `base_sweeping_fee_max`: The highest amount of BTC that operators can
+- `base_btc_fee_max`: The highest amount of BTC that operators can
   initially propose as a fee for miners in a sweeping transaction.
 - `sweeping_fee_bump_period`: The amount of time we wait to see if a sweeping
   tranaction is mined before increasing the fee.
@@ -267,7 +267,7 @@ base_fee * fee_multiplier`. We repeat until either the transaction posts or
 *Note*: We do not allow users to specify a max btc fee. When users deposit,
 they're agreeing to be swept at whatever fee the operators decide is
 appropriate (based on https://blockstream.info/api/fee-estimates). Operators
-cannot pick a starting fee higher than `base_sweeping_fee_max`.
+cannot pick a starting fee higher than `base_btc_fee_max`.
 
 When the transaction clears, and the information has made its way
 over the relay maintainer, then another transaction needs to be created to on
@@ -389,6 +389,8 @@ Governable Parameters:
 - `redemption_request_timeout_redemeer_bonus_multiplier`: The percentage of the
   notifier reward from the staking contract the redeemer receives in case of a
   redemption timeout.
+- `redemption_treasury_fee`: The percentage of redeemed amount put aside as a
+  treasury fee.
 - `wallet_min_btc`: The smallest amount of BTC a wallet can hold before we
   attempt to close the wallet and transfer the funds to a randomly selected
   wallet.
@@ -701,11 +703,13 @@ advantage of manipulating btc fee consensus I would be very surprised.
 == Governable Parameters
 Alphabetized list of Governable Parameters with additional notes.
 
-- `base_sweeping_fee_max`: The highest amount of BTC that operators can
-  initially propose as a fee for miners in a sweeping transaction.
+- `base_btc_fee_max`: The highest amount of BTC that operators can
+  initially propose as a fee for miners for Bitcoin transaction.
 - `btc_fee_broadcast_timeout`: The amount of time an operator has to provide a
   suggested BTC fee before the other operators give up and try the next
   operator.
+- `btc_fee_max`: The highest amount of BTC that operators can eventually
+  propose as a fee for miners for Bitcoin transaction.
 - `consecutive_failed_heartbeats`: The number of times a heartbeat can fail in
   a row that triggers a move to close the wallet.
 - `dkg`: The minimum number of members we're allowed to drop down to during the
@@ -744,6 +748,8 @@ Alphabetized list of Governable Parameters with additional notes.
 - `redemption_request_timeout_redemeer_bonus_multiplier`: The percentage of the
   notifier reward from the staking contract the redeemer receives in case of a
   redemption timeout.
+- `redemption_treasury_fee`: The percentage of redeemed amount put aside as a
+  treasury fee.
 - `wallet_creation_period`: How frequently we attempt to create new wallets.
 - `wallet_max_age`: The oldest we allow a wallet to become before we transfer the funds
   to a randomly selected wallet.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -226,7 +226,8 @@ Governable Parameters
 - `sweeping_fee_max_multiplier`: The highest we will try to increment the fee
   multiplier to before giving up and picking a new base fee and different
   deposits to sweep.
-
+- `btc_fee_max`: The highest amount of BTC that operators can eventually
+  propose as a fee for miners for sweeping transaction.
 
 The operators sign a transaction that unlocks all of the revealed deposits
 above the `dust_threshold`, combines them into a single UTXO with the existing
@@ -267,7 +268,8 @@ base_fee * fee_multiplier`. We repeat until either the transaction posts or
 *Note*: We do not allow users to specify a max btc fee. When users deposit,
 they're agreeing to be swept at whatever fee the operators decide is
 appropriate (based on https://blockstream.info/api/fee-estimates). Operators
-cannot pick a starting fee higher than `base_btc_fee_max`.
+cannot pick a starting fee higher than `base_btc_fee_max` and they can never
+choose a fee higher than `btc_fee_max`.
 
 When the transaction clears, and the information has made its way
 over the relay maintainer, then another transaction needs to be created to on

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -496,15 +496,7 @@ the redemption transaction.
 Submit redemption proof function updates the main wallet UTXO. Bitcoin balances
 in the bridge are cleared out for successfully processed redemption requests.
 
-==== Fraud Proof
-
-When a redemption is requested, the redeeming bitcoin public key and amount are
-known on the ethereum chain. Any bitcoin transactions with the main wallet
-wallet UTXO as the input must have outputs that match those known redemption
-requests, otherwise the transaction was fraudulent. Redemption request timeout
-is also considered a fraud.
-
-===== Redemption timeout
+==== Redemption timeout
 
 Redemption proof for the given timed-out redemption request is accepted and
 processed unless that redemption request was reported as timed out. Anyone can
@@ -527,7 +519,12 @@ as timed out.
 The wallet is ordered to move the BTC to another random wallet and is no longer
 accepting redemption requests.
 
-===== Redemption fraud
+==== Fraud Proof
+
+When a redemption is requested, the redeeming bitcoin public key and amount are
+known on the ethereum chain. Any bitcoin transactions with the main wallet
+wallet UTXO as the input must have outputs that match those known redemption
+requests, otherwise the transaction was fraudulent.
 
 Redemption proof containing UTXO identified as fraud is reverting the redemption
 proof submit transaction. Such a fraud must first be reported by calling a

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -424,6 +424,7 @@ requested before the pending one gets cleared out.
 
 At a minimum, pending redemption request needs to capture the following
 information:
+
 - Expected range of value for redemption UTXO: needed to validate the amount
   released by the system when processing the redemption proof. Fees are
   governable and the expected amount redeemed needs to be captured at the moment
@@ -434,7 +435,7 @@ information:
   redemption timeout.
 
 There is a governable redemption request timeout value,
-`redemption_request_timeout`. If redemption request proof was not submitted and
+`redemption_request_timeout`. If redemption proof was not submitted and
 timeout is exceeded, the wallet is slashed and balances are returned back to the
 redeemer, no matter if Bitcoin was released or not. The system is as
 decentralized as the least decentralized element of it. Redeemers need to have
@@ -456,6 +457,12 @@ confirmations between redemptions. To minimize the risk for the wallet and to do
 not disincentivize it for waiting for enough redemption requests to accumulate,
 the redemption timeout should be long enough, for example, 72 hours and ideally
 even longer in the early days of the system.
+
+A timed-out redemption request is considered a <<heartbeat,heartbeat>> failure
+and the wallet is ordered to move the BTC to another random wallet. The wallet
+that timed out on processing redemption request can not be requested for another
+redemption. Operators are slashed for a timeout but they continue to earn
+rewards.
 
 ==== Redemption proof
 
@@ -512,10 +519,13 @@ receives a percentage of a misbehavior notifier reward, as specified in
 the list of pending redemption requests and it is marked as timed-out. This way,
 when redemption proof gets submitted, the timed-out redemption request will be
 skipped. This mechanism allows proving whatever can still be proved and
-unblocking the wallet for future redemptions.
+unblocking the wallet by updating its main UTXO.
 
 The transaction must revert if the given redemption request was already reported
 as timed out.
+
+The wallet is ordered to move the BTC to another random wallet and is no longer
+accepting redemption requests.
 
 ===== Redemption fraud
 
@@ -545,7 +555,10 @@ some part of outputs fraudulent and some part of outputs valid, it should be
 possible to submit redemption proof. Because information about fraudulent
 outputs is stored on-chain, these outputs can be skipped by the Bridge and the
 main wallet UTXO can be updated. This mechanism allows proving whatever can
-still be proved and unblocking the wallet for future redemptions.
+still be proved and unblocking the wallet by updating its main UTXO.
+
+The wallet is ordered to move the BTC to another random wallet and is no longer
+accepting redemption requests.
 
 === Wallet Lifecycle
 


### PR DESCRIPTION
RFC 1 is updated with more details about the redemption mechanism. Specifically:
- redemption constraints related to EVM limitations,
- how the redemption proof should behave,
- what is happening in case of a timeout,
- what is happening in case of fraud,
- how to rebalance the Bridge after fraud.

This change is an outcome of a long discussion with @lukasz-zimnoch and @tomaszslabon regarding the problems that occurred when implementing Solidity code in #128. The code in #128 has been adjusted to follow the approach described here.