### PR TITLE
Refactor seven: BitcoinTx is no longer an externally linked library

### DIFF
--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -161,8 +161,8 @@ library BitcoinTx {
     function validateProof(
         Info calldata txInfo,
         Proof calldata proof,
-        ProofDifficulty calldata proofDifficulty
-    ) external view returns (bytes32 txHash) {
+        ProofDifficulty memory proofDifficulty
+    ) internal view returns (bytes32 txHash) {
         require(
             txInfo.inputVector.validateVin(),
             "Invalid input vector provided"
@@ -203,7 +203,7 @@ library BitcoinTx {
     /// @param proofDifficulty Bitcoin proof difficulty context.
     function evaluateProofDifficulty(
         bytes memory bitcoinHeaders,
-        ProofDifficulty calldata proofDifficulty
+        ProofDifficulty memory proofDifficulty
     ) internal view {
         uint256 requestedDiff = 0;
         uint256 firstHeaderDiff = bitcoinHeaders

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -12,7 +12,6 @@ import type {
   Bank,
   BankStub,
   BankStub__factory,
-  BitcoinTx__factory,
   Bridge,
   BridgeStub,
   BridgeStub__factory,
@@ -88,12 +87,6 @@ const fixture = async () => {
     value: ethers.utils.parseEther("1"),
   })
 
-  const BitcoinTx = await ethers.getContractFactory<BitcoinTx__factory>(
-    "BitcoinTx"
-  )
-  const bitcoinTx = await BitcoinTx.deploy()
-  await bitcoinTx.deployed()
-
   const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
   const wallets = await Wallets.deploy()
   await wallets.deployed()
@@ -102,17 +95,12 @@ const fixture = async () => {
   const deposit = await Deposit.deploy()
   await deposit.deployed()
 
-  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep", {
-    libraries: {
-      BitcoinTx: bitcoinTx.address,
-    },
-  })
+  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep")
   const sweep = await Sweep.deploy()
   await sweep.deployed()
 
   const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem", {
     libraries: {
-      BitcoinTx: bitcoinTx.address,
       Wallets: wallets.address,
     },
   })
@@ -123,7 +111,6 @@ const fixture = async () => {
     "MovingFunds",
     {
       libraries: {
-        BitcoinTx: bitcoinTx.address,
         Wallets: wallets.address,
       },
     }

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -4,7 +4,6 @@ import type {
   Bank,
   BankStub,
   BankStub__factory,
-  BitcoinTx__factory,
   Deposit__factory,
   Sweep__factory,
   Redeem__factory,
@@ -39,12 +38,6 @@ const bridgeFixture = async () => {
     value: ethers.utils.parseEther("1"),
   })
 
-  const BitcoinTx = await ethers.getContractFactory<BitcoinTx__factory>(
-    "BitcoinTx"
-  )
-  const bitcoinTx = await BitcoinTx.deploy()
-  await bitcoinTx.deployed()
-
   const Wallets = await ethers.getContractFactory<Wallets__factory>("Wallets")
   const wallets = await Wallets.deploy()
   await wallets.deployed()
@@ -53,17 +46,12 @@ const bridgeFixture = async () => {
   const deposit = await Deposit.deploy()
   await deposit.deployed()
 
-  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep", {
-    libraries: {
-      BitcoinTx: bitcoinTx.address,
-    },
-  })
+  const Sweep = await ethers.getContractFactory<Sweep__factory>("Sweep")
   const sweep = await Sweep.deploy()
   await sweep.deployed()
 
   const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem", {
     libraries: {
-      BitcoinTx: bitcoinTx.address,
       Wallets: wallets.address,
     },
   })
@@ -74,7 +62,6 @@ const bridgeFixture = async () => {
     "MovingFunds",
     {
       libraries: {
-        BitcoinTx: bitcoinTx.address,
         Wallets: wallets.address,
       },
     }


### PR DESCRIPTION
~~Depends on #203~~
After extracting pieces of `Bridge` contract into separate, externally
linked libraries, we have space to make `BitcoinTx` library code inlined
and reduce the gas cost of proofs by ~5200 units of gas.

The size of `MovingFunds`, `Redeem`, and `Sweep` libraries increased by 3KB.

The gas cost of `submitSweepProof`, `submitRedemptionProof`, and
`submitMovingFundsProof` decreased by ~5200 units of gas.

Gas consumption comparison before and after:
```
 | submitSweepProof        ·  196167  ·  350538  ·  269679 │
 | submitSweepProof        ·  190843  ·  345200  ·  264341 │
 | submitRedemptionProof   ·  132038  ·  209681  ·  177521 │
 | submitRedemptionProof   ·  126830  ·  204488  ·  172598 │
 | submitMovingFundsProof  ·  138735  ·  158895  ·  151751 │
 | submitMovingFundsProof  ·  133412  ·  153560  ·  146420 │
```