### PR TITLE
Deposit dust threshold

### DIFF
--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -31,6 +31,10 @@ contract BridgeStub is Bridge {
         wallets[walletPubKeyHash] = wallet;
     }
 
+    function setDepositDustThreshold(uint64 _depositDustThreshold) external {
+        depositDustThreshold = _depositDustThreshold;
+    }
+
     function setDepositTxMaxFee(uint64 _depositTxMaxFee) external {
         depositTxMaxFee = _depositTxMaxFee;
     }


### PR DESCRIPTION
Closes: #154 

This change introduces `depositDustThreshold` that protects against too small deposits. This mechanism is the same as the one existing for redemption requests.