### PR TITLE
RFC 1: Redesigning fraud proofs

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -389,11 +389,11 @@ and closes.
 
 Governable Parameters:
 
-- `fraud_slashing_amount`: The amount or stake slashed from each member of a
+- `fraud_slashing_amount`: The amount of stake slashed from each member of a
   wallet for a fraud.
 - `fraud_notifier_reward_multiplier`: The percentage of the notifier reward from
   the staking contract the notifier of a fraud receives.
-- `fraud_challenge_defeat_timeout`: The amount of the the wallet has to defend
+- `fraud_challenge_defend_timeout`: The amount of time the wallet has to defend
   against a fraud challenge.
 - `fraud_challenge_deposit_amount`: The amount of ETH the party challenging the
   wallet for fraud needs to deposit.
@@ -410,6 +410,7 @@ sighash. From that moment, the wallet has a certain time to defend itself
 against the challenge and prove that the UTXO was spent in an honest way.
 
 UTXO unlocked by the wallet is spent in a fraudulent way if:
+
 - that unlocked UTXO is a revealed deposit that was not proved as swept and
   can not be proved as swept, or
 - that unlocked UTXO was not and is not the main wallet's UTXO.
@@ -418,7 +419,7 @@ The wallet is allowed to execute only transactions that are accepted by the
 submit sweep proof, submit redemption proof, or submit funds migrated functions.
 All other transactions are considered fraud. In other words, if the wallet signed
 some UTXO, it needs to use that UTXO, and prove to the Bridge this is a valid
-usage. If none of it happens within the timeout the wallet has to defeat against
+usage. If none of it happens within the timeout the wallet has to defend against
 the challenge, this is considered a fraud.
 
 The consequence of this approach is that we need to track all UTXOs spent by the
@@ -453,31 +454,31 @@ sure it's neither closed nor terminated. It should also validate if the signatur
 over the sighash is valid and if it belongs to the wallet.
 
 The function should require the challenger to provide a deposit in ETH that is
-returned to the challenger once the fraud is confirmed. If the wallet defeats the
+returned to the challenger once the fraud is confirmed. If the wallet defends the
 challenge, the deposit is sent to the treasury.
 
-==== Defeating Against Fraud Challenge
+==== Defending Against Fraud Challenge
 
-Anyone can defeat the wallet against the fraud challenge by submitting a transaction
+Anyone can defend the wallet against the fraud challenge by submitting a transaction
 preimage matching the challenged sighash and proving that transaction was valid to
 the protocol.
 
-The function allowing to defend against the challenge, should first validate the
-submitted preimage against challenged sighash, and try to locate the revealed deposit
+The function allowing to defend against the challenge should first validate the
+submitted preimage against challenged sighash and try to locate the revealed deposit
 for the input corresponding to the sighash.
 
 If there is a revealed deposit matching the sighash and that deposit was swept by the
-Bridge, everything is fine and the wallet defeated the challenge.
+Bridge, everything is fine and the wallet defended the challenge.
 
 If there is a revealed deposit matching the sighash and it was not yet swept by the
-Bridge, the defeat function should revert. The wallet should first submit the sweep
-proof for that deposit and then call the defeat function again.
+Bridge, the defend function should revert. The wallet should first submit the sweep
+proof for that deposit and then call the defend function again.
 
-If the revealed deposit does not exist, the defeat function should check if the sighash
+If the revealed deposit does not exist, the defend function should check if the sighash
 belongs to one of the wallet's spent UTXOs from `spentMainUTXOs` mapping. If it does,
-everything is fine and the wallet defeated the challenge. If it does not, the defeat
+everything is fine and the wallet defended the challenge. If it does not, the defend
 function reverts. The wallet should submit the redemption proof and then, call the
-defeat function again.
+defend function again.
 
 === Wallet Lifecycle
 
@@ -713,11 +714,11 @@ Alphabetized list of Governable Parameters with additional notes.
 - `wallet_min_btc`: The smallest amount of btc a wallet can hold before we
   attempt to close the wallet and transfer the funds to a randomly selected
   wallet.
-- `fraud_slashing_amount`: The amount or stake slashed from each member of a
+- `fraud_slashing_amount`: The amount of stake slashed from each member of a
   wallet for a fraud.
 - `fraud_notifier_reward_multiplier`: The percentage of the notifier reward from
   the staking contract the notifier of a fraud receives.
