### PR TITLE
Check wallet state during submit sweep proof

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -838,7 +838,12 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             walletPubKeyHash
         ];
 
-        // TODO: Validate if `walletPubKeyHash` is a known and live wallet.
+        Wallets.WalletState walletState = wallet.state;
+        require(
+            walletState == Wallets.WalletState.Live ||
+                walletState == Wallets.WalletState.MovingFunds,
+            "Wallet must be in Live or MovingFunds state"
+        );
 
         // Check if the main UTXO for given wallet exists. If so, validate
         // passed main UTXO data against the stored hash and use them for

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -709,18 +709,301 @@ describe("Bridge", () => {
   })
 
   describe("submitSweepProof", () => {
-    context("when transaction proof is valid", () => {
-      context("when there is only one output", () => {
-        context("when wallet public key hash length is 20 bytes", () => {
-          context("when main UTXO data are valid", () => {
-            context(
-              "when transaction fee does not exceed the deposit transaction maximum fee",
-              () => {
-                context("when there is only one input", () => {
-                  context(
-                    "when the single input is a revealed unswept P2SH deposit",
-                    () => {
-                      let tx: ContractTransaction
+    context("when the wallet state is Live", () => {
+      context("when transaction proof is valid", () => {
+        context("when there is only one output", () => {
+          context("when wallet public key hash length is 20 bytes", () => {
+            context("when main UTXO data are valid", () => {
+              context(
+                "when transaction fee does not exceed the deposit transaction maximum fee",
+                () => {
+                  context("when there is only one input", () => {
+                    context(
+                      "when the single input is a revealed unswept P2SH deposit",
+                      () => {
+                        let tx: ContractTransaction
+                        const data: SweepTestData = SingleP2SHDeposit
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          tx = await runSweepScenario(data)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should mark deposit as swept", async () => {
+                          // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+                          const depositKey = ethers.utils.solidityKeccak256(
+                            ["bytes32", "uint32"],
+                            [
+                              data.deposits[0].fundingTx.hash,
+                              data.deposits[0].reveal.fundingOutputIndex,
+                            ]
+                          )
+
+                          const deposit = await bridge.deposits(depositKey)
+
+                          expect(deposit.sweptAt).to.be.equal(
+                            await lastBlockTime()
+                          )
+                        })
+
+                        it("should update main UTXO for the given wallet", async () => {
+                          const { mainUtxoHash } = await bridge.getWallet(
+                            walletPubKeyHash
+                          )
+
+                          // Amount can be checked by opening the sweep tx in a Bitcoin
+                          // testnet explorer. In this case, the sum of inputs is
+                          // 20000 satoshi (from the single deposit) and there is a
+                          // fee of 1500 so the output value is 18500.
+                          const expectedMainUtxo =
+                            ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32", "uint64"],
+                              [data.sweepTx.hash, 0, 18500]
+                            )
+
+                          expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
+                        })
+
+                        it("should update the depositor's balance", async () => {
+                          // The sum of sweep tx inputs is 20000 satoshi. The output
+                          // value is 18500 so the transaction fee is 1500. There is
+                          // only one deposit so it incurs the entire transaction fee.
+                          // The deposit should also incur the treasury fee whose
+                          // initial value is 0.05% of the deposited amount so the
+                          // final depositor balance should be cut by 10 satoshi.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[0].reveal.depositor
+                            )
+                          ).to.be.equal(18490)
+                        })
+
+                        it("should transfer collected treasury fee", async () => {
+                          expect(
+                            await bank.balanceOf(treasury.address)
+                          ).to.be.equal(10)
+                        })
+
+                        it("should emit DepositsSwept event", async () => {
+                          await expect(tx)
+                            .to.emit(bridge, "DepositsSwept")
+                            .withArgs(walletPubKeyHash, data.sweepTx.hash)
+                        })
+                      }
+                    )
+
+                    context(
+                      "when the single input is a revealed unswept P2WSH deposit",
+                      () => {
+                        let tx: ContractTransaction
+                        const data: SweepTestData = SingleP2WSHDeposit
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          tx = await runSweepScenario(data)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should mark deposit as swept", async () => {
+                          // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+                          const depositKey = ethers.utils.solidityKeccak256(
+                            ["bytes32", "uint32"],
+                            [
+                              data.deposits[0].fundingTx.hash,
+                              data.deposits[0].reveal.fundingOutputIndex,
+                            ]
+                          )
+
+                          const deposit = await bridge.deposits(depositKey)
+
+                          expect(deposit.sweptAt).to.be.equal(
+                            await lastBlockTime()
+                          )
+                        })
+
+                        it("should update main UTXO for the given wallet", async () => {
+                          const { mainUtxoHash } = await bridge.getWallet(
+                            walletPubKeyHash
+                          )
+
+                          // Amount can be checked by opening the sweep tx in a Bitcoin
+                          // testnet explorer. In this case, the sum of inputs is
+                          // 80000 satoshi (from the single deposit) and there is a
+                          // fee of 2000 so the output value is 78000.
+                          const expectedMainUtxo =
+                            ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32", "uint64"],
+                              [data.sweepTx.hash, 0, 78000]
+                            )
+
+                          expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
+                        })
+
+                        it("should update the depositor's balance", async () => {
+                          // The sum of sweep tx inputs is 80000 satoshi. The output
+                          // value is 78000 so the fee is 2000. There is only one
+                          // deposit so it incurs the entire fee. The deposit should
+                          // also incur the treasury fee whose initial value is 0.05%
+                          // of the deposited amount so the final depositor balance
+                          // should be cut by 40 satoshi.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[0].reveal.depositor
+                            )
+                          ).to.be.equal(77960)
+                        })
+
+                        it("should transfer collected treasury fee", async () => {
+                          expect(
+                            await bank.balanceOf(treasury.address)
+                          ).to.be.equal(40)
+                        })
+
+                        it("should emit DepositsSwept event", async () => {
+                          await expect(tx)
+                            .to.emit(bridge, "DepositsSwept")
+                            .withArgs(walletPubKeyHash, data.sweepTx.hash)
+                        })
+                      }
+                    )
+
+                    context(
+                      "when the single input is the expected main UTXO",
+                      () => {
+                        const previousData: SweepTestData = SingleP2SHDeposit
+                        const data: SweepTestData = SingleMainUtxo
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } =
+                          previousData.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          // Make the first sweep which is actually the predecessor
+                          // of the sweep tested within this scenario.
+                          await runSweepScenario(previousData)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should revert", async () => {
+                          await expect(
+                            runSweepScenario(data)
+                          ).to.be.revertedWith(
+                            "Sweep transaction must process at least one deposit"
+                          )
+                        })
+                      }
+                    )
+
+                    context(
+                      "when the single input is a revealed but already swept deposit",
+                      () => {
+                        const data: SweepTestData = SingleP2SHDeposit
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          // Make a proper sweep to turn the tested deposit into
+                          // the swept state.
+                          await runSweepScenario(data)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should revert", async () => {
+                          // Main UTXO parameter must point to the properly
+                          // made sweep to avoid revert at validation stage.
+                          const mainUtxo = {
+                            txHash: data.sweepTx.hash,
+                            txOutputIndex: 0,
+                            txOutputValue: 18500,
+                          }
+
+                          // Try replaying the already done sweep.
+                          await expect(
+                            bridge.submitSweepProof(
+                              data.sweepTx,
+                              data.sweepProof,
+                              mainUtxo
+                            )
+                          ).to.be.revertedWith("Deposit already swept")
+                        })
+                      }
+                    )
+
+                    context("when the single input is an unknown", () => {
                       const data: SweepTestData = SingleP2SHDeposit
                       // Take wallet public key hash from first deposit. All
                       // deposits in same sweep batch should have the same value
@@ -730,8 +1013,7 @@ describe("Bridge", () => {
                       before(async () => {
                         await createSnapshot()
 
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
+                        // Simulate the wallet is an Live one and is known in the system.
                         await bridge.setWallet(walletPubKeyHash, {
                           ecdsaWalletID: ethers.constants.HashZero,
                           mainUtxoHash: ethers.constants.HashZero,
@@ -741,196 +1023,11 @@ describe("Bridge", () => {
                           state: walletState.Live,
                         })
 
-                        tx = await runSweepScenario(data)
-                      })
-
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
-
-                      it("should mark deposit as swept", async () => {
-                        // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
-                        const depositKey = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32"],
-                          [
-                            data.deposits[0].fundingTx.hash,
-                            data.deposits[0].reveal.fundingOutputIndex,
-                          ]
+                        // Necessary to pass the proof validation.
+                        await relay.setCurrentEpochDifficulty(
+                          data.chainDifficulty
                         )
-
-                        const deposit = await bridge.deposits(depositKey)
-
-                        expect(deposit.sweptAt).to.be.equal(
-                          await lastBlockTime()
-                        )
-                      })
-
-                      it("should update main UTXO for the given wallet", async () => {
-                        const { mainUtxoHash } = await bridge.getWallet(
-                          walletPubKeyHash
-                        )
-
-                        // Amount can be checked by opening the sweep tx in a Bitcoin
-                        // testnet explorer. In this case, the sum of inputs is
-                        // 20000 satoshi (from the single deposit) and there is a
-                        // fee of 1500 so the output value is 18500.
-                        const expectedMainUtxo = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32", "uint64"],
-                          [data.sweepTx.hash, 0, 18500]
-                        )
-
-                        expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
-                      })
-
-                      it("should update the depositor's balance", async () => {
-                        // The sum of sweep tx inputs is 20000 satoshi. The output
-                        // value is 18500 so the transaction fee is 1500. There is
-                        // only one deposit so it incurs the entire transaction fee.
-                        // The deposit should also incur the treasury fee whose
-                        // initial value is 0.05% of the deposited amount so the
-                        // final depositor balance should be cut by 10 satoshi.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[0].reveal.depositor
-                          )
-                        ).to.be.equal(18490)
-                      })
-
-                      it("should transfer collected treasury fee", async () => {
-                        expect(
-                          await bank.balanceOf(treasury.address)
-                        ).to.be.equal(10)
-                      })
-
-                      it("should emit DepositsSwept event", async () => {
-                        await expect(tx)
-                          .to.emit(bridge, "DepositsSwept")
-                          .withArgs(walletPubKeyHash, data.sweepTx.hash)
-                      })
-                    }
-                  )
-
-                  context(
-                    "when the single input is a revealed unswept P2WSH deposit",
-                    () => {
-                      let tx: ContractTransaction
-                      const data: SweepTestData = SingleP2WSHDeposit
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } = data.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
-                        })
-
-                        tx = await runSweepScenario(data)
-                      })
-
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
-
-                      it("should mark deposit as swept", async () => {
-                        // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
-                        const depositKey = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32"],
-                          [
-                            data.deposits[0].fundingTx.hash,
-                            data.deposits[0].reveal.fundingOutputIndex,
-                          ]
-                        )
-
-                        const deposit = await bridge.deposits(depositKey)
-
-                        expect(deposit.sweptAt).to.be.equal(
-                          await lastBlockTime()
-                        )
-                      })
-
-                      it("should update main UTXO for the given wallet", async () => {
-                        const { mainUtxoHash } = await bridge.getWallet(
-                          walletPubKeyHash
-                        )
-
-                        // Amount can be checked by opening the sweep tx in a Bitcoin
-                        // testnet explorer. In this case, the sum of inputs is
-                        // 80000 satoshi (from the single deposit) and there is a
-                        // fee of 2000 so the output value is 78000.
-                        const expectedMainUtxo = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32", "uint64"],
-                          [data.sweepTx.hash, 0, 78000]
-                        )
-
-                        expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
-                      })
-
-                      it("should update the depositor's balance", async () => {
-                        // The sum of sweep tx inputs is 80000 satoshi. The output
-                        // value is 78000 so the fee is 2000. There is only one
-                        // deposit so it incurs the entire fee. The deposit should
-                        // also incur the treasury fee whose initial value is 0.05%
-                        // of the deposited amount so the final depositor balance
-                        // should be cut by 40 satoshi.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[0].reveal.depositor
-                          )
-                        ).to.be.equal(77960)
-                      })
-
-                      it("should transfer collected treasury fee", async () => {
-                        expect(
-                          await bank.balanceOf(treasury.address)
-                        ).to.be.equal(40)
-                      })
-
-                      it("should emit DepositsSwept event", async () => {
-                        await expect(tx)
-                          .to.emit(bridge, "DepositsSwept")
-                          .withArgs(walletPubKeyHash, data.sweepTx.hash)
-                      })
-                    }
-                  )
-
-                  context(
-                    "when the single input is the expected main UTXO",
-                    () => {
-                      const previousData: SweepTestData = SingleP2SHDeposit
-                      const data: SweepTestData = SingleMainUtxo
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } =
-                        previousData.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
-                        })
-
-                        // Make the first sweep which is actually the predecessor
-                        // of the sweep tested within this scenario.
-                        await runSweepScenario(previousData)
+                        await relay.setPrevEpochDifficulty(data.chainDifficulty)
                       })
 
                       after(async () => {
@@ -938,1054 +1035,659 @@ describe("Bridge", () => {
                       })
 
                       it("should revert", async () => {
-                        await expect(runSweepScenario(data)).to.be.revertedWith(
-                          "Sweep transaction must process at least one deposit"
-                        )
-                      })
-                    }
-                  )
-
-                  context(
-                    "when the single input is a revealed but already swept deposit",
-                    () => {
-                      const data: SweepTestData = SingleP2SHDeposit
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } = data.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
-                        })
-
-                        // Make a proper sweep to turn the tested deposit into
-                        // the swept state.
-                        await runSweepScenario(data)
-                      })
-
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
-
-                      it("should revert", async () => {
-                        // Main UTXO parameter must point to the properly
-                        // made sweep to avoid revert at validation stage.
-                        const mainUtxo = {
-                          txHash: data.sweepTx.hash,
-                          txOutputIndex: 0,
-                          txOutputValue: 18500,
-                        }
-
-                        // Try replaying the already done sweep.
+                        // Try to sweep a deposit which was not revealed before and
+                        // is unknown from system's point of view.
                         await expect(
                           bridge.submitSweepProof(
                             data.sweepTx,
                             data.sweepProof,
-                            mainUtxo
+                            NO_MAIN_UTXO
                           )
-                        ).to.be.revertedWith("Deposit already swept")
+                        ).to.be.revertedWith("Unknown input type")
                       })
