### PR TITLE
Refactor ten: move the state out of Wallets library

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -862,10 +862,14 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         fraudChallengeDepositAmount = self.fraudChallengeDepositAmount;
     }
 
-    /// @return walletCreationPeriod Value of the wallet creation period
-    /// @return walletMinBtcBalance Value of the minimum BTC balance
-    /// @return walletMaxBtcBalance Value of the maximum BTC balance
-    /// @return walletMaxAge Value of the wallet max age
+    /// @return walletCreationPeriod Determines how frequently a new wallet
+    ///         creation can be requested. Value in seconds.
+    /// @return walletMinBtcBalance The minimum BTC threshold in satoshi that is
+    ///         used to decide about wallet creation or closing.
+    /// @return walletMaxBtcBalance The maximum BTC threshold in satoshi that is
+    ///         used to decide about wallet creation.
+    /// @return walletMaxAge The maximum age of a wallet in seconds, after which
+    ///         the wallet moving funds process can be requested.
     function walletParameters()
         external
         view
@@ -883,10 +887,16 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     }
 
     /// @notice Updates parameters of wallets.
-    /// @param walletCreationPeriod New value of the wallet creation period
+    /// @param walletCreationPeriod New value of the wallet creation period in
+    ///        seconds, determines how frequently a new wallet creation can be
+    ///        requested
     /// @param walletMinBtcBalance New value of the wallet minimum BTC balance
+    ///        in sathoshis, used to decide about wallet creation or closing
     /// @param walletMaxBtcBalance New value of the wallet maximum BTC balance
-    /// @param walletMaxAge New value of the wallet maximum age
+    ///        in sathoshis, used to decide about wallet creation
+    /// @param walletMaxAge New value of the wallet maximum age in seconds,
+    ///        indicates the maximum age of a wallet in seconds, after which
+    ///        the wallet moving funds process can be requested
     /// @dev Requirements:
     ///      - Wallet minimum BTC balance must be greater than zero
     ///      - Wallet maximum BTC balance must be greater than the wallet

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -66,7 +66,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     using Redeem for BridgeState.Storage;
     using MovingFunds for BridgeState.Storage;
     using Fraud for BridgeState.Storage;
-    using Wallets for Wallets.Data;
+    using Wallets for BridgeState.Storage;
 
     using BTCUtils for bytes;
     using BTCUtils for uint256;
@@ -74,17 +74,12 @@ contract Bridge is Ownable, EcdsaWalletOwner {
 
     BridgeState.Storage internal self;
 
-    /// @notice State related with wallets.
-    Wallets.Data internal wallets;
-
-    event WalletCreationPeriodUpdated(uint32 newCreationPeriod);
-
-    event WalletBtcBalanceRangeUpdated(
-        uint64 newMinBtcBalance,
-        uint64 newMaxBtcBalance
+    event WalletParametersUpdated(
+        uint32 walletCreationPeriod,
+        uint64 walletMinBtcBalance,
+        uint64 walletMaxBtcBalance,
+        uint32 walletMaxAge
     );
-
-    event WalletMaxAgeUpdated(uint32 newMaxAge);
 
     event NewWalletRequested();
 
@@ -190,6 +185,12 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         require(_relay != address(0), "Relay address cannot be zero");
         self.relay = IRelay(_relay);
 
+        require(
+            _ecdsaWalletRegistry != address(0),
+            "ECDSA Wallet Registry address cannot be zero"
+        );
+        self.ecdsaWalletRegistry = EcdsaWalletRegistry(_ecdsaWalletRegistry);
+
         require(_treasury != address(0), "Treasury address cannot be zero");
         self.treasury = _treasury;
 
@@ -208,54 +209,10 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         self.fraudNotifierRewardMultiplier = 100; // 100%
         self.fraudChallengeDefeatTimeout = 7 days;
         self.fraudChallengeDepositAmount = 2 ether;
-
-        // TODO: Revisit initial values.
-        wallets.init(_ecdsaWalletRegistry);
-        wallets.setCreationPeriod(1 weeks);
-        wallets.setBtcBalanceRange(1 * 1e8, 10 * 1e8); // [1 BTC, 10 BTC]
-        wallets.setMaxAge(26 weeks); // ~6 months
-    }
-
-    /// @notice Updates parameters used by the `Wallets` library.
-    /// @param creationPeriod New value of the wallet creation period
-    /// @param minBtcBalance New value of the minimum BTC balance
-    /// @param maxBtcBalance New value of the maximum BTC balance
-    /// @param maxAge New value of the wallet maximum age
-    /// @dev Requirements:
-    ///      - Caller must be the contract owner.
-    ///      - Minimum BTC balance must be greater than zero
-    ///      - Maximum BTC balance must be greater than minimum BTC balance
-    function updateWalletsParameters(
-        uint32 creationPeriod,
-        uint64 minBtcBalance,
-        uint64 maxBtcBalance,
-        uint32 maxAge
-    ) external onlyOwner {
-        wallets.setCreationPeriod(creationPeriod);
-        wallets.setBtcBalanceRange(minBtcBalance, maxBtcBalance);
-        wallets.setMaxAge(maxAge);
-    }
-
-    /// @return creationPeriod Value of the wallet creation period
-    /// @return minBtcBalance Value of the minimum BTC balance
-    /// @return maxBtcBalance Value of the maximum BTC balance
-    /// @return maxAge Value of the wallet max age
-    function getWalletsParameters()
-        external
-        view
-        returns (
-            uint32 creationPeriod,
-            uint64 minBtcBalance,
-            uint64 maxBtcBalance,
-            uint32 maxAge
-        )
-    {
-        creationPeriod = wallets.creationPeriod;
-        minBtcBalance = wallets.minBtcBalance;
-        maxBtcBalance = wallets.maxBtcBalance;
-        maxAge = wallets.maxAge;
-
-        return (creationPeriod, minBtcBalance, maxBtcBalance, maxAge);
+        self.walletCreationPeriod = 1 weeks;
+        self.walletMinBtcBalance = 1e8; // 1 BTC
+        self.walletMaxBtcBalance = 10e8; // 10 BTC
+        self.walletMaxAge = 26 weeks; // ~6 months
     }
 
     /// @notice Allows the Governance to mark the given vault address as trusted
@@ -299,7 +256,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     function requestNewWallet(BitcoinTx.UTXO calldata activeWalletMainUtxo)
         external
     {
-        wallets.requestNewWallet(activeWalletMainUtxo);
+        self.requestNewWallet(activeWalletMainUtxo);
     }
 
     /// @notice A callback function that is called by the ECDSA Wallet Registry
@@ -315,7 +272,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes32 publicKeyX,
         bytes32 publicKeyY
     ) external override {
-        wallets.registerNewWallet(ecdsaWalletID, publicKeyX, publicKeyY);
+        self.registerNewWallet(ecdsaWalletID, publicKeyX, publicKeyY);
     }
 
     /// @notice A callback function that is called by the ECDSA Wallet Registry