-- `fraud_challenge_defeat_timeout`: The amount of the the wallet has to defend
+- `fraud_challenge_defend_timeout`: The amount of time the wallet has to defend
   against a fraud challenge.
 - `fraud_challenge_deposit_amount`: The amount of ETH the party challenging the
   wallet for fraud needs to deposit.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -361,22 +361,6 @@ If the depositor does not pay to unlock their account balance within the
 `skip_sweep_timeout`, then the system siezes the balance, mints TBTC, uses it
 to buy back T tokens, and then uses those to reimburse the operator.
 
-==== Fraud Proof
-
-There are only two valid types of transactions for an unswept deposit UTXO:
-
-1) A collection of deposit UTXO's plus the main UTXO for the wallet are the
-inputs are unlocked using the `signingGroupPubkey` and locked under a single
-UTXO using the same `signingGroupPubkey`. This is a normal non-fraudulent sweep.
-
-2) After the 30-day refund time has passed, a particular UTXO is unlocked using
-the `refundPubkey` and then locked with whatever script the refunder wants. This
-is a normal refund.
-
-Any transaction that unlocks a UTXO using the `signingGroupPubkey` and then
-locks it using any other script other than to a single UTXO to any other public
-key than the same `signingGroupPubkey` is fraud.
-
 [[redemption]]
 === Redemption
 
@@ -401,12 +385,88 @@ to submit multiple redemptions. After a redemption, if the wallet has under
 `wallet_min_btc` remaining, it transfers that BTC to a randomly selected wallet
 and closes.
 
-==== Fraud Proof
+=== Fraud Proofs
 
-When a redemption is requested, the redeeming bitcoin public key and amount are
-known on the ethereum chain. Any bitcoin transactions with the main wallet
-wallet UTXO as the input must have outputs that match those known redemption
-requests, otherwise the transaction was fraudulent.
+For every UTXO spent by the wallet in an incorrect way, anyone should be able
+to provide a fraud proof. Given that a Bitcoin transaction could be so large
+that proving it on Ethereum would be impossible, fraud proofs need to be
+processed with a challenge-response approach. 
+
+When a wallet unlocks a UTXO it needs to calculate a sighash and provide
+a signature over that sighash, one for each unlocked UTXO. Fraud is reported
+for a UTXO by providing a sighash along with the wallet's signature over that
+sighash. From that moment, the wallet has a certain time to defend itself
+against the challenge and prove that the UTXO was spent in an honest way.
+
+UTXO unlocked by the wallet is spent in a fraudulent way if:
+- that unlocked UTXO is a revealed deposit that was not proved as swept and
+  can not be proved as swept, or
+- that unlocked UTXO was not and is not the main wallet's UTXO.
+
+The wallet is allowed to execute only transactions that are accepted by the
+submit sweep proof, submit redemption proof, or submit funds migrated functions.
+All other transactions are considered fraud. In other words, if the wallet signed
+some UTXO, it needs to use that UTXO, and prove to the Bridge this is a valid
+usage. If none of it happens within the timeout the wallet has to defeat against
+the challenge, this is considered a fraud.
+
+The consequence of this approach is that we need to track all UTXOs spent by the
+wallet next to the main wallet's UTXO:
+
+```
+// wallet pubkey hash to the current main's UTXO hash computed
+// as keccak256(txHash | txOutputIndex | txOutputValue)
+mapping(bytes20 => bytes32) public mainUtxos;
+
+// wallet pubkey hash to the spent main UTXO hash computed
+// as keccak256(txHash | txOutputIndex)
+mapping(bytes20 => mapping(bytes32 => bool)) spentMainUTXOs
+
+```
+
+Note that this approach is stricter than just validating the public key in the
+UTXO. For example, if we were considering that a collection of deposit UTXO’s
+plus the main UTXO for the wallet unlocked using the wallet public key and
+locked under a single UTXO using the same wallet public key is not a fraud but
+a normal sweep, the Bridge would be susceptible to attacks when the malicious
+wallet steals revealed deposits by sweeping them to another UTXO but not the main
+UTXO known by the Bridge.
+
+
+==== Submitting Fraud Challenge
+
+Anyone should be able to submit a fraud challenge. At a minimum, the function
+should accept the wallet's signature and the sighash uniquely identifying UTXO
+unlocked by the wallet. The function should validate the wallet state to make
+sure it's neither closed nor terminated. It should also validate if the signature
+over the sighash is valid and if it belongs to the wallet.
+
+The function should require the challenger to provide a deposit in ETH that is
+returned to the challenger once the fraud is confirmed. If the wallet defeats the
+challenge, the deposit is sent to the treasury.
+
+==== Defeating Against Fraud Challenge
+
+Anyone can defeat the wallet against the fraud challenge by submitting a transaction
+preimage matching the challenged sighash and proving that transaction was valid to
+the protocol.
+
+The function allowing to defend against the challenge, should first validate the
+submitted preimage against challenged sighash, and try to locate the revealed deposit
+for the input corresponding to the sighash.
+
+If there is a revealed deposit matching the sighash and that deposit was swept by the
+Bridge, everything is fine and the wallet defeated the challenge.
+
+If there is a revealed deposit matching the sighash and it was not yet swept by the
+Bridge, the defeat function should revert. The wallet should first submit the sweep
+proof for that deposit and then call the defeat function again.
+
+If the revealed deposit does not exist, the defeat function should check if the sighash
+belongs to one of the wallet's spent UTXOs from `spentMainUTXOs` mapping. If it does,
+everything is fine and the wallet defeated the challenge. If it does not, the defeat
+function reverts. The wallet should submit the redemption proof and then, call the
+defeat function again.
 
 === Wallet Lifecycle
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -387,6 +387,17 @@ and closes.
 
 === Fraud Proofs
 