-                    }
-                  )
-
-                  context("when the single input is an unknown", () => {
-                    const data: SweepTestData = SingleP2SHDeposit
-                    // Take wallet public key hash from first deposit. All
-                    // deposits in same sweep batch should have the same value
-                    // of that field.
-                    const { walletPubKeyHash } = data.deposits[0].reveal
-
-                    before(async () => {
-                      await createSnapshot()
-
-                      // Simulate the wallet is an Live one and is known in the system.
-                      await bridge.setWallet(walletPubKeyHash, {
-                        ecdsaWalletID: ethers.constants.HashZero,
-                        mainUtxoHash: ethers.constants.HashZero,
-                        pendingRedemptionsValue: 0,
-                        createdAt: await lastBlockTime(),
-                        moveFundsRequestedAt: 0,
-                        state: walletState.Live,
-                      })
-
-                      // Necessary to pass the proof validation.
-                      await relay.setCurrentEpochDifficulty(
-                        data.chainDifficulty
-                      )
-                      await relay.setPrevEpochDifficulty(data.chainDifficulty)
-                    })
-
-                    after(async () => {
-                      await restoreSnapshot()
-                    })
-
-                    it("should revert", async () => {
-                      // Try to sweep a deposit which was not revealed before and
-                      // is unknown from system's point of view.
-                      await expect(
-                        bridge.submitSweepProof(
-                          data.sweepTx,
-                          data.sweepProof,
-                          NO_MAIN_UTXO
-                        )
-                      ).to.be.revertedWith("Unknown input type")
                     })
                   })
-                })
 
