### PR TITLE
RFC 1: `intention-to-move`

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -670,26 +670,28 @@ referred to as `move_funds_start_timestamp`. If the balance is less than
 `wallet_dust_leftover`, we simply close the wallet and abandon the funds. We
 can maintain the peg via a <<donate,donation>>.
 
-That operator proposes a BTC fee (as in <<sweeping,sweeping>>) and the
-operators use the wallet's public key hash to choose viable (it must also have
-a passing heartbeat and be above `wallet_min_closure_btc`, and not exceeded the
-`wallet_max_age) wallet(s) to transfer the remaining funds to. They construct a
-P2PKH transaction moving the wallet's main UTXO to that wallet. For more
+The first operator posts a signed, <<operator-only,reimbursable>>
+`intention-to-move` transaction to the ethereum chain declaring which wallets
+the operators intend to move the funds to. This starts a challenge period in
+which <<public-knowledge,the public>> can challenge the destination wallets.
+They do so by showing there exists a live, valid wallet which was created
+before `move_funds_start_timestamp` that _wasn't_ chosen _and_ should have
+been. See <<wallet-closure-transaction,the dedicated section>> for how wallets
+are chosen.
+
+If the challenge period passes, that operator proposes a BTC fee (as in
+<<sweeping,sweeping>>) and the operators transfer the funds evenly between the
+wallets proposed in the `intention-to-move` transaction. They construct a P2PKH
+transaction moving the wallet's main UTXO to each of those wallets. For more
 details on exactly how a wallet is chosen and how the funds are split up see
 <<wallet-closure-transaction,the dedicated section>>.
 
 After this transaction is complete, <<public-knowledge,the public>> is able to
 submit a SPV proof to let ethereum know that the funds were transferred
-nonfraudulently. Later, a <<donate,donation>> can be made by governance to
-handle any difference in outstanding v2 token supply and locked BTC due to
-mining transfer fees.
-
-Later, <<public-knowledge,the public>> at any time can challenge the operator's
-wallet choice. They do so by showing that there exists a live, valid wallet
-which was created before `move_funds_start_timestamp` that _wasn't_ chosen
-_and_ should have been. These challenges are incentivized to happen sooner
-rather than later, as eventually all of the relevant operators may be fully
-unstaked and there will be no stake to slash, and thus no reward.
+nonfraudulently (they match the `intention-to-move` wallets, the fee isn't too
+high, and the funds are split evently). Later, a <<donate,donation>> can be
+made by governance to handle any difference in outstanding v2 token supply and
+locked BTC due to mining transfer fees.
 
 *Notes*: Transferring the BTC to any address other than the P2PKH of one of the
 other wallet addresses is fraud, and is <<Punishment,punishable>>. Moving funds


### PR DESCRIPTION
This PR changes the wallet closure approach to iron out some wrinkles in the previous challenge process.

Previously, we were letting the wallet transfer the bitcoin to whichever wallets they pleased, and then relying on a challenge to show that the chosen wallets were the closest, live wallets at the time.

Since we don't (want to) keep track of wallet state history (only the current state of wallets), we have no way of telling if there *was* another closer live wallet back when the wallet decided to move the funds - we can only tell if there is *still* a live wallet. This means that the challenge becomes a race where the state of the wallet you're using to challenge with can change out from under you.

To solve this, we separate out the concern into "these are the wallets I want to transfer to" and "did you transfer to the wallets you said you would". We can verify at the time you post the original "these are the wallets I want to transfer to" list if those are valid via a challenge (the tx fails if any of the wallets aren't live, and I can challenge with any closer wallet live wallet).

Tagging @lukasz-zimnoch @pdyraga and @michalinacienciala for review