### PR TITLE
Deposit treasury fee

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -101,10 +101,38 @@ contract Bridge is Ownable {
         // Address of the Bank vault the deposit is routed to.
         // Optional, can be 0x0.
         address vault;
+        // Treasury TBTC fee in satoshi at the moment of deposit reveal.
+        uint64 treasuryFee;
         // UNIX timestamp the deposit was swept at. Note this is not the
         // time when the deposit was swept on the Bitcoin chain but actually
         // the time when the sweep proof was delivered to the Ethereum chain.
         uint32 sweptAt;
+    }
+
+    /// @notice Represents an outcome of the sweep Bitcoin transaction
+    ///         inputs processing.
+    struct SweepTxInputsInfo {
+        // Sum of all inputs values i.e. all deposits and main UTXO value,
+        // if present.
+        uint256 inputsTotalValue;
+        // Addresses of depositors who performed processed deposits. Ordered in
+        // the same order as deposits inputs in the input vector. Size of this
+        // array is either equal to the number of inputs (main UTXO doesn't
+        // exist) or less by one (main UTXO exists and is pointed by one of
+        // the inputs).
+        address[] depositors;
+        // Amounts of deposits corresponding to processed deposits. Ordered in
+        // the same order as deposits inputs in the input vector. Size of this
+        // array is either equal to the number of inputs (main UTXO doesn't
+        // exist) or less by one (main UTXO exists and is pointed by one of
+        // the inputs).
+        uint256[] depositedAmounts;
+        // Values of the treasury fee corresponding to processed deposits.
+        // Ordered in the same order as deposits inputs in the input vector.
+        // Size of this array is either equal to the number of inputs (main
+        // UTXO doesn't exist) or less by one (main UTXO exists and is pointed
+        // by one of the inputs).
+        uint256[] treasuryFees;
     }
 
     /// @notice Represents a redemption request.
