### PR TITLE
Refactor two: Extract logic resolving sweeping wallet to separate function, make Bridge fields mutable

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -750,6 +750,10 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
+    /// @dev Requirements:
+    ///     - Sweeping wallet must be either in Live or MovingFunds state.
+    ///     - If the main UTXO of the sweeping wallet exists in the storage,
+    ///       the passed `mainUTXO` parameter must be equal to the stored one.
     function resolveSweepingWallet(
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata mainUtxo

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -670,7 +670,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         (
             Wallets.Wallet storage wallet,
             BitcoinTx.UTXO memory resolvedMainUtxo
-        ) = resolveWallet(walletPubKeyHash, mainUtxo);
+        ) = resolveSweepingWallet(walletPubKeyHash, mainUtxo);
 
         // Process sweep transaction inputs and extract all information needed
         // to perform deposit bookkeeping.
@@ -750,7 +750,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
-    function resolveWallet(
+    function resolveSweepingWallet(
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata mainUtxo
     )

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -135,20 +135,20 @@ contract Bridge is Ownable, EcdsaWalletOwner {
 
     /// @notice The number of confirmations on the Bitcoin chain required to
     ///         successfully evaluate an SPV proof.
-    uint256 public immutable txProofDifficultyFactor;
+    uint256 public txProofDifficultyFactor;
 
     /// TODO: Revisit whether it should be governable or not.
     /// @notice Address of the Bank this Bridge belongs to.
-    Bank public immutable bank;
+    Bank public bank;
 
     /// TODO: Make it governable.
     /// @notice Handle to the Bitcoin relay.
-    IRelay public immutable relay;
+    IRelay public relay;
 
     /// TODO: Revisit whether it should be governable or not.
     /// @notice Address where the redemptions treasury fees will be sent to.
     ///         Treasury takes part in the operators rewarding process.
-    address public immutable treasury;
+    address public treasury;
 
     BridgeState.Storage internal self;
 
@@ -744,7 +744,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
 
     /// @notice Resolves sweeping wallet based on the provided wallet public key
     ///         hash. Validates the wallet state and current main UTXO, as
-    ///         currently known on the Ethereum chain.  
+    ///         currently known on the Ethereum chain.
     /// @param walletPubKeyHash public key hash of the wallet proving the sweep
     ///        Bitcoin transaction.
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on


### PR DESCRIPTION
~~Depends on #196~~

The part of the logic resolving the wallet, validating its state and
validating the main wallet UTXO has been moved to a separate function.
This is needed to avoid "stack too deep" problems when refactoring the
code moving sweeping functionality to a separate library, out of the
`Bridge` contract (will be done in the next PR).

Gas usage increased a little (~164 units worst case):
```
|  submitSweepProof       ·   181754  ·   336087  ·    255233  │
|  submitSweepProof       ·   181884  ·   336251  ·    255380  │
```

Also, made `Bridge` `immutable` fields mutable.
These fields will have to be extracted into `BridgeState` structure to fix the
problem with `Bridge` contract size (in the next PR) so we will no
longer be able to use the `immutable` keyword for them. Also, these fields 
need to become governable at some point. Doing this change in a separate PR
allows to clearly compare the gas costs of library refactoring that will be done
in a separate PR.

Gas before vs gas after:
```
|  revealDeposit           ·    94028  ·    96659  ·    94690  │
|  revealDeposit           ·    94028  ·    96659  ·    94690  │
|  submitSweepProof        ·   181884  ·   336251  ·   255380  │
|  submitSweepProof        ·   190576  ·   344943  ·   264072  │
|  submitRedemptionProof   ·   117680  ·   194572  ·   163334  │
|  submitRedemptionProof   ·   126354  ·   203246  ·   171551  │
```
Gas consumption increased by ~8600 units for `submitSweepProof` and for
`submitRedemptionProof`.
