### PR TITLE
Refactor five: Extract Bridge redemption logic into a separate library

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -26,6 +26,7 @@ import "./IRelay.sol";
 import "./BridgeState.sol";
 import "./Deposit.sol";
 import "./Sweep.sol";
+import "./Redeem.sol";
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./Wallets.sol";
@@ -53,14 +54,15 @@ import "../bank/Bank.sol";
 ///         balances in the Bank.
 /// @dev Bridge is an upgradeable component of the Bank.
 ///
-/// TODO: All wallets-related operations that are currently done directly
-///       by the Bridge can be probably delegated to the Wallets library.
-///       Examples of such operations are main UTXO or pending redemptions
-///       value updates.
+// TODO: All wallets-related operations that are currently done directly
+//       by the Bridge can be probably delegated to the Wallets library.
+//       Examples of such operations are main UTXO or pending redemptions
+//       value updates.
 contract Bridge is Ownable, EcdsaWalletOwner {
     using BridgeState for BridgeState.Storage;
     using Deposit for BridgeState.Storage;
     using Sweep for BridgeState.Storage;
+    using Redeem for BridgeState.Storage;
     using Frauds for Frauds.Data;
     using Wallets for Wallets.Data;
 
@@ -68,90 +70,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     using BTCUtils for uint256;
     using BytesLib for bytes;
 
-    /// @notice Represents a redemption request.
-    struct RedemptionRequest {
-        // ETH address of the redeemer who created the request.
-        address redeemer;
-        // Requested TBTC amount in satoshi.
-        uint64 requestedAmount;
-        // Treasury TBTC fee in satoshi at the moment of request creation.
-        uint64 treasuryFee;
-        // Transaction maximum BTC fee in satoshi at the moment of request
-        // creation.
-        uint64 txMaxFee;
-        // UNIX timestamp the request was created at.
-        uint32 requestedAt;
-    }
-
-    /// @notice Represents an outcome of the redemption Bitcoin transaction
-    ///         outputs processing.
-    struct RedemptionTxOutputsInfo {
-        // Total TBTC value in satoshi that should be burned by the Bridge.
-        // It includes the total amount of all BTC redeemed in the transaction
-        // and the fee paid to BTC miners for the redemption transaction.
-        uint64 totalBurnableValue;
-        // Total TBTC value in satoshi that should be transferred to
-        // the treasury. It is a sum of all treasury fees paid by all
-        // redeemers included in the redemption transaction.
-        uint64 totalTreasuryFee;
-        // Index of the change output. The change output becomes
-        // the new main wallet's UTXO.
-        uint32 changeIndex;
-        // Value in satoshi of the change output.
-        uint64 changeValue;
-    }
-
-    /// @notice Represents temporary information needed during the processing of
-    ///         the redemption Bitcoin transaction outputs. This structure is an
-    ///         internal one and should not be exported outside of the redemption
-    ///         transaction processing code.
-    /// @dev Allows to mitigate "stack too deep" errors on EVM.
-    struct RedemptionTxOutputsProcessingInfo {
-        // The first output starting index in the transaction.
-        uint256 outputStartingIndex;
-        // The number of outputs in the transaction.
-        uint256 outputsCount;
-        // P2PKH script for the wallet. Needed to determine the change output.
-        bytes32 walletP2PKHScriptKeccak;
-        // P2WPKH script for the wallet. Needed to determine the change output.
-        bytes32 walletP2WPKHScriptKeccak;
-    }
-
     BridgeState.Storage internal self;
-
-    /// TODO: Make it governable.
-    /// @notice The minimal amount that can be requested for redemption.
-    ///         Value of this parameter must take into account the value of
-    ///         `redemptionTreasuryFeeDivisor` and `redemptionTxMaxFee`
-    ///         parameters in order to make requests that can incur the
-    ///         treasury and transaction fee and still satisfy the redeemer.
-    uint64 public redemptionDustThreshold;
-
-    /// TODO: Make it governable.
-    /// @notice Divisor used to compute the treasury fee taken from each
-    ///         redemption request and transferred to the treasury upon
-    ///         successful request finalization. That fee is computed as follows:
-    ///         `treasuryFee = requestedAmount / redemptionTreasuryFeeDivisor`
-    ///         For example, if the treasury fee needs to be 2% of each
-    ///         redemption request, the `redemptionTreasuryFeeDivisor` should
-    ///         be set to `50` because `1/50 = 0.02 = 2%`.
-    uint64 public redemptionTreasuryFeeDivisor;
-
-    /// TODO: Make it governable.
-    /// @notice Maximum amount of BTC transaction fee that can be incurred by
-    ///         each redemption request being part of the given redemption
-    ///         transaction. If the maximum BTC transaction fee is exceeded, such
-    ///         transaction is considered a fraud.
-    /// @dev This is a per-redemption output max fee for the redemption transaction.
-    uint64 public redemptionTxMaxFee;
-
-    /// TODO: Make it governable.
-    /// @notice Time after which the redemption request can be reported as
-    ///         timed out. It is counted from the moment when the redemption
-    ///         request was created via `requestRedemption` call. Reported
-    ///         timed out requests are cancelled and locked TBTC is returned
-    ///         to the redeemer in full amount.
-    uint256 public redemptionTimeout;
 
     /// TODO: Make it governable.
     /// @notice Maximum amount of the total BTC transaction fee that is
@@ -161,37 +80,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///      if per single redemption. `movingFundsTxMaxTotalFee` is a total fee
     ///      for the entire transaction.
     uint64 public movingFundsTxMaxTotalFee;
-
-    /// @notice Collection of all pending redemption requests indexed by
-    ///         redemption key built as
-    ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
-    ///         walletPubKeyHash is the 20-byte wallet's public key hash
-    ///         (computed using Bitcoin HASH160 over the compressed ECDSA
-    ///         public key) and redeemerOutputScript is a Bitcoin script
-    ///         (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to lock
-    ///         redeemed BTC as requested by the redeemer. Requests are added
-    ///         to this mapping by the `requestRedemption` method (duplicates
-    ///         not allowed) and are removed by one of the following methods:
-    ///         - `submitRedemptionProof` in case the request was handled
-    ///           successfully
-    ///         - `notifyRedemptionTimeout` in case the request was reported
-    ///           to be timed out
-    mapping(uint256 => RedemptionRequest) public pendingRedemptions;
-
-    /// @notice Collection of all timed out redemptions requests indexed by
-    ///         redemption key built as
-    ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
-    ///         walletPubKeyHash is the 20-byte wallet's public key hash
-    ///         (computed using Bitcoin HASH160 over the compressed ECDSA
-    ///         public key) and redeemerOutputScript is the Bitcoin script
-    ///         (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the timed
-    ///         out request. Timed out requests are stored in this mapping to
-    ///         avoid slashing the wallets multiple times for the same timeout.
-    ///         Only one method can add to this mapping:
-    ///         - `notifyRedemptionTimeout` which puts the redemption key
-    ///           to this mapping basing on a timed out request stored
-    ///           previously in `pendingRedemptions` mapping.
-    mapping(uint256 => RedemptionRequest) public timedOutRedemptions;
 
     /// @notice Contains parameters related to frauds and the collection of all
     ///         submitted fraud challenges.
@@ -322,10 +210,10 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         self.depositDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
         self.depositTxMaxFee = 10000; // 10000 satoshi
         self.depositTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
-        redemptionDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
-        redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
-        redemptionTxMaxFee = 10000; // 10000 satoshi
-        redemptionTimeout = 172800; // 48 hours
+        self.redemptionDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
+        self.redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
+        self.redemptionTxMaxFee = 10000; // 10000 satoshi
+        self.redemptionTimeout = 172800; // 48 hours
         movingFundsTxMaxTotalFee = 10000; // 10000 satoshi
 
         // TODO: Revisit initial values.
@@ -797,123 +685,13 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes calldata redeemerOutputScript,
         uint64 amount
     ) external {
-        Wallets.Wallet storage wallet = wallets.registeredWallets[
-            walletPubKeyHash
-        ];
-
-        require(
-            wallet.state == Wallets.WalletState.Live,
-            "Wallet must be in Live state"
-        );
-
-        bytes32 mainUtxoHash = wallet.mainUtxoHash;
-        require(
-            mainUtxoHash != bytes32(0),
-            "No main UTXO for the given wallet"
-        );
-        require(
-            keccak256(
-                abi.encodePacked(
-                    mainUtxo.txHash,
-                    mainUtxo.txOutputIndex,
-                    mainUtxo.txOutputValue
-                )
-            ) == mainUtxoHash,
-            "Invalid main UTXO data"
-        );
-
-        // TODO: Confirm if `walletPubKeyHash` should be validated by checking
-        //       if it is the oldest one who can handle the request. This will
-        //       be suggested by the dApp but may not be respected by users who
-        //       interact directly with the contract. Do we need to enforce it
-        //       here? One option is not to enforce it, to save on gas, but if
-        //       we see this rule is not respected, upgrade Bridge contract to
-        //       require it.
-
-        // Validate if redeemer output script is a correct standard type
-        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by building a stub
-        // output with 0 as value and using `BTCUtils.extractHash` on it. Such
-        // a function extracts the payload properly only from standard outputs
-        // so if it succeeds, we have a guarantee the redeemer output script
-        // is proper. Worth to note `extractHash` ignores the value at all
-        // so this is why we can use 0 safely. This way of validation is the
-        // same as in tBTC v1.
-        bytes memory redeemerOutputScriptPayload = abi
-            .encodePacked(bytes8(0), redeemerOutputScript)
-            .extractHash();
-        require(
-            redeemerOutputScriptPayload.length > 0,
-            "Redeemer output script must be a standard type"
-        );
-        // Check if the redeemer output script payload does not point to the
-        // wallet public key hash.
-        require(
-            keccak256(abi.encodePacked(walletPubKeyHash)) !=
-                keccak256(redeemerOutputScriptPayload),
-            "Redeemer output script must not point to the wallet PKH"
-        );
-
-        require(
-            amount >= redemptionDustThreshold,
-            "Redemption amount too small"
-        );
-
-        // The redemption key is built on top of the wallet public key hash
-        // and redeemer output script pair. That means there can be only one
-        // request asking for redemption from the given wallet to the given
-        // BTC script at the same time.
-        uint256 redemptionKey = uint256(
-            keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
-        );
-
-        // Check if given redemption key is not used by a pending redemption.
-        // There is no need to check for existence in `timedOutRedemptions`
-        // since the wallet's state is changed to other than Live after
-        // first time out is reported so making new requests is not possible.
-        // slither-disable-next-line incorrect-equality
-        require(
-            pendingRedemptions[redemptionKey].requestedAt == 0,
-            "There is a pending redemption request from this wallet to the same address"
-        );
-
-        // No need to check whether `amount - treasuryFee - txMaxFee > 0`
-        // since the `redemptionDustThreshold` should force that condition
-        // to be always true.
-        uint64 treasuryFee = redemptionTreasuryFeeDivisor > 0
-            ? amount / redemptionTreasuryFeeDivisor
-            : 0;
-        uint64 txMaxFee = redemptionTxMaxFee;
-
-        // The main wallet UTXO's value doesn't include all pending redemptions.
-        // To determine if the requested redemption can be performed by the
-        // wallet we need to subtract the total value of all pending redemptions
-        // from that wallet's main UTXO value. Given that the treasury fee is
-        // not redeemed from the wallet, we are subtracting it.
-        wallet.pendingRedemptionsValue += amount - treasuryFee;
-        require(
-            mainUtxo.txOutputValue >= wallet.pendingRedemptionsValue,
-            "Insufficient wallet funds"
-        );
-
-        pendingRedemptions[redemptionKey] = RedemptionRequest(
-            msg.sender,
-            amount,
-            treasuryFee,
-            txMaxFee,
-            /* solhint-disable-next-line not-rely-on-time */
-            uint32(block.timestamp)
-        );
-
-        emit RedemptionRequested(
+        self.requestRedemption(
+            wallets,
             walletPubKeyHash,
+            mainUtxo,
             redeemerOutputScript,
-            msg.sender,
-            amount,
-            treasuryFee,
-            txMaxFee
+            amount
         );
-
-        self.bank.transferBalanceFrom(msg.sender, address(this), amount);
     }
 
     /// @notice Used by the wallet to prove the BTC redemption transaction
@@ -966,443 +744,13 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         BitcoinTx.UTXO calldata mainUtxo,
         bytes20 walletPubKeyHash
     ) external {
-        // TODO: Just as for `submitSweepProof`, fail early if the function
-        //       call gets frontrunned. See discussion:
-        //       https://github.com/keep-network/tbtc-v2/pull/106#discussion_r801745204
-
-        // The actual transaction proof is performed here. After that point, we
-        // can assume the transaction happened on Bitcoin chain and has
-        // a sufficient number of confirmations as determined by
-        // `txProofDifficultyFactor` constant.
-        bytes32 redemptionTxHash = BitcoinTx.validateProof(
+        self.submitRedemptionProof(
+            wallets,
             redemptionTx,
             redemptionProof,
-            self.proofDifficultyContext()
-        );
-
-        // Process the redemption transaction input. Specifically, check if it
-        // refers to the expected wallet's main UTXO.
-        processWalletOutboundTxInput(
-            redemptionTx.inputVector,
             mainUtxo,
             walletPubKeyHash
         );
-
-        Wallets.Wallet storage wallet = wallets.registeredWallets[
-            walletPubKeyHash
-        ];
-
-        Wallets.WalletState walletState = wallet.state;
-        require(
-            walletState == Wallets.WalletState.Live ||
-                walletState == Wallets.WalletState.MovingFunds,
-            "Wallet must be in Live or MovingFuds state"
-        );
-
-        // Process redemption transaction outputs to extract some info required
-        // for further processing.
-        RedemptionTxOutputsInfo memory outputsInfo = processRedemptionTxOutputs(
-            redemptionTx.outputVector,
-            walletPubKeyHash
-        );
-
-        if (outputsInfo.changeValue > 0) {
-            // If the change value is grater than zero, it means the change
-            // output exists and can be used as new wallet's main UTXO.
-            wallet.mainUtxoHash = keccak256(
-                abi.encodePacked(
-                    redemptionTxHash,
-                    outputsInfo.changeIndex,
-                    outputsInfo.changeValue
-                )
-            );
-        } else {
-            // If the change value is zero, it means the change output doesn't
-            // exists and no funds left on the wallet. Delete the main UTXO
-            // for that wallet to represent that state in a proper way.
-            delete wallet.mainUtxoHash;
-        }
-
-        wallet.pendingRedemptionsValue -= outputsInfo.totalBurnableValue;
-
-        emit RedemptionsCompleted(walletPubKeyHash, redemptionTxHash);
-
-        self.bank.decreaseBalance(outputsInfo.totalBurnableValue);
-        self.bank.transferBalance(self.treasury, outputsInfo.totalTreasuryFee);
-    }
-
-    /// @notice Checks whether an outbound Bitcoin transaction performed from
-    ///         the given wallet has an input vector that contains a single
-    ///         input referring to the wallet's main UTXO. Marks that main UTXO
-    ///         as correctly spent if the validation succeeds. Reverts otherwise.
-    ///         There are two outbound transactions from a wallet possible: a
-    ///         redemption transaction or a moving funds to another wallet
-    ///         transaction.
-    /// @param walletOutboundTxInputVector Bitcoin outbound transaction's input
-    ///        vector. This function assumes vector's structure is valid so it
-    ///        must be validated using e.g. `BTCUtils.validateVin` function
-    ///        before it is passed here
-    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
-    ///        the Ethereum chain.
-    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
-    //         HASH160 over the compressed ECDSA public key) of the wallet which
-    ///        performed the outbound transaction.
-    function processWalletOutboundTxInput(
-        bytes memory walletOutboundTxInputVector,
-        BitcoinTx.UTXO calldata mainUtxo,
-        bytes20 walletPubKeyHash
-    ) internal {
-        // Assert that main UTXO for passed wallet exists in storage.
-        bytes32 mainUtxoHash = wallets
-            .registeredWallets[walletPubKeyHash]
-            .mainUtxoHash;
-        require(mainUtxoHash != bytes32(0), "No main UTXO for given wallet");
-
-        // Assert that passed main UTXO parameter is the same as in storage and
-        // can be used for further processing.
-        require(
-            keccak256(
-                abi.encodePacked(
-                    mainUtxo.txHash,
-                    mainUtxo.txOutputIndex,
-                    mainUtxo.txOutputValue
-                )
-            ) == mainUtxoHash,
-            "Invalid main UTXO data"
-        );
-
-        // Assert that the single outbound transaction input actually
-        // refers to the wallet's main UTXO.
-        (
-            bytes32 outpointTxHash,
-            uint32 outpointIndex
-        ) = parseWalletOutboundTxInput(walletOutboundTxInputVector);
-        require(
-            mainUtxo.txHash == outpointTxHash &&
-                mainUtxo.txOutputIndex == outpointIndex,
-            "Outbound transaction input must point to the wallet's main UTXO"
-        );
-
-        // Main UTXO used as an input, mark it as spent.
-        self.spentMainUTXOs[
-            uint256(
-                keccak256(
-                    abi.encodePacked(mainUtxo.txHash, mainUtxo.txOutputIndex)
-                )
-            )
-        ] = true;
-    }
-
-    /// @notice Parses the input vector of an outbound Bitcoin transaction
-    ///         performed from the given wallet. It extracts the single input
-    ///         then the transaction hash and output index from its outpoint.
-    ///         There are two outbound transactions from a wallet possible: a
-    ///         redemption transaction or a moving funds to another wallet
-    ///         transaction.
-    /// @param walletOutboundTxInputVector Bitcoin outbound transaction input
-    ///        vector. This function assumes vector's structure is valid so it
-    ///        must be validated using e.g. `BTCUtils.validateVin` function
-    ///        before it is passed here
-    /// @return outpointTxHash 32-byte hash of the Bitcoin transaction which is
-    ///         pointed in the input's outpoint.
-    /// @return outpointIndex 4-byte index of the Bitcoin transaction output
-    ///         which is pointed in the input's outpoint.
-    function parseWalletOutboundTxInput(
-        bytes memory walletOutboundTxInputVector
-    ) internal pure returns (bytes32 outpointTxHash, uint32 outpointIndex) {
-        // To determine the total number of Bitcoin transaction inputs,
-        // we need to parse the compactSize uint (VarInt) the input vector is
-        // prepended by. That compactSize uint encodes the number of vector
-        // elements using the format presented in:
-        // https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
-        // We don't need asserting the compactSize uint is parseable since it
-        // was already checked during `validateVin` validation.
-        // See `BitcoinTx.inputVector` docs for more details.
-        (, uint256 inputsCount) = walletOutboundTxInputVector.parseVarInt();
-        require(
-            inputsCount == 1,
-            "Outbound transaction must have a single input"
-        );
-
-        bytes memory input = walletOutboundTxInputVector.extractInputAtIndex(0);
-
-        outpointTxHash = input.extractInputTxIdLE();
-
-        outpointIndex = BTCUtils.reverseUint32(
-            uint32(input.extractTxIndexLE())
-        );
-
-        // There is only one input in the transaction. Input has an outpoint
-        // field that is a reference to the transaction being spent (see
-        // `BitcoinTx` docs). The outpoint contains the hash of the transaction
-        // to spend (`outpointTxHash`) and the index of the specific output
-        // from that transaction (`outpointIndex`).
-        return (outpointTxHash, outpointIndex);
-    }
-
-    /// @notice Processes the Bitcoin redemption transaction output vector.
-    ///         It extracts each output and tries to identify it as a pending
-    ///         redemption request, reported timed out request, or change.
-    ///         Reverts if one of the outputs cannot be recognized properly.
-    ///         This function also marks each request as processed by removing
-    ///         them from `pendingRedemptions` mapping.
-    /// @param redemptionTxOutputVector Bitcoin redemption transaction output
-    ///        vector. This function assumes vector's structure is valid so it
-    ///        must be validated using e.g. `BTCUtils.validateVout` function
-    ///        before it is passed here
-    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
-    //         HASH160 over the compressed ECDSA public key) of the wallet which
-    ///        performed the redemption transaction.
-    /// @return info Outcomes of the processing.
-    function processRedemptionTxOutputs(
-        bytes memory redemptionTxOutputVector,
-        bytes20 walletPubKeyHash
-    ) internal returns (RedemptionTxOutputsInfo memory info) {
-        // Determining the total number of redemption transaction outputs in
-        // the same way as for number of inputs. See `BitcoinTx.outputVector`
-        // docs for more details.
-        (
-            uint256 outputsCompactSizeUintLength,
-            uint256 outputsCount
-        ) = redemptionTxOutputVector.parseVarInt();
-
-        // To determine the first output starting index, we must jump over
-        // the compactSize uint which prepends the output vector. One byte
-        // must be added because `BtcUtils.parseVarInt` does not include
-        // compactSize uint tag in the returned length.
-        //
-        // For >= 0 && <= 252, `BTCUtils.determineVarIntDataLengthAt`
-        // returns `0`, so we jump over one byte of compactSize uint.
-        //
-        // For >= 253 && <= 0xffff there is `0xfd` tag,
-        // `BTCUtils.determineVarIntDataLengthAt` returns `2` (no
-        // tag byte included) so we need to jump over 1+2 bytes of
-        // compactSize uint.
-        //
-        // Please refer `BTCUtils` library and compactSize uint
-        // docs in `BitcoinTx` library for more details.
-        uint256 outputStartingIndex = 1 + outputsCompactSizeUintLength;
-
-        // Calculate the keccak256 for two possible wallet's P2PKH or P2WPKH
-        // scripts that can be used to lock the change. This is done upfront to
-        // save on gas. Both scripts have a strict format defined by Bitcoin.
-        //
-        // The P2PKH script has the byte format: <0x1976a914> <20-byte PKH> <0x88ac>.
-        // According to https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
-        // - 0x19: Byte length of the entire script
-        // - 0x76: OP_DUP
-        // - 0xa9: OP_HASH160
-        // - 0x14: Byte length of the public key hash
-        // - 0x88: OP_EQUALVERIFY
-        // - 0xac: OP_CHECKSIG
-        // which matches the P2PKH structure as per:
-        // https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash
-        bytes32 walletP2PKHScriptKeccak = keccak256(
-            abi.encodePacked(hex"1976a914", walletPubKeyHash, hex"88ac")
-        );
-        // The P2WPKH script has the byte format: <0x160014> <20-byte PKH>.
-        // According to https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
-        // - 0x16: Byte length of the entire script
-        // - 0x00: OP_0
-        // - 0x14: Byte length of the public key hash
-        // which matches the P2WPKH structure as per:
-        // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH
-        bytes32 walletP2WPKHScriptKeccak = keccak256(
-            abi.encodePacked(hex"160014", walletPubKeyHash)
-        );
-
-        return
-            processRedemptionTxOutputs(
-                redemptionTxOutputVector,
-                walletPubKeyHash,
-                RedemptionTxOutputsProcessingInfo(
-                    outputStartingIndex,
-                    outputsCount,
-                    walletP2PKHScriptKeccak,
-                    walletP2WPKHScriptKeccak
-                )
-            );
-    }
-
-    /// @notice Processes all outputs from the redemption transaction. Tries to
-    ///         identify output as a change output, pending redemption request
-    //          or reported redemption. Reverts if one of the outputs cannot be
-    ///         recognized properly. Marks each request as processed by removing
-    ///         them from `pendingRedemptions` mapping.
-    /// @param redemptionTxOutputVector Bitcoin redemption transaction output
-    ///        vector. This function assumes vector's structure is valid so it
-    ///        must be validated using e.g. `BTCUtils.validateVout` function
-    ///        before it is passed here
-    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
-    //         HASH160 over the compressed ECDSA public key) of the wallet which
-    ///        performed the redemption transaction.
-    /// @param processInfo RedemptionTxOutputsProcessingInfo identifying output
-    ///        starting index, the number of outputs and possible wallet change
-    ///        P2PKH and P2WPKH scripts.
-    function processRedemptionTxOutputs(
-        bytes memory redemptionTxOutputVector,
-        bytes20 walletPubKeyHash,
-        RedemptionTxOutputsProcessingInfo memory processInfo
-    ) internal returns (RedemptionTxOutputsInfo memory resultInfo) {
-        // Helper variable that counts the number of processed redemption
-        // outputs. Redemptions can be either pending or reported as timed out.
-        // TODO: Revisit the approach with redemptions count according to
-        //       https://github.com/keep-network/tbtc-v2/pull/128#discussion_r808237765
-        uint256 processedRedemptionsCount = 0;
-
-        // Outputs processing loop.
-        for (uint256 i = 0; i < processInfo.outputsCount; i++) {
-            // TODO: Check if we can optimize gas costs by adding
-            //       `extractValueAt` and `extractHashAt` in `bitcoin-spv-sol`
-            //       in order to avoid allocating bytes in memory.
-            uint256 outputLength = redemptionTxOutputVector
-                .determineOutputLengthAt(processInfo.outputStartingIndex);
-            bytes memory output = redemptionTxOutputVector.slice(
-                processInfo.outputStartingIndex,
-                outputLength
-            );
-
-            // Extract the value from given output.
-            uint64 outputValue = output.extractValue();
-            // The output consists of an 8-byte value and a variable length
-            // script. To extract that script we slice the output starting from
-            // 9th byte until the end.
-            bytes memory outputScript = output.slice(8, output.length - 8);
-
-            if (
-                resultInfo.changeValue == 0 &&
-                (keccak256(outputScript) ==
-                    processInfo.walletP2PKHScriptKeccak ||
-                    keccak256(outputScript) ==
-                    processInfo.walletP2WPKHScriptKeccak) &&
-                outputValue > 0
-            ) {
-                // If we entered here, that means the change output with a
-                // proper non-zero value was found.
-                resultInfo.changeIndex = uint32(i);
-                resultInfo.changeValue = outputValue;
-            } else {
-                // If we entered here, that the means the given output is
-                // supposed to represent a redemption.
-                (
-                    uint64 burnableValue,
-                    uint64 treasuryFee
-                ) = processNonChangeRedemptionTxOutput(
-                        walletPubKeyHash,
-                        outputScript,
-                        outputValue
-                    );
-                resultInfo.totalBurnableValue += burnableValue;
-                resultInfo.totalTreasuryFee += treasuryFee;
-                processedRedemptionsCount++;
-            }
-
-            // Make the `outputStartingIndex` pointing to the next output by
-            // increasing it by current output's length.
-            processInfo.outputStartingIndex += outputLength;
-        }
-
-        // Protect against the cases when there is only a single change output
-        // referring back to the wallet PKH and just burning main UTXO value
-        // for transaction fees.
-        require(
-            processedRedemptionsCount > 0,
-            "Redemption transaction must process at least one redemption"
-        );
-    }
-
-    /// @notice Processes a single redemption transaction output. Tries to
-    ///         identify output as a pending redemption request or reported
-    ///         redemption timeout. Output script passed to this function must
-    ///         not be the change output. Such output needs to be identified
-    ///         separately before calling this function.
-    ///         Reverts if output is neither requested pending redemption nor
-    ///         requested and reported timed-out redemption.
-    ///         This function also marks each pending request as processed by
-    ///         removing it from `pendingRedemptions` mapping.
-    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
-    //         HASH160 over the compressed ECDSA public key) of the wallet which
-    ///        performed the redemption transaction.
-    /// @param outputScript Non-change output script to be processed
-    /// @param outputValue Value of the output being processed
-    /// @return burnableValue The value burnable as a result of processing this
-    ///         single redemption output. This value needs to be summed up with
-    ///         burnable values of all other outputs to evaluate total burnable
-    ///         value for the entire redemption transaction. This value is 0
-    ///         for a timed-out redemption request.
-    /// @return treasuryFee The treasury fee from this single redemption output.
-    ///         This value needs to be summed up with treasury fees of all other
-    ///         outputs to evaluate the total treasury fee for the entire
-    ///         redemption transaction. This value is 0 for a timed-out
-    ///         redemption request.
-    function processNonChangeRedemptionTxOutput(
-        bytes20 walletPubKeyHash,
-        bytes memory outputScript,
-        uint64 outputValue
-    ) internal returns (uint64 burnableValue, uint64 treasuryFee) {
-        // This function should be called only if the given output is
-        // supposed to represent a redemption. Build the redemption key
-        // to perform that check.
-        uint256 redemptionKey = uint256(
-            keccak256(abi.encodePacked(walletPubKeyHash, outputScript))
-        );
-
-        if (pendingRedemptions[redemptionKey].requestedAt != 0) {
-            // If we entered here, that means the output was identified
-            // as a pending redemption request.
-            RedemptionRequest storage request = pendingRedemptions[
-                redemptionKey
-            ];
-            // Compute the request's redeemable amount as the requested
-            // amount reduced by the treasury fee. The request's
-            // minimal amount is then the redeemable amount reduced by
-            // the maximum transaction fee.
-            uint64 redeemableAmount = request.requestedAmount -
-                request.treasuryFee;
-            // Output value must fit between the request's redeemable
-            // and minimal amounts to be deemed valid.
-            require(
-                redeemableAmount - request.txMaxFee <= outputValue &&
-                    outputValue <= redeemableAmount,
-                "Output value is not within the acceptable range of the pending request"
-            );
-            // Add the redeemable amount to the total burnable value
-            // the Bridge will use to decrease its balance in the Bank.
-            burnableValue = redeemableAmount;
-            // Add the request's treasury fee to the total treasury fee
-            // value the Bridge will transfer to the treasury.
-            treasuryFee = request.treasuryFee;
-            // Request was properly handled so remove its redemption
-            // key from the mapping to make it reusable for further
-            // requests.
-            delete pendingRedemptions[redemptionKey];
-        } else {
-            // If we entered here, the output is not a redemption
-            // request but there is still a chance the given output is
-            // related to a reported timed out redemption request.
-            // If so, check if the output value matches the request
-            // amount to confirm this is an overdue request fulfillment
-            // then bypass this output and process the subsequent
-            // ones. That also means the wallet was already punished
-            // for the inactivity. Otherwise, just revert.
-            RedemptionRequest storage request = timedOutRedemptions[
-                redemptionKey
-            ];
-
-            require(
-                request.requestedAt != 0,
-                "Output is a non-requested redemption"
-            );
-
-            uint64 redeemableAmount = request.requestedAmount -
-                request.treasuryFee;
-
-            require(
-                redeemableAmount - request.txMaxFee <= outputValue &&
-                    outputValue <= redeemableAmount,
-                "Output value is not within the acceptable range of the timed out request"
-            );
-        }
     }
 
     /// @notice Notifies that there is a pending redemption request associated
@@ -1433,56 +781,11 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 walletPubKeyHash,
         bytes calldata redeemerOutputScript
     ) external {
-        uint256 redemptionKey = uint256(
-            keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
+        self.notifyRedemptionTimeout(
+            wallets,
+            walletPubKeyHash,
+            redeemerOutputScript
         );
-        RedemptionRequest memory request = pendingRedemptions[redemptionKey];
-
-        require(request.requestedAt > 0, "Redemption request does not exist");
-        require(
-            /* solhint-disable-next-line not-rely-on-time */
-            request.requestedAt + redemptionTimeout < block.timestamp,
-            "Redemption request has not timed out"
-        );
-
-        // Update the wallet's pending redemptions value
-        Wallets.Wallet storage wallet = wallets.registeredWallets[
-            walletPubKeyHash
-        ];
-        wallet.pendingRedemptionsValue -=
-            request.requestedAmount -
-            request.treasuryFee;
-
-        require(
-            // TODO: Allow the wallets in `Closing` state when the state is added
-            wallet.state == Wallets.WalletState.Live ||
-                wallet.state == Wallets.WalletState.MovingFunds ||
-                wallet.state == Wallets.WalletState.Terminated,
-            "The wallet must be in Live, MovingFunds or Terminated state"
-        );
-
-        // It is worth noting that there is no need to check if
-        // `timedOutRedemption` mapping already contains the given redemption
-        // key. There is no possibility to re-use a key of a reported timed-out
-        // redemption because the wallet responsible for causing the timeout is
-        // moved to a state that prevents it to receive new redemption requests.
-
-        // Move the redemption from pending redemptions to timed-out redemptions
-        timedOutRedemptions[redemptionKey] = request;
-        delete pendingRedemptions[redemptionKey];
-
-        if (
-            wallet.state == Wallets.WalletState.Live ||
-            wallet.state == Wallets.WalletState.MovingFunds
-        ) {
-            // Propagate timeout consequences to the wallet
-            wallets.notifyRedemptionTimedOut(walletPubKeyHash);
-        }
-
-        emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
-
-        // Return the requested amount of tokens to the redeemer
-        self.bank.transferBalance(request.redeemer, request.requestedAmount);
     }
 
     /// @notice Used by the wallet to prove the BTC moving funds transaction
@@ -1548,7 +851,9 @@ contract Bridge is Ownable, EcdsaWalletOwner {
 
         // Process the moving funds transaction input. Specifically, check if
         // it refers to the expected wallet's main UTXO.
-        processWalletOutboundTxInput(
+        OutboundTx.processWalletOutboundTxInput(
+            self,
+            wallets,
             movingFundsTx.inputVector,
             mainUtxo,
             walletPubKeyHash
@@ -1725,6 +1030,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         return (targetWalletsHash, outputsTotalValue);
     }
 
+    /// @notice Returns the addresses of contracts Bridge is interacting with.
     /// @return bank Address of the Bank the Bridge belongs to.
     /// @return relay Address of the Bitcoin relay providing the current Bitcoin
     ///         network difficulty.
@@ -1772,6 +1078,53 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         txProofDifficultyFactor = self.txProofDifficultyFactor;
     }
 
+    /// @notice Returns the current values of Bridge redemption parameters.
+    /// @return redemptionDustThreshold The minimal amount that can be requested
+    ///         for redemption. Value of this parameter must take into account
+    ///         the value of `redemptionTreasuryFeeDivisor` and `redemptionTxMaxFee`
+    ///         parameters in order to make requests that can incur the
+    ///         treasury and transaction fee and still satisfy the redeemer.
+    /// @return redemptionTreasuryFeeDivisor Divisor used to compute the treasury
+    ///         fee taken from each redemption request and transferred to the
+    ///         treasury upon successful request finalization. That fee is
+    ///         computed as follows:
+    ///         `treasuryFee = requestedAmount / redemptionTreasuryFeeDivisor`
+    ///         For example, if the treasury fee needs to be 2% of each
+    ///         redemption request, the `redemptionTreasuryFeeDivisor` should
+    ///         be set to `50` because `1/50 = 0.02 = 2%`.
+    /// @return redemptionTxMaxFee Maximum amount of BTC transaction fee that
+    ///         can be incurred by each redemption request being part of the
+    ///         given redemption transaction. If the maximum BTC transaction
+    ///         fee is exceeded, such transaction is considered a fraud.
+    /// @return redemptionTimeout Time after which the redemption request can be
+    ///         reported as timed out. It is counted from the moment when the
+    ///         redemption request was created via `requestRedemption` call.
+    ///         Reported  timed out requests are cancelled and locked TBTC is
+    ///         returned to the redeemer in full amount.
+    /// @return treasury Address where the redemption treasury fees will be
+    ///         sent to. Treasury takes part in the operators rewarding process.
+    /// @return txProofDifficultyFactor The number of confirmations on the
+    ///         Bitcoin chain required to successfully evaluate an SPV proof.
+    function redemptionParameters()
+        external
+        view
+        returns (
+            uint64 redemptionDustThreshold,
+            uint64 redemptionTreasuryFeeDivisor,
+            uint64 redemptionTxMaxFee,
+            uint256 redemptionTimeout,
+            address treasury,
+            uint256 txProofDifficultyFactor
+        )
+    {
+        redemptionDustThreshold = self.redemptionDustThreshold;
+        redemptionTreasuryFeeDivisor = self.redemptionTreasuryFeeDivisor;
+        redemptionTxMaxFee = self.redemptionTxMaxFee;
+        redemptionTimeout = self.redemptionTimeout;
+        treasury = self.treasury;
+        txProofDifficultyFactor = self.txProofDifficultyFactor;
+    }
+
     /// @notice Indicates if the vault with the given address is trusted or not.
     ///         Depositors can route their revealed deposits only to trusted
     ///         vaults and have trusted vaults notified about new deposits as
@@ -1794,7 +1147,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         view
         returns (Deposit.Request memory)
     {
-        // TODO: rename to getDeposit?
         return self.deposits[depositKey];
     }
 
@@ -1806,5 +1158,48 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         proven in the Bridge.
     function spentMainUTXOs(uint256 utxoKey) external view returns (bool) {
         return self.spentMainUTXOs[utxoKey];
+    }
+
+    /// @notice Collection of all pending redemption requests indexed by
+    ///         redemption key built as
+    ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
+    ///         walletPubKeyHash is the 20-byte wallet's public key hash
+    ///         (computed using Bitcoin HASH160 over the compressed ECDSA
+    ///         public key) and redeemerOutputScript is a Bitcoin script
+    ///         (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to lock
+    ///         redeemed BTC as requested by the redeemer. Requests are added
+    ///         to this mapping by the `requestRedemption` method (duplicates
+    ///         not allowed) and are removed by one of the following methods:
+    ///         - `submitRedemptionProof` in case the request was handled
+    ///           successfully
+    ///         - `notifyRedemptionTimeout` in case the request was reported
+    ///           to be timed out
+    function pendingRedemptions(uint256 redemptionKey)
+        external
+        view
+        returns (Redeem.RedemptionRequest memory)
+    {
+        return self.pendingRedemptions[redemptionKey];
+    }
+
+    /// @notice Collection of all timed out redemptions requests indexed by
+    ///         redemption key built as
+    ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
+    ///         walletPubKeyHash is the 20-byte wallet's public key hash
+    ///         (computed using Bitcoin HASH160 over the compressed ECDSA
+    ///         public key) and redeemerOutputScript is the Bitcoin script
+    ///         (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the timed
+    ///         out request. Timed out requests are stored in this mapping to
+    ///         avoid slashing the wallets multiple times for the same timeout.
+    ///         Only one method can add to this mapping:
+    ///         - `notifyRedemptionTimeout` which puts the redemption key
+    ///           to this mapping basing on a timed out request stored
+    ///           previously in `pendingRedemptions` mapping.
+    function timedOutRedemptions(uint256 redemptionKey)
+        external
+        view
+        returns (Redeem.RedemptionRequest memory)
+    {
+        return self.timedOutRedemptions[redemptionKey];
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -17,6 +17,9 @@ pragma solidity ^0.8.9;
 
 import "./IRelay.sol";
 import "./Deposit.sol";
+import "./Redeem.sol";
+
+import "../bank/Bank.sol";
 
 import "../bank/Bank.sol";
 
@@ -75,6 +78,65 @@ library BridgeState {
         ///         responsibility - anyone can approve their Bank balance to any
         ///         address.
         mapping(address => bool) isVaultTrusted;
+        /// TODO: Make it governable.
+        /// @notice The minimal amount that can be requested for redemption.
+        ///         Value of this parameter must take into account the value of
+        ///         `redemptionTreasuryFeeDivisor` and `redemptionTxMaxFee`
+        ///         parameters in order to make requests that can incur the
+        ///         treasury and transaction fee and still satisfy the redeemer.
+        uint64 redemptionDustThreshold;
+        /// TODO: Make it governable.
+        /// @notice Divisor used to compute the treasury fee taken from each
+        ///         redemption request and transferred to the treasury upon
+        ///         successful request finalization. That fee is computed as follows:
+        ///         `treasuryFee = requestedAmount / redemptionTreasuryFeeDivisor`
+        ///         For example, if the treasury fee needs to be 2% of each
+        ///         redemption request, the `redemptionTreasuryFeeDivisor` should
+        ///         be set to `50` because `1/50 = 0.02 = 2%`.
+        uint64 redemptionTreasuryFeeDivisor;
+        /// TODO: Make it governable.
+        /// @notice Maximum amount of BTC transaction fee that can be incurred by
+        ///         each redemption request being part of the given redemption
+        ///         transaction. If the maximum BTC transaction fee is exceeded, such
+        ///         transaction is considered a fraud.
+        /// @dev This is a per-redemption output max fee for the redemption transaction.
+        uint64 redemptionTxMaxFee;
+        /// TODO: Make it governable.
+        /// @notice Time after which the redemption request can be reported as
+        ///         timed out. It is counted from the moment when the redemption
+        ///         request was created via `requestRedemption` call. Reported
+        ///         timed out requests are cancelled and locked TBTC is returned
+        ///         to the redeemer in full amount.
+        uint256 redemptionTimeout;
+        /// @notice Collection of all pending redemption requests indexed by
+        ///         redemption key built as
+        ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
+        ///         walletPubKeyHash is the 20-byte wallet's public key hash
+        ///         (computed using Bitcoin HASH160 over the compressed ECDSA
+        ///         public key) and redeemerOutputScript is a Bitcoin script
+        ///         (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to lock
+        ///         redeemed BTC as requested by the redeemer. Requests are added
+        ///         to this mapping by the `requestRedemption` method (duplicates
+        ///         not allowed) and are removed by one of the following methods:
+        ///         - `submitRedemptionProof` in case the request was handled
+        ///           successfully
+        ///         - `notifyRedemptionTimeout` in case the request was reported
+        ///           to be timed out
+        mapping(uint256 => Redeem.RedemptionRequest) pendingRedemptions;
+        /// @notice Collection of all timed out redemptions requests indexed by
+        ///         redemption key built as
+        ///         keccak256(walletPubKeyHash | redeemerOutputScript). The
+        ///         walletPubKeyHash is the 20-byte wallet's public key hash
+        ///         (computed using Bitcoin HASH160 over the compressed ECDSA
+        ///         public key) and redeemerOutputScript is the Bitcoin script
+        ///         (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the timed
+        ///         out request. Timed out requests are stored in this mapping to
+        ///         avoid slashing the wallets multiple times for the same timeout.
+        ///         Only one method can add to this mapping:
+        ///         - `notifyRedemptionTimeout` which puts the redemption key
+        ///           to this mapping basing on a timed out request stored
+        ///           previously in `pendingRedemptions` mapping.
+        mapping(uint256 => Redeem.RedemptionRequest) timedOutRedemptions;
         /// @notice Collection of main UTXOs that are honestly spent indexed by
         ///         keccak256(fundingTxHash | fundingOutputIndex). The fundingTxHash
         ///         is bytes32 (ordered as in Bitcoin internally) and

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -21,8 +21,6 @@ import "./Redeem.sol";
 
 import "../bank/Bank.sol";
 
-import "../bank/Bank.sol";
-
 library BridgeState {
     struct Storage {
         /// @notice The number of confirmations on the Bitcoin chain required to

--- a/solidity/contracts/bridge/Redeem.sol
+++ b/solidity/contracts/bridge/Redeem.sol
@@ -456,7 +456,7 @@ library Redeem {
         require(
             walletState == Wallets.WalletState.Live ||
                 walletState == Wallets.WalletState.MovingFunds,
-            "Wallet must be in Live or MovingFuds state"
+            "Wallet must be in Live or MovingFunds state"
         );
 
         // Process redemption transaction outputs to extract some info required

--- a/solidity/contracts/bridge/Redeem.sol
+++ b/solidity/contracts/bridge/Redeem.sol
@@ -1,0 +1,848 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Wallets.sol";
+
+import "../bank/Bank.sol";
+
+/// @notice Aggregates functions common to the redemption transaction proof
+///         validation and to the moving funds transaction proof validation.
+library OutboundTx {
+    using BTCUtils for bytes;
+
+    /// @notice Checks whether an outbound Bitcoin transaction performed from
+    ///         the given wallet has an input vector that contains a single
+    ///         input referring to the wallet's main UTXO. Marks that main UTXO
+    ///         as correctly spent if the validation succeeds. Reverts otherwise.
+    ///         There are two outbound transactions from a wallet possible: a
+    ///         redemption transaction or a moving funds to another wallet
+    ///         transaction.
+    /// @param walletOutboundTxInputVector Bitcoin outbound transaction's input
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVin` function
+    ///        before it is passed here
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain.
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the outbound transaction.
+    function processWalletOutboundTxInput(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        bytes memory walletOutboundTxInputVector,
+        BitcoinTx.UTXO calldata mainUtxo,
+        bytes20 walletPubKeyHash
+    ) internal {
+        // Assert that main UTXO for passed wallet exists in storage.
+        bytes32 mainUtxoHash = wallets
+            .registeredWallets[walletPubKeyHash]
+            .mainUtxoHash;
+        require(mainUtxoHash != bytes32(0), "No main UTXO for given wallet");
+
+        // Assert that passed main UTXO parameter is the same as in storage and
+        // can be used for further processing.
+        require(
+            keccak256(
+                abi.encodePacked(
+                    mainUtxo.txHash,
+                    mainUtxo.txOutputIndex,
+                    mainUtxo.txOutputValue
+                )
+            ) == mainUtxoHash,
+            "Invalid main UTXO data"
+        );
+
+        // Assert that the single outbound transaction input actually
+        // refers to the wallet's main UTXO.
+        (
+            bytes32 outpointTxHash,
+            uint32 outpointIndex
+        ) = parseWalletOutboundTxInput(walletOutboundTxInputVector);
+        require(
+            mainUtxo.txHash == outpointTxHash &&
+                mainUtxo.txOutputIndex == outpointIndex,
+            "Outbound transaction input must point to the wallet's main UTXO"
+        );
+
+        // Main UTXO used as an input, mark it as spent.
+        self.spentMainUTXOs[
+            uint256(
+                keccak256(
+                    abi.encodePacked(mainUtxo.txHash, mainUtxo.txOutputIndex)
+                )
+            )
+        ] = true;
+    }
+
+    /// @notice Parses the input vector of an outbound Bitcoin transaction
+    ///         performed from the given wallet. It extracts the single input
+    ///         then the transaction hash and output index from its outpoint.
+    ///         There are two outbound transactions from a wallet possible: a
+    ///         redemption transaction or a moving funds to another wallet
+    ///         transaction.
+    /// @param walletOutboundTxInputVector Bitcoin outbound transaction input
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVin` function
+    ///        before it is passed here
+    /// @return outpointTxHash 32-byte hash of the Bitcoin transaction which is
+    ///         pointed in the input's outpoint.
+    /// @return outpointIndex 4-byte index of the Bitcoin transaction output
+    ///         which is pointed in the input's outpoint.
+    function parseWalletOutboundTxInput(
+        bytes memory walletOutboundTxInputVector
+    ) internal pure returns (bytes32 outpointTxHash, uint32 outpointIndex) {
+        // To determine the total number of Bitcoin transaction inputs,
+        // we need to parse the compactSize uint (VarInt) the input vector is
+        // prepended by. That compactSize uint encodes the number of vector
+        // elements using the format presented in:
+        // https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+        // We don't need asserting the compactSize uint is parseable since it
+        // was already checked during `validateVin` validation.
+        // See `BitcoinTx.inputVector` docs for more details.
+        (, uint256 inputsCount) = walletOutboundTxInputVector.parseVarInt();
+        require(
+            inputsCount == 1,
+            "Outbound transaction must have a single input"
+        );
+
+        bytes memory input = walletOutboundTxInputVector.extractInputAtIndex(0);
+
+        outpointTxHash = input.extractInputTxIdLE();
+
+        outpointIndex = BTCUtils.reverseUint32(
+            uint32(input.extractTxIndexLE())
+        );
+
+        // There is only one input in the transaction. Input has an outpoint
+        // field that is a reference to the transaction being spent (see
+        // `BitcoinTx` docs). The outpoint contains the hash of the transaction
+        // to spend (`outpointTxHash`) and the index of the specific output
+        // from that transaction (`outpointIndex`).
+        return (outpointTxHash, outpointIndex);
+    }
+}
+
+library Redeem {
+    using BridgeState for BridgeState.Storage;
+    using Wallets for Wallets.Data;
+
+    using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    /// @notice Represents a redemption request.
+    struct RedemptionRequest {
+        // ETH address of the redeemer who created the request.
+        address redeemer;
+        // Requested TBTC amount in satoshi.
+        uint64 requestedAmount;
+        // Treasury TBTC fee in satoshi at the moment of request creation.
+        uint64 treasuryFee;
+        // Transaction maximum BTC fee in satoshi at the moment of request
+        // creation.
+        uint64 txMaxFee;
+        // UNIX timestamp the request was created at.
+        uint32 requestedAt;
+    }
+
+    /// @notice Represents an outcome of the redemption Bitcoin transaction
+    ///         outputs processing.
+    struct RedemptionTxOutputsInfo {
+        // Total TBTC value in satoshi that should be burned by the Bridge.
+        // It includes the total amount of all BTC redeemed in the transaction
+        // and the fee paid to BTC miners for the redemption transaction.
+        uint64 totalBurnableValue;
+        // Total TBTC value in satoshi that should be transferred to
+        // the treasury. It is a sum of all treasury fees paid by all
+        // redeemers included in the redemption transaction.
+        uint64 totalTreasuryFee;
+        // Index of the change output. The change output becomes
+        // the new main wallet's UTXO.
+        uint32 changeIndex;
+        // Value in satoshi of the change output.
+        uint64 changeValue;
+    }
+
+    /// @notice Represents temporary information needed during the processing of
+    ///         the redemption Bitcoin transaction outputs. This structure is an
+    ///         internal one and should not be exported outside of the redemption
+    ///         transaction processing code.
+    /// @dev Allows to mitigate "stack too deep" errors on EVM.
+    struct RedemptionTxOutputsProcessingInfo {
+        // The first output starting index in the transaction.
+        uint256 outputStartingIndex;
+        // The number of outputs in the transaction.
+        uint256 outputsCount;
+        // P2PKH script for the wallet. Needed to determine the change output.
+        bytes32 walletP2PKHScriptKeccak;
+        // P2WPKH script for the wallet. Needed to determine the change output.
+        bytes32 walletP2WPKHScriptKeccak;
+    }
+
+    event RedemptionRequested(
+        bytes20 walletPubKeyHash,
+        bytes redeemerOutputScript,
+        address redeemer,
+        uint64 requestedAmount,
+        uint64 treasuryFee,
+        uint64 txMaxFee
+    );
+
+    event RedemptionsCompleted(
+        bytes20 walletPubKeyHash,
+        bytes32 redemptionTxHash
+    );
+
+    event RedemptionTimedOut(
+        bytes20 walletPubKeyHash,
+        bytes redeemerOutputScript
+    );
+
+    /// @notice Requests redemption of the given amount from the specified
+    ///         wallet to the redeemer Bitcoin output script.
+    /// @param walletPubKeyHash The 20-byte wallet public key hash (computed
+    ///        using Bitcoin HASH160 over the compressed ECDSA public key)
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to lock
+    ///        redeemed BTC
+    /// @param amount Requested amount in satoshi. This is also the TBTC amount
+    ///        that is taken from redeemer's balance in the Bank upon request.
+    ///        Once the request is handled, the actual amount of BTC locked
+    ///        on the redeemer output script will be always lower than this value
+    ///        since the treasury and Bitcoin transaction fees must be incurred.
+    ///        The minimal amount satisfying the request can be computed as:
+    ///        `amount - (amount / redemptionTreasuryFeeDivisor) - redemptionTxMaxFee`.
+    ///        Fees values are taken at the moment of request creation.
+    /// @dev Requirements:
+    ///      - Wallet behind `walletPubKeyHash` must be live
+    ///      - `mainUtxo` components must point to the recent main UTXO
+    ///        of the given wallet, as currently known on the Ethereum chain.
+    ///      - `redeemerOutputScript` must be a proper Bitcoin script
+    ///      - `redeemerOutputScript` cannot have wallet PKH as payload
+    ///      - `amount` must be above or equal the `redemptionDustThreshold`
+    ///      - Given `walletPubKeyHash` and `redeemerOutputScript` pair can be
+    ///        used for only one pending request at the same time
+    ///      - Wallet must have enough Bitcoin balance to proceed the request
+    ///      - Redeemer must make an allowance in the Bank that the Bridge
+    ///        contract can spend the given `amount`.
+    function requestRedemption(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        bytes20 walletPubKeyHash,
+        BitcoinTx.UTXO calldata mainUtxo,
+        bytes calldata redeemerOutputScript,
+        uint64 amount
+    ) external {
+        Wallets.Wallet storage wallet = wallets.registeredWallets[
+            walletPubKeyHash
+        ];
+
+        require(
+            wallet.state == Wallets.WalletState.Live,
+            "Wallet must be in Live state"
+        );
+
+        bytes32 mainUtxoHash = wallet.mainUtxoHash;
+        require(
+            mainUtxoHash != bytes32(0),
+            "No main UTXO for the given wallet"
+        );
+        require(
+            keccak256(
+                abi.encodePacked(
+                    mainUtxo.txHash,
+                    mainUtxo.txOutputIndex,
+                    mainUtxo.txOutputValue
+                )
+            ) == mainUtxoHash,
+            "Invalid main UTXO data"
+        );
+
+        // TODO: Confirm if `walletPubKeyHash` should be validated by checking
+        //       if it is the oldest one who can handle the request. This will
+        //       be suggested by the dApp but may not be respected by users who
+        //       interact directly with the contract. Do we need to enforce it
+        //       here? One option is not to enforce it, to save on gas, but if
+        //       we see this rule is not respected, upgrade Bridge contract to
+        //       require it.
+
+        // Validate if redeemer output script is a correct standard type
+        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by building a stub
+        // output with 0 as value and using `BTCUtils.extractHash` on it. Such
+        // a function extracts the payload properly only from standard outputs
+        // so if it succeeds, we have a guarantee the redeemer output script
+        // is proper. Worth to note `extractHash` ignores the value at all
+        // so this is why we can use 0 safely. This way of validation is the
+        // same as in tBTC v1.
+        bytes memory redeemerOutputScriptPayload = abi
+            .encodePacked(bytes8(0), redeemerOutputScript)
+            .extractHash();
+        require(
+            redeemerOutputScriptPayload.length > 0,
+            "Redeemer output script must be a standard type"
+        );
+        // Check if the redeemer output script payload does not point to the
+        // wallet public key hash.
+        require(
+            keccak256(abi.encodePacked(walletPubKeyHash)) !=
+                keccak256(redeemerOutputScriptPayload),
+            "Redeemer output script must not point to the wallet PKH"
+        );
+
+        require(
+            amount >= self.redemptionDustThreshold,
+            "Redemption amount too small"
+        );
+
+        // The redemption key is built on top of the wallet public key hash
+        // and redeemer output script pair. That means there can be only one
+        // request asking for redemption from the given wallet to the given
+        // BTC script at the same time.
+        uint256 redemptionKey = uint256(
+            keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
+        );
+
+        // Check if given redemption key is not used by a pending redemption.
+        // There is no need to check for existence in `timedOutRedemptions`
+        // since the wallet's state is changed to other than Live after
+        // first time out is reported so making new requests is not possible.
+        // slither-disable-next-line incorrect-equality
+        require(
+            self.pendingRedemptions[redemptionKey].requestedAt == 0,
+            "There is a pending redemption request from this wallet to the same address"
+        );
+
+        // No need to check whether `amount - treasuryFee - txMaxFee > 0`
+        // since the `redemptionDustThreshold` should force that condition
+        // to be always true.
+        uint64 treasuryFee = self.redemptionTreasuryFeeDivisor > 0
+            ? amount / self.redemptionTreasuryFeeDivisor
+            : 0;
+        uint64 txMaxFee = self.redemptionTxMaxFee;
+
+        // The main wallet UTXO's value doesn't include all pending redemptions.
+        // To determine if the requested redemption can be performed by the
+        // wallet we need to subtract the total value of all pending redemptions
+        // from that wallet's main UTXO value. Given that the treasury fee is
+        // not redeemed from the wallet, we are subtracting it.
+        wallet.pendingRedemptionsValue += amount - treasuryFee;
+        require(
+            mainUtxo.txOutputValue >= wallet.pendingRedemptionsValue,
+            "Insufficient wallet funds"
+        );
+
+        self.pendingRedemptions[redemptionKey] = RedemptionRequest(
+            msg.sender,
+            amount,
+            treasuryFee,
+            txMaxFee,
+            /* solhint-disable-next-line not-rely-on-time */
+            uint32(block.timestamp)
+        );
+
+        emit RedemptionRequested(
+            walletPubKeyHash,
+            redeemerOutputScript,
+            msg.sender,
+            amount,
+            treasuryFee,
+            txMaxFee
+        );
+
+        self.bank.transferBalanceFrom(msg.sender, address(this), amount);
+    }
+
+    /// @notice Used by the wallet to prove the BTC redemption transaction
+    ///         and to make the necessary bookkeeping. Redemption is only
+    ///         accepted if it satisfies SPV proof.
+    ///
+    ///         The function is performing Bank balance updates by burning
+    ///         the total redeemed Bitcoin amount from Bridge balance and
+    ///         transferring the treasury fee sum to the treasury address.
+    ///
+    ///         It is possible to prove the given redemption only one time.
+    /// @param redemptionTx Bitcoin redemption transaction data
+    /// @param redemptionProof Bitcoin redemption proof data
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    ///        HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction
+    /// @dev Requirements:
+    ///      - `redemptionTx` components must match the expected structure. See
+    ///        `BitcoinTx.Info` docs for reference. Their values must exactly
+    ///        correspond to appropriate Bitcoin transaction fields to produce
+    ///        a provable transaction hash.
+    ///      - The `redemptionTx` should represent a Bitcoin transaction with
+    ///        exactly 1 input that refers to the wallet's main UTXO. That
+    ///        transaction should have 1..n outputs handling existing pending
+    ///        redemption requests or pointing to reported timed out requests.
+    ///        There can be also 1 optional output representing the
+    ///        change and pointing back to the 20-byte wallet public key hash.
+    ///        The change should be always present if the redeemed value sum
+    ///        is lower than the total wallet's BTC balance.
+    ///      - `redemptionProof` components must match the expected structure.
+    ///        See `BitcoinTx.Proof` docs for reference. The `bitcoinHeaders`
+    ///        field must contain a valid number of block headers, not less
+    ///        than the `txProofDifficultyFactor` contract constant.
+    ///      - `mainUtxo` components must point to the recent main UTXO
+    ///        of the given wallet, as currently known on the Ethereum chain.
+    ///        Additionally, the recent main UTXO on Ethereum must be set.
+    ///      - `walletPubKeyHash` must be connected with the main UTXO used
+    ///        as transaction single input.
+    ///      Other remarks:
+    ///      - Putting the change output as the first transaction output can
+    ///        save some gas because the output processing loop begins each
+    ///        iteration by checking whether the given output is the change
+    ///        thus uses some gas for making the comparison. Once the change
+    ///        is identified, that check is omitted in further iterations.
+    function submitRedemptionProof(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        BitcoinTx.Info calldata redemptionTx,
+        BitcoinTx.Proof calldata redemptionProof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        bytes20 walletPubKeyHash
+    ) external {
+        // TODO: Just as for `submitSweepProof`, fail early if the function
+        //       call gets frontrunned. See discussion:
+        //       https://github.com/keep-network/tbtc-v2/pull/106#discussion_r801745204
+
+        // The actual transaction proof is performed here. After that point, we
+        // can assume the transaction happened on Bitcoin chain and has
+        // a sufficient number of confirmations as determined by
+        // `txProofDifficultyFactor` constant.
+        bytes32 redemptionTxHash = BitcoinTx.validateProof(
+            redemptionTx,
+            redemptionProof,
+            self.proofDifficultyContext()
+        );
+
+        // Process the redemption transaction input. Specifically, check if it
+        // refers to the expected wallet's main UTXO.
+        OutboundTx.processWalletOutboundTxInput(
+            self,
+            wallets,
+            redemptionTx.inputVector,
+            mainUtxo,
+            walletPubKeyHash
+        );
+
+        Wallets.Wallet storage wallet = wallets.registeredWallets[
+            walletPubKeyHash
+        ];
+
+        Wallets.WalletState walletState = wallet.state;
+        require(
+            walletState == Wallets.WalletState.Live ||
+                walletState == Wallets.WalletState.MovingFunds,
+            "Wallet must be in Live or MovingFuds state"
+        );
+
+        // Process redemption transaction outputs to extract some info required
+        // for further processing.
+        RedemptionTxOutputsInfo memory outputsInfo = processRedemptionTxOutputs(
+            self,
+            redemptionTx.outputVector,
+            walletPubKeyHash
+        );
+
+        if (outputsInfo.changeValue > 0) {
+            // If the change value is grater than zero, it means the change
+            // output exists and can be used as new wallet's main UTXO.
+            wallet.mainUtxoHash = keccak256(
+                abi.encodePacked(
+                    redemptionTxHash,
+                    outputsInfo.changeIndex,
+                    outputsInfo.changeValue
+                )
+            );
+        } else {
+            // If the change value is zero, it means the change output doesn't
+            // exists and no funds left on the wallet. Delete the main UTXO
+            // for that wallet to represent that state in a proper way.
+            delete wallet.mainUtxoHash;
+        }
+
+        wallet.pendingRedemptionsValue -= outputsInfo.totalBurnableValue;
+
+        emit RedemptionsCompleted(walletPubKeyHash, redemptionTxHash);
+
+        self.bank.decreaseBalance(outputsInfo.totalBurnableValue);
+        self.bank.transferBalance(self.treasury, outputsInfo.totalTreasuryFee);
+    }
+
+    /// @notice Processes the Bitcoin redemption transaction output vector.
+    ///         It extracts each output and tries to identify it as a pending
+    ///         redemption request, reported timed out request, or change.
+    ///         Reverts if one of the outputs cannot be recognized properly.
+    ///         This function also marks each request as processed by removing
+    ///         them from `pendingRedemptions` mapping.
+    /// @param redemptionTxOutputVector Bitcoin redemption transaction output
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVout` function
+    ///        before it is passed here
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction.
+    /// @return info Outcomes of the processing.
+    function processRedemptionTxOutputs(
+        BridgeState.Storage storage self,
+        bytes memory redemptionTxOutputVector,
+        bytes20 walletPubKeyHash
+    ) internal returns (RedemptionTxOutputsInfo memory info) {
+        // Determining the total number of redemption transaction outputs in
+        // the same way as for number of inputs. See `BitcoinTx.outputVector`
+        // docs for more details.
+        (
+            uint256 outputsCompactSizeUintLength,
+            uint256 outputsCount
+        ) = redemptionTxOutputVector.parseVarInt();
+
+        // To determine the first output starting index, we must jump over
+        // the compactSize uint which prepends the output vector. One byte
+        // must be added because `BtcUtils.parseVarInt` does not include
+        // compactSize uint tag in the returned length.
+        //
+        // For >= 0 && <= 252, `BTCUtils.determineVarIntDataLengthAt`
+        // returns `0`, so we jump over one byte of compactSize uint.
+        //
+        // For >= 253 && <= 0xffff there is `0xfd` tag,
+        // `BTCUtils.determineVarIntDataLengthAt` returns `2` (no
+        // tag byte included) so we need to jump over 1+2 bytes of
+        // compactSize uint.
+        //
+        // Please refer `BTCUtils` library and compactSize uint
+        // docs in `BitcoinTx` library for more details.
+        uint256 outputStartingIndex = 1 + outputsCompactSizeUintLength;
+
+        // Calculate the keccak256 for two possible wallet's P2PKH or P2WPKH
+        // scripts that can be used to lock the change. This is done upfront to
+        // save on gas. Both scripts have a strict format defined by Bitcoin.
+        //
+        // The P2PKH script has the byte format: <0x1976a914> <20-byte PKH> <0x88ac>.
+        // According to https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
+        // - 0x19: Byte length of the entire script
+        // - 0x76: OP_DUP
+        // - 0xa9: OP_HASH160
+        // - 0x14: Byte length of the public key hash
+        // - 0x88: OP_EQUALVERIFY
+        // - 0xac: OP_CHECKSIG
+        // which matches the P2PKH structure as per:
+        // https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash
+        bytes32 walletP2PKHScriptKeccak = keccak256(
+            abi.encodePacked(hex"1976a914", walletPubKeyHash, hex"88ac")
+        );
+        // The P2WPKH script has the byte format: <0x160014> <20-byte PKH>.
+        // According to https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
+        // - 0x16: Byte length of the entire script
+        // - 0x00: OP_0
+        // - 0x14: Byte length of the public key hash
+        // which matches the P2WPKH structure as per:
+        // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH
+        bytes32 walletP2WPKHScriptKeccak = keccak256(
+            abi.encodePacked(hex"160014", walletPubKeyHash)
+        );
+
+        return
+            processRedemptionTxOutputs(
+                self,
+                redemptionTxOutputVector,
+                walletPubKeyHash,
+                RedemptionTxOutputsProcessingInfo(
+                    outputStartingIndex,
+                    outputsCount,
+                    walletP2PKHScriptKeccak,
+                    walletP2WPKHScriptKeccak
+                )
+            );
+    }
+
+    /// @notice Processes all outputs from the redemption transaction. Tries to
+    ///         identify output as a change output, pending redemption request
+    //          or reported redemption. Reverts if one of the outputs cannot be
+    ///         recognized properly. Marks each request as processed by removing
+    ///         them from `pendingRedemptions` mapping.
+    /// @param redemptionTxOutputVector Bitcoin redemption transaction output
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVout` function
+    ///        before it is passed here
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction.
+    /// @param processInfo RedemptionTxOutputsProcessingInfo identifying output
+    ///        starting index, the number of outputs and possible wallet change
+    ///        P2PKH and P2WPKH scripts.
+    function processRedemptionTxOutputs(
+        BridgeState.Storage storage self,
+        bytes memory redemptionTxOutputVector,
+        bytes20 walletPubKeyHash,
+        RedemptionTxOutputsProcessingInfo memory processInfo
+    ) internal returns (RedemptionTxOutputsInfo memory resultInfo) {
+        // Helper variable that counts the number of processed redemption
+        // outputs. Redemptions can be either pending or reported as timed out.
+        // TODO: Revisit the approach with redemptions count according to
+        //       https://github.com/keep-network/tbtc-v2/pull/128#discussion_r808237765
+        uint256 processedRedemptionsCount = 0;
+
+        // Outputs processing loop.
+        for (uint256 i = 0; i < processInfo.outputsCount; i++) {
+            // TODO: Check if we can optimize gas costs by adding
+            //       `extractValueAt` and `extractHashAt` in `bitcoin-spv-sol`
+            //       in order to avoid allocating bytes in memory.
+            uint256 outputLength = redemptionTxOutputVector
+                .determineOutputLengthAt(processInfo.outputStartingIndex);
+            bytes memory output = redemptionTxOutputVector.slice(
+                processInfo.outputStartingIndex,
+                outputLength
+            );
+
+            // Extract the value from given output.
+            uint64 outputValue = output.extractValue();
+            // The output consists of an 8-byte value and a variable length
+            // script. To extract that script we slice the output starting from
+            // 9th byte until the end.
+            bytes memory outputScript = output.slice(8, output.length - 8);
+
+            if (
+                resultInfo.changeValue == 0 &&
+                (keccak256(outputScript) ==
+                    processInfo.walletP2PKHScriptKeccak ||
+                    keccak256(outputScript) ==
+                    processInfo.walletP2WPKHScriptKeccak) &&
+                outputValue > 0
+            ) {
+                // If we entered here, that means the change output with a
+                // proper non-zero value was found.
+                resultInfo.changeIndex = uint32(i);
+                resultInfo.changeValue = outputValue;
+            } else {
+                // If we entered here, that the means the given output is
+                // supposed to represent a redemption.
+                (
+                    uint64 burnableValue,
+                    uint64 treasuryFee
+                ) = processNonChangeRedemptionTxOutput(
+                        self,
+                        walletPubKeyHash,
+                        outputScript,
+                        outputValue
+                    );
+                resultInfo.totalBurnableValue += burnableValue;
+                resultInfo.totalTreasuryFee += treasuryFee;
+                processedRedemptionsCount++;
+            }
+
+            // Make the `outputStartingIndex` pointing to the next output by
+            // increasing it by current output's length.
+            processInfo.outputStartingIndex += outputLength;
+        }
+
+        // Protect against the cases when there is only a single change output
+        // referring back to the wallet PKH and just burning main UTXO value
+        // for transaction fees.
+        require(
+            processedRedemptionsCount > 0,
+            "Redemption transaction must process at least one redemption"
+        );
+    }
+
+    /// @notice Processes a single redemption transaction output. Tries to
+    ///         identify output as a pending redemption request or reported
+    ///         redemption timeout. Output script passed to this function must
+    ///         not be the change output. Such output needs to be identified
+    ///         separately before calling this function.
+    ///         Reverts if output is neither requested pending redemption nor
+    ///         requested and reported timed-out redemption.
+    ///         This function also marks each pending request as processed by
+    ///         removing them from `pendingRedemptions` mapping.
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    //         HASH160 over the compressed ECDSA public key) of the wallet which
+    ///        performed the redemption transaction.
+    /// @param outputScript Non-change output script to be processed
+    /// @param outputValue Value of the output being processed
+    /// @return burnableValue The value burnable as a result of processing this
+    ///         single redemption output. This value needs to be summed up with
+    ///         burnable values of all other outputs to evaluate total burnable
+    ///         value for the entire redemption transaction. This value is 0
+    ///         for a timed-out redemption request.
+    /// @return treasuryFee The treasury fee from this single redemption output.
+    ///         This value needs to be summed up with treasury fees of all other
+    ///         outputs to evaluate the total treasury fee for the entire
+    ///         redemption transaction. This value is 0 for a timed-out
+    ///         redemption request.
+    function processNonChangeRedemptionTxOutput(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash,
+        bytes memory outputScript,
+        uint64 outputValue
+    ) internal returns (uint64 burnableValue, uint64 treasuryFee) {
+        // This function should be called only if the given output is
+        // supposed to represent a redemption. Build the redemption key
+        // to perform that check.
+        uint256 redemptionKey = uint256(
+            keccak256(abi.encodePacked(walletPubKeyHash, outputScript))
+        );
+
+        if (self.pendingRedemptions[redemptionKey].requestedAt != 0) {
+            // If we entered here, that means the output was identified
+            // as a pending redemption request.
+            RedemptionRequest storage request = self.pendingRedemptions[
+                redemptionKey
+            ];
+            // Compute the request's redeemable amount as the requested
+            // amount reduced by the treasury fee. The request's
+            // minimal amount is then the redeemable amount reduced by
+            // the maximum transaction fee.
+            uint64 redeemableAmount = request.requestedAmount -
+                request.treasuryFee;
+            // Output value must fit between the request's redeemable
+            // and minimal amounts to be deemed valid.
+            require(
+                redeemableAmount - request.txMaxFee <= outputValue &&
+                    outputValue <= redeemableAmount,
+                "Output value is not within the acceptable range of the pending request"
+            );
+            // Add the redeemable amount to the total burnable value
+            // the Bridge will use to decrease its balance in the Bank.
+            burnableValue = redeemableAmount;
+            // Add the request's treasury fee to the total treasury fee
+            // value the Bridge will transfer to the treasury.
+            treasuryFee = request.treasuryFee;
+            // Request was properly handled so remove its redemption
+            // key from the mapping to make it reusable for further
+            // requests.
+            delete self.pendingRedemptions[redemptionKey];
+        } else {
+            // If we entered here, the output is not a redemption
+            // request but there is still a chance the given output is
+            // related to a reported timed out redemption request.
+            // If so, check if the output value matches the request
+            // amount to confirm this is an overdue request fulfillment
+            // then bypass this output and process the subsequent
+            // ones. That also means the wallet was already punished
+            // for the inactivity. Otherwise, just revert.
+            RedemptionRequest storage request = self.timedOutRedemptions[
+                redemptionKey
+            ];
+
+            require(
+                request.requestedAt != 0,
+                "Output is a non-requested redemption"
+            );
+
+            uint64 redeemableAmount = request.requestedAmount -
+                request.treasuryFee;
+
+            require(
+                redeemableAmount - request.txMaxFee <= outputValue &&
+                    outputValue <= redeemableAmount,
+                "Output value is not within the acceptable range of the timed out request"
+            );
+        }
+    }
+
+    /// @notice Notifies that there is a pending redemption request associated
+    ///         with the given wallet, that has timed out. The redemption
+    ///         request is identified by the key built as
+    ///         `keccak256(walletPubKeyHash | redeemerOutputScript)`.
+    ///         The results of calling this function: the pending redemptions
+    ///         value for the wallet will be decreased by the requested amount
+    ///         (minus treasury fee), the tokens taken from the redeemer on
+    ///         redemption request will be returned to the redeemer, the request
+    ///         will be moved from pending redemptions to timed-out redemptions.
+    ///         If the state of the wallet is `Live` or `MovingFunds`, the
+    ///         wallet operators will be slashed.
+    ///         Additionally, if the state of wallet is `Live`, the wallet will
+    ///         be closed or marked as `MovingFunds` (depending on the presence
+    ///         or absence of the wallet's main UTXO) and the wallet will no
+    ///         longer be marked as the active wallet (if it was marked as such).
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet
+    /// @param redeemerOutputScript  The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH)
+    /// @dev Requirements:
+    ///      - The redemption request identified by `walletPubKeyHash` and
+    ///        `redeemerOutputScript` must exist
+    ///      - The amount of time defined by `redemptionTimeout` must have
+    ///        passed since the redemption was requested (the request must be
+    ///        timed-out).
+    function notifyRedemptionTimeout(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        bytes20 walletPubKeyHash,
+        bytes calldata redeemerOutputScript
+    ) external {
+        uint256 redemptionKey = uint256(
+            keccak256(abi.encodePacked(walletPubKeyHash, redeemerOutputScript))
+        );
+        Redeem.RedemptionRequest memory request = self.pendingRedemptions[
+            redemptionKey
+        ];
+
+        require(request.requestedAt > 0, "Redemption request does not exist");
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            request.requestedAt + self.redemptionTimeout < block.timestamp,
+            "Redemption request has not timed out"
+        );
+
+        // Update the wallet's pending redemptions value
+        Wallets.Wallet storage wallet = wallets.registeredWallets[
+            walletPubKeyHash
+        ];
+        wallet.pendingRedemptionsValue -=
+            request.requestedAmount -
+            request.treasuryFee;
+
+        require(
+            // TODO: Allow the wallets in `Closing` state when the state is added
+            wallet.state == Wallets.WalletState.Live ||
+                wallet.state == Wallets.WalletState.MovingFunds ||
+                wallet.state == Wallets.WalletState.Terminated,
+            "The wallet must be in Live, MovingFunds or Terminated state"
+        );
+
+        // It is worth noting that there is no need to check if
+        // `timedOutRedemption` mapping already contains the given redemption
+        // key. There is no possibility to re-use a key of a reported timed-out
+        // redemption because the wallet responsible for causing the timeout is
+        // moved to a state that prevents it to receive new redemption requests.
+
+        // Move the redemption from pending redemptions to timed-out redemptions
+        self.timedOutRedemptions[redemptionKey] = request;
+        delete self.pendingRedemptions[redemptionKey];
+
+        if (
+            wallet.state == Wallets.WalletState.Live ||
+            wallet.state == Wallets.WalletState.MovingFunds
+        ) {
+            // Propagate timeout consequences to the wallet
+            wallets.notifyRedemptionTimedOut(walletPubKeyHash);
+        }
+
+        emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
+
+        // Return the requested amount of tokens to the redeemer
+        self.bank.transferBalance(request.redeemer, request.requestedAmount);
+    }
+}

--- a/solidity/contracts/bridge/Redeem.sol
+++ b/solidity/contracts/bridge/Redeem.sol
@@ -141,6 +141,7 @@ library OutboundTx {
     }
 }
 
+// TODO: Rename to Redemption. All library names are nouns.
 library Redeem {
     using BridgeState for BridgeState.Storage;
     using Wallets for Wallets.Data;

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -85,13 +85,13 @@ contract BridgeStub is Bridge {
     function setRedemptionDustThreshold(uint64 _redemptionDustThreshold)
         external
     {
-        redemptionDustThreshold = _redemptionDustThreshold;
+        self.redemptionDustThreshold = _redemptionDustThreshold;
     }
 
     function setRedemptionTreasuryFeeDivisor(
         uint64 _redemptionTreasuryFeeDivisor
     ) external {
-        redemptionTreasuryFeeDivisor = _redemptionTreasuryFeeDivisor;
+        self.redemptionTreasuryFeeDivisor = _redemptionTreasuryFeeDivisor;
     }
 
     function setMovingFundsTxMaxTotalFee(uint64 _movingFundsTxMaxTotalFee)

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -4926,7 +4926,7 @@ describe("Bridge", () => {
 
                       it("should revert", async () => {
                         await expect(outcome).to.be.revertedWith(
-                          "'Wallet must be in Live or MovingFuds state"
+                          "'Wallet must be in Live or MovingFunds state"
                         )
                       })
                     })
@@ -4965,7 +4965,7 @@ describe("Bridge", () => {
 
                       it("should revert", async () => {
                         await expect(outcome).to.be.revertedWith(
-                          "'Wallet must be in Live or MovingFuds state"
+                          "'Wallet must be in Live or MovingFunds state"
                         )
                       })
                     })
@@ -5004,7 +5004,7 @@ describe("Bridge", () => {
 
                       it("should revert", async () => {
                         await expect(outcome).to.be.revertedWith(
-                          "'Wallet must be in Live or MovingFuds state"
+                          "'Wallet must be in Live or MovingFunds state"
                         )
                       })
                     })

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -7,6 +7,7 @@ import type {
   BitcoinTx__factory,
   Deposit__factory,
   Sweep__factory,
+  Redeem__factory,
   Wallets__factory,
   Bridge,
   BridgeStub,
@@ -43,6 +44,10 @@ const bridgeFixture = async () => {
   const bitcoinTx = await BitcoinTx.deploy()
   await bitcoinTx.deployed()
 
+  const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
+  const wallets = await Wallets.deploy()
+  await wallets.deployed()
+
   const Deposit = await ethers.getContractFactory<Deposit__factory>("Deposit")
   const deposit = await Deposit.deploy()
   await deposit.deployed()
@@ -55,9 +60,14 @@ const bridgeFixture = async () => {
   const sweep = await Sweep.deploy()
   await sweep.deployed()
 
-  const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
-  const wallets = await Wallets.deploy()
-  await wallets.deployed()
+  const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem", {
+    libraries: {
+      BitcoinTx: bitcoinTx.address,
+      Wallets: wallets.address,
+    },
+  })
+  const redeem = await Redeem.deploy()
+  await redeem.deployed()
 
   const Frauds = await ethers.getContractFactory<Frauds__factory>("Frauds")
   const frauds: Frauds = await Frauds.deploy()
@@ -70,6 +80,7 @@ const bridgeFixture = async () => {
         BitcoinTx: bitcoinTx.address,
         Deposit: deposit.address,
         Sweep: sweep.address,
+        Redeem: redeem.address,
         Wallets: wallets.address,
         Frauds: frauds.address,
       },


### PR DESCRIPTION
~~Depends on #201~~

A refactoring of the Bridge contract is required given the contract size
constraints. This change is another step on this journey. Redemption
functionality is extracted to a separate, externally linked library. No
changes to the logic in the redemption code were applied.

Bridge contract size comparison before and after:
```
 |  Bridge               ·     20.826   │
 |  Bridge               ·     15.495   │
```

Gas costs comparison before and after:
```
 | revealDeposit          ·   96041  ·   98672  ·   96703  │
 | revealDeposit          ·   96005  ·   98636  ·   96667  │
 | requestRedemption      ·  100601  ·  118446  ·  108329  │
 | requestRedemption      ·  105448  ·  123275  ·  113159  │
 | submitSweepProof       ·  196251  ·  350622  ·  269763  │
 | submitSweepProof       ·  196167  ·  350538  ·  269679  │
 | submitRedemptionProof  ·  126671  ·  204876  ·  172773  │
 | submitRedemptionProof  ·  132050  ·  209693  ·  177533  │
```

The gas cost of `requestRedemption` and `submitRedemptionProof` increased by
approximately 4800 gas units.