-                // Since P2SH vs P2WSH path has been already checked in the scenario
-                // "when there is only one input", we no longer differentiate deposits
-                // using that criterion during "when there are multiple inputs" scenario.
-                context("when there are multiple inputs", () => {
-                  context(
-                    "when input vector consists only of revealed unswept " +
-                      "deposits and the expected main UTXO",
-                    () => {
-                      let tx: ContractTransaction
-                      const previousData: SweepTestData =
-                        MultipleDepositsNoMainUtxo
-                      const data: SweepTestData = MultipleDepositsWithMainUtxo
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } = data.deposits[0].reveal
+                  // Since P2SH vs P2WSH path has been already checked in the scenario
+                  // "when there is only one input", we no longer differentiate deposits
+                  // using that criterion during "when there are multiple inputs" scenario.
+                  context("when there are multiple inputs", () => {
+                    context(
+                      "when input vector consists only of revealed unswept " +
+                        "deposits and the expected main UTXO",
+                      () => {
+                        let tx: ContractTransaction
+                        const previousData: SweepTestData =
+                          MultipleDepositsNoMainUtxo
+                        const data: SweepTestData = MultipleDepositsWithMainUtxo
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
 
-                      before(async () => {
-                        await createSnapshot()
+                        before(async () => {
+                          await createSnapshot()
 
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          // Make the first sweep which is actually the predecessor
+                          // of the sweep tested within this scenario.
+                          await runSweepScenario(previousData)
+
+                          tx = await runSweepScenario(data)
                         })
 
-                        // Make the first sweep which is actually the predecessor
-                        // of the sweep tested within this scenario.
-                        await runSweepScenario(previousData)
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
 
-                        tx = await runSweepScenario(data)
-                      })
+                        it("should mark deposits as swept", async () => {
+                          for (let i = 0; i < data.deposits.length; i++) {
+                            // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+                            const depositKey = ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32"],
+                              [
+                                data.deposits[i].fundingTx.hash,
+                                data.deposits[i].reveal.fundingOutputIndex,
+                              ]
+                            )
 
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
-
-                      it("should mark deposits as swept", async () => {
-                        for (let i = 0; i < data.deposits.length; i++) {
-                          // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
-                          const depositKey = ethers.utils.solidityKeccak256(
-                            ["bytes32", "uint32"],
-                            [
-                              data.deposits[i].fundingTx.hash,
-                              data.deposits[i].reveal.fundingOutputIndex,
-                            ]
-                          )
-
-                          // eslint-disable-next-line no-await-in-loop
-                          const deposit = await bridge.deposits(depositKey)
-
-                          expect(deposit.sweptAt).to.be.equal(
                             // eslint-disable-next-line no-await-in-loop
-                            await lastBlockTime(),
-                            `Deposit with index ${i} has an unexpected swept time`
-                          )
-                        }
-                      })
+                            const deposit = await bridge.deposits(depositKey)
 
-                      it("should update main UTXO for the given wallet", async () => {
-                        const { mainUtxoHash } = await bridge.getWallet(
-                          walletPubKeyHash
-                        )
-
-                        // Amount can be checked by opening the sweep tx in a Bitcoin
-                        // testnet explorer. In this case, the sum of inputs is
-                        // 4148000 satoshi and there is a fee of 2999 so the output
-                        // value is 4145001.
-                        const expectedMainUtxo = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32", "uint64"],
-                          [data.sweepTx.hash, 0, 4145001]
-                        )
-
-                        expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
-                      })
-
-                      it("should update the depositors balances", async () => {
-                        // The sum of sweep tx inputs is 4148000 satoshi. The output
-                        // value is 4145001 so the sweep transaction fee is 2999.
-                        // There are 5 deposits so the fee per deposit is 599
-                        // and the indivisible remainder is 4 which means the
-                        // last deposit should incur 603 satoshi. Worth noting
-                        // the order of deposits used by this test scenario
-                        // data does not correspond to the order of sweep
-                        // transaction inputs. Each deposit should also incur
-                        // the treasury fee whose initial value is 0.05% of the
-                        // deposited amount.
-
-                        // Deposit with index 0 used as input with index 5
-                        // in the sweep transaction. This is the last deposit
-                        // (according to inputs order) and it should incur the
-                        // remainder of the transaction fee.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[0].reveal.depositor
-                          )
-                        ).to.be.equal(219287)
-
-                        // Deposit with index 1 used as input with index 3
-                        // in the sweep transaction.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[1].reveal.depositor
-                          )
-                        ).to.be.equal(759021)
-
-                        // Deposit with index 2 used as input with index 1
-                        // in the sweep transaction.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[2].reveal.depositor
-                          )
-                        ).to.be.equal(938931)
-
-                        // Deposit with index 3 used as input with index 2
-                        // in the sweep transaction.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[3].reveal.depositor
-                          )
-                        ).to.be.equal(878961)
-
-                        // Deposit with index 4 used as input with index 4
-                        // in the sweep transaction.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[4].reveal.depositor
-                          )
-                        ).to.be.equal(289256)
-                      })
-
-                      it("should transfer collected treasury fee", async () => {
-                        expect(
-                          await bank.balanceOf(treasury.address)
-                        ).to.be.equal(2075)
-                      })
-
-                      it("should mark the previous main UTXO as spent", async () => {
-                        const mainUtxoKey = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32"],
-                          [data.mainUtxo.txHash, data.mainUtxo.txOutputIndex]
-                        )
-
-                        expect(await bridge.spentMainUTXOs(mainUtxoKey)).to.be
-                          .true
-                      })
-
-                      it("should emit DepositsSwept event", async () => {
-                        await expect(tx)
-                          .to.emit(bridge, "DepositsSwept")
-                          .withArgs(walletPubKeyHash, data.sweepTx.hash)
-                      })
-                    }
-                  )
-
-                  context(
-                    "when input vector consists only of revealed unswept " +
-                      "deposits but there is no main UTXO since it is not expected",
-                    () => {
-                      let tx: ContractTransaction
-                      const data: SweepTestData = MultipleDepositsNoMainUtxo
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } = data.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
+                            expect(deposit.sweptAt).to.be.equal(
+                              // eslint-disable-next-line no-await-in-loop
+                              await lastBlockTime(),
+                              `Deposit with index ${i} has an unexpected swept time`
+                            )
+                          }
                         })
 
-                        tx = await runSweepScenario(data)
-                      })
+                        it("should update main UTXO for the given wallet", async () => {
+                          const { mainUtxoHash } = await bridge.getWallet(
+                            walletPubKeyHash
+                          )
 
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
+                          // Amount can be checked by opening the sweep tx in a Bitcoin
+                          // testnet explorer. In this case, the sum of inputs is
+                          // 4148000 satoshi and there is a fee of 2999 so the output
+                          // value is 4145001.
+                          const expectedMainUtxo =
+                            ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32", "uint64"],
+                              [data.sweepTx.hash, 0, 4145001]
+                            )
 
-                      it("should mark deposits as swept", async () => {
-                        for (let i = 0; i < data.deposits.length; i++) {
-                          // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
-                          const depositKey = ethers.utils.solidityKeccak256(
+                          expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
+                        })
+
+                        it("should update the depositors balances", async () => {
+                          // The sum of sweep tx inputs is 4148000 satoshi. The output
+                          // value is 4145001 so the sweep transaction fee is 2999.
+                          // There are 5 deposits so the fee per deposit is 599
+                          // and the indivisible remainder is 4 which means the
+                          // last deposit should incur 603 satoshi. Worth noting
+                          // the order of deposits used by this test scenario
+                          // data does not correspond to the order of sweep
+                          // transaction inputs. Each deposit should also incur
+                          // the treasury fee whose initial value is 0.05% of the
+                          // deposited amount.
+
+                          // Deposit with index 0 used as input with index 5
+                          // in the sweep transaction. This is the last deposit
+                          // (according to inputs order) and it should incur the
+                          // remainder of the transaction fee.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[0].reveal.depositor
+                            )
+                          ).to.be.equal(219287)
+
+                          // Deposit with index 1 used as input with index 3
+                          // in the sweep transaction.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[1].reveal.depositor
+                            )
+                          ).to.be.equal(759021)
+
+                          // Deposit with index 2 used as input with index 1
+                          // in the sweep transaction.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[2].reveal.depositor
+                            )
+                          ).to.be.equal(938931)
+
+                          // Deposit with index 3 used as input with index 2
+                          // in the sweep transaction.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[3].reveal.depositor
+                            )
+                          ).to.be.equal(878961)
+
+                          // Deposit with index 4 used as input with index 4
+                          // in the sweep transaction.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[4].reveal.depositor
+                            )
+                          ).to.be.equal(289256)
+                        })
+
+                        it("should transfer collected treasury fee", async () => {
+                          expect(
+                            await bank.balanceOf(treasury.address)
+                          ).to.be.equal(2075)
+                        })
+
+                        it("should mark the previous main UTXO as spent", async () => {
+                          const mainUtxoKey = ethers.utils.solidityKeccak256(
                             ["bytes32", "uint32"],
-                            [
-                              data.deposits[i].fundingTx.hash,
-                              data.deposits[i].reveal.fundingOutputIndex,
-                            ]
+                            [data.mainUtxo.txHash, data.mainUtxo.txOutputIndex]
                           )
 
-                          // eslint-disable-next-line no-await-in-loop
-                          const deposit = await bridge.deposits(depositKey)
+                          expect(await bridge.spentMainUTXOs(mainUtxoKey)).to.be
+                            .true
+                        })
 
-                          expect(deposit.sweptAt).to.be.equal(
+                        it("should emit DepositsSwept event", async () => {
+                          await expect(tx)
+                            .to.emit(bridge, "DepositsSwept")
+                            .withArgs(walletPubKeyHash, data.sweepTx.hash)
+                        })
+                      }
+                    )
+
+                    context(
+                      "when input vector consists only of revealed unswept " +
+                        "deposits but there is no main UTXO since it is not expected",
+                      () => {
+                        let tx: ContractTransaction
+                        const data: SweepTestData = MultipleDepositsNoMainUtxo
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          tx = await runSweepScenario(data)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should mark deposits as swept", async () => {
+                          for (let i = 0; i < data.deposits.length; i++) {
+                            // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+                            const depositKey = ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32"],
+                              [
+                                data.deposits[i].fundingTx.hash,
+                                data.deposits[i].reveal.fundingOutputIndex,
+                              ]
+                            )
+
                             // eslint-disable-next-line no-await-in-loop
-                            await lastBlockTime(),
-                            `Deposit with index ${i} has an unexpected swept time`
-                          )
-                        }
-                      })
+                            const deposit = await bridge.deposits(depositKey)
 