@@ -186,6 +214,16 @@ contract Bridge is Ownable {
     /// @notice Address where the redemptions treasury fees will be sent to.
     ///         Treasury takes part in the operators rewarding process.
     address public immutable treasury;
+
+    /// TODO: Make it governable.
+    /// @notice Divisor used to compute the treasury fee taken from each
+    ///         deposit and transferred to the treasury upon sweep proof
+    ///         submission. That fee is computed as follows:
+    ///         `treasuryFee = depositedAmount / depositTreasuryFeeDivisor`
+    ///         For example, if the treasury fee needs to be 2% of each deposit,
+    ///         the `redemptionTreasuryFeeDivisor` should be set to `50`
+    ///         because `1/50 = 0.02 = 2%`.
+    uint64 public depositTreasuryFeeDivisor;
 
     /// TODO: Make it governable.
     /// @notice The minimal amount that can be requested for redemption.
@@ -339,6 +377,7 @@ contract Bridge is Ownable {
         txProofDifficultyFactor = _txProofDifficultyFactor;
 
         // TODO: Revisit initial values.
+        depositTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
         redemptionDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
         redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
         redemptionTxMaxFee = 1000; // 1000 satoshi
@@ -496,6 +535,9 @@ contract Bridge is Ownable {
         /* solhint-disable-next-line not-rely-on-time */
         deposit.revealedAt = uint32(block.timestamp);
         deposit.vault = reveal.vault;
+        deposit.treasuryFee = depositTreasuryFeeDivisor > 0
+            ? fundingOutputAmount / depositTreasuryFeeDivisor
+            : 0;
 
         emit DepositRevealed(
             fundingTxHash,
@@ -592,30 +634,39 @@ contract Bridge is Ownable {
             resolvedMainUtxo = mainUtxo;
         }
 
-        // Process sweep transaction inputs and extract their value sum and
-        // all information needed to perform deposit bookkeeping.
-        (
-            uint256 sweepTxInputsValue,
-            address[] memory depositors,
-            uint256[] memory depositedAmounts
-        ) = processSweepTxInputs(sweepTx.inputVector, resolvedMainUtxo);
+        // Process sweep transaction inputs and extract all information needed
+        // to perform deposit bookkeeping.
+        SweepTxInputsInfo memory inputsInfo = processSweepTxInputs(
+            sweepTx.inputVector,
+            resolvedMainUtxo
+        );
 
-        // Compute the sweep transaction fee which is a difference between
-        // inputs amounts sum and the output amount.
-        // TODO: Check fee against max fee.
-        uint256 fee = sweepTxInputsValue - sweepTxOutputValue;
-        // Calculate fee share by dividing the total fee by deposits count.
+        // Helper variable that will hold the sum of treasury fees paid by
+        // all deposits.
+        uint256 totalTreasuryFee = 0;
+
+        // Calculate the transaction fee per deposit by dividing the total
+        // transaction fee by deposits count. The total fee is just the
+        // difference between inputs amounts sum and the output amount.
         // TODO: Deal with precision loss by having the last depositor pay
-        //       the higher fee than others if there is a change, just like it has
-        //       been proposed for the redemption flow. See:
+        //       the higher transaction fee than others if there is a change,
+        //       just like it has been proposed in discussion:
         //       https://github.com/keep-network/tbtc-v2/pull/128#discussion_r800555359.
-        uint256 feeShare = fee / depositedAmounts.length;
-        // Reduce each deposit amount by fee share value.
-        for (uint256 i = 0; i < depositedAmounts.length; i++) {
-            // We don't have to check if `feeShare` is bigger than the amount
-            // since we have the dust threshold preventing against too small
-            // deposits amounts.
-            depositedAmounts[i] -= feeShare;
+        // TODO: Check txFee against max fee.
+        uint256 txFee = (inputsInfo.inputsTotalValue - sweepTxOutputValue) /
+            inputsInfo.depositedAmounts.length;
+
+        // Reduce each deposit amount by treasury fee and transaction fee.
+        for (uint256 i = 0; i < inputsInfo.depositedAmounts.length; i++) {
+            // There is no need to check whether
+            // `inputsInfo.depositedAmounts[i] - inputsInfo.treasuryFees[i] - txFee > 0`
+            // since the `depositDustThreshold` should force that condition
+            // to be always true.
+            inputsInfo.depositedAmounts[i] =
+                inputsInfo.depositedAmounts[i] -
+                inputsInfo.treasuryFees[i] -
+                txFee;
+            totalTreasuryFee += inputsInfo.treasuryFees[i];
         }
 
         // Record this sweep data and assign them to the wallet public key hash
@@ -628,7 +679,12 @@ contract Bridge is Ownable {
         emit DepositsSwept(walletPubKeyHash, sweepTxHash);
 
         // Update depositors balances in the Bank.
-        bank.increaseBalances(depositors, depositedAmounts);
+        bank.increaseBalances(
+            inputsInfo.depositors,
+            inputsInfo.depositedAmounts
+        );
+        // Pass the treasury fee to the treasury address.
+        bank.increaseBalance(treasury, totalTreasuryFee);
 
         // TODO: Handle deposits having `vault` set.
     }
@@ -789,29 +845,11 @@ contract Bridge is Ownable {
     /// @param mainUtxo Data of the wallet's main UTXO. If no main UTXO
     ///        exists for the given the wallet, this parameter's fields should
     ///        be zeroed to bypass the main UTXO validation
-    /// @return inputsTotalValue Sum of all inputs values i.e. all deposits and
-    ///         main UTXO value, if present.
-    /// @return depositors Addresses of depositors who performed processed
-    ///         deposits. Ordered in the same order as deposits inputs in the
-    ///         input vector. Size of this array is either equal to the
-    ///         number of inputs (main UTXO doesn't exist) or less by one
-    ///         (main UTXO exists and is pointed by one of the inputs).
-    /// @return depositedAmounts Amounts of deposits corresponding to processed
-    ///         deposits. Ordered in the same order as deposits inputs in the
-    ///         input vector. Size of this array is either equal to the
-    ///         number of inputs (main UTXO doesn't exist) or less by one
-    ///         (main UTXO exists and is pointed by one of the inputs).
+    /// @return info Outcomes of the processing.
     function processSweepTxInputs(
         bytes memory sweepTxInputVector,
         BitcoinTx.UTXO memory mainUtxo
-    )
-        internal
-        returns (
-            uint256 inputsTotalValue,
-            address[] memory depositors,
-            uint256[] memory depositedAmounts
-        )
-    {
+    ) internal returns (SweepTxInputsInfo memory info) {
         // If the passed `mainUtxo` parameter's values are zeroed, the main UTXO
         // for the given wallet doesn't exist and it is not expected to be
         // included in the sweep transaction input vector.
@@ -846,10 +884,11 @@ contract Bridge is Ownable {
         // Determine the swept deposits count. If main UTXO is NOT expected,
         // all inputs should be deposits. If main UTXO is expected, one input
         // should point to that main UTXO.
-        depositors = new address[](
+        info.depositors = new address[](
             !mainUtxoExpected ? inputsCount : inputsCount - 1
         );
-        depositedAmounts = new uint256[](depositors.length);
+        info.depositedAmounts = new uint256[](info.depositors.length);
+        info.treasuryFees = new uint256[](info.depositors.length);
 
         // Initialize helper variables.
         uint256 processedDepositsCount = 0;
@@ -873,7 +912,7 @@ contract Bridge is Ownable {
                 // a revealed deposit.
                 require(deposit.sweptAt == 0, "Deposit already swept");
 
-                if (processedDepositsCount == depositors.length) {
+                if (processedDepositsCount == info.depositors.length) {
                     // If this condition is true, that means a deposit input
                     // took place of an expected main UTXO input.
                     // In other words, there is no expected main UTXO
@@ -886,9 +925,12 @@ contract Bridge is Ownable {
                 /* solhint-disable-next-line not-rely-on-time */
                 deposit.sweptAt = uint32(block.timestamp);
 
-                depositors[processedDepositsCount] = deposit.depositor;
-                depositedAmounts[processedDepositsCount] = deposit.amount;
-                inputsTotalValue += depositedAmounts[processedDepositsCount];
+                info.depositors[processedDepositsCount] = deposit.depositor;
+                info.depositedAmounts[processedDepositsCount] = deposit.amount;
+                info.inputsTotalValue += info.depositedAmounts[
+                    processedDepositsCount
+                ];
+                info.treasuryFees[processedDepositsCount] = deposit.treasuryFee;
 
                 processedDepositsCount++;
             } else if (
@@ -897,7 +939,7 @@ contract Bridge is Ownable {
             ) {
                 // If we entered here, that means the input was identified as
                 // the expected main UTXO.
-                inputsTotalValue += mainUtxo.txOutputValue;
+                info.inputsTotalValue += mainUtxo.txOutputValue;
                 mainUtxoFound = true;
             } else {
                 revert("Unknown input type");
@@ -909,7 +951,7 @@ contract Bridge is Ownable {
         }
 
         // Construction of the input processing loop guarantees that:
-        // `processedDepositsCount == depositors.length == depositedAmounts.length`
+        // `processedDepositsCount == info.depositors.length == info.depositedAmounts.length`
         // is always true at this point. We just use the first variable
         // to assert the total count of swept deposit is bigger than zero.
         require(
@@ -924,7 +966,7 @@ contract Bridge is Ownable {
             "Expected main UTXO not present in sweep transaction inputs"
         );
 
-        return (inputsTotalValue, depositors, depositedAmounts);
+        return info;
     }
 
     /// @notice Parses a Bitcoin transaction input starting at the given index.

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -600,6 +600,12 @@ describe("Bridge", () => {
                     ).to.be.equal(18490)
                   })
 
+                  it("should transfer collected treasury fee", async () => {
+                    expect(await bank.balanceOf(treasury.address)).to.be.equal(
+                      10
+                    )
+                  })
+
                   it("should emit DepositsSwept event", async () => {
                     await expect(tx)
                       .to.emit(bridge, "DepositsSwept")
@@ -670,6 +676,12 @@ describe("Bridge", () => {
                     expect(
                       await bank.balanceOf(data.deposits[0].reveal.depositor)
                     ).to.be.equal(77960)
+                  })
+
+                  it("should transfer collected treasury fee", async () => {
+                    expect(await bank.balanceOf(treasury.address)).to.be.equal(
+                      40
+                    )
                   })
 
                   it("should emit DepositsSwept event", async () => {
@@ -862,6 +874,12 @@ describe("Bridge", () => {
                     ).to.be.equal(289256)
                   })
 
+                  it("should transfer collected treasury fee", async () => {
+                    expect(await bank.balanceOf(treasury.address)).to.be.equal(
+                      2075
+                    )
+                  })
+
                   it("should emit DepositsSwept event", async () => {
                     await expect(tx)
                       .to.emit(bridge, "DepositsSwept")
@@ -951,6 +969,12 @@ describe("Bridge", () => {
                     expect(
                       await bank.balanceOf(data.deposits[4].reveal.depositor)
                     ).to.be.equal(439380)
+                  })
+
+                  it("should transfer collected treasury fee", async () => {
+                    expect(await bank.balanceOf(treasury.address)).to.be.equal(
+                      530
+                    )
                   })
 
                   it("should emit DepositsSwept event", async () => {

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -232,24 +232,25 @@ describe("Bridge", () => {
 
               const deposit = await bridge.deposits(depositKey)
 
-              // Should contain: depositor, amount, revealedAt, vault, sweptAt.
-              expect(deposit.length).to.be.equal(5)
               // Depositor address, same as in `reveal.depositor`.
-              expect(deposit[0]).to.be.equal(
+              expect(deposit.depositor).to.be.equal(
                 "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637"
               )
               // Deposit amount in satoshi. In this case it's 10000 satoshi
               // because the P2SH deposit transaction set this value for the
               // funding output.
-              expect(deposit[1]).to.be.equal(10000)
+              expect(deposit.amount).to.be.equal(10000)
               // Revealed time should be set.
-              expect(deposit[2]).to.be.equal(await lastBlockTime())
+              expect(deposit.revealedAt).to.be.equal(await lastBlockTime())
               // Deposit vault, same as in `reveal.vault`.
-              expect(deposit[3]).to.be.equal(
+              expect(deposit.vault).to.be.equal(
                 "0x594cfd89700040163727828AE20B52099C58F02C"
               )
+              // Treasury fee should be computed according to the current
+              // value of the `depositTreasuryFeeDivisor`.
+              expect(deposit.treasuryFee).to.be.equal(5)
               // Swept time should be unset.
-              expect(deposit[4]).to.be.equal(0)
+              expect(deposit.sweptAt).to.be.equal(0)
             })
 
             it("should emit DepositRevealed event", async () => {
@@ -386,24 +387,25 @@ describe("Bridge", () => {
 
               const deposit = await bridge.deposits(depositKey)
 
-              // Should contain: depositor, amount, revealedAt and vault.
-              expect(deposit.length).to.be.equal(5)
               // Depositor address, same as in `reveal.depositor`.
-              expect(deposit[0]).to.be.equal(
+              expect(deposit.depositor).to.be.equal(
                 "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637"
               )
               // Deposit amount in satoshi. In this case it's 10000 satoshi
-              // because the P2WSH deposit transaction set this value for the
+              // because the P2SH deposit transaction set this value for the
               // funding output.
-              expect(deposit[1]).to.be.equal(10000)
+              expect(deposit.amount).to.be.equal(10000)
               // Revealed time should be set.
-              expect(deposit[2]).to.be.equal(await lastBlockTime())
+              expect(deposit.revealedAt).to.be.equal(await lastBlockTime())
               // Deposit vault, same as in `reveal.vault`.
-              expect(deposit[3]).to.be.equal(
+              expect(deposit.vault).to.be.equal(
                 "0x594cfd89700040163727828AE20B52099C58F02C"
               )
+              // Treasury fee should be computed according to the current
+              // value of the `depositTreasuryFeeDivisor`.
+              expect(deposit.treasuryFee).to.be.equal(5)
               // Swept time should be unset.
-              expect(deposit[4]).to.be.equal(0)
+              expect(deposit.sweptAt).to.be.equal(0)
             })
 
             it("should emit DepositRevealed event", async () => {
@@ -566,8 +568,7 @@ describe("Bridge", () => {
 
                     const deposit = await bridge.deposits(depositKey)
 
-                    // Swept time is the last item.
-                    expect(deposit[4]).to.be.equal(await lastBlockTime())
+                    expect(deposit.sweptAt).to.be.equal(await lastBlockTime())
                   })
 
                   it("should update main UTXO for the given wallet", async () => {
@@ -589,11 +590,14 @@ describe("Bridge", () => {
 
                   it("should update the depositor's balance", async () => {
                     // The sum of sweep tx inputs is 20000 satoshi. The output
-                    // value is 18500 so the fee is 1500. There is only one
-                    // deposit so it incurs the entire fee.
+                    // value is 18500 so the transaction fee is 1500. There is
+                    // only one deposit so it incurs the entire transaction fee.
+                    // The deposit should also incur the treasury fee whose
+                    // initial value is 0.05% of the deposited amount so the
+                    // final depositor balance should be cut by 10 satoshi.
                     expect(
                       await bank.balanceOf(data.deposits[0].reveal.depositor)
-                    ).to.be.equal(18500)
+                    ).to.be.equal(18490)
                   })
 
                   it("should emit DepositsSwept event", async () => {
@@ -636,8 +640,7 @@ describe("Bridge", () => {
 
                     const deposit = await bridge.deposits(depositKey)
 
-                    // Swept time is the last item.
-                    expect(deposit[4]).to.be.equal(await lastBlockTime())
+                    expect(deposit.sweptAt).to.be.equal(await lastBlockTime())
                   })
 
                   it("should update main UTXO for the given wallet", async () => {
@@ -660,10 +663,13 @@ describe("Bridge", () => {
                   it("should update the depositor's balance", async () => {
                     // The sum of sweep tx inputs is 80000 satoshi. The output
                     // value is 78000 so the fee is 2000. There is only one
-                    // deposit so it incurs the entire fee.
+                    // deposit so it incurs the entire fee. The deposit should
+                    // also incur the treasury fee whose initial value is 0.05%
+                    // of the deposited amount so the final depositor balance
+                    // should be cut by 40 satoshi.
                     expect(
                       await bank.balanceOf(data.deposits[0].reveal.depositor)
-                    ).to.be.equal(78000)
+                    ).to.be.equal(77960)
                   })
 
                   it("should emit DepositsSwept event", async () => {
@@ -808,8 +814,7 @@ describe("Bridge", () => {
                       // eslint-disable-next-line no-await-in-loop
                       const deposit = await bridge.deposits(depositKey)
 
-                      // Swept time is the last item.
-                      expect(deposit[4]).to.be.equal(
+                      expect(deposit.sweptAt).to.be.equal(
                         // eslint-disable-next-line no-await-in-loop
                         await lastBlockTime(),
                         `Deposit with index ${i} has an unexpected swept time`
@@ -838,21 +843,23 @@ describe("Bridge", () => {
                     // The sum of sweep tx inputs is 4148000 satoshi. The output
                     // value is 4145001 so the fee is 2999. There is 5 deposits
                     // so 599 satoshi fee should be incurred per deposit.
+                    // Each deposit should also incur the treasury fee whose
+                    // initial value is 0.05% of the deposited amount.
                     expect(
                       await bank.balanceOf(data.deposits[0].reveal.depositor)
-                    ).to.be.equal(219401)
+                    ).to.be.equal(219291)
                     expect(
                       await bank.balanceOf(data.deposits[1].reveal.depositor)
-                    ).to.be.equal(759401)
+                    ).to.be.equal(759021)
                     expect(
                       await bank.balanceOf(data.deposits[2].reveal.depositor)
-                    ).to.be.equal(939401)
+                    ).to.be.equal(938931)
                     expect(
                       await bank.balanceOf(data.deposits[3].reveal.depositor)
-                    ).to.be.equal(879401)
+                    ).to.be.equal(878961)
                     expect(
                       await bank.balanceOf(data.deposits[4].reveal.depositor)
-                    ).to.be.equal(289401)
+                    ).to.be.equal(289256)
                   })
 
                   it("should emit DepositsSwept event", async () => {
@@ -898,8 +905,7 @@ describe("Bridge", () => {
                       // eslint-disable-next-line no-await-in-loop
                       const deposit = await bridge.deposits(depositKey)
 
-                      // Swept time is the last item.
-                      expect(deposit[4]).to.be.equal(
+                      expect(deposit.sweptAt).to.be.equal(
                         // eslint-disable-next-line no-await-in-loop
                         await lastBlockTime(),
                         `Deposit with index ${i} has an unexpected swept time`
@@ -928,21 +934,23 @@ describe("Bridge", () => {
                     // The sum of sweep tx inputs is 1060000 satoshi. The output
                     // value is 1058000 so the fee is 2000. There is 5 deposits
                     // so 400 satoshi fee should be incurred per deposit.
+                    // Each deposit should also incur the treasury fee whose
+                    // initial value is 0.05% of the deposited amount.
                     expect(
                       await bank.balanceOf(data.deposits[0].reveal.depositor)
-                    ).to.be.equal(29600)
+                    ).to.be.equal(29585)
                     expect(
                       await bank.balanceOf(data.deposits[1].reveal.depositor)
-                    ).to.be.equal(9600)
+                    ).to.be.equal(9595)
                     expect(
                       await bank.balanceOf(data.deposits[2].reveal.depositor)
-                    ).to.be.equal(209600)
+                    ).to.be.equal(209495)
                     expect(
                       await bank.balanceOf(data.deposits[3].reveal.depositor)
-                    ).to.be.equal(369600)
+                    ).to.be.equal(369415)
                     expect(
                       await bank.balanceOf(data.deposits[4].reveal.depositor)
-                    ).to.be.equal(439600)
+                    ).to.be.equal(439380)
                   })
 
                   it("should emit DepositsSwept event", async () => {


### PR DESCRIPTION
Closes: #137 

This change introduces a deposit treasury fee which works in the same way as the existing redemption fee. This is achieved using the governable `depositTreasuryFeeDivisor` parameter that determines how much of the deposited amount should be taken as a treasury fee. Since that parameter is governable and may change over time, the actual fee value is computed and stored upon deposit reveal. During the sweep proof submission, the fee is cut from each depositor's balance and the total collected fee is used to increase the treasury balance accordingly. This changeset also involves some refactoring intended to reduce the number of declared variables in order to avoid `stack too deep` error fired by the Solidity compiler.