### PR TITLE
Refactor three: Extract deposit sweeping into a separate library

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -22,23 +22,12 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 import {IWalletOwner as EcdsaWalletOwner} from "@keep-network/ecdsa/contracts/api/IWalletOwner.sol";
 
 import "../bank/Bank.sol";
+import "./IRelay.sol";
 import "./BridgeState.sol";
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./Wallets.sol";
 import "./Frauds.sol";
-
-/// @title Interface for the Bitcoin relay
-/// @notice Contains only the methods needed by tBTC v2. The Bitcoin relay
-///         provides the difficulty of the previous and current epoch. One
-///         difficulty epoch spans 2016 blocks.
-interface IRelay {
-    /// @notice Returns the difficulty of the current epoch.
-    function getCurrentEpochDifficulty() external view returns (uint256);
-
-    /// @notice Returns the difficulty of the previous epoch.
-    function getPrevEpochDifficulty() external view returns (uint256);
-}
 
 /// @title Bitcoin Bridge
 /// @notice Bridge manages BTC deposit and redemption flow and is increasing and

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -89,11 +89,10 @@ library BridgeState {
         view
         returns (BitcoinTx.ProofDifficulty memory proofDifficulty)
     {
-        proofDifficulty.currentEpochDifficulty = self
-            .relay
+        IRelay relay = self.relay;
+        proofDifficulty.currentEpochDifficulty = relay
             .getCurrentEpochDifficulty();
-        proofDifficulty.previousEpochDifficulty = self
-            .relay
+        proofDifficulty.previousEpochDifficulty = relay
             .getPrevEpochDifficulty();
         proofDifficulty.difficultyFactor = self.txProofDifficultyFactor;
 

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -15,10 +15,26 @@
 
 pragma solidity ^0.8.9;
 
+import "./IRelay.sol";
 import "./Deposit.sol";
+
+import "../bank/Bank.sol";
 
 library BridgeState {
     struct Storage {
+        /// @notice The number of confirmations on the Bitcoin chain required to
+        ///         successfully evaluate an SPV proof.
+        uint256 txProofDifficultyFactor;
+        /// TODO: Revisit whether it should be governable or not.
+        /// @notice Address of the Bank this Bridge belongs to.
+        Bank bank;
+        /// TODO: Make it governable.
+        /// @notice Handle to the Bitcoin relay.
+        IRelay relay;
+        /// TODO: Revisit whether it should be governable or not.
+        /// @notice Address where the redemptions treasury fees will be sent to.
+        ///         Treasury takes part in the operators rewarding process.
+        address treasury;
         /// TODO: Make it governable.
         /// @notice The minimal amount that can be requested to deposit.
         ///         Value of this parameter must take into account the value of
@@ -35,6 +51,13 @@ library BridgeState {
         ///         the `depositTreasuryFeeDivisor` should be set to `50`
         ///         because `1/50 = 0.02 = 2%`.
         uint64 depositTreasuryFeeDivisor;
+        /// TODO: Make it governable.
+        /// @notice Maximum amount of BTC transaction fee that can be incurred by
+        ///         each swept deposit being part of the given sweep
+        ///         transaction. If the maximum BTC transaction fee is exceeded,
+        ///         such transaction is considered a fraud.
+        /// @dev This is a per-deposit input max fee for the sweep transaction.
+        uint64 depositTxMaxFee;
         /// @notice Collection of all revealed deposits indexed by
         ///         keccak256(fundingTxHash | fundingOutputIndex).
         ///         The fundingTxHash is bytes32 (ordered as in Bitcoin internally)
@@ -50,5 +73,30 @@ library BridgeState {
         ///         responsibility - anyone can approve their Bank balance to any
         ///         address.
         mapping(address => bool) isVaultTrusted;
+        /// @notice Collection of main UTXOs that are honestly spent indexed by
+        ///         keccak256(fundingTxHash | fundingOutputIndex). The fundingTxHash
+        ///         is bytes32 (ordered as in Bitcoin internally) and
+        ///         fundingOutputIndex an uint32. A main UTXO is considered honestly
+        ///         spent if it was used as an input of a transaction that have been
+        ///         proven in the Bridge.
+        mapping(uint256 => bool) spentMainUTXOs;
+    }
+
+    /// @notice Determines the current Bitcoin SPV proof difficulty context.
+    /// @return proofDifficulty Bitcoin proof difficulty context.
+    function proofDifficultyContext(Storage storage self)
+        internal
+        view
+        returns (BitcoinTx.ProofDifficulty memory proofDifficulty)
+    {
+        proofDifficulty.currentEpochDifficulty = self
+            .relay
+            .getCurrentEpochDifficulty();
+        proofDifficulty.previousEpochDifficulty = self
+            .relay
+            .getPrevEpochDifficulty();
+        proofDifficulty.difficultyFactor = self.txProofDifficultyFactor;
+
+        return proofDifficulty;
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -84,6 +84,7 @@ library BridgeState {
         mapping(uint256 => bool) spentMainUTXOs;
     }
 
+    // TODO: Is it the right place for this function? Should we move it to Bridge?
     /// @notice Determines the current Bitcoin SPV proof difficulty context.
     /// @return proofDifficulty Bitcoin proof difficulty context.
     function proofDifficultyContext(Storage storage self)

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -29,11 +29,13 @@ library BridgeState {
         /// @notice Address of the Bank this Bridge belongs to.
         Bank bank;
         /// TODO: Make it governable.
-        /// @notice Handle to the Bitcoin relay.
+        /// @notice Bitcoin relay providing the current Bitcoin network
+        ///         difficulty.
         IRelay relay;
         /// TODO: Revisit whether it should be governable or not.
-        /// @notice Address where the redemptions treasury fees will be sent to.
-        ///         Treasury takes part in the operators rewarding process.
+        /// @notice Address where the deposit and redemption treasury fees will 
+        ///         be sent to. Treasury takes part in the operators rewarding
+        ///         process.
         address treasury;
         /// TODO: Make it governable.
         /// @notice The minimal amount that can be requested to deposit.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -33,7 +33,7 @@ library BridgeState {
         ///         difficulty.
         IRelay relay;
         /// TODO: Revisit whether it should be governable or not.
-        /// @notice Address where the deposit and redemption treasury fees will 
+        /// @notice Address where the deposit and redemption treasury fees will
         ///         be sent to. Treasury takes part in the operators rewarding
         ///         process.
         address treasury;

--- a/solidity/contracts/bridge/IRelay.sol
+++ b/solidity/contracts/bridge/IRelay.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+/// @title Interface for the Bitcoin relay
+/// @notice Contains only the methods needed by tBTC v2. The Bitcoin relay
+///         provides the difficulty of the previous and current epoch. One
+///         difficulty epoch spans 2016 blocks.
+interface IRelay {
+    /// @notice Returns the difficulty of the current epoch.
+    function getCurrentEpochDifficulty() external view returns (uint256);
+
+    /// @notice Returns the difficulty of the previous epoch.
+    function getPrevEpochDifficulty() external view returns (uint256);
+}

--- a/solidity/contracts/bridge/Sweep.sol
+++ b/solidity/contracts/bridge/Sweep.sol
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Wallets.sol";
+
+import "../bank/Bank.sol";
+
+library Sweep {
+    using BridgeState for BridgeState.Storage;
+
+    using BTCUtils for bytes;
+
+    /// @notice Represents an outcome of the sweep Bitcoin transaction
+    ///         inputs processing.
+    struct SweepTxInputsInfo {
+        // Sum of all inputs values i.e. all deposits and main UTXO value,
+        // if present.
+        uint256 inputsTotalValue;
+        // Addresses of depositors who performed processed deposits. Ordered in
+        // the same order as deposits inputs in the input vector. Size of this
+        // array is either equal to the number of inputs (main UTXO doesn't
+        // exist) or less by one (main UTXO exists and is pointed by one of
+        // the inputs).
+        address[] depositors;
+        // Amounts of deposits corresponding to processed deposits. Ordered in
+        // the same order as deposits inputs in the input vector. Size of this
+        // array is either equal to the number of inputs (main UTXO doesn't
+        // exist) or less by one (main UTXO exists and is pointed by one of
+        // the inputs).
+        uint256[] depositedAmounts;
+        // Values of the treasury fee corresponding to processed deposits.
+        // Ordered in the same order as deposits inputs in the input vector.
+        // Size of this array is either equal to the number of inputs (main
+        // UTXO doesn't exist) or less by one (main UTXO exists and is pointed
+        // by one of the inputs).
+        uint256[] treasuryFees;
+    }
+
+    event DepositsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
+
+    /// @notice Used by the wallet to prove the BTC deposit sweep transaction
+    ///         and to update Bank balances accordingly. Sweep is only accepted
+    ///         if it satisfies SPV proof.
+    ///
+    ///         The function is performing Bank balance updates by first
+    ///         computing the Bitcoin fee for the sweep transaction. The fee is
+    ///         divided evenly between all swept deposits. Each depositor
+    ///         receives a balance in the bank equal to the amount inferred
+    ///         during the reveal transaction, minus their fee share.
+    ///
+    ///         It is possible to prove the given sweep only one time.
+    /// @param sweepTx Bitcoin sweep transaction data
+    /// @param sweepProof Bitcoin sweep proof data
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain. If no main UTXO exists for the given wallet,
+    ///        this parameter is ignored
+    /// @dev Requirements:
+    ///      - `sweepTx` components must match the expected structure. See
+    ///        `BitcoinTx.Info` docs for reference. Their values must exactly
+    ///        correspond to appropriate Bitcoin transaction fields to produce
+    ///        a provable transaction hash.
+    ///      - The `sweepTx` should represent a Bitcoin transaction with 1..n
+    ///        inputs. If the wallet has no main UTXO, all n inputs should
+    ///        correspond to P2(W)SH revealed deposits UTXOs. If the wallet has
+    ///        an existing main UTXO, one of the n inputs must point to that
+    ///        main UTXO and remaining n-1 inputs should correspond to P2(W)SH
+    ///        revealed deposits UTXOs. That transaction must have only
+    ///        one P2(W)PKH output locking funds on the 20-byte wallet public
+    ///        key hash.
+    ///      - `sweepProof` components must match the expected structure. See
+    ///        `BitcoinTx.Proof` docs for reference. The `bitcoinHeaders`
+    ///        field must contain a valid number of block headers, not less
+    ///        than the `txProofDifficultyFactor` contract constant.
+    ///      - `mainUtxo` components must point to the recent main UTXO
+    ///        of the given wallet, as currently known on the Ethereum chain.
+    ///        If there is no main UTXO, this parameter is ignored.
+    function submitSweepProof(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        BitcoinTx.Info calldata sweepTx,
+        BitcoinTx.Proof calldata sweepProof,
+        BitcoinTx.UTXO calldata mainUtxo
+    ) external {
+        // TODO: Fail early if the function call gets frontrunned. See discussion:
+        //       https://github.com/keep-network/tbtc-v2/pull/106#discussion_r801745204
+
+        // The actual transaction proof is performed here. After that point, we
+        // can assume the transaction happened on Bitcoin chain and has
+        // a sufficient number of confirmations as determined by
+        // `txProofDifficultyFactor` constant.
+        bytes32 sweepTxHash = BitcoinTx.validateProof(
+            sweepTx,
+            sweepProof,
+            self.proofDifficultyContext()
+        );
+
+        // Process sweep transaction output and extract its target wallet
+        // public key hash and value.
+        (
+            bytes20 walletPubKeyHash,
+            uint64 sweepTxOutputValue
+        ) = processSweepTxOutput(sweepTx.outputVector);
+
+        (
+            Wallets.Wallet storage wallet,
+            BitcoinTx.UTXO memory resolvedMainUtxo
+        ) = resolveWallet(wallets, walletPubKeyHash, mainUtxo);
+
+        // Process sweep transaction inputs and extract all information needed
+        // to perform deposit bookkeeping.
+        SweepTxInputsInfo memory inputsInfo = processSweepTxInputs(
+            self,
+            sweepTx.inputVector,
+            resolvedMainUtxo
+        );
+
+        // Helper variable that will hold the sum of treasury fees paid by
+        // all deposits.
+        uint256 totalTreasuryFee = 0;
+
+        // Determine the transaction fee that should be incurred by each deposit
+        // and the indivisible remainder that should be additionally incurred
+        // by the last deposit.
+        (
+            uint256 depositTxFee,
+            uint256 depositTxFeeRemainder
+        ) = sweepTxFeeDistribution(
+                inputsInfo.inputsTotalValue,
+                sweepTxOutputValue,
+                inputsInfo.depositedAmounts.length
+            );
+
+        // Make sure the highest value of the deposit transaction fee does not
+        // exceed the maximum value limited by the governable parameter.
+        require(
+            depositTxFee + depositTxFeeRemainder <= self.depositTxMaxFee,
+            "Transaction fee is too high"
+        );
+
+        // Reduce each deposit amount by treasury fee and transaction fee.
+        for (uint256 i = 0; i < inputsInfo.depositedAmounts.length; i++) {
+            // The last deposit should incur the deposit transaction fee
+            // remainder.
+            uint256 depositTxFeeIncurred = i ==
+                inputsInfo.depositedAmounts.length - 1
+                ? depositTxFee + depositTxFeeRemainder
+                : depositTxFee;
+
+            // There is no need to check whether
+            // `inputsInfo.depositedAmounts[i] - inputsInfo.treasuryFees[i] - txFee > 0`
+            // since the `depositDustThreshold` should force that condition
+            // to be always true.
+            inputsInfo.depositedAmounts[i] =
+                inputsInfo.depositedAmounts[i] -
+                inputsInfo.treasuryFees[i] -
+                depositTxFeeIncurred;
+            totalTreasuryFee += inputsInfo.treasuryFees[i];
+        }
+
+        // Record this sweep data and assign them to the wallet public key hash
+        // as new main UTXO. Transaction output index is always 0 as sweep
+        // transaction always contains only one output.
+        wallet.mainUtxoHash = keccak256(
+            abi.encodePacked(sweepTxHash, uint32(0), sweepTxOutputValue)
+        );
+
+        emit DepositsSwept(walletPubKeyHash, sweepTxHash);
+
+        // Update depositors balances in the Bank.
+        self.bank.increaseBalances(
+            inputsInfo.depositors,
+            inputsInfo.depositedAmounts
+        );
+        // Pass the treasury fee to the treasury address.
+        self.bank.increaseBalance(self.treasury, totalTreasuryFee);
+
+        // TODO: Handle deposits having `vault` set.
+    }
+
+    /// @notice Resolves sweeping wallet based on the provided wallet public key
+    ///         hash. Validates the wallet state and current main UTXO, as
+    ///         currently known on the Ethereum chain.
+    /// @param walletPubKeyHash public key hash of the wallet proving the sweep
+    ///        Bitcoin transaction.
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain. If no main UTXO exists for the given wallet,
+    ///        this parameter is ignored
+    function resolveWallet(
+        Wallets.Data storage wallets,
+        bytes20 walletPubKeyHash,
+        BitcoinTx.UTXO calldata mainUtxo
+    )
+        internal
+        returns (
+            Wallets.Wallet storage wallet,
+            BitcoinTx.UTXO memory resolvedMainUtxo
+        )
+    {
+        wallet = wallets.registeredWallets[walletPubKeyHash];
+
+        Wallets.WalletState walletState = wallet.state;
+        require(
+            walletState == Wallets.WalletState.Live ||
+                walletState == Wallets.WalletState.MovingFunds,
+            "Wallet must be in Live or MovingFunds state"
+        );
+
+        // Check if the main UTXO for given wallet exists. If so, validate
+        // passed main UTXO data against the stored hash and use them for
+        // further processing. If no main UTXO exists, use empty data.
+        resolvedMainUtxo = BitcoinTx.UTXO(bytes32(0), 0, 0);
+        bytes32 mainUtxoHash = wallet.mainUtxoHash;
+        if (mainUtxoHash != bytes32(0)) {
+            require(
+                keccak256(
+                    abi.encodePacked(
+                        mainUtxo.txHash,
+                        mainUtxo.txOutputIndex,
+                        mainUtxo.txOutputValue
+                    )
+                ) == mainUtxoHash,
+                "Invalid main UTXO data"
+            );
+            resolvedMainUtxo = mainUtxo;
+        }
+    }
+
+    /// @notice Processes the Bitcoin sweep transaction output vector by
+    ///         extracting the single output and using it to gain additional
+    ///         information required for further processing (e.g. value and
+    ///         wallet public key hash).
+    /// @param sweepTxOutputVector Bitcoin sweep transaction output vector.
+    ///        This function assumes vector's structure is valid so it must be
+    ///        validated using e.g. `BTCUtils.validateVout` function before
+    ///        it is passed here
+    /// @return walletPubKeyHash 20-byte wallet public key hash.
+    /// @return value 8-byte sweep transaction output value.
+    function processSweepTxOutput(bytes memory sweepTxOutputVector)
+        internal
+        pure
+        returns (bytes20 walletPubKeyHash, uint64 value)
+    {
+        // To determine the total number of sweep transaction outputs, we need to
+        // parse the compactSize uint (VarInt) the output vector is prepended by.
+        // That compactSize uint encodes the number of vector elements using the
+        // format presented in:
+        // https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+        // We don't need asserting the compactSize uint is parseable since it
+        // was already checked during `validateVout` validation.
+        // See `BitcoinTx.outputVector` docs for more details.
+        (, uint256 outputsCount) = sweepTxOutputVector.parseVarInt();
+        require(
+            outputsCount == 1,
+            "Sweep transaction must have a single output"
+        );
+
+        bytes memory output = sweepTxOutputVector.extractOutputAtIndex(0);
+        value = output.extractValue();
+        bytes memory walletPubKeyHashBytes = output.extractHash();
+        // The sweep transaction output should always be P2PKH or P2WPKH.
+        // In both cases, the wallet public key hash should be 20 bytes length.
+        require(
+            walletPubKeyHashBytes.length == 20,
+            "Wallet public key hash should have 20 bytes"
+        );
+        /* solhint-disable-next-line no-inline-assembly */
+        assembly {
+            walletPubKeyHash := mload(add(walletPubKeyHashBytes, 32))
+        }
+
+        return (walletPubKeyHash, value);
+    }
+
+    /// @notice Processes the Bitcoin sweep transaction input vector. It
+    ///         extracts each input and tries to obtain associated deposit or
+    ///         main UTXO data, depending on the input type. Reverts
+    ///         if one of the inputs cannot be recognized as a pointer to a
+    ///         revealed deposit or expected main UTXO.
+    ///         This function also marks each processed deposit as swept.
+    /// @param sweepTxInputVector Bitcoin sweep transaction input vector.
+    ///        This function assumes vector's structure is valid so it must be
+    ///        validated using e.g. `BTCUtils.validateVin` function before
+    ///        it is passed here
+    /// @param mainUtxo Data of the wallet's main UTXO. If no main UTXO
+    ///        exists for the given the wallet, this parameter's fields should
+    ///        be zeroed to bypass the main UTXO validation
+    /// @return info Outcomes of the processing.
+    function processSweepTxInputs(
+        BridgeState.Storage storage self,
+        bytes memory sweepTxInputVector,
+        BitcoinTx.UTXO memory mainUtxo
+    ) internal returns (SweepTxInputsInfo memory info) {
+        // If the passed `mainUtxo` parameter's values are zeroed, the main UTXO
+        // for the given wallet doesn't exist and it is not expected to be
+        // included in the sweep transaction input vector.
+        bool mainUtxoExpected = mainUtxo.txHash != bytes32(0);
+        bool mainUtxoFound = false;
+
+        // Determining the total number of sweep transaction inputs in the same
+        // way as for number of outputs. See `BitcoinTx.inputVector` docs for
+        // more details.
+        (
+            uint256 inputsCompactSizeUintLength,
+            uint256 inputsCount
+        ) = sweepTxInputVector.parseVarInt();
+
+        // To determine the first input starting index, we must jump over
+        // the compactSize uint which prepends the input vector. One byte
+        // must be added because `BtcUtils.parseVarInt` does not include
+        // compactSize uint tag in the returned length.
+        //
+        // For >= 0 && <= 252, `BTCUtils.determineVarIntDataLengthAt`
+        // returns `0`, so we jump over one byte of compactSize uint.
+        //
+        // For >= 253 && <= 0xffff there is `0xfd` tag,
+        // `BTCUtils.determineVarIntDataLengthAt` returns `2` (no
+        // tag byte included) so we need to jump over 1+2 bytes of
+        // compactSize uint.
+        //
+        // Please refer `BTCUtils` library and compactSize uint
+        // docs in `BitcoinTx` library for more details.
+        uint256 inputStartingIndex = 1 + inputsCompactSizeUintLength;
+
+        // Determine the swept deposits count. If main UTXO is NOT expected,
+        // all inputs should be deposits. If main UTXO is expected, one input
+        // should point to that main UTXO.
+        info.depositors = new address[](
+            !mainUtxoExpected ? inputsCount : inputsCount - 1
+        );
+        info.depositedAmounts = new uint256[](info.depositors.length);
+        info.treasuryFees = new uint256[](info.depositors.length);
+
+        // Initialize helper variables.
+        uint256 processedDepositsCount = 0;
+
+        // Inputs processing loop.
+        for (uint256 i = 0; i < inputsCount; i++) {
+            (
+                bytes32 outpointTxHash,
+                uint32 outpointIndex,
+                uint256 inputLength
+            ) = parseTxInputAt(sweepTxInputVector, inputStartingIndex);
+
+            Deposit.Request storage deposit = self.deposits[
+                uint256(
+                    keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+                )
+            ];
+
+            if (deposit.revealedAt != 0) {
+                // If we entered here, that means the input was identified as
+                // a revealed deposit.
+                require(deposit.sweptAt == 0, "Deposit already swept");
+
+                if (processedDepositsCount == info.depositors.length) {
+                    // If this condition is true, that means a deposit input
+                    // took place of an expected main UTXO input.
+                    // In other words, there is no expected main UTXO
+                    // input and all inputs come from valid, revealed deposits.
+                    revert(
+                        "Expected main UTXO not present in sweep transaction inputs"
+                    );
+                }
+
+                /* solhint-disable-next-line not-rely-on-time */
+                deposit.sweptAt = uint32(block.timestamp);
+
+                info.depositors[processedDepositsCount] = deposit.depositor;
+                info.depositedAmounts[processedDepositsCount] = deposit.amount;
+                info.inputsTotalValue += info.depositedAmounts[
+                    processedDepositsCount
+                ];
+                info.treasuryFees[processedDepositsCount] = deposit.treasuryFee;
+
+                processedDepositsCount++;
+            } else if (
+                mainUtxoExpected != mainUtxoFound &&
+                mainUtxo.txHash == outpointTxHash
+            ) {
+                // If we entered here, that means the input was identified as
+                // the expected main UTXO.
+                info.inputsTotalValue += mainUtxo.txOutputValue;
+                mainUtxoFound = true;
+
+                // Main UTXO used as an input, mark it as spent.
+                self.spentMainUTXOs[
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(outpointTxHash, outpointIndex)
+                        )
+                    )
+                ] = true;
+            } else {
+                revert("Unknown input type");
+            }
+
+            // Make the `inputStartingIndex` pointing to the next input by
+            // increasing it by current input's length.
+            inputStartingIndex += inputLength;
+        }
+
+        // Construction of the input processing loop guarantees that:
+        // `processedDepositsCount == info.depositors.length == info.depositedAmounts.length`
+        // is always true at this point. We just use the first variable
+        // to assert the total count of swept deposit is bigger than zero.
+        require(
+            processedDepositsCount > 0,
+            "Sweep transaction must process at least one deposit"
+        );
+
+        // Assert the main UTXO was used as one of current sweep's inputs if
+        // it was actually expected.
+        require(
+            mainUtxoExpected == mainUtxoFound,
+            "Expected main UTXO not present in sweep transaction inputs"
+        );
+
+        return info;
+    }
+
+    /// @notice Parses a Bitcoin transaction input starting at the given index.
+    /// @param inputVector Bitcoin transaction input vector
+    /// @param inputStartingIndex Index the given input starts at
+    /// @return outpointTxHash 32-byte hash of the Bitcoin transaction which is
+    ///         pointed in the given input's outpoint.
+    /// @return outpointIndex 4-byte index of the Bitcoin transaction output
+    ///         which is pointed in the given input's outpoint.
+    /// @return inputLength Byte length of the given input.
+    /// @dev This function assumes vector's structure is valid so it must be
+    ///      validated using e.g. `BTCUtils.validateVin` function before it
+    ///      is passed here.
+    function parseTxInputAt(
+        bytes memory inputVector,
+        uint256 inputStartingIndex
+    )
+        internal
+        pure
+        returns (
+            bytes32 outpointTxHash,
+            uint32 outpointIndex,
+            uint256 inputLength
+        )
+    {
+        outpointTxHash = inputVector.extractInputTxIdLeAt(inputStartingIndex);
+
+        outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+
+        inputLength = inputVector.determineInputLengthAt(inputStartingIndex);
+
+        return (outpointTxHash, outpointIndex, inputLength);
+    }
+
+    /// @notice Determines the distribution of the sweep transaction fee
+    ///         over swept deposits.
+    /// @param sweepTxInputsTotalValue Total value of all sweep transaction inputs.
+    /// @param sweepTxOutputValue Value of the sweep transaction output.
+    /// @param depositsCount Count of the deposits swept by the sweep transaction.
+    /// @return depositTxFee Transaction fee per deposit determined by evenly
+    ///         spreading the divisible part of the sweep transaction fee
+    ///         over all deposits.
+    /// @return depositTxFeeRemainder The indivisible part of the sweep
+    ///         transaction fee than cannot be distributed over all deposits.
+    /// @dev It is up to the caller to decide how the remainder should be
+    ///      counted in. This function only computes its value.
+    function sweepTxFeeDistribution(
+        uint256 sweepTxInputsTotalValue,
+        uint256 sweepTxOutputValue,
+        uint256 depositsCount
+    )
+        internal
+        pure
+        returns (uint256 depositTxFee, uint256 depositTxFeeRemainder)
+    {
+        // The sweep transaction fee is just the difference between inputs
+        // amounts sum and the output amount.
+        uint256 sweepTxFee = sweepTxInputsTotalValue - sweepTxOutputValue;
+        // Compute the indivisible remainder that remains after dividing the
+        // sweep transaction fee over all deposits evenly.
+        depositTxFeeRemainder = sweepTxFee % depositsCount;
+        // Compute the transaction fee per deposit by dividing the sweep
+        // transaction fee (reduced by the remainder) by the number of deposits.
+        depositTxFee = (sweepTxFee - depositTxFeeRemainder) / depositsCount;
+
+        return (depositTxFee, depositTxFeeRemainder);
+    }
+}

--- a/solidity/contracts/bridge/Sweep.sol
+++ b/solidity/contracts/bridge/Sweep.sol
@@ -122,7 +122,7 @@ library Sweep {
         (
             Wallets.Wallet storage wallet,
             BitcoinTx.UTXO memory resolvedMainUtxo
-        ) = resolveWallet(wallets, walletPubKeyHash, mainUtxo);
+        ) = resolveSweepingWallet(wallets, walletPubKeyHash, mainUtxo);
 
         // Process sweep transaction inputs and extract all information needed
         // to perform deposit bookkeeping.
@@ -203,7 +203,11 @@ library Sweep {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
-    function resolveWallet(
+    /// @dev Requirements:
+    ///     - Sweeping wallet must be either in Live or MovingFunds state.
+    ///     - If the main UTXO of the sweeping wallet exists in the storage,
+    ///       the passed `mainUTXO` parameter must be equal to the stored one.
+    function resolveSweepingWallet(
         Wallets.Data storage wallets,
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata mainUtxo

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -43,7 +43,7 @@ contract BridgeStub is Bridge {
                     abi.encodePacked(utxos[i].txHash, utxos[i].txOutputIndex)
                 )
             );
-            spentMainUTXOs[utxoKey] = true;
+            self.spentMainUTXOs[utxoKey] = true;
         }
     }
 
@@ -79,7 +79,7 @@ contract BridgeStub is Bridge {
     }
 
     function setDepositTxMaxFee(uint64 _depositTxMaxFee) external {
-        depositTxMaxFee = _depositTxMaxFee;
+        self.depositTxMaxFee = _depositTxMaxFee;
     }
 
     function setRedemptionDustThreshold(uint64 _redemptionDustThreshold)

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -101,7 +101,7 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
-    except: ["BridgeStub$", "Bridge$"], // TODO: Remove it once the problem of contracts' size is solved
+    except: ["BridgeStub$"], // TODO: Remove it once the problem of contracts' size is solved
   },
   typechain: {
     outDir: "typechain",

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -17,6 +17,7 @@ import type {
   BridgeStub,
   BridgeStub__factory,
   Deposit__factory,
+  Sweep__factory,
   TestRelay,
   TestRelay__factory,
   IWalletRegistry,
@@ -95,6 +96,14 @@ const fixture = async () => {
   const deposit = await Deposit.deploy()
   await deposit.deployed()
 
+  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep", {
+    libraries: {
+      BitcoinTx: bitcoinTx.address,
+    },
+  })
+  const sweep = await Sweep.deploy()
+  await sweep.deployed()
+
   const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
   const wallets = await Wallets.deploy()
   await wallets.deployed()
@@ -109,6 +118,7 @@ const fixture = async () => {
       libraries: {
         BitcoinTx: bitcoinTx.address,
         Deposit: deposit.address,
+        Sweep: sweep.address,
         Wallets: wallets.address,
         Frauds: frauds.address,
       },

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -6,6 +6,7 @@ import type {
   BankStub__factory,
   BitcoinTx__factory,
   Deposit__factory,
+  Sweep__factory,
   Wallets__factory,
   Bridge,
   BridgeStub,
@@ -46,6 +47,14 @@ const bridgeFixture = async () => {
   const deposit = await Deposit.deploy()
   await deposit.deployed()
 
+  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep", {
+    libraries: {
+      BitcoinTx: bitcoinTx.address,
+    },
+  })
+  const sweep = await Sweep.deploy()
+  await sweep.deployed()
+
   const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
   const wallets = await Wallets.deploy()
   await wallets.deployed()
@@ -60,6 +69,7 @@ const bridgeFixture = async () => {
       libraries: {
         BitcoinTx: bitcoinTx.address,
         Deposit: deposit.address,
+        Sweep: sweep.address,
         Wallets: wallets.address,
         Frauds: frauds.address,
       },


### PR DESCRIPTION
~~Depends on #198~~

A refactoring of the Bridge contract is required given the contract size
constraints. This change is another step on this journey. Sweep
functionality is extracted to a separate, externally linked library. No
changes to the logic in the sweeping code were applied.
There were to small changes to the code and docs in `BridgeState`
committed separately: 7b4fefd1b40f51e9f49152cbebb95242f37a8efd, 0cb7816ce2f1ff338f3fb72fdfd82920dfb7d9b6.

Bridge contract size comparison before and after:
```
 |  Bridge               ·     24.852   │
 |  Bridge               ·     20.689   │
```

Gas costs comparison before and after:
```
 |  revealDeposit           ·    94028  ·    96659  ·    94690   │
 |  revealDeposit           ·    96041  ·    98672  ·    96703   │
 |  submitSweepProof        ·   190576  ·   344943  ·   264072   │
 |  submitSweepProof        ·   196251  ·   350622  ·   269763   │
 |  submitRedemptionProof   ·   126354  ·   203246  ·   171551   │
 |  submitRedemptionProof   ·   126280  ·   203172  ·   171481   │
```