-                      it("should update main UTXO for the given wallet", async () => {
-                        const { mainUtxoHash } = await bridge.getWallet(
-                          walletPubKeyHash
-                        )
-
-                        // Amount can be checked by opening the sweep tx in a Bitcoin
-                        // testnet explorer. In this case, the sum of inputs is
-                        // 1060000 satoshi and there is a fee of 2000 so the output
-                        // value is 1058000.
-                        const expectedMainUtxo = ethers.utils.solidityKeccak256(
-                          ["bytes32", "uint32", "uint64"],
-                          [data.sweepTx.hash, 0, 1058000]
-                        )
-
-                        expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
-                      })
-
-                      it("should update the depositors balances", async () => {
-                        // The sum of sweep tx inputs is 1060000 satoshi. The output
-                        // value is 1058000 so the sweep transaction fee is 2000.
-                        // There are 5 deposits so the fee per deposit is 400
-                        // and there is no indivisible remainder. Each deposit
-                        // should also incur the treasury fee whose initial
-                        // value is 0.05% of the deposited amount.
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[0].reveal.depositor
-                          )
-                        ).to.be.equal(29585)
-
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[1].reveal.depositor
-                          )
-                        ).to.be.equal(9595)
-
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[2].reveal.depositor
-                          )
-                        ).to.be.equal(209495)
-
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[3].reveal.depositor
-                          )
-                        ).to.be.equal(369415)
-
-                        expect(
-                          await bank.balanceOf(
-                            data.deposits[4].reveal.depositor
-                          )
-                        ).to.be.equal(439380)
-                      })
-
-                      it("should transfer collected treasury fee", async () => {
-                        expect(
-                          await bank.balanceOf(treasury.address)
-                        ).to.be.equal(530)
-                      })
-
-                      it("should emit DepositsSwept event", async () => {
-                        await expect(tx)
-                          .to.emit(bridge, "DepositsSwept")
-                          .withArgs(walletPubKeyHash, data.sweepTx.hash)
-                      })
-                    }
-                  )
-
-                  context(
-                    "when input vector consists only of revealed unswept " +
-                      "deposits but there is no main UTXO despite it is expected",
-                    () => {
-                      const previousData: SweepTestData = SingleP2WSHDeposit
-                      const data: SweepTestData = JSON.parse(
-                        JSON.stringify(MultipleDepositsNoMainUtxo)
-                      )
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } =
-                        previousData.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
+                            expect(deposit.sweptAt).to.be.equal(
+                              // eslint-disable-next-line no-await-in-loop
+                              await lastBlockTime(),
+                              `Deposit with index ${i} has an unexpected swept time`
+                            )
+                          }
                         })
 
-                        // Make the first sweep to create an on-chain expectation
-                        // that the tested sweep will contain the main UTXO
-                        // input.
-                        await runSweepScenario(previousData)
-                      })
+                        it("should update main UTXO for the given wallet", async () => {
+                          const { mainUtxoHash } = await bridge.getWallet(
+                            walletPubKeyHash
+                          )
 
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
+                          // Amount can be checked by opening the sweep tx in a Bitcoin
+                          // testnet explorer. In this case, the sum of inputs is
+                          // 1060000 satoshi and there is a fee of 2000 so the output
+                          // value is 1058000.
+                          const expectedMainUtxo =
+                            ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32", "uint64"],
+                              [data.sweepTx.hash, 0, 1058000]
+                            )
 
-                      it("should revert", async () => {
-                        // Use sweep data which doesn't reference the main UTXO.
-                        // However, pass a correct main UTXO parameter in order
-                        // to pass main UTXO validation in the contract.
-                        data.mainUtxo = {
-                          txHash: previousData.sweepTx.hash,
-                          txOutputIndex: 0,
-                          txOutputValue: 78000,
-                        }
-
-                        await expect(runSweepScenario(data)).to.be.revertedWith(
-                          "Expected main UTXO not present in sweep transaction inputs"
-                        )
-                      })
-                    }
-                  )
-
-                  context(
-                    "when input vector contains a revealed but already swept deposit",
-                    () => {
-                      const data: SweepTestData = MultipleDepositsNoMainUtxo
-                      // Take wallet public key hash from first deposit. All
-                      // deposits in same sweep batch should have the same value
-                      // of that field.
-                      const { walletPubKeyHash } = data.deposits[0].reveal
-
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Simulate the wallet is an Live one and is known in
-                        // the system.
-                        await bridge.setWallet(walletPubKeyHash, {
-                          ecdsaWalletID: ethers.constants.HashZero,
-                          mainUtxoHash: ethers.constants.HashZero,
-                          pendingRedemptionsValue: 0,
-                          createdAt: await lastBlockTime(),
-                          moveFundsRequestedAt: 0,
-                          state: walletState.Live,
+                          expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
                         })
 
-                        // Make a proper sweep to turn the tested deposits into
-                        // the swept state.
-                        await runSweepScenario(data)
-                      })
+                        it("should update the depositors balances", async () => {
+                          // The sum of sweep tx inputs is 1060000 satoshi. The output
+                          // value is 1058000 so the sweep transaction fee is 2000.
+                          // There are 5 deposits so the fee per deposit is 400
+                          // and there is no indivisible remainder. Each deposit
+                          // should also incur the treasury fee whose initial
+                          // value is 0.05% of the deposited amount.
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[0].reveal.depositor
+                            )
+                          ).to.be.equal(29585)
 
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[1].reveal.depositor
+                            )
+                          ).to.be.equal(9595)
 
-                      it("should revert", async () => {
-                        // Main UTXO parameter must point to the properly
-                        // made sweep to avoid revert at validation stage.
-                        const mainUtxo = {
-                          txHash: data.sweepTx.hash,
-                          txOutputIndex: 0,
-                          txOutputValue: 1058000,
-                        }
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[2].reveal.depositor
+                            )
+                          ).to.be.equal(209495)
 
-                        // Try replaying the already done sweep.
-                        await expect(
-                          bridge.submitSweepProof(
-                            data.sweepTx,
-                            data.sweepProof,
-                            mainUtxo
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[3].reveal.depositor
+                            )
+                          ).to.be.equal(369415)
+
+                          expect(
+                            await bank.balanceOf(
+                              data.deposits[4].reveal.depositor
+                            )
+                          ).to.be.equal(439380)
+                        })
+
+                        it("should transfer collected treasury fee", async () => {
+                          expect(
+                            await bank.balanceOf(treasury.address)
+                          ).to.be.equal(530)
+                        })
+
+                        it("should emit DepositsSwept event", async () => {
+                          await expect(tx)
+                            .to.emit(bridge, "DepositsSwept")
+                            .withArgs(walletPubKeyHash, data.sweepTx.hash)
+                        })
+                      }
+                    )
+
+                    context(
+                      "when input vector consists only of revealed unswept " +
+                        "deposits but there is no main UTXO despite it is expected",
+                      () => {
+                        const previousData: SweepTestData = SingleP2WSHDeposit
+                        const data: SweepTestData = JSON.parse(
+                          JSON.stringify(MultipleDepositsNoMainUtxo)
+                        )
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } =
+                          previousData.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+
+                          // Make the first sweep to create an on-chain expectation
+                          // that the tested sweep will contain the main UTXO
+                          // input.
+                          await runSweepScenario(previousData)
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should revert", async () => {
+                          // Use sweep data which doesn't reference the main UTXO.
+                          // However, pass a correct main UTXO parameter in order
+                          // to pass main UTXO validation in the contract.
+                          data.mainUtxo = {
+                            txHash: previousData.sweepTx.hash,
+                            txOutputIndex: 0,
+                            txOutputValue: 78000,
+                          }
+
+                          await expect(
+                            runSweepScenario(data)
+                          ).to.be.revertedWith(
+                            "Expected main UTXO not present in sweep transaction inputs"
                           )
-                        ).to.be.revertedWith("Deposit already swept")
-                      })
-                    }
-                  )
+                        })
+                      }
+                    )
 
-                  context("when input vector contains an unknown input", () => {
-                    const data: SweepTestData = MultipleDepositsWithMainUtxo
-                    // Take wallet public key hash from first deposit. All
-                    // deposits in same sweep batch should have the same value
-                    // of that field.
-                    const { walletPubKeyHash } = data.deposits[0].reveal
+                    context(
+                      "when input vector contains a revealed but already swept deposit",
+                      () => {
+                        const data: SweepTestData = MultipleDepositsNoMainUtxo
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
 
-                    before(async () => {
-                      await createSnapshot()
+                        before(async () => {
+                          await createSnapshot()
 
-                      // Simulate the wallet is an Live one and is known in
-                      // the system.
-                      await bridge.setWallet(walletPubKeyHash, {
-                        ecdsaWalletID: ethers.constants.HashZero,
-                        mainUtxoHash: ethers.constants.HashZero,
-                        pendingRedemptionsValue: 0,
-                        createdAt: await lastBlockTime(),
-                        moveFundsRequestedAt: 0,
-                        state: walletState.Live,
-                      })
-                    })
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
 
-                    after(async () => {
-                      await restoreSnapshot()
-                    })
+                          // Make a proper sweep to turn the tested deposits into
+                          // the swept state.
+                          await runSweepScenario(data)
+                        })
 
-                    it("should revert", async () => {
-                      // Used test data contains an actual main UTXO input
-                      // but the previous action proof was not submitted on-chain
-                      // so input is unknown from contract's perspective.
-                      await expect(runSweepScenario(data)).to.be.revertedWith(
-                        "Unknown input type"
-                      )
-                    })
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should revert", async () => {
+                          // Main UTXO parameter must point to the properly
+                          // made sweep to avoid revert at validation stage.
+                          const mainUtxo = {
+                            txHash: data.sweepTx.hash,
+                            txOutputIndex: 0,
+                            txOutputValue: 1058000,
+                          }
+
+                          // Try replaying the already done sweep.
+                          await expect(
+                            bridge.submitSweepProof(
+                              data.sweepTx,
+                              data.sweepProof,
+                              mainUtxo
+                            )
+                          ).to.be.revertedWith("Deposit already swept")
+                        })
+                      }
+                    )
+
+                    context(
+                      "when input vector contains an unknown input",
+                      () => {
+                        const data: SweepTestData = MultipleDepositsWithMainUtxo
+                        // Take wallet public key hash from first deposit. All
+                        // deposits in same sweep batch should have the same value
+                        // of that field.
+                        const { walletPubKeyHash } = data.deposits[0].reveal
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          // Simulate the wallet is an Live one and is known in
+                          // the system.
+                          await bridge.setWallet(walletPubKeyHash, {
+                            ecdsaWalletID: ethers.constants.HashZero,
+                            mainUtxoHash: ethers.constants.HashZero,
+                            pendingRedemptionsValue: 0,
+                            createdAt: await lastBlockTime(),
+                            moveFundsRequestedAt: 0,
+                            state: walletState.Live,
+                          })
+                        })
+
+                        after(async () => {
+                          await restoreSnapshot()
+                        })
+
+                        it("should revert", async () => {
+                          // Used test data contains an actual main UTXO input
+                          // but the previous action proof was not submitted on-chain
+                          // so input is unknown from contract's perspective.
+                          await expect(
+                            runSweepScenario(data)
+                          ).to.be.revertedWith("Unknown input type")
+                        })
+                      }
+                    )
                   })
