### PR TITLE
Implement deployment scripts for Bank and Bridge

### DIFF
--- a/solidity/deploy/00_resolve_relay.ts
+++ b/solidity/deploy/00_resolve_relay.ts
@@ -1,0 +1,28 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments, helpers } = hre
+  const { log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const Relay = await deployments.getOrNull("Relay")
+
+  if (Relay && helpers.address.isValid(Relay.address)) {
+    log(`using external Relay at ${Relay.address}`)
+  } else if (hre.network.name !== "hardhat") {
+    throw new Error("deployed Relay contract not found")
+  } else {
+    log("deploying Relay stub")
+
+    await deployments.deploy("Relay", {
+      contract: "TestRelay",
+      from: deployer,
+      log: true,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["Relay"]

--- a/solidity/deploy/04_deploy_bank.ts
+++ b/solidity/deploy/04_deploy_bank.ts
@@ -1,0 +1,25 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const Bank = await deploy("Bank", {
+    from: deployer,
+    args: [],
+    log: true,
+  })
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "Bank",
+      address: Bank.address,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["Bank"]

--- a/solidity/deploy/05_deploy_bridge.ts
+++ b/solidity/deploy/05_deploy_bridge.ts
@@ -1,0 +1,60 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy } = deployments
+  const { deployer, treasury } = await getNamedAccounts()
+
+  const Bank = await deployments.get("Bank")
+  const Relay = await deployments.get("Relay")
+
+  // TODO: Test for mainnet deployment that when `WalletRegistry` is provided
+  // in `external/mainnet/` directory it gets resolved correctly, and the deployment
+  // script from `@keep-network/ecdsa` is not invoked once again.
+  const WalletRegistry = await deployments.get("WalletRegistry")
+
+  const txProofDifficultyFactor = 0 // TODO: Set initial value
+
+  const Deposit = await deploy("Deposit", { from: deployer, log: true })
+  const Sweep = await deploy("Sweep", { from: deployer, log: true })
+  const Redemption = await deploy("Redemption", { from: deployer, log: true })
+  const Wallets = await deploy("Wallets", { from: deployer, log: true })
+  const Fraud = await deploy("Fraud", { from: deployer, log: true })
+  const MovingFunds = await deploy("MovingFunds", {
+    from: deployer,
+    log: true,
+  })
+
+  const Bridge = await deploy("Bridge", {
+    from: deployer,
+    args: [
+      Bank.address,
+      Relay.address,
+      treasury,
+      WalletRegistry.address,
+      txProofDifficultyFactor,
+    ],
+    libraries: {
+      Deposit: Deposit.address,
+      Sweep: Sweep.address,
+      Redemption: Redemption.address,
+      Wallets: Wallets.address,
+      Fraud: Fraud.address,
+      MovingFunds: MovingFunds.address,
+    },
+    log: true,
+  })
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "Bridge",
+      address: Bridge.address,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["Bridge"]
+func.dependencies = ["Bank", "Relay", "Treasury", "WalletRegistry"]

--- a/solidity/deploy/06_bank_update_bridge.ts
+++ b/solidity/deploy/06_bank_update_bridge.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments } = hre
+  const { execute, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const Bridge = await deployments.get("Bridge")
+
+  log("updating Bridge in Bank")
+
+  await execute("Bank", { from: deployer }, "updateBridge", Bridge.address)
+}
+
+export default func
+
+func.tags = ["BankUpdateBridge"]
+func.dependencies = ["Bank", "Bridge"]

--- a/solidity/deploy/07_transfer_ownership.ts
+++ b/solidity/deploy/07_transfer_ownership.ts
@@ -1,0 +1,17 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, governance } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership("Bank", governance, deployer)
+
+  await helpers.ownable.transferOwnership("Bridge", governance, deployer)
+}
+
+export default func
+
+func.tags = ["TransferOwnership"]
+func.dependencies = ["Bank", "Bridge"]
+func.runAtTheEnd = true

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -71,6 +71,16 @@ const config: HardhatUserConfig = {
       {
         artifacts: "node_modules/@keep-network/tbtc/artifacts",
       },
+      {
+        artifacts:
+          "node_modules/@threshold-network/solidity-contracts/export/artifacts",
+        deploy:
+          "node_modules/@threshold-network/solidity-contracts/export/deploy",
+      },
+      {
+        artifacts: "node_modules/@keep-network/ecdsa/export/artifacts",
+        deploy: "node_modules/@keep-network/ecdsa/export/deploy",
+      },
     ],
     deployments: {
       // For development environment we expect the local dependencies to be
@@ -83,7 +93,13 @@ const config: HardhatUserConfig = {
 
   namedAccounts: {
     deployer: {
-      default: 0, // take the first account as deployer
+      default: 1,
+    },
+    treasury: {
+      default: 2,
+    },
+    governance: {
+      default: 3,
     },
     keepTechnicalWalletTeam: {
       mainnet: "0xB3726E69Da808A689F2607939a2D9E958724FC2A",


### PR DESCRIPTION
Here we implement hardhat deployment script for Bank and Bridge
contracts.

Bridge contract requires a reference to WalletRegistry, so we added an
external deploy scripts definition in hardhat config.