### PR TITLE
Bridge refactoring - extract proof validation code to `BitcoinTx` library

### DIFF
--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -15,6 +15,9 @@
 
 pragma solidity ^0.8.9;
 
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+import {ValidateSPV} from "@keep-network/bitcoin-spv-sol/contracts/ValidateSPV.sol";
+
 /// @title Bitcoin transaction
 /// @notice Allows to reference Bitcoin raw transaction in Solidity.
 /// @dev See https://developer.bitcoin.org/reference/transactions.html#raw-transaction-format
@@ -69,8 +72,12 @@ pragma solidity ^0.8.9;
 ///      (*) compactSize uint is often references as VarInt)
 ///
 library BitcoinTx {
-    /// @notice Represents Bitcoin transaction data for funding BTC deposit
-    ///         P2(W)SH transaction.
+    using BTCUtils for bytes;
+    using BTCUtils for uint256;
+    using ValidateSPV for bytes;
+    using ValidateSPV for bytes32;
+
+    /// @notice Represents Bitcoin transaction data.
     struct Info {
         /// @notice Bitcoin transaction version
         /// @dev `version` from raw Bitcon transaction data.
@@ -113,6 +120,17 @@ library BitcoinTx {
         bytes bitcoinHeaders;
     }
 
+    /// @notice Determines the difficulty context for a Bitcoin SPV proof.
+    struct ProofDifficulty {
+        /// @notice Difficulty of the current epoch.
+        uint256 currentEpochDifficulty;
+        /// @notice Difficulty of the previous epoch.
+        uint256 previousEpochDifficulty;
+        /// @notice The number of confirmations on the Bitcoin chain required
+        ///         to successfully evaluate an SPV proof.
+        uint256 difficultyFactor;
+    }
+
     /// @notice Represents info about an unspent transaction output.
     struct UTXO {
         /// @notice Hash of the transaction the output belongs to.
@@ -122,5 +140,92 @@ library BitcoinTx {
         uint32 txOutputIndex;
         /// @notice Value of the transaction output.
         uint64 txOutputValue;
+    }
+
+    /// @notice Validates the SPV proof of the Bitcoin transaction.
+    ///         Reverts in case the validation or proof verification fail.
+    /// @param txInfo Bitcoin transaction data
+    /// @param proof Bitcoin proof data
+    /// @param proofDifficulty Bitcoin proof difficulty context.
+    /// @return txHash Proven 32-byte transaction hash.
+    function validateProof(
+        Info calldata txInfo,
+        Proof calldata proof,
+        ProofDifficulty calldata proofDifficulty
+    ) external view returns (bytes32 txHash) {
+        require(
+            txInfo.inputVector.validateVin(),
+            "Invalid input vector provided"
+        );
+        require(
+            txInfo.outputVector.validateVout(),
+            "Invalid output vector provided"
+        );
+
+        txHash = abi
+            .encodePacked(
+                txInfo.version,
+                txInfo.inputVector,
+                txInfo.outputVector,
+                txInfo.locktime
+            )
+            .hash256View();
+
+        require(
+            txHash.prove(
+                proof.bitcoinHeaders.extractMerkleRootLE(),
+                proof.merkleProof,
+                proof.txIndexInBlock
+            ),
+            "Tx merkle proof is not valid for provided header and tx hash"
+        );
+
+        evaluateProofDifficulty(proof.bitcoinHeaders, proofDifficulty);
+
+        return txHash;
+    }
+
+    /// @notice Evaluates the given Bitcoin proof difficulty against the actual
+    ///         Bitcoin chain difficulty provided by the relay oracle.
+    ///         Reverts in case the evaluation fails.
+    /// @param bitcoinHeaders Bitcoin headers chain being part of the SPV
+    ///        proof. Used to extract the observed proof difficulty
+    /// @param proofDifficulty Bitcoin proof difficulty context.
+    function evaluateProofDifficulty(
+        bytes memory bitcoinHeaders,
+        ProofDifficulty calldata proofDifficulty
+    ) internal view {
+        uint256 requestedDiff = 0;
+        uint256 firstHeaderDiff = bitcoinHeaders
+            .extractTarget()
+            .calculateDifficulty();
+
+        if (firstHeaderDiff == proofDifficulty.currentEpochDifficulty) {
+            requestedDiff = proofDifficulty.currentEpochDifficulty;
+        } else if (firstHeaderDiff == proofDifficulty.previousEpochDifficulty) {
+            requestedDiff = proofDifficulty.previousEpochDifficulty;
+        } else {
+            revert("Not at current or previous difficulty");
+        }
+
+        uint256 observedDiff = bitcoinHeaders.validateHeaderChain();
+
+        require(
+            observedDiff != ValidateSPV.getErrBadLength(),
+            "Invalid length of the headers chain"
+        );
+        require(
+            observedDiff != ValidateSPV.getErrInvalidChain(),
+            "Invalid headers chain"
+        );
+        require(
+            observedDiff != ValidateSPV.getErrLowWork(),
+            "Insufficient work in a header"
+        );
+
+        require(
+            observedDiff >= requestedDiff * proofDifficulty.difficultyFactor,
+            "Insufficient accumulated difficulty in header chain"
+        );
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -412,7 +412,7 @@ contract Bridge is Ownable {
 
     /// @notice Determines the current Bitcoin SPV proof difficulty context.
     /// @return proofDifficulty Bitcoin proof difficulty context.
-    function proofDifficulty()
+    function proofDifficultyContext()
         internal
         view
         returns (BitcoinTx.ProofDifficulty memory proofDifficulty)
@@ -624,7 +624,7 @@ contract Bridge is Ownable {
         bytes32 sweepTxHash = BitcoinTx.validateProof(
             sweepTx,
             sweepProof,
-            proofDifficulty()
+            proofDifficultyContext()
         );
 
         // Process sweep transaction output and extract its target wallet
@@ -1194,7 +1194,7 @@ contract Bridge is Ownable {
         bytes32 redemptionTxHash = BitcoinTx.validateProof(
             redemptionTx,
             redemptionProof,
-            proofDifficulty()
+            proofDifficultyContext()
         );
 
         // Perform validation of the redemption transaction input. Specifically,

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -5,6 +5,7 @@ import "@keep-network/hardhat-local-networks-config"
 import "@nomiclabs/hardhat-waffle"
 import "@nomiclabs/hardhat-etherscan"
 import "hardhat-gas-reporter"
+import "hardhat-contract-sizer"
 import "hardhat-deploy"
 import "@tenderly/hardhat-tenderly"
 import "@typechain/hardhat"
@@ -90,8 +91,16 @@ const config: HardhatUserConfig = {
       mainnet: "0x19FcB32347ff4656E4E6746b4584192D185d640d",
     },
   },
+
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,
+  },
+
+  contractSizer: {
+    alphaSort: true,
+    disambiguatePaths: false,
+    runOnCompile: true,
+    strict: true,
   },
 }
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -49,6 +49,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.7",
     "hardhat": "^2.6.4",
+    "hardhat-contract-sizer": "^2.5.0",
     "hardhat-deploy": "^0.8.11",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.5.1",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -3929,6 +3929,15 @@ cli-table3@^0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -4001,7 +4010,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -6596,6 +6605,14 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-contract-sizer@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.5.0.tgz#ae0ef708efbc433a129f655827478741cba84606"
+  integrity sha512-579Bm3QjrGyInL4RuPFPV/2jLDekw+fGmeLQ85GeiBciIKPHVS3ZYuZJDrp7E9J6A4Czk+QVCRA9YPT2Svn7lQ==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
 
 hardhat-deploy@^0.8.11:
   version "0.8.11"


### PR DESCRIPTION
Refs: #165 

Proof validation logic is the first candidate to be moved out of the `Bridge` contract in order to reduce its size. It can be placed in the `BitcoinTx` library which already contains Bitcoin-specific types so placing the logic operating on those types seems to be the right move. Since `BitcoinTx` becomes a linked lib due to that change, the gas cost of the main functions will change as well as the `Bridge` contract size:

| Parameter                    | Before     | After      |
|------------------------------|------------|------------|
| `revealDeposit` cost         | 87606 gas  | 87746 gas  |
| `submitSweepProof` cost      | 249183 gas | 254624 gas |
| `requestRedemption` cost     | 105723 gas | 105774 gas |
| `submitRedemptionProof` cost | 138182 gas | 143300 gas |
| `Bridge` size                | 21.488 KB  | 18.924 KB  |

The `Bridge` refactoring whose first part is presented in this PR is driven according to the following assumptions:
- Extracted libraries should be linked ones
- The `Bridge` contract will hold the common parts like main UTXO management, wallet lifecycle, third-party contract (especially `Bank`) interaction, and so on.

Next steps:
- Extract deposit flow code to `Deposit` library
- Extraxt redemption flow code to `Redemption` library