### PR TITLE
Use flag instead of counter when checking redemptions present

### DIFF
--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -603,11 +603,10 @@ library Redemption {
         bytes20 walletPubKeyHash,
         RedemptionTxOutputsProcessingInfo memory processInfo
     ) internal returns (RedemptionTxOutputsInfo memory resultInfo) {
-        // Helper variable that counts the number of processed redemption
-        // outputs. Redemptions can be either pending or reported as timed out.
-        // TODO: Revisit the approach with redemptions count according to
-        //       https://github.com/keep-network/tbtc-v2/pull/128#discussion_r808237765
-        uint256 processedRedemptionsCount = 0;
+        // Helper flag indicating whether there was at least one redemption
+        // output present (redemption must be either pending or reported as
+        // timed out).
+        bool redemptionPresent = false;
 
         // Outputs processing loop.
         for (uint256 i = 0; i < processInfo.outputsCount; i++) {
@@ -654,7 +653,7 @@ library Redemption {
                     );
                 resultInfo.totalBurnableValue += burnableValue;
                 resultInfo.totalTreasuryFee += treasuryFee;
-                processedRedemptionsCount++;
+                redemptionPresent = true;
             }
 
             // Make the `outputStartingIndex` pointing to the next output by
@@ -666,7 +665,7 @@ library Redemption {
         // referring back to the wallet PKH and just burning main UTXO value
         // for transaction fees.
         require(
-            processedRedemptionsCount > 0,
+            redemptionPresent,
             "Redemption transaction must process at least one redemption"
         );
     }


### PR DESCRIPTION
This PR replaces the use of a counter with a flag when checking at least one redemption output is present when redemption proof is submitted.

It causes a slight drop in gas usage for `submitRedemptionProof`:
* with integer counter: 
```
|  Contract        ·  Method                                      ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
|  BridgeStub      ·  submitRedemptionProof                       ·     126677  ·     204334  ·      172452  ·           19  ·          -  │
```

* with boolean flag:
```
|  Contract        ·  Method                                      ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
|  BridgeStub      ·  submitRedemptionProof                       ·     126599  ·     203968  ·      172197  ·           19  ·          -  │
```