### PR TITLE
Refactor six: Extract Bridge moving funds between wallets logic into a library

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -31,6 +31,7 @@ import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./Wallets.sol";
 import "./Frauds.sol";
+import "./MovingFunds.sol";
 
 import "../bank/Bank.sol";
 
@@ -63,6 +64,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     using Deposit for BridgeState.Storage;
     using Sweep for BridgeState.Storage;
     using Redeem for BridgeState.Storage;
+    using MovingFunds for BridgeState.Storage;
     using Frauds for Frauds.Data;
     using Wallets for Wallets.Data;
 
@@ -71,15 +73,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     using BytesLib for bytes;
 
     BridgeState.Storage internal self;
-
-    /// TODO: Make it governable.
-    /// @notice Maximum amount of the total BTC transaction fee that is
-    ///         acceptable in a single moving funds transaction.
-    /// @dev This is a TOTAL max fee for the moving funds transaction. Note that
-    ///      `depositTxMaxFee` is per single deposit and `redemptionTxMaxFee`
-    ///      if per single redemption. `movingFundsTxMaxTotalFee` is a total fee
-    ///      for the entire transaction.
-    uint64 public movingFundsTxMaxTotalFee;
 
     /// @notice Contains parameters related to frauds and the collection of all
     ///         submitted fraud challenges.
@@ -214,7 +207,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         self.redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
         self.redemptionTxMaxFee = 10000; // 10000 satoshi
         self.redemptionTimeout = 172800; // 48 hours
-        movingFundsTxMaxTotalFee = 10000; // 10000 satoshi
+        self.movingFundsTxMaxTotalFee = 10000; // 10000 satoshi
 
         // TODO: Revisit initial values.
         frauds.setSlashingAmount(10000 * 1e18); // 10000 T