@@ -330,7 +287,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes32 publicKeyX,
         bytes32 publicKeyY
     ) external override {
-        wallets.notifyWalletHeartbeatFailed(publicKeyX, publicKeyY);
+        self.notifyWalletHeartbeatFailed(publicKeyX, publicKeyY);
     }
 
     /// @notice Notifies that the wallet is either old enough or has too few
@@ -352,7 +309,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata walletMainUtxo
     ) external {
-        wallets.notifyCloseableWallet(walletPubKeyHash, walletMainUtxo);
+        self.notifyCloseableWallet(walletPubKeyHash, walletMainUtxo);
     }
 
     /// @notice Gets details about a registered wallet.
@@ -364,7 +321,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         view
         returns (Wallets.Wallet memory)
     {
-        return wallets.registeredWallets[walletPubKeyHash];
+        return self.registeredWallets[walletPubKeyHash];
     }
 
     /// @notice Gets the public key hash of the active wallet.
@@ -372,7 +329,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
     ///         over the compressed ECDSA public key) of the active wallet.
     ///         Returns bytes20(0) if there is no active wallet at the moment.
     function getActiveWalletPubKeyHash() external view returns (bytes20) {
-        return wallets.activeWalletPubKeyHash;
+        return self.activeWalletPubKeyHash;
     }
 
     /// @notice Used by the depositor to reveal information about their P2(W)SH
@@ -413,7 +370,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         BitcoinTx.Info calldata fundingTx,
         Deposit.DepositRevealInfo calldata reveal
     ) external {
-        self.revealDeposit(wallets, fundingTx, reveal);
+        self.revealDeposit(fundingTx, reveal);
     }
 
     /// @notice Used by the wallet to prove the BTC deposit sweep transaction
@@ -457,7 +414,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         BitcoinTx.Proof calldata sweepProof,
         BitcoinTx.UTXO calldata mainUtxo
     ) external {
-        self.submitSweepProof(wallets, sweepTx, sweepProof, mainUtxo);
+        self.submitSweepProof(sweepTx, sweepProof, mainUtxo);
     }
 
     /// @notice Submits a fraud challenge indicating that a UTXO being under
@@ -497,7 +454,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes32 sighash,
         BitcoinTx.RSVSignature calldata signature
     ) external payable {
-        self.submitFraudChallenge(wallets, walletPublicKey, sighash, signature);
+        self.submitFraudChallenge(walletPublicKey, sighash, signature);
     }
 
     /// @notice Allows to defeat a pending fraud challenge against a wallet if
