### PR TITLE
Configure git to don't use unauthenticated protocol

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -92,6 +92,15 @@ jobs:
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `tbtc-v2` dependencies by
+      # default uses `git://` and we needed to manually remove it every time
+      # it re-appeared in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
@@ -115,16 +124,18 @@ jobs:
           cache-dependency-path: solidity/yarn.lock
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
       # We need this step because the `@keep-network/tbtc` which we update in
       # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
       # downloads one of its sub-dependencies via unathenticated `git://`
       # protocol. That protocol is no longer supported. Thanks to this step
-      # `https://` is used instead of `git://`.
+      # `https://` is used instead of `git://`. This step also prevents the
+      # error during `yarn install --frozen-lockfile` step in case `git://` gets
+      # introduced to tbtc-v2's `yarn.lock`.
       - name: Configure git to don't use unauthenticated protocol
         run: git config --global url."https://".insteadOf git://
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Get upstream packages versions
         uses: keep-network/ci/actions/upstream-builds-query@v1
@@ -203,6 +214,15 @@ jobs:
           node-version: "14.x"
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock
+
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `tbtc-v2` dependencies by
+      # default uses `git://` and we needed to manually remove it every time
+      # it re-appeared in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install needed dependencies
         run: yarn install --frozen-lockfile

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -108,7 +108,7 @@
   resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-0.1.11.tgz#c35e3b385091fc6f0c0c355b73270f4a8559ad38"
   integrity sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==
   dependencies:
-    "@umpirsky/country-list" "git://github.com/umpirsky/country-list#05fda51"
+    "@umpirsky/country-list" "git+https://github.com/umpirsky/country-list#05fda51"
     bigi "^1.1.0"
     bignumber.js "^9.0.0"
     bip32 "2.0.5"


### PR DESCRIPTION
In this PR we're changing the unauthenticated `git://` protocol used in
one `yarn.lock` dependency to `git+https://`. Using of unauthenticated
protocol is no longer supported by github and results in `The
unauthenticated git protocol on port 9418 is no longer supported error`.

We already had that change from `git://` to `git+https://` done before,
but as it is done manually, it gets easily overwritten when changes in
`yarn.lock` are introduced, for example when `yarn.lock` gets created
from scratch. To prevent getting failures of GHA workflows if that
happens again, we're adding steps that force Git to download
dependencies using `https://` protocol, even if `yarn.json` refers to
some package via `git://`.