@@ -839,195 +832,13 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         BitcoinTx.UTXO calldata mainUtxo,
         bytes20 walletPubKeyHash
     ) external {
-        // The actual transaction proof is performed here. After that point, we
-        // can assume the transaction happened on Bitcoin chain and has
-        // a sufficient number of confirmations as determined by
-        // `txProofDifficultyFactor` constant.
-        bytes32 movingFundsTxHash = BitcoinTx.validateProof(
+        self.submitMovingFundsProof(
+            wallets,
             movingFundsTx,
             movingFundsProof,
-            self.proofDifficultyContext()
-        );
-
-        // Process the moving funds transaction input. Specifically, check if
-        // it refers to the expected wallet's main UTXO.
-        OutboundTx.processWalletOutboundTxInput(
-            self,
-            wallets,
-            movingFundsTx.inputVector,
             mainUtxo,
             walletPubKeyHash
         );
-
-        (
-            bytes32 targetWalletsHash,
-            uint256 outputsTotalValue
-        ) = processMovingFundsTxOutputs(movingFundsTx.outputVector);
-
-        require(
-            mainUtxo.txOutputValue - outputsTotalValue <=
-                movingFundsTxMaxTotalFee,
-            "Transaction fee is too high"
-        );
-
-        wallets.notifyFundsMoved(walletPubKeyHash, targetWalletsHash);
-
-        emit MovingFundsCompleted(walletPubKeyHash, movingFundsTxHash);
-    }
-
-    /// @notice Processes the moving funds Bitcoin transaction output vector
-    ///         and extracts information required for further processing.
-    /// @param movingFundsTxOutputVector Bitcoin moving funds transaction output
-    ///        vector. This function assumes vector's structure is valid so it
-    ///        must be validated using e.g. `BTCUtils.validateVout` function
-    ///        before it is passed here
-    /// @return targetWalletsHash keccak256 hash over the list of actual
-    ///         target wallets used in the transaction.
-    /// @return outputsTotalValue Sum of all outputs values.
-    /// @dev Requirements:
-    ///      - The `movingFundsTxOutputVector` must be parseable, i.e. must
-    ///        be validated by the caller as stated in their parameter doc.
-    ///      - Each output must refer to a 20-byte public key hash.
-    ///      - The total outputs value must be evenly divided over all outputs.
-    function processMovingFundsTxOutputs(bytes memory movingFundsTxOutputVector)
-        internal
-        view
-        returns (bytes32 targetWalletsHash, uint256 outputsTotalValue)
-    {
-        // Determining the total number of Bitcoin transaction outputs in
-        // the same way as for number of inputs. See `BitcoinTx.outputVector`
-        // docs for more details.
-        (
-            uint256 outputsCompactSizeUintLength,
-            uint256 outputsCount
-        ) = movingFundsTxOutputVector.parseVarInt();
-
-        // To determine the first output starting index, we must jump over
-        // the compactSize uint which prepends the output vector. One byte
-        // must be added because `BtcUtils.parseVarInt` does not include
-        // compactSize uint tag in the returned length.
-        //
-        // For >= 0 && <= 252, `BTCUtils.determineVarIntDataLengthAt`
-        // returns `0`, so we jump over one byte of compactSize uint.
-        //
-        // For >= 253 && <= 0xffff there is `0xfd` tag,
-        // `BTCUtils.determineVarIntDataLengthAt` returns `2` (no
-        // tag byte included) so we need to jump over 1+2 bytes of
-        // compactSize uint.
-        //
-        // Please refer `BTCUtils` library and compactSize uint
-        // docs in `BitcoinTx` library for more details.
-        uint256 outputStartingIndex = 1 + outputsCompactSizeUintLength;
-
-        bytes20[] memory targetWallets = new bytes20[](outputsCount);
-        uint64[] memory outputsValues = new uint64[](outputsCount);
-
-        // Outputs processing loop.
-        for (uint256 i = 0; i < outputsCount; i++) {
-            uint256 outputLength = movingFundsTxOutputVector
-                .determineOutputLengthAt(outputStartingIndex);
-
-            bytes memory output = movingFundsTxOutputVector.slice(
-                outputStartingIndex,
-                outputLength
-            );
-
-            // Extract the output script payload.
-            bytes memory targetWalletPubKeyHashBytes = output.extractHash();
-            // Output script payload must refer to a known wallet public key
-            // hash which is always 20-byte.
-            require(
-                targetWalletPubKeyHashBytes.length == 20,
-                "Target wallet public key hash must have 20 bytes"
-            );
-
-            bytes20 targetWalletPubKeyHash = targetWalletPubKeyHashBytes
-                .slice20(0);
-
-            // The next step is making sure that the 20-byte public key hash
-            // is actually used in the right context of a P2PKH or P2WPKH
-            // output. To do so, we must extract the full script from the output
-            // and compare with the expected P2PKH and P2WPKH scripts
-            // referring to that 20-byte public key hash. The output consists
-            // of an 8-byte value and a variable length script. To extract the
-            // script we slice the output starting from 9th byte until the end.
-            bytes32 outputScriptKeccak = keccak256(
-                output.slice(8, output.length - 8)
-            );
-            // Build the expected P2PKH script which has the following byte
-            // format: <0x1976a914> <20-byte PKH> <0x88ac>. According to
-            // https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
-            // - 0x19: Byte length of the entire script
-            // - 0x76: OP_DUP
-            // - 0xa9: OP_HASH160
-            // - 0x14: Byte length of the public key hash
-            // - 0x88: OP_EQUALVERIFY
-            // - 0xac: OP_CHECKSIG
-            // which matches the P2PKH structure as per:
-            // https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash
-            bytes32 targetWalletP2PKHScriptKeccak = keccak256(
-                abi.encodePacked(
-                    hex"1976a914",
-                    targetWalletPubKeyHash,
-                    hex"88ac"
-                )
-            );
-            // Build the expected P2WPKH script which has the following format:
-            // <0x160014> <20-byte PKH>. According to
-            // https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
-            // - 0x16: Byte length of the entire script
-            // - 0x00: OP_0
-            // - 0x14: Byte length of the public key hash
-            // which matches the P2WPKH structure as per:
-            // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH
-            bytes32 targetWalletP2WPKHScriptKeccak = keccak256(
-                abi.encodePacked(hex"160014", targetWalletPubKeyHash)
-            );
-            // Make sure the actual output script matches either the P2PKH
-            // or P2WPKH format.
-            require(
-                outputScriptKeccak == targetWalletP2PKHScriptKeccak ||
-                    outputScriptKeccak == targetWalletP2WPKHScriptKeccak,
-                "Output must be P2PKH or P2WPKH"
-            );
-
-            // Add the wallet public key hash to the list that will be used
-            // to build the result list hash. There is no need to check if
-            // given output is a change here because the actual target wallet
-            // list must be exactly the same as the pre-committed target wallet
-            // list which is guaranteed to be valid.
-            targetWallets[i] = targetWalletPubKeyHash;
-
-            // Extract the value from given output.
-            outputsValues[i] = output.extractValue();
-            outputsTotalValue += outputsValues[i];
-
-            // Make the `outputStartingIndex` pointing to the next output by
-            // increasing it by current output's length.
-            outputStartingIndex += outputLength;
-        }
-
-        // Compute the indivisible remainder that remains after dividing the
-        // outputs total value over all outputs evenly.
-        uint256 outputsTotalValueRemainder = outputsTotalValue % outputsCount;
-        // Compute the minimum allowed output value by dividing the outputs
-        // total value (reduced by the remainder) by the number of outputs.
-        uint256 minOutputValue = (outputsTotalValue -
-            outputsTotalValueRemainder) / outputsCount;
-        // Maximum possible value is the minimum value with the remainder included.
-        uint256 maxOutputValue = minOutputValue + outputsTotalValueRemainder;
-
-        for (uint256 i = 0; i < outputsCount; i++) {
-            require(
-                minOutputValue <= outputsValues[i] &&
-                    outputsValues[i] <= maxOutputValue,
-                "Transaction amount is not distributed evenly"
-            );
-        }
-
-        targetWalletsHash = keccak256(abi.encodePacked(targetWallets));
-
-        return (targetWalletsHash, outputsTotalValue);
     }
 
     /// @notice Returns the addresses of contracts Bridge is interacting with.
@@ -1123,6 +934,21 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         redemptionTimeout = self.redemptionTimeout;
         treasury = self.treasury;
         txProofDifficultyFactor = self.txProofDifficultyFactor;
+    }
+
+    /// @notice Returns the current values of Bridge moving funds between
+    ///         wallets parameters.
+    /// @return movingFundsTxMaxTotalFee Maximum amount of the total BTC
+    ///         transaction fee that is acceptable in a single moving funds
+    ///         transaction. This is a _total_ max fee for the entire moving
+    ///         funds transaction.
+    function movingFundsParameters()
+        external
+        view
+        returns (uint64 movingFundsTxMaxTotalFee)
+    {
+        // TODO: we will have more parameters here, for example moving funds timeout
+        movingFundsTxMaxTotalFee = self.movingFundsTxMaxTotalFee;
     }
 
     /// @notice Indicates if the vault with the given address is trusted or not.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -77,6 +77,14 @@ library BridgeState {
         ///         address.
         mapping(address => bool) isVaultTrusted;
         /// TODO: Make it governable.
