### PR TITLE
Bump up `@keep-network/bitcoin-spv-sol` to `3.3.0-solc-0.8`

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
     "@openzeppelin/contracts": "^4.1.0",
-    "@keep-network/bitcoin-spv-sol": "3.2.0-solc-0.8",
+    "@keep-network/bitcoin-spv-sol": "3.3.0-solc-0.8",
     "@tenderly/hardhat-tenderly": "^1.0.12",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1416,10 +1416,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@keep-network/bitcoin-spv-sol@3.2.0-solc-0.8":
-  version "3.2.0-solc-0.8"
-  resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.2.0-solc-0.8.tgz#3a4696f5941854224d665b7a12da991a3e1a1862"
-  integrity sha512-I/Y760SZfFPE3fvbSTyF37McqwIi96wvl5O8VAIYPEduyuCy1GFqgZR//lX+fOrgnVMe7q0PPFt6kOhL0wBJAA==
+"@keep-network/bitcoin-spv-sol@3.3.0-solc-0.8":
+  version "3.3.0-solc-0.8"
+  resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.3.0-solc-0.8.tgz#5dfd552f9437e865038c1e97a2d27967c399dcbc"
+  integrity sha512-AG2fJqqniXVzwitHQcYQK5dZIyUPDo5xS1RZzW+LngcIuKA/f0cvTDEjWxgjf4D5MbStJNFWaCTtWwAJUCzsIw==
 
 "@keep-network/hardhat-helpers@0.4.1-pre.1":
   version "0.4.1-pre.1"


### PR DESCRIPTION
We update that dependency to employ recent gas optimizations made in the library.