@@ -612,7 +569,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         uint64 amount
     ) external {
         self.requestRedemption(
-            wallets,
             walletPubKeyHash,
             mainUtxo,
             redeemerOutputScript,
@@ -671,7 +627,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 walletPubKeyHash
     ) external {
         self.submitRedemptionProof(
-            wallets,
             redemptionTx,
             redemptionProof,
             mainUtxo,
@@ -707,11 +662,7 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 walletPubKeyHash,
         bytes calldata redeemerOutputScript
     ) external {
-        self.notifyRedemptionTimeout(
-            wallets,
-            walletPubKeyHash,
-            redeemerOutputScript
-        );
+        self.notifyRedemptionTimeout(walletPubKeyHash, redeemerOutputScript);
     }
 
     /// @notice Used by the wallet to prove the BTC moving funds transaction
@@ -766,7 +717,6 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         bytes20 walletPubKeyHash
     ) external {
         self.submitMovingFundsProof(
-            wallets,
             movingFundsTx,
             movingFundsProof,
             mainUtxo,
@@ -910,6 +860,49 @@ contract Bridge is Ownable, EcdsaWalletOwner {
         fraudNotifierRewardMultiplier = self.fraudNotifierRewardMultiplier;
         fraudChallengeDefeatTimeout = self.fraudChallengeDefeatTimeout;
         fraudChallengeDepositAmount = self.fraudChallengeDepositAmount;
+    }
+
+    /// @return walletCreationPeriod Value of the wallet creation period
+    /// @return walletMinBtcBalance Value of the minimum BTC balance
+    /// @return walletMaxBtcBalance Value of the maximum BTC balance
+    /// @return walletMaxAge Value of the wallet max age
+    function walletParameters()
+        external
+        view
+        returns (
+            uint32 walletCreationPeriod,
+            uint64 walletMinBtcBalance,
+            uint64 walletMaxBtcBalance,
+            uint32 walletMaxAge
+        )
+    {
+        walletCreationPeriod = self.walletCreationPeriod;
+        walletMinBtcBalance = self.walletMinBtcBalance;
+        walletMaxBtcBalance = self.walletMaxBtcBalance;
+        walletMaxAge = self.walletMaxAge;
+    }
+
+    /// @notice Updates parameters of wallets.
+    /// @param walletCreationPeriod New value of the wallet creation period
+    /// @param walletMinBtcBalance New value of the wallet minimum BTC balance
+    /// @param walletMaxBtcBalance New value of the wallet maximum BTC balance
+    /// @param walletMaxAge New value of the wallet maximum age
+    /// @dev Requirements:
+    ///      - Wallet minimum BTC balance must be greater than zero
+    ///      - Wallet maximum BTC balance must be greater than the wallet
+    ///        minimum BTC balance
+    function updateWalletParameters(
+        uint32 walletCreationPeriod,
+        uint64 walletMinBtcBalance,
+        uint64 walletMaxBtcBalance,
+        uint32 walletMaxAge
+    ) external onlyOwner {
+        self.updateWalletParameters(
+            walletCreationPeriod,
+            walletMinBtcBalance,
+            walletMaxBtcBalance,
+            walletMaxAge
+        );
     }
 
     /// @notice Indicates if the vault with the given address is trusted or not.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -188,10 +188,16 @@ library BridgeState {
     );
 
     /// @notice Updates parameters of wallets.
-    /// @param _walletCreationPeriod New value of the wallet creation period
+    /// @param _walletCreationPeriod New value of the wallet creation period in
+    ///        seconds, determines how frequently a new wallet creation can be
+    ///        requested
     /// @param _walletMinBtcBalance New value of the wallet minimum BTC balance
+    ///        in sathoshis, used to decide about wallet creation or closing
     /// @param _walletMaxBtcBalance New value of the wallet maximum BTC balance
-    /// @param _walletMaxAge New value of the wallet maximum age
+    ///        in sathoshis, used to decide about wallet creation
+    /// @param _walletMaxAge New value of the wallet maximum age in seconds,
+    ///        indicates the maximum age of a wallet in seconds, after which
+    ///        the wallet moving funds process can be requested
     /// @dev Requirements:
     ///      - Wallet minimum BTC balance must be greater than zero
     ///      - Wallet maximum BTC balance must be greater than the wallet

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -23,8 +23,6 @@ import "./BridgeState.sol";
 import "./Wallets.sol";
 
 library Deposit {
-    using Wallets for Wallets.Data;
-
     using BTCUtils for bytes;
     using BytesLib for bytes;
 
@@ -123,12 +121,11 @@ library Deposit {
     ///      deposit script unlocks to receive their BTC back.
     function revealDeposit(
         BridgeState.Storage storage self,
-        Wallets.Data storage wallets,
         BitcoinTx.Info calldata fundingTx,
         DepositRevealInfo calldata reveal
     ) external {
         require(
-            wallets.registeredWallets[reveal.walletPubKeyHash].state ==
+            self.registeredWallets[reveal.walletPubKeyHash].state ==
                 Wallets.WalletState.Live,
             "Wallet is not in Live state"
         );

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -104,7 +104,6 @@ library Fraud {
     ///      - Wallet can be challenged for the given signature only once
     function submitFraudChallenge(
         BridgeState.Storage storage self,
-        Wallets.Data storage wallets,
         bytes calldata walletPublicKey,
         bytes32 sighash,
         BitcoinTx.RSVSignature calldata signature
@@ -131,7 +130,7 @@ library Fraud {
         );
         bytes20 walletPubKeyHash = compressedWalletPublicKey.hash160View();
 
-        Wallets.Wallet storage wallet = wallets.registeredWallets[
+        Wallets.Wallet storage wallet = self.registeredWallets[
             walletPubKeyHash
         ];
 

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -24,7 +24,7 @@ import "./Redeem.sol";
 
 library MovingFunds {
     using BridgeState for BridgeState.Storage;
-    using Wallets for Wallets.Data;
+    using Wallets for BridgeState.Storage;
 
     using BTCUtils for bytes;
     using BytesLib for bytes;
@@ -81,7 +81,6 @@ library MovingFunds {
     ///        to `movingFundsTxMaxTotalFee` governable parameter.
     function submitMovingFundsProof(
         BridgeState.Storage storage self,
-        Wallets.Data storage wallets,
         BitcoinTx.Info calldata movingFundsTx,
         BitcoinTx.Proof calldata movingFundsProof,
         BitcoinTx.UTXO calldata mainUtxo,
@@ -101,7 +100,6 @@ library MovingFunds {
         // it refers to the expected wallet's main UTXO.
         OutboundTx.processWalletOutboundTxInput(
             self,
-            wallets,
             movingFundsTx.inputVector,
             mainUtxo,
             walletPubKeyHash
@@ -118,7 +116,7 @@ library MovingFunds {
             "Transaction fee is too high"
         );
 
-        wallets.notifyFundsMoved(walletPubKeyHash, targetWalletsHash);
+        self.notifyWalletFundsMoved(walletPubKeyHash, targetWalletsHash);
 
         emit MovingFundsCompleted(walletPubKeyHash, movingFundsTxHash);
     }

--- a/solidity/contracts/bridge/Sweep.sol
+++ b/solidity/contracts/bridge/Sweep.sol
@@ -94,7 +94,6 @@ library Sweep {
     ///        If there is no main UTXO, this parameter is ignored.
     function submitSweepProof(
         BridgeState.Storage storage self,
-        Wallets.Data storage wallets,
         BitcoinTx.Info calldata sweepTx,
         BitcoinTx.Proof calldata sweepProof,
         BitcoinTx.UTXO calldata mainUtxo
@@ -122,7 +121,7 @@ library Sweep {
         (
             Wallets.Wallet storage wallet,
             BitcoinTx.UTXO memory resolvedMainUtxo
-        ) = resolveSweepingWallet(wallets, walletPubKeyHash, mainUtxo);
+        ) = resolveSweepingWallet(self, walletPubKeyHash, mainUtxo);
 
         // Process sweep transaction inputs and extract all information needed
         // to perform deposit bookkeeping.
@@ -208,7 +207,7 @@ library Sweep {
     ///     - If the main UTXO of the sweeping wallet exists in the storage,
     ///       the passed `mainUTXO` parameter must be equal to the stored one.
     function resolveSweepingWallet(
-        Wallets.Data storage wallets,
+        BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata mainUtxo
     )
@@ -218,7 +217,7 @@ library Sweep {
             BitcoinTx.UTXO memory resolvedMainUtxo
         )
     {
-        wallet = wallets.registeredWallets[walletPubKeyHash];
+        wallet = self.registeredWallets[walletPubKeyHash];
 
         Wallets.WalletState walletState = wallet.state;
         require(

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -282,7 +282,7 @@ library Wallets {
     function notifyWalletTimedOutRedemption(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
-    ) external {
+    ) internal {
         WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -411,7 +411,7 @@ library Wallets {
     function notifyWalletFraud(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
-    ) external {
+    ) internal {
         WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -21,38 +21,13 @@ import {EcdsaDkg} from "@keep-network/ecdsa/contracts/libraries/EcdsaDkg.sol";
 
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
+import "./BridgeState.sol";
 
 /// @title Wallet library
 /// @notice Library responsible for handling integration between Bridge
 ///         contract and ECDSA wallets.
 library Wallets {
     using BTCUtils for bytes;
-
-    /// @notice Struct that groups the state managed by the library.
-    struct Data {
-        // ECDSA Wallet Registry contract handle.
-        EcdsaWalletRegistry registry;
-        // Determines how frequently a new wallet creation can be requested.
-        // Value in seconds.
-        uint32 creationPeriod;
-        // The minimum BTC threshold in satoshi that is used to decide about
-        // wallet creation or closing.
-        uint64 minBtcBalance;
-        // The maximum BTC threshold in satoshi that is used to decide about
-        // wallet creation.
-        uint64 maxBtcBalance;
-        // The maximum age of a wallet in seconds, after which the wallet
-        // moving funds process can be requested.
-        uint32 maxAge;
-        // 20-byte wallet public key hash being reference to the currently
-        // active wallet. Can be unset to the zero value under certain
-        // circumstances.
-        bytes20 activeWalletPubKeyHash;
-        // Maps the 20-byte wallet public key hash (computed using Bitcoin
-        // HASH160 over the compressed ECDSA public key) to the basic wallet
-        // information like state and pending redemptions value.
-        mapping(bytes20 => Wallet) registeredWallets;
-    }
 
     /// @notice Represents wallet state:
     enum WalletState {
@@ -101,15 +76,6 @@ library Wallets {
         bytes32 movingFundsTargetWalletsCommitmentHash;
     }
 
-    event WalletCreationPeriodUpdated(uint32 newCreationPeriod);
-
-    event WalletBtcBalanceRangeUpdated(
-        uint64 newMinBtcBalance,
-        uint64 newMaxBtcBalance
-    );
-
-    event WalletMaxAgeUpdated(uint32 newMaxAge);
-
     event NewWalletRequested();
 
     event NewWalletRegistered(
@@ -132,64 +98,6 @@ library Wallets {
         bytes20 indexed walletPubKeyHash
     );
 
-    /// @notice Initializes state invariants.
-    /// @param registry ECDSA Wallet Registry reference
-    /// @dev Requirements:
-    ///      - ECDSA Wallet Registry address must not be initialized
-    function init(Data storage self, address registry) external {
-        require(
-            registry != address(0),
-            "ECDSA Wallet Registry address cannot be zero"
-        );
-        require(
-            address(self.registry) == address(0),
-            "ECDSA Wallet Registry address already set"
-        );
-
-        self.registry = EcdsaWalletRegistry(registry);
-    }
-
-    /// @notice Sets the wallet creation period.
-    /// @param creationPeriod New value of the wallet creation period
-    function setCreationPeriod(Data storage self, uint32 creationPeriod)
-        external
-    {
-        self.creationPeriod = creationPeriod;
-
-        emit WalletCreationPeriodUpdated(creationPeriod);
-    }
-
-    /// @notice Sets the minimum and maximum BTC balance parameters.
-    /// @param minBtcBalance New value of the minimum BTC balance
-    /// @param maxBtcBalance New value of the maximum BTC balance
-    /// @dev Requirements:
-    ///      - Minimum BTC balance must be greater than zero
-    ///      - Maximum BTC balance must be greater than minimum BTC balance
-    function setBtcBalanceRange(
-        Data storage self,
-        uint64 minBtcBalance,
-        uint64 maxBtcBalance
-    ) external {
-        require(minBtcBalance > 0, "Minimum must be greater than zero");
-        require(
-            maxBtcBalance > minBtcBalance,
-            "Maximum must be greater than the minimum"
-        );
-
-        self.minBtcBalance = minBtcBalance;
-        self.maxBtcBalance = maxBtcBalance;
-
-        emit WalletBtcBalanceRangeUpdated(minBtcBalance, maxBtcBalance);
-    }
-
-    /// @notice Sets the wallet maximum age.
-    /// @param maxAge New value of the wallet maximum age
-    function setMaxAge(Data storage self, uint32 maxAge) external {
-        self.maxAge = maxAge;
-
-        emit WalletMaxAgeUpdated(maxAge);
-    }
-
     /// @notice Requests creation of a new wallet. This function just
     ///         forms a request and the creation process is performed
     ///         asynchronously. Outcome of that process should be delivered
@@ -210,11 +118,12 @@ library Wallets {
     ///           was elapsed since its creation time
     ///        - The active wallet BTC balance is above the maximum threshold
     function requestNewWallet(
-        Data storage self,
+        BridgeState.Storage storage self,
         BitcoinTx.UTXO calldata activeWalletMainUtxo
     ) external {
         require(
-            self.registry.getWalletCreationState() == EcdsaDkg.State.IDLE,
+            self.ecdsaWalletRegistry.getWalletCreationState() ==
+                EcdsaDkg.State.IDLE,
             "Wallet creation already in progress"
         );
 
@@ -235,19 +144,19 @@ library Wallets {
                 .createdAt;
             /* solhint-disable-next-line not-rely-on-time */
             bool activeWalletOldEnough = block.timestamp >=
-                activeWalletCreatedAt + self.creationPeriod;
+                activeWalletCreatedAt + self.walletCreationPeriod;
 
             require(
                 (activeWalletOldEnough &&
-                    activeWalletBtcBalance >= self.minBtcBalance) ||
-                    activeWalletBtcBalance >= self.maxBtcBalance,
+                    activeWalletBtcBalance >= self.walletMinBtcBalance) ||
+                    activeWalletBtcBalance >= self.walletMaxBtcBalance,
                 "Wallet creation conditions are not met"
             );
         }
 
         emit NewWalletRequested();
 
-        self.registry.requestNewWallet();
+        self.ecdsaWalletRegistry.requestNewWallet();
     }
 
     /// @notice Gets BTC balance for given the wallet.
@@ -261,7 +170,7 @@ library Wallets {
     ///        If the wallet has no main UTXO, this parameter can be empty as it
     ///        is ignored.
     function getWalletBtcBalance(
-        Data storage self,
+        BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata walletMainUtxo
     ) internal view returns (uint64 walletBtcBalance) {
@@ -300,13 +209,13 @@ library Wallets {
     ///      - The only caller authorized to call this function is `registry`
     ///      - Given wallet data must not belong to an already registered wallet
     function registerNewWallet(
-        Data storage self,
+        BridgeState.Storage storage self,
         bytes32 ecdsaWalletID,
         bytes32 publicKeyX,
         bytes32 publicKeyY
     ) external {
         require(
-            msg.sender == address(self.registry),
+            msg.sender == address(self.ecdsaWalletRegistry),
             "Caller is not the ECDSA Wallet Registry"
         );
 
@@ -339,12 +248,12 @@ library Wallets {
     ///      - The only caller authorized to call this function is `registry`
     ///      - Wallet must be in Live state
     function notifyWalletHeartbeatFailed(
-        Data storage self,
+        BridgeState.Storage storage self,
         bytes32 publicKeyX,
         bytes32 publicKeyY
     ) external {
         require(
-            msg.sender == address(self.registry),
+            msg.sender == address(self.ecdsaWalletRegistry),
             "Caller is not the ECDSA Wallet Registry"
         );
 
@@ -370,8 +279,8 @@ library Wallets {
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
     /// @dev Requirements:
     ///      - The wallet must be in the `Live` or `MovingFunds` state
-    function notifyRedemptionTimedOut(
-        Data storage self,
+    function notifyWalletTimedOutRedemption(
+        BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
     ) external {
         WalletState walletState = self
@@ -408,7 +317,7 @@ library Wallets {
     ///        assumed to be zero.
     ///      - Wallet must be in Live state
     function notifyCloseableWallet(
-        Data storage self,
+        BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata walletMainUtxo
     ) external {
@@ -425,12 +334,12 @@ library Wallets {
 
         /* solhint-disable-next-line not-rely-on-time */
         bool walletOldEnough = block.timestamp >=
-            wallet.createdAt + self.maxAge;
+            wallet.createdAt + self.walletMaxAge;
 
         require(
             walletOldEnough ||
                 getWalletBtcBalance(self, walletPubKeyHash, walletMainUtxo) <
-                self.minBtcBalance,
+                self.walletMinBtcBalance,
             "Wallet needs to be old enough or have too few satoshis"
         );
 
@@ -446,7 +355,10 @@ library Wallets {
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
     /// @dev Requirements:
     ///      - The caller must make sure that the wallet is in the Live state
-    function moveFunds(Data storage self, bytes20 walletPubKeyHash) internal {
+    function moveFunds(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
 
         if (wallet.mainUtxoHash == bytes32(0)) {
@@ -476,14 +388,17 @@ library Wallets {
     /// @dev Requirements:
     ///      - The caller must make sure that the wallet is in the
     ///        Live or MovingFunds state.
-    function closeWallet(Data storage self, bytes20 walletPubKeyHash) internal {
+    function closeWallet(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
 
         wallet.state = WalletState.Closed;
 
         emit WalletClosed(wallet.ecdsaWalletID, walletPubKeyHash);
 
-        self.registry.closeWallet(wallet.ecdsaWalletID);
+        self.ecdsaWalletRegistry.closeWallet(wallet.ecdsaWalletID);
     }
 
     /// @notice Reports about a fraud committed by the given wallet. This
@@ -493,7 +408,10 @@ library Wallets {
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
     /// @dev Requirements:
     ///      - Wallet must be in Live or MovingFunds state
-    function notifyFraud(Data storage self, bytes20 walletPubKeyHash) external {
+    function notifyWalletFraud(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) external {
         WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;
@@ -518,9 +436,10 @@ library Wallets {
     /// @dev Requirements:
     ///      - The caller must make sure that the wallet is in the
     ///        Live or MovingFunds state.
-    function terminateWallet(Data storage self, bytes20 walletPubKeyHash)
-        internal
-    {
+    function terminateWallet(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
 
         wallet.state = WalletState.Terminated;
@@ -534,7 +453,7 @@ library Wallets {
             delete self.activeWalletPubKeyHash;
         }
 
-        self.registry.closeWallet(wallet.ecdsaWalletID);
+        self.ecdsaWalletRegistry.closeWallet(wallet.ecdsaWalletID);
     }
 
     /// @notice Notifies that the wallet completed the moving funds process
@@ -553,8 +472,8 @@ library Wallets {
     ///        wallet.
     ///      - The actual target wallets used in the moving funds transaction
     ///        must be exactly the same as the target wallets commitment.
-    function notifyFundsMoved(
-        Data storage self,
+    function notifyWalletFundsMoved(
+        BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
         bytes32 targetWalletsHash
     ) external {

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -476,7 +476,7 @@ library Wallets {
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
         bytes32 targetWalletsHash
-    ) external {
+    ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         // Check that the wallet is in the MovingFunds state but don't check
         // if the moving funds timeout is exceeded. That should give a

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -48,14 +48,14 @@ contract BridgeStub is Bridge {
     }
 
     function setActiveWallet(bytes20 activeWalletPubKeyHash) external {
-        wallets.activeWalletPubKeyHash = activeWalletPubKeyHash;
+        self.activeWalletPubKeyHash = activeWalletPubKeyHash;
     }
 
     function setWalletMainUtxo(
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata utxo
     ) external {
-        wallets.registeredWallets[walletPubKeyHash].mainUtxoHash = keccak256(
+        self.registeredWallets[walletPubKeyHash].mainUtxoHash = keccak256(
             abi.encodePacked(
                 utxo.txHash,
                 utxo.txOutputIndex,
@@ -65,13 +65,13 @@ contract BridgeStub is Bridge {
     }
 
     function unsetWalletMainUtxo(bytes20 walletPubKeyHash) external {
-        delete wallets.registeredWallets[walletPubKeyHash].mainUtxoHash;
+        delete self.registeredWallets[walletPubKeyHash].mainUtxoHash;
     }
 
     function setWallet(bytes20 walletPubKeyHash, Wallets.Wallet calldata wallet)
         external
     {
-        wallets.registeredWallets[walletPubKeyHash] = wallet;
+        self.registeredWallets[walletPubKeyHash] = wallet;
     }
 
     function setDepositDustThreshold(uint64 _depositDustThreshold) external {

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -31,13 +31,13 @@ describe("Bridge - Wallets", () => {
       await waffle.loadFixture(fixture))
   })
 
-  describe("updateWalletsParameters", () => {
+  describe("updateWalletParameters", () => {
     context("when caller is the contract owner", () => {
       context("when all new parameter values are correct", () => {
-        const newCreationPeriod = constants.walletCreationPeriod * 2
-        const newMinBtcBalance = constants.walletMinBtcBalance.add(1000)
-        const newMaxBtcBalance = constants.walletMaxBtcBalance.add(2000)
-        const newMaxAge = constants.walletMaxAge * 2
+        const newWalletCreationPeriod = constants.walletCreationPeriod * 2
+        const newWalletMinBtcBalance = constants.walletMinBtcBalance.add(1000)
+        const newWalletMaxBtcBalance = constants.walletMaxBtcBalance.add(2000)
+        const newWalletMaxAge = constants.walletMaxAge * 2
 
         let tx: ContractTransaction
 
@@ -46,11 +46,11 @@ describe("Bridge - Wallets", () => {
 
           tx = await bridge
             .connect(governance)
-            .updateWalletsParameters(
-              newCreationPeriod,
-              newMinBtcBalance,
-              newMaxBtcBalance,
-              newMaxAge
+            .updateWalletParameters(
+              newWalletCreationPeriod,
+              newWalletMinBtcBalance,
+              newWalletMaxBtcBalance,
+              newWalletMaxAge
             )
         })
 
@@ -59,26 +59,25 @@ describe("Bridge - Wallets", () => {
         })
 
         it("should set correct values", async () => {
-          const params = await bridge.getWalletsParameters()
+          const params = await bridge.walletParameters()
 
-          expect(params.creationPeriod).to.be.equal(newCreationPeriod)
-          expect(params.minBtcBalance).to.be.equal(newMinBtcBalance)
-          expect(params.maxBtcBalance).to.be.equal(newMaxBtcBalance)
-          expect(params.maxAge).to.be.equal(newMaxAge)
+          expect(params.walletCreationPeriod).to.be.equal(
+            newWalletCreationPeriod
+          )
+          expect(params.walletMinBtcBalance).to.be.equal(newWalletMinBtcBalance)
+          expect(params.walletMaxBtcBalance).to.be.equal(newWalletMaxBtcBalance)
+          expect(params.walletMaxAge).to.be.equal(newWalletMaxAge)
         })
 
-        it("should emit correct events", async () => {
+        it("should emit WalletParametersUpdated event", async () => {
           await expect(tx)
-            .to.emit(bridge, "WalletCreationPeriodUpdated")
-            .withArgs(newCreationPeriod)
-
-          await expect(tx)
-            .to.emit(bridge, "WalletBtcBalanceRangeUpdated")
-            .withArgs(newMinBtcBalance, newMaxBtcBalance)
-
-          await expect(tx)
-            .to.emit(bridge, "WalletMaxAgeUpdated")
-            .withArgs(newMaxAge)
+            .to.emit(bridge, "WalletParametersUpdated")
+            .withArgs(
+              newWalletCreationPeriod,
+              newWalletMinBtcBalance,
+              newWalletMaxBtcBalance,
+              newWalletMaxAge
+            )
         })
       })
 
@@ -87,13 +86,15 @@ describe("Bridge - Wallets", () => {
           await expect(
             bridge
               .connect(governance)
-              .updateWalletsParameters(
+              .updateWalletParameters(
                 constants.walletCreationPeriod,
                 0,
                 constants.walletMaxBtcBalance,
                 constants.walletMaxAge
               )
-          ).to.be.revertedWith("Minimum must be greater than zero")
+          ).to.be.revertedWith(
+            "Wallet minimum BTC balance must be greater than zero"
+          )
         })
       })
 
@@ -104,13 +105,15 @@ describe("Bridge - Wallets", () => {
             await expect(
               bridge
                 .connect(governance)
-                .updateWalletsParameters(
+                .updateWalletParameters(
                   constants.walletCreationPeriod,
                   constants.walletMinBtcBalance,
                   constants.walletMinBtcBalance,
                   constants.walletMaxAge
                 )
-            ).to.be.revertedWith("Maximum must be greater than the minimum")
+            ).to.be.revertedWith(
+              "Wallet maximum BTC balance must be greater than the minimum"
+            )
           })
         }
       )
@@ -121,7 +124,7 @@ describe("Bridge - Wallets", () => {
         await expect(
           bridge
             .connect(thirdParty)
-            .updateWalletsParameters(
+            .updateWalletParameters(
               constants.walletCreationPeriod,
               constants.walletMinBtcBalance,
               constants.walletMaxBtcBalance,
@@ -1026,7 +1029,7 @@ describe("Bridge - Wallets", () => {
           before(async () => {
             await createSnapshot()
 
-            await increaseTime((await bridge.getWalletsParameters()).maxAge)
+            await increaseTime((await bridge.walletParameters()).walletMaxAge)
           })
 
           after(async () => {

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -104,12 +104,7 @@ const fixture = async () => {
   await redeem.deployed()
 
   const MovingFunds = await ethers.getContractFactory<MovingFunds__factory>(
-    "MovingFunds",
-    {
-      libraries: {
-        Wallets: wallets.address,
-      },
-    }
+    "MovingFunds"
   )
   const movingFunds = await MovingFunds.deploy()
   await movingFunds.deployed()

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -99,11 +99,7 @@ const fixture = async () => {
   const sweep = await Sweep.deploy()
   await sweep.deployed()
 
-  const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem", {
-    libraries: {
-      Wallets: wallets.address,
-    },
-  })
+  const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem")
   const redeem = await Redeem.deploy()
   await redeem.deployed()
 

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -55,12 +55,7 @@ const bridgeFixture = async () => {
   await redeem.deployed()
 
   const MovingFunds = await ethers.getContractFactory<MovingFunds__factory>(
-    "MovingFunds",
-    {
-      libraries: {
-        Wallets: wallets.address,
-      },
-    }
+    "MovingFunds"
   )
   const movingFunds = await MovingFunds.deploy()
   await movingFunds.deployed()

--- a/solidity/test/bridge/bridge-fixture.ts
+++ b/solidity/test/bridge/bridge-fixture.ts
@@ -50,11 +50,7 @@ const bridgeFixture = async () => {
   const sweep = await Sweep.deploy()
   await sweep.deployed()
 
-  const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem", {
-    libraries: {
-      Wallets: wallets.address,
-    },
-  })
+  const Redeem = await ethers.getContractFactory<Redeem__factory>("Redeem")
   const redeem = await Redeem.deploy()
   await redeem.deployed()
 


### PR DESCRIPTION
Refs https://github.com/keep-network/tbtc-v2/issues/165

Moved `Wallets` library internal storage fields out to the `BridgeState`.

This change aligns `Wallets` library with other libraries used by the
`Bridge` that keeps all the state inside `BridgeState` library. No major
changes to the logic - the only ones are around `updateWalletParameters`:
emitting just one event and updating parameters in one shot.


Bridge contract size change (before/after):
```
|  Bridge   ·      8.666 | 
|  Bridge   ·      8.750 │
```

Gas consumption change (before/after):
```
|  __ecdsaWalletCreatedCallback          ·   80851  ·   80875  ·   80868  │
|  __ecdsaWalletCreatedCallback          ·   80771  ·   97881  ·   88108  │
|  __ecdsaWalletHeartbeatFailedCallback  ·   43093  ·   46803  ·   44948  │
|  __ecdsaWalletHeartbeatFailedCallback  ·   41276  ·   43738  ·   42507  │
|  defeatFraudChallenge                  ·   59716  ·   76745  ·   64196  │
|  defeatFraudChallenge                  ·   59761  ·   76790  ·   64241  │
|  notifyCloseableWallet                 ·   40409  ·   43581  ·   42457  │
|  notifyCloseableWallet                 ·   42295  ·   45000  ·   43812  │
|  notifyFraudChallengeDefeatTimeout     ·       -  ·       -  ·   49174  │
|  notifyFraudChallengeDefeatTimeout     ·       -  ·       -  ·   49197  │
|  notifyRedemptionTimeout               ·  113072  ·  132720  ·  123057  │
|  notifyRedemptionTimeout               ·  113039  ·  126078  ·  119063  │
|  requestNewWallet                      ·   33920  ·   40044  ·   37999  │
|  requestNewWallet                      ·   33958  ·   41963  ·   39295  │
|  requestRedemption                     ·  105469  ·  123302  ·  113185  │
|  requestRedemption                     ·  105474  ·  123307  ·  113190  │
|  submitFraudChallenge                  ·  107727  ·  107887  ·  107742  │
|  submitFraudChallenge                  ·  107592  ·  107752  ·  107607  │
|  submitMovingFundsProof                ·  133434  ·  153582  ·  146442  │
|  submitMovingFundsProof                ·  130076  ·  150223  ·  143084  │
|  submitRedemptionProof                 ·  126852  ·  204510  ·  172619  │
|  submitRedemptionProof                 ·  126863  ·  204521  ·  172629  │
|  submitSweepProof                      ·  190821  ·  345178  ·  264319  │
|  submitSweepProof                      ·  190700  ·  345057  ·  264198  │
```