-                })
-              }
-            )
+                }
+              )
 
-            context(
-              "when transaction fee exceeds the deposit transaction maximum fee",
-              () => {
-                const data: SweepTestData = SingleP2SHDeposit
-                // Take wallet public key hash from first deposit. All
-                // deposits in same sweep batch should have the same value
-                // of that field.
-                const { walletPubKeyHash } = data.deposits[0].reveal
+              context(
+                "when transaction fee exceeds the deposit transaction maximum fee",
+                () => {
+                  const data: SweepTestData = SingleP2SHDeposit
+                  // Take wallet public key hash from first deposit. All
+                  // deposits in same sweep batch should have the same value
+                  // of that field.
+                  const { walletPubKeyHash } = data.deposits[0].reveal
 
-                before(async () => {
-                  await createSnapshot()
+                  before(async () => {
+                    await createSnapshot()
 
-                  // Simulate the wallet is an Live one and is known in
-                  // the system.
-                  await bridge.setWallet(walletPubKeyHash, {
-                    ecdsaWalletID: ethers.constants.HashZero,
-                    mainUtxoHash: ethers.constants.HashZero,
-                    pendingRedemptionsValue: 0,
-                    createdAt: await lastBlockTime(),
-                    moveFundsRequestedAt: 0,
-                    state: walletState.Live,
+                    // Simulate the wallet is an Live one and is known in
+                    // the system.
+                    await bridge.setWallet(walletPubKeyHash, {
+                      ecdsaWalletID: ethers.constants.HashZero,
+                      mainUtxoHash: ethers.constants.HashZero,
+                      pendingRedemptionsValue: 0,
+                      createdAt: await lastBlockTime(),
+                      moveFundsRequestedAt: 0,
+                      state: walletState.Live,
+                    })
+
+                    // Set the deposit transaction maximum fee to a value much
+                    // lower than the fee used by the test data transaction.
+                    await bridge.setDepositTxMaxFee(100)
                   })
 
-                  // Set the deposit transaction maximum fee to a value much
-                  // lower than the fee used by the test data transaction.
-                  await bridge.setDepositTxMaxFee(100)
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
+
+                  it("should revert", async () => {
+                    await expect(runSweepScenario(data)).to.be.revertedWith(
+                      "'Transaction fee is too high"
+                    )
+                  })
+                }
+              )
+            })
+
+            context("when main UTXO data are invalid", () => {
+              const previousData: SweepTestData = MultipleDepositsNoMainUtxo
+              const data: SweepTestData = JSON.parse(
+                JSON.stringify(MultipleDepositsWithMainUtxo)
+              )
+              // Take wallet public key hash from first deposit. All
+              // deposits in same sweep batch should have the same value
+              // of that field.
+              const { walletPubKeyHash } = data.deposits[0].reveal
+
+              before(async () => {
+                await createSnapshot()
+
+                // Simulate the wallet is an Live one and is known in
+                // the system.
+                await bridge.setWallet(walletPubKeyHash, {
+                  ecdsaWalletID: ethers.constants.HashZero,
+                  mainUtxoHash: ethers.constants.HashZero,
+                  pendingRedemptionsValue: 0,
+                  createdAt: await lastBlockTime(),
+                  moveFundsRequestedAt: 0,
+                  state: walletState.Live,
                 })
 
-                after(async () => {
-                  await restoreSnapshot()
-                })
-
-                it("should revert", async () => {
-                  await expect(runSweepScenario(data)).to.be.revertedWith(
-                    "'Transaction fee is too high"
-                  )
-                })
-              }
-            )
-          })
-
-          context("when main UTXO data are invalid", () => {
-            const previousData: SweepTestData = MultipleDepositsNoMainUtxo
-            const data: SweepTestData = JSON.parse(
-              JSON.stringify(MultipleDepositsWithMainUtxo)
-            )
-            // Take wallet public key hash from first deposit. All
-            // deposits in same sweep batch should have the same value
-            // of that field.
-            const { walletPubKeyHash } = data.deposits[0].reveal
-
-            before(async () => {
-              await createSnapshot()
-
-              // Simulate the wallet is an Live one and is known in
-              // the system.
-              await bridge.setWallet(walletPubKeyHash, {
-                ecdsaWalletID: ethers.constants.HashZero,
-                mainUtxoHash: ethers.constants.HashZero,
-                pendingRedemptionsValue: 0,
-                createdAt: await lastBlockTime(),
-                moveFundsRequestedAt: 0,
-                state: walletState.Live,
+                // Make the first sweep which is actually the predecessor
+                // of the sweep tested within this scenario.
+                await runSweepScenario(previousData)
               })
 
-              // Make the first sweep which is actually the predecessor
-              // of the sweep tested within this scenario.
-              await runSweepScenario(previousData)
-            })
+              after(async () => {
+                await restoreSnapshot()
+              })
 
-            after(async () => {
-              await restoreSnapshot()
-            })
+              it("should revert", async () => {
+                // Forge the main UTXO parameter to force validation crash.
+                data.mainUtxo = NO_MAIN_UTXO
 
-            it("should revert", async () => {
-              // Forge the main UTXO parameter to force validation crash.
-              data.mainUtxo = NO_MAIN_UTXO
-
-              await expect(runSweepScenario(data)).to.be.revertedWith(
-                "Invalid main UTXO data"
-              )
+                await expect(runSweepScenario(data)).to.be.revertedWith(
+                  "Invalid main UTXO data"
+                )
+              })
             })
           })
+
+          context(
+            "when wallet public key hash length is other than 20 bytes",
+            () => {
+              before(async () => {
+                await createSnapshot()
+
+                // Necessary to pass the proof validation.
+                await relay.setCurrentEpochDifficulty(20870012)
+                await relay.setPrevEpochDifficulty(20870012)
+              })
+
+              after(async () => {
+                await restoreSnapshot()
+              })
+
+              it("should revert", async () => {
+                // To test this case, an arbitrary transaction with single
+                // P2WSH output is used. In that case, the wallet public key
+                // hash will have a wrong length of 32 bytes. Used transaction:
+                // https://live.blockcypher.com/btc-testnet/tx/af56cae479215c5e44a6a4db0eeb10a1abdd98020a6c01b9c26ea7b829aa2809
+                const sweepTx = {
+                  version: "0x01000000",
+                  inputVector:
+                    "0x01d32586237f6a832c3aa324bb83151e43e6cca2e4312d676f14" +
+                    "dbbd6b1f04f4680100000000ffffffff",
+                  outputVector:
+                    "0x012ea3090000000000220020af802a76c10b6a646fff8d358241" +
+                    "c121c9be1c53628adb26bd6554631bfc7d8b",
+                  locktime: "0x00000000",
+                }
+
+                const sweepProof = {
+                  merkleProof:
+                    "0xf09955dcfb05b1c369eb9f58b6e583e49f47b9b8d6e63537dcac" +
+                    "10bf0cc5407d06e76ee2d75b5be5ec365a4c1272067b786d79a64d" +
+                    "c015eb40dedd3c813f4dee40c149ee21036bba713d14b3c22454ef" +
+                    "44c958293a015e9e186983f20c46d74a29ca5f705913e210229078" +
+                    "af993e89d90bb731dab3c8cf8907d683ab60faca1866036118737e" +
+                    "07aaa74d489e80f773b4d9ff2887a4855b805aaf1b5a7a1b0bf382" +
+                    "be8dab2401ec758a705b648724f93d14c3b72ce4fb3cd7d414e8a1" +
+                    "75ef173e",
+                  txIndexInBlock: 20,
+                  bitcoinHeaders:
+                    "0x0000e020fbeb3a876746438f1fd793add061b0b7af2f88a387ee" +
+                    "f5b38600000000000000933a0cec98a028727df04dafbbe691c8ad" +
+                    "442351db7321c9f7cc169aa9f64a9a7af6f361cbcd001a65073028",
+                }
+
+                await expect(
+                  bridge.submitSweepProof(sweepTx, sweepProof, NO_MAIN_UTXO)
+                ).to.be.revertedWith(
+                  "Wallet public key hash should have 20 bytes"
+                )
+              })
+            }
+          )
         })
 
-        context(
-          "when wallet public key hash length is other than 20 bytes",
-          () => {
-            before(async () => {
-              await createSnapshot()
+        context("when output count is other than one", () => {
+          before(async () => {
+            await createSnapshot()
 
-              // Necessary to pass the proof validation.
-              await relay.setCurrentEpochDifficulty(20870012)
-              await relay.setPrevEpochDifficulty(20870012)
-            })
+            // Necessary to pass the proof validation.
+            await relay.setCurrentEpochDifficulty(1)
+            await relay.setPrevEpochDifficulty(1)
+          })
 
-            after(async () => {
-              await restoreSnapshot()
-            })
+          after(async () => {
+            await restoreSnapshot()
+          })
 
-            it("should revert", async () => {
-              // To test this case, an arbitrary transaction with single
-              // P2WSH output is used. In that case, the wallet public key
-              // hash will have a wrong length of 32 bytes. Used transaction:
-              // https://live.blockcypher.com/btc-testnet/tx/af56cae479215c5e44a6a4db0eeb10a1abdd98020a6c01b9c26ea7b829aa2809
-              const sweepTx = {
-                version: "0x01000000",
-                inputVector:
-                  "0x01d32586237f6a832c3aa324bb83151e43e6cca2e4312d676f14" +
-                  "dbbd6b1f04f4680100000000ffffffff",
-                outputVector:
-                  "0x012ea3090000000000220020af802a76c10b6a646fff8d358241" +
-                  "c121c9be1c53628adb26bd6554631bfc7d8b",
-                locktime: "0x00000000",
-              }
+          it("should revert", async () => {
+            // To test this case, an arbitrary transaction with two
+            // outputs is used. Used transaction:
+            // https://live.blockcypher.com/btc-testnet/tx/af56cae479215c5e44a6a4db0eeb10a1abdd98020a6c01b9c26ea7b829aa2809
+            const sweepTx = {
+              version: "0x01000000",
+              inputVector:
+                "0x011d9b71144a3ddbb56dd099ee94e6dd8646d7d1eb37fe1195367e6f" +
+                "a844a388e7010000006a47304402206f8553c07bcdc0c3b90631188810" +
+                "3d623ca9096ca0b28b7d04650a029a01fcf9022064cda02e39e65ace71" +
+                "2029845cfcf58d1b59617d753c3fd3556f3551b609bbb00121039d61d6" +
+                "2dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa" +
+                "ffffffff",
+              outputVector:
+                "0x02204e00000000000017a9143ec459d0f3c29286ae5df5fcc421e278" +
+                "6024277e87a6c2140000000000160014e257eccafbc07c381642ce6e7e" +
+                "55120fb077fbed",
+              locktime: "0x00000000",
+            }
 
-              const sweepProof = {
-                merkleProof:
-                  "0xf09955dcfb05b1c369eb9f58b6e583e49f47b9b8d6e63537dcac" +
-                  "10bf0cc5407d06e76ee2d75b5be5ec365a4c1272067b786d79a64d" +
-                  "c015eb40dedd3c813f4dee40c149ee21036bba713d14b3c22454ef" +
-                  "44c958293a015e9e186983f20c46d74a29ca5f705913e210229078" +
-                  "af993e89d90bb731dab3c8cf8907d683ab60faca1866036118737e" +
-                  "07aaa74d489e80f773b4d9ff2887a4855b805aaf1b5a7a1b0bf382" +
-                  "be8dab2401ec758a705b648724f93d14c3b72ce4fb3cd7d414e8a1" +
-                  "75ef173e",
-                txIndexInBlock: 20,
-                bitcoinHeaders:
-                  "0x0000e020fbeb3a876746438f1fd793add061b0b7af2f88a387ee" +
-                  "f5b38600000000000000933a0cec98a028727df04dafbbe691c8ad" +
-                  "442351db7321c9f7cc169aa9f64a9a7af6f361cbcd001a65073028",
-              }
+            const sweepProof = {
+              merkleProof:
+                "0x161d24e53fc61db783f0271d45ef43b76e69fc975cf38decbba654ae" +
+                "3d09f5d1a060c3448c0c06ededa9749e559ffa65e2d5f3abac749b278e" +
+                "1189aa5b49a499b032963ea3fad337c4a9c8df4e748865503b5aea083f" +
+                "b32efe4dca057a741a020790cde5b50acc2cdbd231e43594036388f1e5" +
+                "d20ebba319465c56e85bf4e4b4f8b7276402b6c114000c59149494f852" +
+                "84507c253bbc505fec7ea50f370aa150",
+              txIndexInBlock: 8,
+              bitcoinHeaders:
+                "0x00000020fbee5222c9fc99c8071cee3fed39b4c0d39f41075469ce9f" +
+                "52000000000000003fd9c72d0611b373ce2b1996e0ebb8bc36dc12d431" +
+                "cae5b9371f343111f3d7519015da61ffff001dbddfb528000040208a9f" +
+                "e49585b4cd8a94daeeb926c6f1e96151c74ae1ae0b18c6a6d564000000" +
+                "0065c05d9ea40cace1b6b0ad0b8a9a18646096b54484fbdd96b1596560" +
+                "f6999194a815da612ac0001a2e4c6405",
+            }
 
-              await expect(
-                bridge.submitSweepProof(sweepTx, sweepProof, NO_MAIN_UTXO)
-              ).to.be.revertedWith(
-                "Wallet public key hash should have 20 bytes"
-              )
-            })
-          }
-        )
-      })
-
-      context("when output count is other than one", () => {
-        before(async () => {
-          await createSnapshot()
-
-          // Necessary to pass the proof validation.
-          await relay.setCurrentEpochDifficulty(1)
-          await relay.setPrevEpochDifficulty(1)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // To test this case, an arbitrary transaction with two
-          // outputs is used. Used transaction:
-          // https://live.blockcypher.com/btc-testnet/tx/af56cae479215c5e44a6a4db0eeb10a1abdd98020a6c01b9c26ea7b829aa2809
-          const sweepTx = {
-            version: "0x01000000",
-            inputVector:
-              "0x011d9b71144a3ddbb56dd099ee94e6dd8646d7d1eb37fe1195367e6f" +
-              "a844a388e7010000006a47304402206f8553c07bcdc0c3b90631188810" +
-              "3d623ca9096ca0b28b7d04650a029a01fcf9022064cda02e39e65ace71" +
-              "2029845cfcf58d1b59617d753c3fd3556f3551b609bbb00121039d61d6" +
-              "2dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa" +
-              "ffffffff",
-            outputVector:
-              "0x02204e00000000000017a9143ec459d0f3c29286ae5df5fcc421e278" +
-              "6024277e87a6c2140000000000160014e257eccafbc07c381642ce6e7e" +
-              "55120fb077fbed",
-            locktime: "0x00000000",
-          }
-
-          const sweepProof = {
-            merkleProof:
-              "0x161d24e53fc61db783f0271d45ef43b76e69fc975cf38decbba654ae" +
-              "3d09f5d1a060c3448c0c06ededa9749e559ffa65e2d5f3abac749b278e" +
-              "1189aa5b49a499b032963ea3fad337c4a9c8df4e748865503b5aea083f" +
-              "b32efe4dca057a741a020790cde5b50acc2cdbd231e43594036388f1e5" +
-              "d20ebba319465c56e85bf4e4b4f8b7276402b6c114000c59149494f852" +
-              "84507c253bbc505fec7ea50f370aa150",
-            txIndexInBlock: 8,
-            bitcoinHeaders:
-              "0x00000020fbee5222c9fc99c8071cee3fed39b4c0d39f41075469ce9f" +
-              "52000000000000003fd9c72d0611b373ce2b1996e0ebb8bc36dc12d431" +
-              "cae5b9371f343111f3d7519015da61ffff001dbddfb528000040208a9f" +
-              "e49585b4cd8a94daeeb926c6f1e96151c74ae1ae0b18c6a6d564000000" +
-              "0065c05d9ea40cace1b6b0ad0b8a9a18646096b54484fbdd96b1596560" +
-              "f6999194a815da612ac0001a2e4c6405",
-          }
-
-          await expect(
-            bridge.submitSweepProof(sweepTx, sweepProof, NO_MAIN_UTXO)
-          ).to.be.revertedWith("Sweep transaction must have a single output")
-        })
-      })
-    })
-
-    context("when transaction proof is not valid", () => {
-      context("when input vector is not valid", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
+            await expect(
+              bridge.submitSweepProof(sweepTx, sweepProof, NO_MAIN_UTXO)
+            ).to.be.revertedWith("Sweep transaction must have a single output")
           })
         })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Corrupt the input vector by setting a compactSize uint claiming
-          // there is no inputs at all.
-          data.sweepTx.inputVector =
-            "0x0079544f374199c68869ce7df906eeb0ee5c0506a512d903e3900d5752" +
-            "e3e080c500000000c847304402205eff3ae003a5903eb33f32737e3442b6" +
-            "516685a1addb19339c2d02d400cf67ce0220707435fc2a0577373c63c99d" +
-            "242c30bea5959ec180169978d43ece50618fe0ff012103989d253b17a6a0" +
-            "f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b" +
-            "98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576" +
-            "a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e2" +
-            "57eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac68ff" +
-            "ffffff"
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Invalid input vector provided"
-          )
-        })
       })
 
