### PR TITLE
Bump Slither version to 0.8.2

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.8.4 # according to solidity.version in hardhat.config.ts
+          SOLC_VERSION: 0.8.9 # according to solidity.version in hardhat.config.ts
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION
@@ -270,7 +270,7 @@ jobs:
 
       - name: Install Slither
         env:
-          SLITHER_VERSION: 0.8.0
+          SLITHER_VERSION: 0.8.2
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
       - name: Install dependencies


### PR DESCRIPTION
This version is more stable and should produce fewer failures upon CI jobs.