### PR TITLE
Redemption timeout

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1969,6 +1969,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             request.treasuryFee;
 
         require(
+            // TODO: Allow the wallets in `Closing` state when the state is added
             wallet.state == Wallets.WalletState.Live ||
                 wallet.state == Wallets.WalletState.MovingFunds ||
                 wallet.state == Wallets.WalletState.Terminated,

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1993,9 +1993,9 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             wallets.notifyRedemptionTimedOut(walletPubKeyHash);
         }
 
+        emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
+
         // Return the requested amount of tokens to the redeemer
         bank.transferBalance(request.redeemer, request.requestedAmount);
-
-        emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1974,16 +1974,11 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         // Return the requested amount of tokens to the redeemer
         bank.transferBalance(request.redeemer, request.requestedAmount);
 
-        // Notice that there is no need to check if `timedOutRedemptions`
-        // mapping already contains the redemption key because
-        // `requestRedemption` blocks requests targeting non-live wallets.
-        // Because `notifyRedemptionTimeout` changes the state of any live-wallet
-        // after the first call, there is no possibility that the given
-        // redemption key could be reported as timed-out multiple times.
-        // At the same time, if the given redemption key was already marked as
-        // fraudulent due to an amount-related fraud, it will not be possible
-        // to report a timeout on it since it will not be present in
-        // `pendingRedemptions` mapping.
+        // It is worth noting that there is no need to check if
+        // `timedOutRedemption` mapping already contains the given redemption
+        // key. There is no possibility to re-use a key of a reported timed-out
+        // redemption because the wallet responsible for causing the timeout is
+        // moved to a state that prevents it to receive new redemption requests.
 
         // Move the redemption from pending redemptions to timed-out redemptions
         timedOutRedemptions[redemptionKey] = request;

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1971,8 +1971,19 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             request.requestedAmount -
             request.treasuryFee;
 
-        // Return the requested amount of tBTC to the redeemer
+        // Return the requested amount of tokens to the redeemer
         bank.transferBalance(request.redeemer, request.requestedAmount);
+
+        // Notice that there is no need to check if `timedOutRedemptions`
+        // mapping already contains the redemption key because
+        // `requestRedemption` blocks requests targeting non-live wallets.
+        // Because `notifyRedemptionTimeout` changes the state of any live-wallet
+        // after the first call, there is no possibility that the given
+        // redemption key could be reported as timed-out multiple times.
+        // At the same time, if the given redemption key was already marked as
+        // fraudulent due to an amount-related fraud, it will not be possible
+        // to report a timeout on it since it will not be present in
+        // `pendingRedemptions` mapping.
 
         // Move the redemption from pending redemptions to timed-out redemptions
         timedOutRedemptions[redemptionKey] = request;

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1971,6 +1971,13 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             request.requestedAmount -
             request.treasuryFee;
 
+        require(
+            wallet.state == Wallets.WalletState.Live ||
+                wallet.state == Wallets.WalletState.MovingFunds ||
+                wallet.state == Wallets.WalletState.Terminated,
+            "The wallet must be in Live, MovingFunds or Terminated state"
+        );
+
         // Return the requested amount of tokens to the redeemer
         bank.transferBalance(request.redeemer, request.requestedAmount);
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1954,7 +1954,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         uint256 redemptionKey = uint256(
             keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
         );
-        RedemptionRequest storage request = pendingRedemptions[redemptionKey];
+        RedemptionRequest memory request = pendingRedemptions[redemptionKey];
 
         require(request.requestedAt > 0, "Redemption request does not exist");
         require(
@@ -1978,9 +1978,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             "The wallet must be in Live, MovingFunds or Terminated state"
         );
 
-        // Return the requested amount of tokens to the redeemer
-        bank.transferBalance(request.redeemer, request.requestedAmount);
-
         // It is worth noting that there is no need to check if
         // `timedOutRedemption` mapping already contains the given redemption
         // key. There is no possibility to re-use a key of a reported timed-out
@@ -1998,6 +1995,9 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             // Propagate timeout consequences to the wallet
             wallets.notifyRedemptionTimedOut(walletPubKeyHash);
         }