+Governable Parameters:
+
+- `fraud_slashing_amount`: The amount or stake slashed from each member of a
+  wallet for a fraud.
+- `fraud_notifier_reward_multiplier`: The percentage of the notifier reward from
+  the staking contract the notifier of a fraud receives.
+- `fraud_challenge_defeat_timeout`: The amount of the the wallet has to defend
+  against a fraud challenge.
+- `fraud_challenge_deposit_amount`: The amount of ETH the party challenging the
+  wallet for fraud needs to deposit.
+
 For every UTXO spent by the wallet in an incorrect way, anyone should be able
 to provide a fraud proof. Given that a Bitcoin transaction could be so large
 that proving it on Ethereum would be impossible, fraud proofs need to be
@@ -702,3 +713,11 @@ Alphabetized list of Governable Parameters with additional notes.
 - `wallet_min_btc`: The smallest amount of btc a wallet can hold before we
   attempt to close the wallet and transfer the funds to a randomly selected
   wallet.
+- `fraud_slashing_amount`: The amount or stake slashed from each member of a
+  wallet for a fraud.
+- `fraud_notifier_reward_multiplier`: The percentage of the notifier reward from
+  the staking contract the notifier of a fraud receives.
+- `fraud_challenge_defeat_timeout`: The amount of the the wallet has to defend
+  against a fraud challenge.
+- `fraud_challenge_deposit_amount`: The amount of ETH the party challenging the
+  wallet for fraud needs to deposit.

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -430,9 +430,8 @@ wallet next to the main wallet's UTXO:
 // as keccak256(txHash | txOutputIndex | txOutputValue)
 mapping(bytes20 => bytes32) public mainUtxos;
 
