### PR TITLE
Get rid of `getActiveWalletPublicKey` function

### DIFF
--- a/typescript/src/deposit.ts
+++ b/typescript/src/deposit.ts
@@ -41,7 +41,7 @@ export interface DepositData {
   refundPublicKey: string
 
   /**
-   * An 8 bytes number. Must be unique for given Ethereum address, signing group
+   * An 8 bytes number. Must be unique for given Ethereum address, wallet
    * public key and refund public key.
    */
   blindingFactor: BigNumber

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,7 +3,6 @@ import {
   createDepositScript,
   createDepositScriptHash,
   createDepositTransaction,
-  getActiveWalletPublicKey,
   DepositData,
   makeDeposit,
   revealDeposit,
@@ -89,9 +88,6 @@ export interface TBTC {
   ): Promise<string>
 
   // TODO: Implementation and documentation.
-  getActiveWalletPublicKey(): Promise<string>
-
-  // TODO: Implementation and documentation.
   revealDeposit(): Promise<void>
 
   /**
@@ -168,7 +164,6 @@ const tbtc: TBTC = {
   createDepositScript,
   createDepositScriptHash,
   createDepositAddress,
-  getActiveWalletPublicKey,
   revealDeposit,
   createSweepTransaction,
   sweepDeposits,

--- a/typescript/src/sweep.ts
+++ b/typescript/src/sweep.ts
@@ -10,11 +10,7 @@ import {
   decomposeRawTransaction,
   isCompressedPublicKey,
 } from "./bitcoin"
-import {
-  createDepositScript,
-  getActiveWalletPublicKey,
-  DepositData,
-} from "./deposit"
+import { createDepositScript, DepositData } from "./deposit"
 import { Bridge } from "./bridge"
 import { createTransactionProof } from "./proof"
 
@@ -247,7 +243,7 @@ async function signMainUtxoInput(
 
 /**
  * Creates and sets `scriptSig` for the transaction input at the given index by
- * combining signature, signing group public key and deposit script.
+ * combining signature, wallet public key and deposit script.
  * @param transaction - Mutable transaction containing the input to be signed.
  * @param inputIndex - Index that points to the input to be signed.
  * @param depositData - Array of deposit data.
@@ -288,7 +284,7 @@ async function signP2SHDepositInput(
 
 /**
  * Creates and sets witness script for the transaction input at the given index
- * by combining signature, signing group public key and deposit script.
+ * by combining signature, wallet public key and deposit script.
  * @param transaction - Mutable transaction containing the input to be signed.
  * @param inputIndex - Index that points to the input to be signed.
  * @param depositData - Array of deposit data.
@@ -353,14 +349,14 @@ async function prepareInputSignData(
     throw new Error("Mismatch between amount in deposit data and deposit tx")
   }
 
-  const signingGroupPublicKey = await getActiveWalletPublicKey()
-  if (!isCompressedPublicKey(signingGroupPublicKey)) {
-    throw new Error("Signing group public key must be compressed")
+  const walletPublicKey = depositData.walletPublicKey
+  if (!isCompressedPublicKey(walletPublicKey)) {
+    throw new Error("Wallet public key must be compressed")
   }
 
-  if (walletKeyRing.getPublicKey("hex") != signingGroupPublicKey) {
+  if (walletKeyRing.getPublicKey("hex") != walletPublicKey) {
     throw new Error(
-      "Signing group public key does not correspond to wallet private key"
+      "Wallet public key does not correspond to wallet private key"
     )
   }
 
@@ -369,7 +365,7 @@ async function prepareInputSignData(
   )
 
   return {
-    walletPublicKey: signingGroupPublicKey,
+    walletPublicKey: walletPublicKey,
     depositScript: depositScript,
     previousOutputValue: previousOutput.value,
   }

--- a/typescript/test/data/sweep.ts
+++ b/typescript/test/data/sweep.ts
@@ -51,6 +51,8 @@ export const sweepWithNoMainUtxo: SweepTestData = {
       data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(25000),
+        walletPublicKey:
+          "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
         refundPublicKey:
           "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
         blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
@@ -75,6 +77,8 @@ export const sweepWithNoMainUtxo: SweepTestData = {
       data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(12000),
+        walletPublicKey:
+          "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
         refundPublicKey:
           "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
         blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
@@ -129,6 +133,8 @@ export const sweepWithMainUtxo: SweepTestData = {
       data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(17000),
+        walletPublicKey:
+          "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
         refundPublicKey:
           "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
         blindingFactor: BigNumber.from("0xf9f0c90d00039523"),
@@ -154,6 +160,8 @@ export const sweepWithMainUtxo: SweepTestData = {
       data: {
         ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         amount: BigNumber.from(10000),
+        walletPublicKey:
+          "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
         refundPublicKey:
           "039d61d62dcd048d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa",
         blindingFactor: BigNumber.from("0xf9f0c90d00039523"),

--- a/typescript/test/deposit.test.ts
+++ b/typescript/test/deposit.test.ts
@@ -19,6 +19,8 @@ describe("Deposit", () => {
   const depositData = {
     ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
     amount: BigNumber.from(10000), // 0.0001 BTC
+    walletPublicKey:
+      "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
     refundPublicKey:
       "0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9",
     blindingFactor: BigNumber.from("0xf9f0c90d00039523"), // 18010115967526606115
@@ -334,13 +336,13 @@ describe("Deposit", () => {
       // OP_HASH160 opcode is 0xa9.
       expect(script.substring(66, 68)).to.be.equal("a9")
 
-      // Assert the signing group public key hash is encoded correctly.
+      // Assert the wallet public key hash is encoded correctly.
       // The first byte (0x14) before the public key is this byte length.
       // In this case it's 20 bytes which is a correct length for a HASH160.
       expect(script.substring(68, 70)).to.be.equal("14")
       expect(script.substring(70, 110)).to.be.equal(
         hash160
-          .digest(Buffer.from(await TBTC.getActiveWalletPublicKey(), "hex"))
+          .digest(Buffer.from(depositData.walletPublicKey, "hex"))
           .toString("hex")
       )
 

--- a/typescript/test/sweep.test.ts
+++ b/typescript/test/sweep.test.ts
@@ -394,7 +394,7 @@ describe("Sweep", () => {
     })
 
     context(
-      "when the wallet private does not correspond to the signing group public key",
+      "when the wallet private does not correspond to the wallet public key",
       () => {
         const utxoWithRaw = sweepWithNoMainUtxo.deposits[0].utxo
         const depositData = sweepWithNoMainUtxo.deposits[0].data
@@ -410,7 +410,7 @@ describe("Sweep", () => {
               [depositData]
             )
           ).to.be.rejectedWith(
-            "Signing group public key does not correspond to wallet private key"
+            "Wallet public key does not correspond to wallet private key"
           )
         })
       }


### PR DESCRIPTION
Refs: #146 

That function was marked as deprecated as it does not fit the current design. This pull request removes it.