-      context("when output vector is not valid", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Corrupt the output vector by setting a compactSize uint claiming
-          // there is no outputs at all.
-          data.sweepTx.outputVector =
-            "0x0044480000000000001600148db50eb52063ea9d98b3eac91489a90f73" +
-            "8986f6"
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Invalid output vector provided"
-          )
-        })
-      })
-
-      context("when merkle proof is not valid", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Corrupt the merkle proof by changing tx index in block to an
-          // invalid one. The proper one is 36 so any other will do the trick.
-          data.sweepProof.txIndexInBlock = 30
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Tx merkle proof is not valid for provided header and tx hash"
-          )
-        })
-      })
-
-      context("when proof difficulty is not current nor previous", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // To pass the proof validation, the difficulty returned by the relay
-          // must be 22350181 for test data used in this scenario. Setting
-          // a different value will cause difficulty comparison failure.
-          data.chainDifficulty = 1
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Not at current or previous difficulty"
-          )
-        })
-      })
-
-      context("when headers chain length is not valid", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Corrupt the bitcoin headers length in the sweep proof. The proper
-          // value is length divisible by 80 so any length violating this
-          // rule will cause failure. In this case, we just remove the last
-          // byte from proper headers chain.
-          const properHeaders = data.sweepProof.bitcoinHeaders.toString()
-          data.sweepProof.bitcoinHeaders = properHeaders.substring(
-            0,
-            properHeaders.length - 2
-          )
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Invalid length of the headers chain"
-          )
-        })
-      })
-
-      context("when headers chain is not valid", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Bitcoin headers must form a chain to pass the proof validation.
-          // That means the `previous block hash` encoded in the given block
-          // header must match the actual previous header's hash. To test
-          // that scenario, we corrupt the `previous block hash` of the
-          // second header. Each header is 80 bytes length. First 4 bytes
-          // of each header is `version` and 32 subsequent bytes is
-          // `previous block hash`. Changing byte 85 of the whole chain will
-          // do the work.
-          const properHeaders = data.sweepProof.bitcoinHeaders.toString()
-          data.sweepProof.bitcoinHeaders = `${properHeaders.substring(
-            0,
-            170
-          )}ff${properHeaders.substring(172)}`
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Invalid headers chain"
-          )
-        })
-      })
-
-      context("when the work in the header is insufficient", () => {
-        const data: SweepTestData = JSON.parse(
-          JSON.stringify(SingleP2SHDeposit)
-        )
-        // Take wallet public key hash from first deposit. All
-        // deposits in same sweep batch should have the same value
-        // of that field.
-        const { walletPubKeyHash } = data.deposits[0].reveal
-
-        before(async () => {
-          await createSnapshot()
-          // Simulate the wallet is an Live one and is known in
-          // the system.
-          await bridge.setWallet(walletPubKeyHash, {
-            ecdsaWalletID: ethers.constants.HashZero,
-            mainUtxoHash: ethers.constants.HashZero,
-            pendingRedemptionsValue: 0,
-            createdAt: await lastBlockTime(),
-            moveFundsRequestedAt: 0,
-            state: walletState.Live,
-          })
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          // Each header encodes a `difficulty target` field in bytes 72-76.
-          // The given header's hash (interpreted as uint) must be bigger than
-          // the `difficulty target`. To test this scenario, we change the
-          // last byte of the last header in such a way their hash becomes
-          // lower than their `difficulty target`.
-          const properHeaders = data.sweepProof.bitcoinHeaders.toString()
-          data.sweepProof.bitcoinHeaders = `${properHeaders.substring(
-            0,
-            properHeaders.length - 2
-          )}ff`
-
-          await expect(runSweepScenario(data)).to.be.revertedWith(
-            "Insufficient work in a header"
-          )
-        })
-      })
-
-      context(
-        "when accumulated difficulty in headers chain is insufficient",
-        () => {
-          let otherBridge: Bridge
+      context("when transaction proof is not valid", () => {
+        context("when input vector is not valid", () => {
           const data: SweepTestData = JSON.parse(
             JSON.stringify(SingleP2SHDeposit)
           )
@@ -2007,24 +1709,6 @@ describe("Bridge", () => {
               moveFundsRequestedAt: 0,
               state: walletState.Live,
             })
-
-            // Necessary to pass the first part of proof validation.
-            await relay.setCurrentEpochDifficulty(data.chainDifficulty)
-            await relay.setPrevEpochDifficulty(data.chainDifficulty)
-
-            // Deploy another bridge which has higher `txProofDifficultyFactor`
-            // than the original bridge. That means it will need 12 confirmations
-            // to deem transaction proof validity. This scenario uses test
-            // data which has only 6 confirmations. That should force the
-            // failure we expect within this scenario.
-            otherBridge = await Bridge.deploy(
-              bank.address,
-              relay.address,
-              treasury.address,
-              ethers.utils.hexZeroPad("0x01", 20),
-              12
-            )
-            await otherBridge.deployed()
           })
 
           after(async () => {
@@ -2032,18 +1716,453 @@ describe("Bridge", () => {
           })
 
           it("should revert", async () => {
-            await expect(
-              otherBridge.submitSweepProof(
-                data.sweepTx,
-                data.sweepProof,
-                data.mainUtxo
-              )
-            ).to.be.revertedWith(
-              "Insufficient accumulated difficulty in header chain"
+            // Corrupt the input vector by setting a compactSize uint claiming
+            // there is no inputs at all.
+            data.sweepTx.inputVector =
+              "0x0079544f374199c68869ce7df906eeb0ee5c0506a512d903e3900d5752" +
+              "e3e080c500000000c847304402205eff3ae003a5903eb33f32737e3442b6" +
+              "516685a1addb19339c2d02d400cf67ce0220707435fc2a0577373c63c99d" +
+              "242c30bea5959ec180169978d43ece50618fe0ff012103989d253b17a6a0" +
+              "f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b" +
+              "98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576" +
+              "a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e2" +
+              "57eccafbc07c381642ce6e7e55120fb077fbed8804e0250162b175ac68ff" +
+              "ffffff"
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Invalid input vector provided"
             )
           })
-        }
-      )
+        })
+
+        context("when output vector is not valid", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // Corrupt the output vector by setting a compactSize uint claiming
+            // there is no outputs at all.
+            data.sweepTx.outputVector =
+              "0x0044480000000000001600148db50eb52063ea9d98b3eac91489a90f73" +
+              "8986f6"
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Invalid output vector provided"
+            )
+          })
+        })
+
+        context("when merkle proof is not valid", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // Corrupt the merkle proof by changing tx index in block to an
+            // invalid one. The proper one is 36 so any other will do the trick.
+            data.sweepProof.txIndexInBlock = 30
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Tx merkle proof is not valid for provided header and tx hash"
+            )
+          })
+        })
+
+        context("when proof difficulty is not current nor previous", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // To pass the proof validation, the difficulty returned by the relay
+            // must be 22350181 for test data used in this scenario. Setting
+            // a different value will cause difficulty comparison failure.
+            data.chainDifficulty = 1
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Not at current or previous difficulty"
+            )
+          })
+        })
+
+        context("when headers chain length is not valid", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // Corrupt the bitcoin headers length in the sweep proof. The proper
+            // value is length divisible by 80 so any length violating this
+            // rule will cause failure. In this case, we just remove the last
+            // byte from proper headers chain.
+            const properHeaders = data.sweepProof.bitcoinHeaders.toString()
+            data.sweepProof.bitcoinHeaders = properHeaders.substring(
+              0,
+              properHeaders.length - 2
+            )
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Invalid length of the headers chain"
+            )
+          })
+        })
+
+        context("when headers chain is not valid", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // Bitcoin headers must form a chain to pass the proof validation.
+            // That means the `previous block hash` encoded in the given block
+            // header must match the actual previous header's hash. To test
+            // that scenario, we corrupt the `previous block hash` of the
+            // second header. Each header is 80 bytes length. First 4 bytes
+            // of each header is `version` and 32 subsequent bytes is
+            // `previous block hash`. Changing byte 85 of the whole chain will
+            // do the work.
+            const properHeaders = data.sweepProof.bitcoinHeaders.toString()
+            data.sweepProof.bitcoinHeaders = `${properHeaders.substring(
+              0,
+              170
+            )}ff${properHeaders.substring(172)}`
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Invalid headers chain"
+            )
+          })
+        })
+
+        context("when the work in the header is insufficient", () => {
+          const data: SweepTestData = JSON.parse(
+            JSON.stringify(SingleP2SHDeposit)
+          )
+          // Take wallet public key hash from first deposit. All
+          // deposits in same sweep batch should have the same value
+          // of that field.
+          const { walletPubKeyHash } = data.deposits[0].reveal
+
+          before(async () => {
+            await createSnapshot()
+            // Simulate the wallet is an Live one and is known in
+            // the system.
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: ethers.constants.HashZero,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: await lastBlockTime(),
+              moveFundsRequestedAt: 0,
+              state: walletState.Live,
+            })
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            // Each header encodes a `difficulty target` field in bytes 72-76.
+            // The given header's hash (interpreted as uint) must be bigger than
+            // the `difficulty target`. To test this scenario, we change the
+            // last byte of the last header in such a way their hash becomes
+            // lower than their `difficulty target`.
+            const properHeaders = data.sweepProof.bitcoinHeaders.toString()
+            data.sweepProof.bitcoinHeaders = `${properHeaders.substring(
+              0,
+              properHeaders.length - 2
+            )}ff`
+
+            await expect(runSweepScenario(data)).to.be.revertedWith(
+              "Insufficient work in a header"
+            )
+          })
+        })
+
+        context(
+          "when accumulated difficulty in headers chain is insufficient",
+          () => {
+            let otherBridge: Bridge
+            const data: SweepTestData = JSON.parse(
+              JSON.stringify(SingleP2SHDeposit)
+            )
+            // Take wallet public key hash from first deposit. All
+            // deposits in same sweep batch should have the same value
+            // of that field.
+            const { walletPubKeyHash } = data.deposits[0].reveal
+
+            before(async () => {
+              await createSnapshot()
+
+              // Simulate the wallet is an Live one and is known in
+              // the system.
+              await bridge.setWallet(walletPubKeyHash, {
+                ecdsaWalletID: ethers.constants.HashZero,
+                mainUtxoHash: ethers.constants.HashZero,
+                pendingRedemptionsValue: 0,
+                createdAt: await lastBlockTime(),
+                moveFundsRequestedAt: 0,
+                state: walletState.Live,
+              })
+
+              // Necessary to pass the first part of proof validation.
+              await relay.setCurrentEpochDifficulty(data.chainDifficulty)
+              await relay.setPrevEpochDifficulty(data.chainDifficulty)
+
+              // Deploy another bridge which has higher `txProofDifficultyFactor`
+              // than the original bridge. That means it will need 12 confirmations
+              // to deem transaction proof validity. This scenario uses test
+              // data which has only 6 confirmations. That should force the
+              // failure we expect within this scenario.
+              otherBridge = await Bridge.deploy(
+                bank.address,
+                relay.address,
+                treasury.address,
+                ethers.utils.hexZeroPad("0x01", 20),
+                12
+              )
+              await otherBridge.deployed()
+            })
+
+            after(async () => {
+              await restoreSnapshot()
+            })
+
+            it("should revert", async () => {
+              await expect(
+                otherBridge.submitSweepProof(
+                  data.sweepTx,
+                  data.sweepProof,
+                  data.mainUtxo
+                )
+              ).to.be.revertedWith(
+                "Insufficient accumulated difficulty in header chain"
+              )
+            })
+          }
+        )
+      })
+    })
+
+    context("when the wallet state is MovingFunds", () => {
+      // The execution of `submitSweepProof` is the same for wallets in
+      // `MovingFunds` state as for the ones in `Live` state. Therefore the
+      // testing of `MovingFunds` state is limited to just one simple test case
+      // (sweeping single P2SH deposit).
+      let tx: ContractTransaction
+      const data: SweepTestData = SingleP2SHDeposit
+      const { fundingTx, reveal } = data.deposits[0]
+
+      before(async () => {
+        await createSnapshot()
+
+        // Initially set the state to Live, so that the deposit can be revealed
+        await bridge.setWallet(reveal.walletPubKeyHash, {
+          ecdsaWalletID: ethers.constants.HashZero,
+          mainUtxoHash: ethers.constants.HashZero,
+          pendingRedemptionsValue: 0,
+          createdAt: await lastBlockTime(),
+          moveFundsRequestedAt: 0,
+          state: walletState.Live,
+        })
+
+        await relay.setCurrentEpochDifficulty(data.chainDifficulty)
+        await relay.setPrevEpochDifficulty(data.chainDifficulty)
+
+        await bridge.revealDeposit(fundingTx, reveal)
+
+        // Simulate the wallet's state has changed to MovingFunds
+        const wallet = await bridge.getWallet(reveal.walletPubKeyHash)
+        await bridge.setWallet(reveal.walletPubKeyHash, {
+          ecdsaWalletID: wallet.ecdsaWalletID,
+          mainUtxoHash: wallet.mainUtxoHash,
+          pendingRedemptionsValue: wallet.pendingRedemptionsValue,
+          createdAt: wallet.createdAt,
+          moveFundsRequestedAt: wallet.moveFundsRequestedAt,
+          state: walletState.MovingFunds,
+        })
+
+        tx = await bridge.submitSweepProof(
+          data.sweepTx,
+          data.sweepProof,
+          data.mainUtxo
+        )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should mark deposit as swept", async () => {
+        // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+        const depositKey = ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [
+            data.deposits[0].fundingTx.hash,
+            data.deposits[0].reveal.fundingOutputIndex,
+          ]
+        )
+
+        const deposit = await bridge.deposits(depositKey)
+
+        expect(deposit.sweptAt).to.be.equal(await lastBlockTime())
+      })
+
+      it("should update main UTXO for the given wallet", async () => {
+        const { mainUtxoHash } = await bridge.getWallet(reveal.walletPubKeyHash)
+
+        // Amount can be checked by opening the sweep tx in a Bitcoin
+        // testnet explorer. In this case, the sum of inputs is
+        // 20000 satoshi (from the single deposit) and there is a
+        // fee of 1500 so the output value is 18500.
+        const expectedMainUtxo = ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [data.sweepTx.hash, 0, 18500]
+        )
+
+        expect(mainUtxoHash).to.be.equal(expectedMainUtxo)
+      })
+
+      it("should update the depositor's balance", async () => {
+        // The sum of sweep tx inputs is 20000 satoshi. The output
+        // value is 18500 so the transaction fee is 1500. There is
+        // only one deposit so it incurs the entire transaction fee.
+        // The deposit should also incur the treasury fee whose
+        // initial value is 0.05% of the deposited amount so the
+        // final depositor balance should be cut by 10 satoshi.
+        expect(
+          await bank.balanceOf(data.deposits[0].reveal.depositor)
+        ).to.be.equal(18490)
+      })
+
+      it("should transfer collected treasury fee", async () => {
+        expect(await bank.balanceOf(treasury.address)).to.be.equal(10)
+      })
+
+      it("should emit DepositsSwept event", async () => {
+        await expect(tx)
+          .to.emit(bridge, "DepositsSwept")
+          .withArgs(reveal.walletPubKeyHash, data.sweepTx.hash)
+      })
+    })
+
+    context("when the wallet state is neither Live or MovingFunds", () => {
+      // TODO: Implement
     })
   })
 

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -2088,11 +2088,7 @@ describe("Bridge", () => {
         // Simulate the wallet's state has changed to MovingFunds
         const wallet = await bridge.getWallet(reveal.walletPubKeyHash)
         await bridge.setWallet(reveal.walletPubKeyHash, {
-          ecdsaWalletID: wallet.ecdsaWalletID,
-          mainUtxoHash: wallet.mainUtxoHash,
-          pendingRedemptionsValue: wallet.pendingRedemptionsValue,
-          createdAt: wallet.createdAt,
-          moveFundsRequestedAt: wallet.moveFundsRequestedAt,
+          ...wallet,
           state: walletState.MovingFunds,
         })
       })
