### PR TITLE
Fix argument of `closeWallet` function call

### DIFF
--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -515,6 +515,6 @@ library Wallets {
             delete self.activeWalletPubKeyHash;
         }
 
-        self.registry.closeWallet(walletPubKeyHash);
+        self.registry.closeWallet(wallet.ecdsaWalletID);
     }
 }


### PR DESCRIPTION
The ECDSA registry's `closeWallet` function expects a `bytes32` `ecdsaWalletID`, not the `bytes20` `walletPubKeyHash`. This change fixes that mistake.