### PR TITLE
Notify `Wallets` library about a proven fraud

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -478,6 +478,15 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         wallets.registerNewWallet(ecdsaWalletID, publicKeyX, publicKeyY);
     }
 
+    // TODO: Documentation.
+    function __ecdsaWalletHeartbeatFailedCallback(
+        bytes32 ecdsaWalletID,
+        bytes32 publicKeyX,
+        bytes32 publicKeyY
+    ) external override {
+        // TODO: Implementation.
+    }
+
     /// @notice Gets details about a registered wallet.
     /// @param walletPubKeyHash The 20-byte wallet public key hash (computed
     ///        using Bitcoin HASH160 over the compressed ECDSA public key)

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -314,6 +314,11 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 indexed walletPubKeyHash
     );
 
+    event WalletTerminated(
+        bytes32 indexed ecdsaWalletID,
+        bytes20 indexed walletPubKeyHash
+    );
+
     event VaultStatusUpdated(address indexed vault, bool isTrusted);
 
     event DepositRevealed(

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -315,8 +315,9 @@ library Wallets {
     ) external {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         require(
-            wallet.state == WalletState.Live,
-            "ECDSA wallet must be in Live state"
+            wallet.state == WalletState.Live ||
+                wallet.state == WalletState.MovingFunds,
+            "ECDSA wallet must be in Live or MovingFunds state"
         );
 
         wallet.state = WalletState.Terminated;

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@keep-network/bitcoin-spv-sol": "3.3.0-solc-0.8",
-    "@keep-network/ecdsa": "2.0.0-dev.2",
+    "@keep-network/ecdsa": "2.0.0-dev.4",
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
     "@openzeppelin/contracts": "^4.1.0",
     "@tenderly/hardhat-tenderly": "^1.0.12",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1508,10 +1508,10 @@
   resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.3.0-solc-0.8.tgz#5dfd552f9437e865038c1e97a2d27967c399dcbc"
   integrity sha512-AG2fJqqniXVzwitHQcYQK5dZIyUPDo5xS1RZzW+LngcIuKA/f0cvTDEjWxgjf4D5MbStJNFWaCTtWwAJUCzsIw==
 
-"@keep-network/ecdsa@2.0.0-dev.2":
-  version "2.0.0-dev.2"
-  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.0.0-dev.2.tgz#5dd5cdc00ae2d865472c0dacbdce263c4528e8e2"
-  integrity sha512-h1dHjHATaXFIuj0p65fe9g6bDUMdb8ZQ4z9tdit4nNwHNKPtROjK8n80gPZguJzBqAQrEdCaD8t9UAGznD8ELQ==
+"@keep-network/ecdsa@2.0.0-dev.4":
+  version "2.0.0-dev.4"
+  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.0.0-dev.4.tgz#5fe1c06079ab9449805c7816e1674fd4109b070e"
+  integrity sha512-3qCzhuNt9gClQrDpdUVG5i1NVSQNOqu7Xbz7sV+r/eTEedHhfNJDrHIiVo15KH18wPUFlvVPtc+6Sio9TGriFQ==
   dependencies:
     "@keep-network/random-beacon" ">2.0.0-dev <2.0.0-ropsten"
     "@keep-network/sortition-pools" "^2.0.0-dev.0"


### PR DESCRIPTION
Refs: #139 

This function allows notifying the `Wallets` library about a proven fraud committed by a wallet and cause appropriate side effects like slashing and wallet termination.