### PR TITLE
Configure git to don't use unauthenticated protocol

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -58,6 +58,14 @@ jobs:
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install dependencies
         run: yarn install
 
@@ -109,6 +117,14 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v1
@@ -229,6 +245,14 @@ jobs:
           cd ..
           yarn install --frozen-lockfile
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install dependencies
         run: yarn install
 
@@ -272,6 +296,14 @@ jobs:
         env:
           SLITHER_VERSION: 0.8.2
         run: pip3 install slither-analyzer==$SLITHER_VERSION
+
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -26,6 +26,14 @@ jobs:
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Resolve latest contracts
         run: |
           yarn upgrade @keep-network/tbtc

--- a/solidity/README.adoc
+++ b/solidity/README.adoc
@@ -31,6 +31,18 @@ yarn build
 ```
 Compiled contracts will land in the `build` directory.
 
+*NOTE:* The `tbtc-v2` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using Yarn may result in `The unauthenticated git
+protocol on port 9418 is no longer supported` error. +
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
+```
+
 === Test contracts
 
 There are multiple test scenarios living in the `test` directory.


### PR DESCRIPTION
We're adding a step that configures git to use `https://` protocol
instead of `git://` when downloading files.
We need this step because the `@keep-network/tbtc` which we update in next
steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
downloads one of its sub-dependencies via unathenticated `git://`
protocol. That protocol is no longer supported. See
https://github.blog/2021-09-01-improving-git-protocol-security-github/.