### PR TITLE
Enabled contract sizing for all contracts again

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -31,7 +31,6 @@ const config: HardhatUserConfig = {
 
   networks: {
     hardhat: {
-      allowUnlimitedContractSize: true, // TODO: Remove it once the problem of BridgeStub's size is solved
       forking: {
         // forking is enabled only if FORKING_URL env is provided
         enabled: !!process.env.FORKING_URL,
@@ -101,7 +100,6 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
-    except: ["BridgeStub$"], // TODO: Remove it once the problem of contracts' size is solved
   },
   typechain: {
     outDir: "typechain",


### PR DESCRIPTION
After the recent refactoring, neither Bridge nor BridgeStub contract
size is a problem.

See https://github.com/keep-network/tbtc-v2/issues/165