@@ -2103,11 +2099,7 @@ describe("Bridge", () => {
 
       it("should succeed", async () => {
         await expect(
-          bridge.submitSweepProof(
-            data.sweepTx,
-            data.sweepProof,
-            data.mainUtxo
-          )
+          bridge.submitSweepProof(data.sweepTx, data.sweepProof, data.mainUtxo)
         ).not.to.be.reverted
       })
     })

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -1000,9 +1000,23 @@ describe("Bridge", () => {
 
                   context("when the single input is an unknown", () => {
                     const data: SweepTestData = SingleP2SHDeposit
+                    // Take wallet public key hash from first deposit. All
+                    // deposits in same sweep batch should have the same value
+                    // of that field.
+                    const { walletPubKeyHash } = data.deposits[0].reveal
 
                     before(async () => {
                       await createSnapshot()
+
+                      // Simulate the wallet is an Live one and is known in the system.
+                      await bridge.setWallet(walletPubKeyHash, {
+                        ecdsaWalletID: ethers.constants.HashZero,
+                        mainUtxoHash: ethers.constants.HashZero,
+                        pendingRedemptionsValue: 0,
+                        createdAt: await lastBlockTime(),
+                        moveFundsRequestedAt: 0,
+                        state: walletState.Live,
+                      })
 
                       // Necessary to pass the proof validation.
                       await relay.setCurrentEpochDifficulty(

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -2178,7 +2178,6 @@ describe("Bridge", () => {
           testName: "when wallet state is Terminated",
           walletState: walletState.Terminated,
         },
-        // TODO: Implement tests for state `Closed` when it's added
       ]
 
       testData.forEach((test) => {


### PR DESCRIPTION
This PR adds a check of the wallet state in `submitSweepProof` (only `Live` and `MovingFunds` wallets can accept the proof).