### PR TITLE
Remove unnecessary TODO

### DIFF
--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -430,10 +430,6 @@ library Redemption {
         BitcoinTx.UTXO calldata mainUtxo,
         bytes20 walletPubKeyHash
     ) external {
-        // TODO: Just as for `submitSweepProof`, fail early if the function
-        //       call gets frontrunned. See discussion:
-        //       https://github.com/keep-network/tbtc-v2/pull/106#discussion_r801745204
-
         // The actual transaction proof is performed here. After that point, we
         // can assume the transaction happened on Bitcoin chain and has
         // a sufficient number of confirmations as determined by

--- a/solidity/contracts/bridge/Sweep.sol
+++ b/solidity/contracts/bridge/Sweep.sol
@@ -109,9 +109,6 @@ library Sweep {
         BitcoinTx.Proof calldata sweepProof,
         BitcoinTx.UTXO calldata mainUtxo
     ) external {
-        // TODO: Fail early if the function call gets frontrunned. See discussion:
-        //       https://github.com/keep-network/tbtc-v2/pull/106#discussion_r801745204
-
         // The actual transaction proof is performed here. After that point, we
         // can assume the transaction happened on Bitcoin chain and has
         // a sufficient number of confirmations as determined by


### PR DESCRIPTION
We decided to remove the TODOs because only a selected set of maintainers will be reimbursed for calling this function, and those maintainers will be working on round-robin duty. There is a low risk that someone will try to frontrun the call. At the same time, doing this change would complicate the code so we think it is not worth it.