-// wallet pubkey hash to the spent main UTXO hash computed
-// as keccak256(txHash | txOutputIndex)
-mapping(bytes20 => mapping(bytes32 => bool)) spentMainUTXOs
+// spent main UTXO hash computed as keccak256(txHash | txOutputIndex)
+mapping(bytes32 => bool) spentMainUTXOs
 
 ```
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -455,8 +455,11 @@ over the sighash is valid and if it belongs to the wallet.
 
 The function should require the challenger to provide a deposit in ETH equal to 
 `fraud_challenge_deposit_amount` that is returned to the challenger once the fraud
-is confirmed. If the wallet defends the challenge, the deposit is sent to the
-treasury.
+is confirmed. If the wallet defends against the challenge, the deposit is sent
+to the treasury. If the wallet does not defend against the challenge, the
+challenger receives misbehavior notifier reward based on
+`fraud_notifier_reward_multiplier` and the wallet gets slashed based on
+`fraud_slashing_amount`.
 
 ==== Defending Against Fraud Challenge
 
@@ -469,7 +472,7 @@ submitted preimage against challenged sighash and try to locate the revealed dep
 for the input corresponding to the sighash.
 
 If there is a revealed deposit matching the sighash and that deposit was swept by the
-Bridge, everything is fine and the wallet defended the challenge.
+Bridge, everything is fine and the wallet defended itself against the challenge.
 
 If there is a revealed deposit matching the sighash and it was not yet swept by the
 Bridge, the defend function should revert. The wallet should first submit the sweep
@@ -477,9 +480,9 @@ proof for that deposit and then call the defend function again.
 
 If the revealed deposit does not exist, the defend function should check if the sighash
 belongs to one of the wallet's spent UTXOs from `spentMainUTXOs` mapping. If it does,
-everything is fine and the wallet defended the challenge. If it does not, the defend
-function reverts. The wallet should submit the redemption proof and then, call the
-defend function again.
+everything is fine and the wallet defended itself against the challenge. If it
+does not, the defend function reverts. The wallet should submit the redemption
+proof and then, call the defend function again.
 
 === Wallet Lifecycle
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -419,8 +419,8 @@ The wallet is allowed to execute only transactions that are accepted by the
 submit sweep proof, submit redemption proof, or submit funds migrated functions.
 All other transactions are considered fraud. In other words, if the wallet signed
 some UTXO, it needs to use that UTXO, and prove to the Bridge this is a valid
-usage. If none of it happens within the timeout the wallet has to defend against
-the challenge, this is considered a fraud.
+usage. If none of it happens within the `fraud_challenge_defeat_timeout` the
+wallet has to defend against the challenge, this is considered a fraud.
 
 The consequence of this approach is that we need to track all UTXOs spent by the
 wallet next to the main wallet's UTXO:
@@ -453,9 +453,10 @@ unlocked by the wallet. The function should validate the wallet state to make
 sure it's neither closed nor terminated. It should also validate if the signature
 over the sighash is valid and if it belongs to the wallet.
 
-The function should require the challenger to provide a deposit in ETH that is
-returned to the challenger once the fraud is confirmed. If the wallet defends the
-challenge, the deposit is sent to the treasury.
+The function should require the challenger to provide a deposit in ETH equal to 
+`fraud_challenge_deposit_amount` that is returned to the challenger once the fraud
+is confirmed. If the wallet defends the challenge, the deposit is sent to the
+treasury.
 
 ==== Defending Against Fraud Challenge
 

--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -443,6 +443,11 @@ a normal sweep, the Bridge would be susceptible to attacks when the malicious
 wallet steals revealed deposits by sweeping them to another UTXO but not the main
 UTXO known by the Bridge.
 
+To protect against chain reorgs capable of causing good-faith transactions to be
+indefensible against fraud proofs, the wallet needs to wait for enough block
+confirmations before undertaking any action. There has to be a reasonable
+compromise between finality and responsivity and suggested values are 6
+confirmations on Bitcoin and 40 confirmations on Ethereum.
 
 ==== Submitting Fraud Challenge
 


### PR DESCRIPTION
Given that a Bitcoin transaction could be so large that proving it on Ethereum would be impossible, fraud proofs need to be processed with a challenge-response approach. 

When a wallet unlocks a UTXO it needs to calculate a sighash and provide a signature over that sighash, one for each unlocked UTXO. Fraud is reported for a UTXO by providing a sighash along with the wallet's signature over that sighash. From that moment, the wallet has a certain time to defend itself against the challenge and prove that the UTXO was spent in an honest way.

UTXO unlocked by the wallet is spent in a fraudulent way if:
- that unlocked UTXO is a revealed deposit that was not proved as swept and can not be proved as swept, or
- that unlocked UTXO was not and is not the main wallet's UTXO.

The wallet is allowed to execute only transactions that are accepted by the submit sweep proof, submit redemption proof, or submit funds migrated proof functions. All other transactions are considered fraud. In other words, if the wallet signed some UTXO, it needs to use that UTXO, and prove to the Bridge this is a valid usage. If none of it happens within the timeout the wallet has to defeat against the challenge, this is considered a fraud.

Note that this approach is stricter than just validating the public key in the UTXO. For example, if we were considering that a collection of deposit UTXO’s plus the main UTXO for the wallet unlocked using the wallet public key and locked under a single UTXO using the same wallet public key is not a fraud but a normal sweep, the Bridge would be susceptible to attacks when the malicious wallet steals revealed deposits by sweeping them to another UTXO but not the main UTXO known by the Bridge.