### PR TITLE
Refactor four: extract parts of redemption transaction outputs processing code to separate functions

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1318,7 +1318,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         separately before calling this function.
     ///         Reverts if output is neither requested pending redemption nor
     ///         requested and reported timed-out redemption.
-    ///         This function also marks each pending request as processed by 
+    ///         This function also marks each pending request as processed by
     ///         removing it from `pendingRedemptions` mapping.
     /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
     //         HASH160 over the compressed ECDSA public key) of the wallet which
@@ -1332,7 +1332,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         for a timed-out redemption request.
     /// @return treasuryFee The treasury fee from this single redemption output.
     ///         This value needs to be summed up with treasury fees of all other
-    ///         outputs to evaluate the total treasury fee for the entire 
+    ///         outputs to evaluate the total treasury fee for the entire
     ///         redemption transaction. This value is 0 for a timed-out
     ///         redemption request.
     function processNonChangeRedemptionTxOutput(

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1267,8 +1267,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
                     // key from the mapping to make it reusable for further
                     // requests.
                     delete pendingRedemptions[redemptionKey];
-
-                    processedRedemptionsCount++;
                 } else {
                     // If we entered here, the output is not a redemption
                     // request but there is still a chance the given output is
@@ -1295,9 +1293,9 @@ contract Bridge is Ownable, EcdsaWalletOwner {
                             outputValue <= redeemableAmount,
                         "Output value is not within the acceptable range of the timed out request"
                     );
-
-                    processedRedemptionsCount++;
                 }
+
+                processedRedemptionsCount++;
             }
 
             // Make the `outputStartingIndex` pointing to the next output by

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1231,69 +1231,16 @@ contract Bridge is Ownable, EcdsaWalletOwner {
                 info.changeIndex = uint32(i);
                 info.changeValue = outputValue;
             } else {
-                // If we entered here, that the means the given output is
-                // supposed to represent a redemption. Build the redemption key
-                // to perform that check.
-                uint256 redemptionKey = uint256(
-                    keccak256(abi.encodePacked(walletPubKeyHash, outputScript))
-                );
-
-                if (pendingRedemptions[redemptionKey].requestedAt != 0) {
-                    // If we entered here, that means the output was identified
-                    // as a pending redemption request.
-                    RedemptionRequest storage request = pendingRedemptions[
-                        redemptionKey
-                    ];
-                    // Compute the request's redeemable amount as the requested
-                    // amount reduced by the treasury fee. The request's
-                    // minimal amount is then the redeemable amount reduced by
-                    // the maximum transaction fee.
-                    uint64 redeemableAmount = request.requestedAmount -
-                        request.treasuryFee;
-                    // Output value must fit between the request's redeemable
-                    // and minimal amounts to be deemed valid.
-                    require(
-                        redeemableAmount - request.txMaxFee <= outputValue &&
-                            outputValue <= redeemableAmount,
-                        "Output value is not within the acceptable range of the pending request"
+                (
+                    uint64 burnableValue,
+                    uint64 treasuryFee
+                ) = processNonChangeRedemptionTxOutput(
+                        walletPubKeyHash,
+                        outputScript,
+                        outputValue
                     );
-                    // Add the redeemable amount to the total burnable value
-                    // the Bridge will use to decrease its balance in the Bank.
-                    info.totalBurnableValue += redeemableAmount;
-                    // Add the request's treasury fee to the total treasury fee
-                    // value the Bridge will transfer to the treasury.
-                    info.totalTreasuryFee += request.treasuryFee;
-                    // Request was properly handled so remove its redemption
-                    // key from the mapping to make it reusable for further
-                    // requests.
-                    delete pendingRedemptions[redemptionKey];
-                } else {
-                    // If we entered here, the output is not a redemption
-                    // request but there is still a chance the given output is
-                    // related to a reported timed out redemption request.
-                    // If so, check if the output value matches the request
-                    // amount to confirm this is an overdue request fulfillment
-                    // then bypass this output and process the subsequent
-                    // ones. That also means the wallet was already punished
-                    // for the inactivity. Otherwise, just revert.
-                    RedemptionRequest storage request = timedOutRedemptions[
-                        redemptionKey
-                    ];
-
-                    require(
-                        request.requestedAt != 0,
-                        "Output is a non-requested redemption"
-                    );
-
-                    uint64 redeemableAmount = request.requestedAmount -
-                        request.treasuryFee;
-
-                    require(
-                        redeemableAmount - request.txMaxFee <= outputValue &&
-                            outputValue <= redeemableAmount,
-                        "Output value is not within the acceptable range of the timed out request"
-                    );
-                }
+                info.totalBurnableValue += burnableValue;
+                info.totalTreasuryFee += treasuryFee;
 
                 processedRedemptionsCount++;
             }
@@ -1312,6 +1259,87 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         );
 
         return info;
