### PR TITLE
Update pragma to ^0.8.9

### DIFF
--- a/solidity/contracts/GovernanceUtils.sol
+++ b/solidity/contracts/GovernanceUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 library GovernanceUtils {
     /// @notice Reverts if the governance delay has not passed since

--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 /// @title Bitcoin transaction
 /// @notice Allows to reference Bitcoin raw transaction in Solidity.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/solidity/contracts/bridge/VendingMachine.sol
+++ b/solidity/contracts/bridge/VendingMachine.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/test/BankStub.sol
+++ b/solidity/contracts/test/BankStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "../bank/Bank.sol";
 

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "../bridge/BitcoinTx.sol";
 import "../bridge/Bridge.sol";

--- a/solidity/contracts/test/ReceiveApprovalStub.sol
+++ b/solidity/contracts/test/ReceiveApprovalStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "../token/TBTC.sol";
 

--- a/solidity/contracts/test/TestERC20.sol
+++ b/solidity/contracts/test/TestERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 

--- a/solidity/contracts/test/TestERC721.sol
+++ b/solidity/contracts/test/TestERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/solidity/contracts/test/TestRelay.sol
+++ b/solidity/contracts/test/TestRelay.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "../bridge/Bridge.sol";
 

--- a/solidity/contracts/token/TBTC.sol
+++ b/solidity/contracts/token/TBTC.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 import "@thesis/solidity-contracts/contracts/token/MisfundRecovery.sol";

--- a/solidity/contracts/vault/IVault.sol
+++ b/solidity/contracts/vault/IVault.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 /// @title Bank Vault interface
 /// @notice `IVault` is an interface for a smart contract consuming Bank

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.9;
 
 import "./IVault.sol";
 import "../bank/Bank.sol";

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -13,7 +13,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.4", // TODO: Revisit solidity version before deploying on mainnet!
+        version: "0.8.9", // TODO: Revisit solidity version before deploying on mainnet!
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
We updated pragma to ^0.8.9 to align it with other projects, e.g.
`@keep-network/ecdsa`. If we don't do that there is a problem with
importing the ECDSA wallets contracts.