### PR TITLE
Deposit transaction maximum fee

### DIFF
--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -31,6 +31,10 @@ contract BridgeStub is Bridge {
         wallets[walletPubKeyHash] = wallet;
     }
 
+    function setDepositTxMaxFee(uint64 _depositTxMaxFee) external {
+        depositTxMaxFee = _depositTxMaxFee;
+    }
+
     function setRedemptionDustThreshold(uint64 _redemptionDustThreshold)
         external
     {


### PR DESCRIPTION
This change implements a mechanism allowing to limit the maximum transaction fee incurred by each deposit being part of a sweep transaction. Transactions that burn too much value for fees are not accepted as proper sweeps and can be successfully challenged as frauds. This fact should force wallets to use decent fees for sweep transactions and discourage fraudulent behavior.