+    }
+
+    /// @notice Processes a single redemption transaction output. Tries to
+    ///         identify output as a pending redemption request or reported
+    ///         timeout. Output script passed to this function must not be
+    ///         the change output. Such output needs to be identified separately
+    ///         before calling this function.
+    ///         Reverts if outut is neither requested pending redemption nor
+    ///         requested and reported timed-out redemption.
+    ///         This function also marks each request as processed by removing
+    ///         them from `pendingRedemptions` mapping.
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction.
+    /// @param outputScript Non-change output script to be processed
+    /// @param outputValue Value of the output being processed
+    function processNonChangeRedemptionTxOutput(
+        bytes20 walletPubKeyHash,
+        bytes memory outputScript,
+        uint64 outputValue
+    ) internal returns (uint64 burnableValue, uint64 treasuryFee) {
+        uint256 redemptionKey = uint256(
+            keccak256(abi.encodePacked(walletPubKeyHash, outputScript))
+        );
+
+        if (pendingRedemptions[redemptionKey].requestedAt != 0) {
+            // If we entered here, that means the output was identified
+            // as a pending redemption request.
+            RedemptionRequest storage request = pendingRedemptions[
+                redemptionKey
+            ];
+            // Compute the request's redeemable amount as the requested
+            // amount reduced by the treasury fee. The request's
+            // minimal amount is then the redeemable amount reduced by
+            // the maximum transaction fee.
+            uint64 redeemableAmount = request.requestedAmount -
+                request.treasuryFee;
+            // Output value must fit between the request's redeemable
+            // and minimal amounts to be deemed valid.
+            require(
+                redeemableAmount - request.txMaxFee <= outputValue &&
+                    outputValue <= redeemableAmount,
+                "Output value is not within the acceptable range of the pending request"
+            );
+            // Add the redeemable amount to the total burnable value
+            // the Bridge will use to decrease its balance in the Bank.
+            burnableValue = redeemableAmount;
+            // Add the request's treasury fee to the total treasury fee
+            // value the Bridge will transfer to the treasury.
+            treasuryFee = request.treasuryFee;
+            // Request was properly handled so remove its redemption
+            // key from the mapping to make it reusable for further
+            // requests.
+            delete pendingRedemptions[redemptionKey];
+        } else {
+            // If we entered here, the output is not a redemption
+            // request but there is still a chance the given output is
+            // related to a reported timed out redemption request.
+            // If so, check if the output value matches the request
+            // amount to confirm this is an overdue request fulfillment
+            // then bypass this output and process the subsequent
+            // ones. That also means the wallet was already punished
+            // for the inactivity. Otherwise, just revert.
+            RedemptionRequest storage request = timedOutRedemptions[
+                redemptionKey
+            ];
+
+            require(
+                request.requestedAt != 0,
+                "Output is a non-requested redemption"
+            );
+
+            uint64 redeemableAmount = request.requestedAmount -
+                request.treasuryFee;
+
+            require(
+                redeemableAmount - request.txMaxFee <= outputValue &&
+                    outputValue <= redeemableAmount,
+                "Output value is not within the acceptable range of the timed out request"
+            );
+        }
     }
 
     /// @notice Notifies that there is a pending redemption request associated

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1283,8 +1283,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
                 resultInfo.changeValue = outputValue;
             } else {
                 // If we entered here, that the means the given output is
-                // supposed to represent a redemption. Build the redemption key
-                // to perform that check.
+                // supposed to represent a redemption.
                 (
                     uint64 burnableValue,
                     uint64 treasuryFee
@@ -1317,20 +1316,33 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         redemption timeout. Output script passed to this function must
     ///         not be the change output. Such output needs to be identified
     ///         separately before calling this function.
-    ///         Reverts if outut is neither requested pending redemption nor
+    ///         Reverts if output is neither requested pending redemption nor
     ///         requested and reported timed-out redemption.
-    ///         This function also marks each request as processed by removing
-    ///         them from `pendingRedemptions` mapping.
+    ///         This function also marks each pending request as processed by 
+    ///         removing it from `pendingRedemptions` mapping.
     /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
     //         HASH160 over the compressed ECDSA public key) of the wallet which
     ///        performed the redemption transaction.
     /// @param outputScript Non-change output script to be processed
     /// @param outputValue Value of the output being processed
+    /// @return burnableValue The value burnable as a result of processing this
+    ///         single redemption output. This value needs to be summed up with
+    ///         burnable values of all other outputs to evaluate total burnable
+    ///         value for the entire redemption transaction. This value is 0
+    ///         for a timed-out redemption request.
+    /// @return treasuryFee The treasury fee from this single redemption output.
+    ///         This value needs to be summed up with treasury fees of all other
+    ///         outputs to evaluate the total treasury fee for the entire 
+    ///         redemption transaction. This value is 0 for a timed-out
+    ///         redemption request.
     function processNonChangeRedemptionTxOutput(
         bytes20 walletPubKeyHash,
         bytes memory outputScript,
         uint64 outputValue
     ) internal returns (uint64 burnableValue, uint64 treasuryFee) {
+        // This function should be called only if the given output is
+        // supposed to represent a redemption. Build the redemption key
+        // to perform that check.
         uint256 redemptionKey = uint256(
             keccak256(abi.encodePacked(walletPubKeyHash, outputScript))
         );

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -101,6 +101,22 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         uint64 changeValue;
     }
 
+    /// @notice Represents temporary information needed during the processing of
+    ///         the redemption Bitcoin transaction outputs. This structure is an
+    ///         internal one and should not be exported outside of the redemption
+    ///         transaction processing code.
+    /// @dev Allows to mitigate "stack too deep" errors on EVM.
+    struct RedemptionTxOutputsProcessingInfo {
+        // The first output starting index in the transaction.
+        uint256 outputStartingIndex;
+        // The number of outputs in the transaction.
+        uint256 outputsCount;
+        // P2PKH script for the wallet. Needed to determine the change output.
+        bytes32 walletP2PKHScriptKeccak;
+        // P2WPKH script for the wallet. Needed to determine the change output.
+        bytes32 walletP2WPKHScriptKeccak;
+    }
+
     BridgeState.Storage internal self;
 
     /// TODO: Make it governable.
@@ -1195,6 +1211,39 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             abi.encodePacked(hex"160014", walletPubKeyHash)
         );
 
+        return
+            processRedemptionTxOutputs(
+                redemptionTxOutputVector,
+                walletPubKeyHash,
+                RedemptionTxOutputsProcessingInfo(
+                    outputStartingIndex,
+                    outputsCount,
+                    walletP2PKHScriptKeccak,
+                    walletP2WPKHScriptKeccak
+                )
+            );
+    }
+
+    /// @notice Processes all outputs from the redemption transaction. Tries to
+    ///         identify output as a change output, pending redemption request
+    //          or reported redemption. Reverts if one of the outputs cannot be
+    ///         recognized properly. Marks each request as processed by removing
+    ///         them from `pendingRedemptions` mapping.
+    /// @param redemptionTxOutputVector Bitcoin redemption transaction output
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVout` function
+    ///        before it is passed here
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction.
+    /// @param processInfo RedemptionTxOutputsProcessingInfo identifying output
+    ///        starting index, the number of outputs and possible wallet change
+    ///        P2PKH and P2WPKH scripts.
+    function processRedemptionTxOutputs(
+        bytes memory redemptionTxOutputVector,
+        bytes20 walletPubKeyHash,
+        RedemptionTxOutputsProcessingInfo memory processInfo
+    ) internal returns (RedemptionTxOutputsInfo memory resultInfo) {
         // Helper variable that counts the number of processed redemption
         // outputs. Redemptions can be either pending or reported as timed out.
         // TODO: Revisit the approach with redemptions count according to
@@ -1202,14 +1251,14 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         uint256 processedRedemptionsCount = 0;
 
         // Outputs processing loop.
-        for (uint256 i = 0; i < outputsCount; i++) {
+        for (uint256 i = 0; i < processInfo.outputsCount; i++) {
             // TODO: Check if we can optimize gas costs by adding
             //       `extractValueAt` and `extractHashAt` in `bitcoin-spv-sol`
             //       in order to avoid allocating bytes in memory.
             uint256 outputLength = redemptionTxOutputVector
-                .determineOutputLengthAt(outputStartingIndex);
+                .determineOutputLengthAt(processInfo.outputStartingIndex);
             bytes memory output = redemptionTxOutputVector.slice(
-                outputStartingIndex,
+                processInfo.outputStartingIndex,
                 outputLength
             );
 
@@ -1221,16 +1270,21 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             bytes memory outputScript = output.slice(8, output.length - 8);
 
             if (
-                info.changeValue == 0 &&
-                (keccak256(outputScript) == walletP2PKHScriptKeccak ||
-                    keccak256(outputScript) == walletP2WPKHScriptKeccak) &&
+                resultInfo.changeValue == 0 &&
+                (keccak256(outputScript) ==
+                    processInfo.walletP2PKHScriptKeccak ||
+                    keccak256(outputScript) ==
+                    processInfo.walletP2WPKHScriptKeccak) &&
                 outputValue > 0
             ) {
                 // If we entered here, that means the change output with a
                 // proper non-zero value was found.
-                info.changeIndex = uint32(i);
-                info.changeValue = outputValue;
+                resultInfo.changeIndex = uint32(i);
+                resultInfo.changeValue = outputValue;
             } else {
+                // If we entered here, that the means the given output is
+                // supposed to represent a redemption. Build the redemption key
+                // to perform that check.
                 (
                     uint64 burnableValue,
                     uint64 treasuryFee
@@ -1239,15 +1293,14 @@ contract Bridge is Ownable, EcdsaWalletOwner {
                         outputScript,
                         outputValue
                     );
-                info.totalBurnableValue += burnableValue;
-                info.totalTreasuryFee += treasuryFee;
-
+                resultInfo.totalBurnableValue += burnableValue;
+                resultInfo.totalTreasuryFee += treasuryFee;
                 processedRedemptionsCount++;
             }
 
             // Make the `outputStartingIndex` pointing to the next output by
             // increasing it by current output's length.
-            outputStartingIndex += outputLength;
+            processInfo.outputStartingIndex += outputLength;
         }
 
         // Protect against the cases when there is only a single change output
@@ -1257,15 +1310,13 @@ contract Bridge is Ownable, EcdsaWalletOwner {
             processedRedemptionsCount > 0,
             "Redemption transaction must process at least one redemption"
         );
-
-        return info;
     }
 
     /// @notice Processes a single redemption transaction output. Tries to
     ///         identify output as a pending redemption request or reported
-    ///         timeout. Output script passed to this function must not be
-    ///         the change output. Such output needs to be identified separately
-    ///         before calling this function.
+    ///         redemption timeout. Output script passed to this function must
+    ///         not be the change output. Such output needs to be identified
+    ///         separately before calling this function.
     ///         Reverts if outut is neither requested pending redemption nor
     ///         requested and reported timed-out redemption.
     ///         This function also marks each request as processed by removing


### PR DESCRIPTION
~~Depends on #200~~

Extracted code processing single non-change redemption output to
a separate function and split the code processing all outputs into two
functions. This should help  with the clarity of the code but most
importantly, help with fixing "stack too deep" problems after extracting
redemption code to an external library, out of the `Bridge` contract.