+
+        // Return the requested amount of tokens to the redeemer
+        bank.transferBalance(request.redeemer, request.requestedAmount);
 
         emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
     }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -302,9 +302,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         - `notifyRedemptionTimeout` which puts the redemption key
     ///           to this mapping basing on a timed out request stored
     ///           previously in `pendingRedemptions` mapping.
-    ///
-    // TODO: Remove that Slither disable once this variable is used.
-    // slither-disable-next-line uninitialized-state
     mapping(uint256 => RedemptionRequest) public timedOutRedemptions;
 
     /// @notice Contains parameters related to frauds and the collection of all

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -389,7 +389,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes32 redemptionTxHash
     );
 
-    event RedemptionTimeout(
+    event RedemptionTimedOut(
         bytes20 walletPubKeyHash,
         bytes redeemerOutputScript
     );
@@ -1996,8 +1996,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             // Propagate timeout consequences to the wallet
             wallets.notifyRedemptionTimedOut(walletPubKeyHash);
         }
-        // TODO: should the notifier be reimbursed?
 
-        emit RedemptionTimeout(walletPubKeyHash, redeemerOutputScript);
+        emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1923,7 +1923,30 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         return info;
     }
 
-    // TODO: description
+    /// @notice Notifies that there is a pending redemption request associated
+    ///         with the given wallet, that has timed out. The redemption
+    ///         request is identified by the key built as
+    ///         `keccak256(walletPubKeyHash | redeemerOutputScript)`.
+    ///         The results of calling this function: the pending redemptions
+    ///         value for the wallet will be decreased by the requested amount
+    ///         (minus treasury fee), the tokens taken from the redeemer on
+    ///         redemption request will be returned to the redeemer, the request
+    ///         will be moved from pending redemptions to timed-out redemptions.
+    ///         If the state of the wallet is `Live` or `MovingFunds`, the
+    ///         wallet operators will be slashed.
+    ///         Additionally, if the state of wallet is `Live`, the wallet will
+    ///         be closed or marked as `MovingFunds` (depending on the presence
+    ///         or absence of the wallet's main UTXO) and the wallet will no
+    ///         longer be marked as the active wallet (if it was marked as such).
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet
+    /// @param redeemerOutputScript  The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH)
+    /// @dev Requirements:
+    ///      - The redemption request identified by `walletPubKeyHash` and
+    ///        `redeemerOutputScript` must exist
+    ///      - The amount of time defined by `redemptionTimeout` must have
+    ///        passed since the redemption was requested (the request must be
+    ///        timed-out).
     function notifyRedemptionTimeout(
         bytes20 walletPubKeyHash,
         bytes calldata redeemerOutputScript

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -364,8 +364,6 @@ library Wallets {
     ///         for the same wallet but only the first report requests the
     ///         wallet to move their funds.
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
-    /// @dev Requirements:
-    ///      - Wallet must be in Live or MovingFunds state
     function notifyRedemptionTimedOut(
         Data storage self,
         bytes20 walletPubKeyHash
@@ -373,12 +371,6 @@ library Wallets {
         WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;
-
-        require(
-            walletState == WalletState.Live ||
-                walletState == WalletState.MovingFunds,
-            "ECDSA wallet must be in Live or MovingFunds state"
-        );
 
         if (walletState == WalletState.Live) {
             moveFunds(self, walletPubKeyHash);

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -365,8 +365,7 @@ library Wallets {
     ///         wallet to move their funds.
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
     /// @dev Requirements:
-    ///      - The caller must make sure that the wallet is in the `Live` or
-    ///        `MovingFunds` state
+    ///      - The wallet must be in the `Live` or `MovingFunds` state
     function notifyRedemptionTimedOut(
         Data storage self,
         bytes20 walletPubKeyHash
@@ -374,6 +373,12 @@ library Wallets {
         WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;
+
+        require(
+            walletState == WalletState.Live ||
+                walletState == WalletState.MovingFunds,
+            "ECDSA wallet must be in Live or MovingFunds state"
+        );
 
         if (walletState == WalletState.Live) {
             moveFunds(self, walletPubKeyHash);

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -379,7 +379,8 @@ library Wallets {
             moveFunds(self, walletPubKeyHash);
         }
 
-        // TODO: Perform slashing of wallet operators.
+        // TODO: Perform slashing of wallet operators and transfer some of the
+        //       slashed tokens to the caller of this function.
     }
 
     /// @notice Notifies that the wallet is either old enough or has too few

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -364,6 +364,9 @@ library Wallets {
     ///         for the same wallet but only the first report requests the
     ///         wallet to move their funds.
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
+    /// @dev Requirements:
+    ///      - The caller must make sure that the wallet is in the `Live` or
+    ///        `MovingFunds` state
     function notifyRedemptionTimedOut(
         Data storage self,
         bytes20 walletPubKeyHash

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -64,6 +64,10 @@ contract BridgeStub is Bridge {
         );
     }
 
+    function unsetWalletMainUtxo(bytes20 walletPubKeyHash) external {
+        delete wallets.registeredWallets[walletPubKeyHash].mainUtxoHash;
+    }
+
     function setWallet(bytes20 walletPubKeyHash, Wallets.Wallet calldata wallet)
         external
     {

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -89,34 +89,4 @@ contract BridgeStub is Bridge {
     ) external {
         redemptionTreasuryFeeDivisor = _redemptionTreasuryFeeDivisor;
     }
-
-    // TODO: Temporary function used for test purposes. Should be removed
-    //       once real `notifyRedemptionTimeout` is implemented.
-    function notifyRedemptionTimeout(
-        bytes20 walletPubKeyHash,
-        bytes calldata redeemerOutputScript
-    ) external {
-        uint256 redemptionKey = uint256(
-            keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
-        );
-        RedemptionRequest storage request = pendingRedemptions[redemptionKey];
-
-        require(request.requestedAt != 0, "Request does not exist");
-        require(
-            /* solhint-disable-next-line not-rely-on-time */
-            request.requestedAt + redemptionTimeout < block.timestamp,
-            "Request not timed out"
-        );
-
-        timedOutRedemptions[redemptionKey] = request;
-        delete pendingRedemptions[redemptionKey];
-
-        Wallets.Wallet storage wallet = wallets.registeredWallets[
-            walletPubKeyHash
-        ];
-        wallet.state = Wallets.WalletState.MovingFunds;
-        wallet.pendingRedemptionsValue -=
-            request.requestedAmount -
-            request.treasuryFee;
-    }
 }

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -101,7 +101,7 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
-    except: ["BridgeStub$"], // TODO: Remove it once the problem of BridgeStub's size is solved
+    except: ["BridgeStub$", "Bridge$"], // TODO: Remove it once the problem of contracts' size is solved
   },
   typechain: {
     outDir: "typechain",

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -4976,12 +4976,6 @@ describe("Bridge", () => {
                 )
                 const request = await bridge.pendingRedemptions(redemptionKey)
 
-                expect(request.redeemer).to.be.equal(
-                  "0x0000000000000000000000000000000000000000"
-                )
-                expect(request.requestedAmount).to.be.equal(0)
-                expect(request.treasuryFee).to.be.equal(0)
-                expect(request.txMaxFee).to.be.equal(0)
                 expect(request.requestedAt).to.be.equal(0)
               })
 
@@ -5173,12 +5167,6 @@ describe("Bridge", () => {
                 )
                 const request = await bridge.pendingRedemptions(redemptionKey)
 
-                expect(request.redeemer).to.be.equal(
-                  "0x0000000000000000000000000000000000000000"
-                )
-                expect(request.requestedAmount).to.be.equal(0)
-                expect(request.treasuryFee).to.be.equal(0)
-                expect(request.txMaxFee).to.be.equal(0)
                 expect(request.requestedAt).to.be.equal(0)
               })
 
@@ -5221,7 +5209,7 @@ describe("Bridge", () => {
 
               it("should not emit WalletClosed events", async () => {
                 // Since the wallet has UTXO set it should be not be closed but
-                // marked as zMovingFunds` and we should not see any `WalletClosed`
+                // marked as `MovingFunds` and we should not see any `WalletClosed`
                 // event
                 await expect(tx).not.to.emit(bridge, "WalletClosed")
               })
@@ -5314,6 +5302,9 @@ describe("Bridge", () => {
               await restoreSnapshot()
             })
 
+            // Only verify the active wallet public key hash has not changed.
+            // The other checks are covered in scenarios where the wallet was
+            // the active wallet and they should not be repeated here.
             it("should not delete the active wallet public key hash", async () => {
               // Check that the active wallet has not changed
               expect(await bridge.getActiveWalletPubKeyHash()).to.be.equal(
@@ -5448,12 +5439,6 @@ describe("Bridge", () => {
             )
             const request = await bridge.pendingRedemptions(redemptionKey)
 
-            expect(request.redeemer).to.be.equal(
-              "0x0000000000000000000000000000000000000000"
-            )
-            expect(request.requestedAmount).to.be.equal(0)
-            expect(request.treasuryFee).to.be.equal(0)
-            expect(request.txMaxFee).to.be.equal(0)
             expect(request.requestedAt).to.be.equal(0)
           })
 
@@ -5619,12 +5604,6 @@ describe("Bridge", () => {
             )
             const request = await bridge.pendingRedemptions(redemptionKey)
 
-            expect(request.redeemer).to.be.equal(
-              "0x0000000000000000000000000000000000000000"
-            )
-            expect(request.requestedAmount).to.be.equal(0)
-            expect(request.treasuryFee).to.be.equal(0)
-            expect(request.txMaxFee).to.be.equal(0)
             expect(request.requestedAt).to.be.equal(0)
           })
 

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -5046,9 +5046,9 @@ describe("Bridge", () => {
                 // TODO: Add test when operator slashing is implemented
               })
 
-              it("should emit RedemptionTimeout event", async () => {
+              it("should emit RedemptionTimedOut event", async () => {
                 await expect(tx)
-                  .to.emit(bridge, "RedemptionTimeout")
+                  .to.emit(bridge, "RedemptionTimedOut")
                   .withArgs(
                     data.wallet.pubKeyHash,
                     data.redemptionRequests[0].redeemerOutputScript
@@ -5242,9 +5242,9 @@ describe("Bridge", () => {
                 // TODO: Add test when operator slashing is implemented
               })
 
-              it("should emit RedemptionTimeout event", async () => {
+              it("should emit RedemptionTimedOut event", async () => {
                 await expect(tx)
-                  .to.emit(bridge, "RedemptionTimeout")
+                  .to.emit(bridge, "RedemptionTimedOut")
                   .withArgs(
                     data.wallet.pubKeyHash,
                     data.redemptionRequests[0].redeemerOutputScript
@@ -5494,9 +5494,9 @@ describe("Bridge", () => {
             await expect(tx).not.to.emit(bridge, "WalletClosed")
           })
 
-          it("should emit RedemptionTimeout event", async () => {
+          it("should emit RedemptionTimedOut event", async () => {
             await expect(tx)
-              .to.emit(bridge, "RedemptionTimeout")
+              .to.emit(bridge, "RedemptionTimedOut")
               .withArgs(
                 data.wallet.pubKeyHash,
                 data.redemptionRequests[0].redeemerOutputScript
@@ -5694,9 +5694,9 @@ describe("Bridge", () => {
                   await expect(tx).not.to.emit(bridge, "WalletClosed")
                 })
 
-                it("should emit RedemptionTimeout event", async () => {
+                it("should emit RedemptionTimedOut event", async () => {
                   await expect(tx)
-                    .to.emit(bridge, "RedemptionTimeout")
+                    .to.emit(bridge, "RedemptionTimedOut")
                     .withArgs(
                       data.wallet.pubKeyHash,
                       data.redemptionRequests[0].redeemerOutputScript

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -5660,6 +5660,10 @@ describe("Bridge", () => {
           })
         })
 
+        context("when the wallet is in Closing state", () => {
+          // TODO: Implement
+        })
+
         context("when the wallet is either in Unknown or Closed state", () => {
           const testData = [
             {
@@ -5747,8 +5751,6 @@ describe("Bridge", () => {
             })
           })
         })
-
-        // TODO: Add tests for Closing state
       })
 
       context("when the redemption request has not timed out", () => {

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -5504,7 +5504,184 @@ describe("Bridge", () => {
           })
         })
 
-        context("when the wallet is neither in Unknown or Closed state", () => {
+        context("when the wallet is in Terminated state", () => {
+          const data: RedemptionTestData = SinglePendingRequestedRedemption
+          let tx: ContractTransaction
+          let initialPendingRedemptionsValue: BigNumber
+          let initialRedeemerBalance: BigNumber
+          let redemptionRequest: {
+            redeemer: string
+            requestedAmount: BigNumber
+            treasuryFee: BigNumber
+            txMaxFee: BigNumber
+            requestedAt: number
+          }
+
+          before(async () => {
+            await createSnapshot()
+
+            await bridge.setWallet(data.wallet.pubKeyHash, {
+              ecdsaWalletID: data.wallet.ecdsaWalletID,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: data.wallet.pendingRedemptionsValue,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              // Initially set the state to Live, so that the redemption
+              // request can be made
+              state: walletState.Live,
+            })
+            await bridge.setWalletMainUtxo(
+              data.wallet.pubKeyHash,
+              data.mainUtxo
+            )
+
+            const redeemerSigner = await impersonateAccount(
+              data.redemptionRequests[0].redeemer,
+              {
+                from: governance,
+                value: null, // use default value
+              }
+            )
+
+            await makeRedemptionAllowance(
+              redeemerSigner,
+              data.redemptionRequests[0].amount
+            )
+
+            await bridge
+              .connect(redeemerSigner)
+              .requestRedemption(
+                data.wallet.pubKeyHash,
+                data.mainUtxo,
+                data.redemptionRequests[0].redeemerOutputScript,
+                data.redemptionRequests[0].amount
+              )
+
+            // Simulate the wallet's state has changed to Terminated
+            const wallet = await bridge.getWallet(data.wallet.pubKeyHash)
+            await bridge.setWallet(data.wallet.pubKeyHash, {
+              ecdsaWalletID: wallet.ecdsaWalletID,
+              mainUtxoHash: wallet.mainUtxoHash,
+              pendingRedemptionsValue: wallet.pendingRedemptionsValue,
+              createdAt: wallet.createdAt,
+              moveFundsRequestedAt: wallet.moveFundsRequestedAt,
+              state: walletState.Terminated,
+            })
+
+            await increaseTime(await bridge.redemptionTimeout())
+
+            initialPendingRedemptionsValue = (
+              await bridge.getWallet(data.wallet.pubKeyHash)
+            ).pendingRedemptionsValue
+
+            initialRedeemerBalance = await bank.balanceOf(
+              data.redemptionRequests[0].redeemer
+            )
+
+            const redemptionKey = buildRedemptionKey(
+              data.wallet.pubKeyHash,
+              data.redemptionRequests[0].redeemerOutputScript
+            )
+
+            redemptionRequest = await bridge.pendingRedemptions(redemptionKey)
+
+            tx = await bridge
+              .connect(thirdParty)
+              .notifyRedemptionTimeout(
+                data.wallet.pubKeyHash,
+                data.redemptionRequests[0].redeemerOutputScript
+              )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should update the wallet's pending redemptions value", async () => {
+            const expectedPendingRedemptionsValue =
+              initialPendingRedemptionsValue
+                .sub(data.redemptionRequests[0].amount)
+                .add(redemptionRequest.treasuryFee)
+
+            const currentPendingRedemptionsValue = (
+              await bridge.getWallet(data.wallet.pubKeyHash)
+            ).pendingRedemptionsValue
+
+            expect(currentPendingRedemptionsValue).to.be.equal(
+              expectedPendingRedemptionsValue
+            )
+          })
+
+          it("should remove the request from the pending redemptions", async () => {
+            const redemptionKey = buildRedemptionKey(
+              data.wallet.pubKeyHash,
+              data.redemptionRequests[0].redeemerOutputScript
+            )
+            const request = await bridge.pendingRedemptions(redemptionKey)
+
+            expect(request.redeemer).to.be.equal(
+              "0x0000000000000000000000000000000000000000"
+            )
+            expect(request.requestedAmount).to.be.equal(0)
+            expect(request.treasuryFee).to.be.equal(0)
+            expect(request.txMaxFee).to.be.equal(0)
+            expect(request.requestedAt).to.be.equal(0)
+          })
+
+          it("should add the request to the timed-out redemptions", async () => {
+            const timedOutRequest = await bridge.timedOutRedemptions(
+              buildRedemptionKey(
+                data.wallet.pubKeyHash,
+                data.redemptionRequests[0].redeemerOutputScript
+              )
+            )
+
+            expect(timedOutRequest.redeemer).to.be.equal(
+              data.redemptionRequests[0].redeemer
+            )
+            expect(timedOutRequest.requestedAmount).to.be.equal(
+              redemptionRequest.requestedAmount
+            )
+            expect(timedOutRequest.treasuryFee).to.be.equal(
+              redemptionRequest.treasuryFee
+            )
+            expect(timedOutRequest.txMaxFee).to.be.equal(
+              redemptionRequest.txMaxFee
+            )
+            expect(timedOutRequest.requestedAt).to.be.equal(
+              redemptionRequest.requestedAt
+            )
+          })
+
+          it("should not emit WalletClosed or WalletMovingFunds events", async () => {
+            // Since the state of the wallet is neither Live or MovingFunds
+            // we should not see any event related to moving funds or
+            // closing the wallet
+            await expect(tx).not.to.emit(bridge, "WalletMovingFunds")
+            await expect(tx).not.to.emit(bridge, "WalletClosed")
+          })
+
+          it("should emit RedemptionTimedOut event", async () => {
+            await expect(tx)
+              .to.emit(bridge, "RedemptionTimedOut")
+              .withArgs(
+                data.wallet.pubKeyHash,
+                data.redemptionRequests[0].redeemerOutputScript
+              )
+          })
+
+          it("should return the requested amount of tokens to the redeemer", async () => {
+            const expectedRedeemerBalance = initialRedeemerBalance.add(
+              data.redemptionRequests[0].amount
+            )
+            const currentRedeemerBalance = await bank.balanceOf(
+              data.redemptionRequests[0].redeemer
+            )
+            expect(currentRedeemerBalance).to.be.equal(expectedRedeemerBalance)
+          })
+        })
+
+        context("when the wallet is either in Unknown or Closed state", () => {
           const testData = [
             {
               testName: "when wallet state is Unknown",
@@ -5591,6 +5768,8 @@ describe("Bridge", () => {
             })
           })
         })
+
+        // TODO: Add tests for Closing state
       })
 
       context("when the redemption request has not timed out", () => {


### PR DESCRIPTION
This PR adds functionality of redemption timeout notification.

One function was added: `notifyRedemptionTimeout`.
The function checks whether the redemption request exists and has timed out.
Further steps depend on the state of the wallet:
* if the wallet is in `Live` state:
  - the wallet's pending redemptions value is decreased by the amount requested in redemption request (minus treasury fee)
  - the tokens taken by the bank during the redemption request are returned to the redeemer
  - the redemption request is moved from pending redemptions to timeout redemptions
  - the wallet's operators are slashed (`TODO`)
  - the wallet is marked as either `MovingFunds` (if there is mainUTXO set for the wallet) or `Closed` (if there is no main UTXO set for the wallet)
  - if the wallet was marked as active - it is no longer marked as such
  
* if the wallet is in `MovingFunds` state:
  - the wallet's pending redemptions value is decreased by the amount requested in redemption request (minus treasury fee)
  - the tokens taken by the bank during the redemption request are returned to the redeemer
  - the redemption request is moved from pending redemptions to timeout redemptions
  - the wallet's operators are slashed (`TODO`)
  
* if the wallet is in `Terminated` state:
   - the wallet's pending redemptions value is decreased by the amount requested in redemption request (minus treasury fee)
  - the tokens taken by the bank during the redemption request are returned to the redeemer
  - the redemption request is moved from pending redemptions to timeout redemptions
  
* if the wallet is in `Unknown` or `Closed` state:
  - revert

The cost of calling `notifyRedemptionTimeout` is between `108k` and  `128k` (`116k` on average).