+        /// @notice Maximum amount of the total BTC transaction fee that is
+        ///         acceptable in a single moving funds transaction.
+        /// @dev This is a TOTAL max fee for the moving funds transaction. Note
+        ///      that `depositTxMaxFee` is per single deposit and `redemptionTxMaxFee`
+        ///      if per single redemption. `movingFundsTxMaxTotalFee` is a total
+        ///      fee for the entire transaction.
+        uint64 movingFundsTxMaxTotalFee;
+        /// TODO: Make it governable.
         /// @notice The minimal amount that can be requested for redemption.
         ///         Value of this parameter must take into account the value of
         ///         `redemptionTreasuryFeeDivisor` and `redemptionTxMaxFee`

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Redeem.sol";
+
+library MovingFunds {
+    using BridgeState for BridgeState.Storage;
+    using Wallets for Wallets.Data;
+
+    using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    event MovingFundsCompleted(
+        bytes20 walletPubKeyHash,
+        bytes32 movingFundsTxHash
+    );
+
+    /// @notice Used by the wallet to prove the BTC moving funds transaction
+    ///         and to make the necessary state changes. Moving funds is only
+    ///         accepted if it satisfies SPV proof.
+    ///
+    ///         The function validates the moving funds transaction structure
+    ///         by checking if it actually spends the main UTXO of the declared
+    ///         wallet and locks the value on the pre-committed target wallets
+    ///         using a reasonable transaction fee. If all preconditions are
+    ///         met, this functions closes the source wallet.
+    ///
+    ///         It is possible to prove the given moving funds transaction only
+    ///         one time.
+    /// @param movingFundsTx Bitcoin moving funds transaction data
+    /// @param movingFundsProof Bitcoin moving funds proof data
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain
+    /// @param walletPubKeyHash 20-byte public key hash (computed using Bitcoin
+    ///        HASH160 over the compressed ECDSA public key) of the wallet
+    ///        which performed the moving funds transaction
+    /// @dev Requirements:
+    ///      - `movingFundsTx` components must match the expected structure. See
+    ///        `BitcoinTx.Info` docs for reference. Their values must exactly
+    ///        correspond to appropriate Bitcoin transaction fields to produce
+    ///        a provable transaction hash.
+    ///      - The `movingFundsTx` should represent a Bitcoin transaction with
+    ///        exactly 1 input that refers to the wallet's main UTXO. That
+    ///        transaction should have 1..n outputs corresponding to the
+    ///        pre-committed target wallets. Outputs must be ordered in the
+    ///        same way as their corresponding target wallets are ordered
+    ///        within the target wallets commitment.
+    ///      - `movingFundsProof` components must match the expected structure.
+    ///        See `BitcoinTx.Proof` docs for reference. The `bitcoinHeaders`
+    ///        field must contain a valid number of block headers, not less
+    ///        than the `txProofDifficultyFactor` contract constant.
+    ///      - `mainUtxo` components must point to the recent main UTXO
+    ///        of the given wallet, as currently known on the Ethereum chain.
+    ///        Additionally, the recent main UTXO on Ethereum must be set.
+    ///      - `walletPubKeyHash` must be connected with the main UTXO used
+    ///        as transaction single input.
+    ///      - The wallet that `walletPubKeyHash` points to must be in the
+    ///        MovingFunds state.
+    ///      - The target wallets commitment must be submitted by the wallet
+    ///        that `walletPubKeyHash` points to.
+    ///      - The total Bitcoin transaction fee must be lesser or equal
+    ///        to `movingFundsTxMaxTotalFee` governable parameter.
+    function submitMovingFundsProof(
+        BridgeState.Storage storage self,
+        Wallets.Data storage wallets,
+        BitcoinTx.Info calldata movingFundsTx,
+        BitcoinTx.Proof calldata movingFundsProof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        bytes20 walletPubKeyHash
+    ) external {
+        // The actual transaction proof is performed here. After that point, we
+        // can assume the transaction happened on Bitcoin chain and has
+        // a sufficient number of confirmations as determined by
+        // `txProofDifficultyFactor` constant.
+        bytes32 movingFundsTxHash = BitcoinTx.validateProof(
+            movingFundsTx,
+            movingFundsProof,
+            self.proofDifficultyContext()
+        );
+
+        // Process the moving funds transaction input. Specifically, check if
+        // it refers to the expected wallet's main UTXO.
+        OutboundTx.processWalletOutboundTxInput(
+            self,
+            wallets,
+            movingFundsTx.inputVector,
+            mainUtxo,
+            walletPubKeyHash
+        );
+
+        (
+            bytes32 targetWalletsHash,
+            uint256 outputsTotalValue
+        ) = processMovingFundsTxOutputs(movingFundsTx.outputVector);
+
+        require(
+            mainUtxo.txOutputValue - outputsTotalValue <=
+                self.movingFundsTxMaxTotalFee,
+            "Transaction fee is too high"
+        );
+
+        wallets.notifyFundsMoved(walletPubKeyHash, targetWalletsHash);
+
+        emit MovingFundsCompleted(walletPubKeyHash, movingFundsTxHash);
+    }
+
+    /// @notice Processes the moving funds Bitcoin transaction output vector
+    ///         and extracts information required for further processing.
+    /// @param movingFundsTxOutputVector Bitcoin moving funds transaction output
+    ///        vector. This function assumes vector's structure is valid so it
+    ///        must be validated using e.g. `BTCUtils.validateVout` function
+    ///        before it is passed here
+    /// @return targetWalletsHash keccak256 hash over the list of actual
+    ///         target wallets used in the transaction.
+    /// @return outputsTotalValue Sum of all outputs values.
+    /// @dev Requirements:
+    ///      - The `movingFundsTxOutputVector` must be parseable, i.e. must
+    ///        be validated by the caller as stated in their parameter doc.
+    ///      - Each output must refer to a 20-byte public key hash.
+    ///      - The total outputs value must be evenly divided over all outputs.
+    function processMovingFundsTxOutputs(bytes memory movingFundsTxOutputVector)
+        internal
+        view
+        returns (bytes32 targetWalletsHash, uint256 outputsTotalValue)
+    {
+        // Determining the total number of Bitcoin transaction outputs in
+        // the same way as for number of inputs. See `BitcoinTx.outputVector`
+        // docs for more details.
+        (
+            uint256 outputsCompactSizeUintLength,
+            uint256 outputsCount
+        ) = movingFundsTxOutputVector.parseVarInt();
+
+        // To determine the first output starting index, we must jump over
+        // the compactSize uint which prepends the output vector. One byte
+        // must be added because `BtcUtils.parseVarInt` does not include
+        // compactSize uint tag in the returned length.
+        //
+        // For >= 0 && <= 252, `BTCUtils.determineVarIntDataLengthAt`
+        // returns `0`, so we jump over one byte of compactSize uint.
+        //
+        // For >= 253 && <= 0xffff there is `0xfd` tag,
+        // `BTCUtils.determineVarIntDataLengthAt` returns `2` (no
+        // tag byte included) so we need to jump over 1+2 bytes of
+        // compactSize uint.
+        //
+        // Please refer `BTCUtils` library and compactSize uint
+        // docs in `BitcoinTx` library for more details.
+        uint256 outputStartingIndex = 1 + outputsCompactSizeUintLength;
+
+        bytes20[] memory targetWallets = new bytes20[](outputsCount);
+        uint64[] memory outputsValues = new uint64[](outputsCount);
+
+        // Outputs processing loop.
+        for (uint256 i = 0; i < outputsCount; i++) {
+            uint256 outputLength = movingFundsTxOutputVector
+                .determineOutputLengthAt(outputStartingIndex);
+
+            bytes memory output = movingFundsTxOutputVector.slice(
+                outputStartingIndex,
+                outputLength
+            );
+
+            // Extract the output script payload.
+            bytes memory targetWalletPubKeyHashBytes = output.extractHash();
+            // Output script payload must refer to a known wallet public key
+            // hash which is always 20-byte.
+            require(
+                targetWalletPubKeyHashBytes.length == 20,
+                "Target wallet public key hash must have 20 bytes"
+            );
+
+            bytes20 targetWalletPubKeyHash = targetWalletPubKeyHashBytes
+                .slice20(0);
+
+            // The next step is making sure that the 20-byte public key hash
+            // is actually used in the right context of a P2PKH or P2WPKH
+            // output. To do so, we must extract the full script from the output
+            // and compare with the expected P2PKH and P2WPKH scripts
+            // referring to that 20-byte public key hash. The output consists
+            // of an 8-byte value and a variable length script. To extract the
+            // script we slice the output starting from 9th byte until the end.
+            bytes32 outputScriptKeccak = keccak256(
+                output.slice(8, output.length - 8)
+            );
+            // Build the expected P2PKH script which has the following byte
+            // format: <0x1976a914> <20-byte PKH> <0x88ac>. According to
+            // https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
+            // - 0x19: Byte length of the entire script
+            // - 0x76: OP_DUP
+            // - 0xa9: OP_HASH160
+            // - 0x14: Byte length of the public key hash
+            // - 0x88: OP_EQUALVERIFY
+            // - 0xac: OP_CHECKSIG
+            // which matches the P2PKH structure as per:
+            // https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash
+            bytes32 targetWalletP2PKHScriptKeccak = keccak256(
+                abi.encodePacked(
+                    hex"1976a914",
+                    targetWalletPubKeyHash,
+                    hex"88ac"
+                )
+            );
+            // Build the expected P2WPKH script which has the following format:
+            // <0x160014> <20-byte PKH>. According to
+            // https://en.bitcoin.it/wiki/Script#Opcodes this translates to:
+            // - 0x16: Byte length of the entire script
+            // - 0x00: OP_0
+            // - 0x14: Byte length of the public key hash
+            // which matches the P2WPKH structure as per:
+            // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH
+            bytes32 targetWalletP2WPKHScriptKeccak = keccak256(
+                abi.encodePacked(hex"160014", targetWalletPubKeyHash)
+            );
+            // Make sure the actual output script matches either the P2PKH
+            // or P2WPKH format.
+            require(
+                outputScriptKeccak == targetWalletP2PKHScriptKeccak ||
+                    outputScriptKeccak == targetWalletP2WPKHScriptKeccak,
+                "Output must be P2PKH or P2WPKH"
+            );
+
+            // Add the wallet public key hash to the list that will be used
+            // to build the result list hash. There is no need to check if
+            // given output is a change here because the actual target wallet
+            // list must be exactly the same as the pre-committed target wallet
+            // list which is guaranteed to be valid.
+            targetWallets[i] = targetWalletPubKeyHash;
+
+            // Extract the value from given output.
+            outputsValues[i] = output.extractValue();
+            outputsTotalValue += outputsValues[i];
+
+            // Make the `outputStartingIndex` pointing to the next output by
+            // increasing it by current output's length.
+            outputStartingIndex += outputLength;
+        }
+
+        // Compute the indivisible remainder that remains after dividing the
+        // outputs total value over all outputs evenly.
+        uint256 outputsTotalValueRemainder = outputsTotalValue % outputsCount;
+        // Compute the minimum allowed output value by dividing the outputs
+        // total value (reduced by the remainder) by the number of outputs.
+        uint256 minOutputValue = (outputsTotalValue -
+            outputsTotalValueRemainder) / outputsCount;
+        // Maximum possible value is the minimum value with the remainder included.
+        uint256 maxOutputValue = minOutputValue + outputsTotalValueRemainder;
+
+        for (uint256 i = 0; i < outputsCount; i++) {
+            require(
+                minOutputValue <= outputsValues[i] &&
+                    outputsValues[i] <= maxOutputValue,
+                "Transaction amount is not distributed evenly"
+            );
+        }
+
+        targetWalletsHash = keccak256(abi.encodePacked(targetWallets));
+
+        return (targetWalletsHash, outputsTotalValue);
+    }
+}

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -97,6 +97,6 @@ contract BridgeStub is Bridge {
     function setMovingFundsTxMaxTotalFee(uint64 _movingFundsTxMaxTotalFee)
         external
     {
-        movingFundsTxMaxTotalFee = _movingFundsTxMaxTotalFee;
+        self.movingFundsTxMaxTotalFee = _movingFundsTxMaxTotalFee;
     }
 }

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -19,6 +19,7 @@ import type {
   Deposit__factory,
   Sweep__factory,
   Redeem__factory,
+  MovingFunds__factory,
   TestRelay,
   TestRelay__factory,
   IWalletRegistry,
@@ -118,6 +119,18 @@ const fixture = async () => {
   const redeem = await Redeem.deploy()
   await redeem.deployed()
 
+  const MovingFunds = await ethers.getContractFactory<MovingFunds__factory>(
+    "MovingFunds",
+    {
+      libraries: {
+        BitcoinTx: bitcoinTx.address,
+        Wallets: wallets.address,
+      },
+    }
+  )
+  const movingFunds = await MovingFunds.deploy()
+  await movingFunds.deployed()
+
   const Frauds = await ethers.getContractFactory<Frauds__factory>("Frauds")
   const frauds: Frauds = await Frauds.deploy()
   await frauds.deployed()
@@ -126,12 +139,12 @@ const fixture = async () => {
     "BridgeStub",
     {
       libraries: {
-        BitcoinTx: bitcoinTx.address,
         Deposit: deposit.address,
         Sweep: sweep.address,
         Redeem: redeem.address,
         Wallets: wallets.address,
         Frauds: frauds.address,
+        MovingFunds: movingFunds.address,
       },
     }
   )

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -8,6 +8,7 @@ import type {
   Deposit__factory,
   Sweep__factory,
   Redeem__factory,
+  MovingFunds__factory,
   Wallets__factory,
   Bridge,
   BridgeStub,
@@ -69,6 +70,18 @@ const bridgeFixture = async () => {
   const redeem = await Redeem.deploy()
   await redeem.deployed()
 
+  const MovingFunds = await ethers.getContractFactory<MovingFunds__factory>(
+    "MovingFunds",
+    {
+      libraries: {
+        BitcoinTx: bitcoinTx.address,
+        Wallets: wallets.address,
+      },
+    }
+  )
+  const movingFunds = await MovingFunds.deploy()
+  await movingFunds.deployed()
+
   const Frauds = await ethers.getContractFactory<Frauds__factory>("Frauds")
   const frauds: Frauds = await Frauds.deploy()
   await frauds.deployed()
@@ -77,12 +90,12 @@ const bridgeFixture = async () => {
     "BridgeStub",
     {
       libraries: {
-        BitcoinTx: bitcoinTx.address,
         Deposit: deposit.address,
         Sweep: sweep.address,
         Redeem: redeem.address,
         Wallets: wallets.address,
         Frauds: frauds.address,
+        MovingFunds: movingFunds.address,
       },
     }
   )


### PR DESCRIPTION
~~Depends on #202~~

A refactoring of the Bridge contract was required given the contract size
constraints. This change is another step on this journey. Moving funds between
wallets functionality is extracted to a separate, externally linked library. No
changes to the logic in the moving funds code were applied. At this point, we
are safe with not exceeding `Bridge` contract size with any more functionalities
we want to add, so it is more about the consistency of the code rather than
fighting for more space in the contract.

Bridge contract size comparison before and after:
```
 |  Bridge               ·     15.495 |
 |  Bridge               ·      9.849 │
```

Gas costs comparison before and after:
```
 |  revealDeposit           ·    96005  ·    98636  ·    96667 │
 |  revealDeposit           ·    95933  ·    98564  ·    96595 │
 |  requestRedemption       ·   105448  ·   123275  ·   113159 │
 |  requestRedemption       ·   105469  ·   123302  ·   113185 │
 |  submitSweepProof        ·   196167  ·   350538  ·   269679 │
 |  submitSweepProof        ·   196167  ·   350538  ·   269679 │
 |  submitRedemptionProof   ·   132050  ·   209693  ·   177533 │
 |  submitRedemptionProof   ·   132038  ·   209681  ·   177521 │
 |  submitMovingFundsProof  ·   133248  ·   153426  ·   146278 │
 |  submitMovingFundsProof  ·   138735  ·   158895  ·   151751 │
```

The gas cost of `submitMovingFundsProof` increased by approximately 5400 gas
units.