### PR TITLE
Use the latest Slither 0.8.3 in CI

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -284,11 +284,9 @@ jobs:
 
   contracts-slither:
     needs: contracts-detect-changes
-    # TODO: remove 'pull_request' condition before merging PR to main
     if: |
       github.event_name == 'push'
         || needs.contracts-detect-changes.outputs.path-filter == 'true'
-        || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -262,53 +262,51 @@ jobs:
       - name: Check formatting
         run: yarn format
 
-  # The check is commented out until slither releases new version, with fix for
-  # https://github.com/crytic/slither/issues/1106.
-  # contracts-slither:
-  #   needs: contracts-detect-changes
-  #   if: |
-  #     github.event_name == 'push'
-  #       || needs.contracts-detect-changes.outputs.path-filter == 'true'
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: ./solidity
-  #   steps:
-  #     - uses: actions/checkout@v2
+  contracts-slither:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: "14.x"
-  #         cache: "yarn"
-  #         cache-dependency-path: solidity/yarn.lock
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
+          cache-dependency-path: solidity/yarn.lock
 
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.5
 
-  #     - name: Install Solidity
-  #       env:
-  #         SOLC_VERSION: 0.8.9 # according to solidity.version in hardhat.config.ts
-  #       run: |
-  #         pip3 install solc-select
-  #         solc-select install $SOLC_VERSION
-  #         solc-select use $SOLC_VERSION
+      - name: Install Solidity
+        env:
+          SOLC_VERSION: 0.8.9 # according to solidity.version in hardhat.config.ts
+        run: |
+          pip3 install solc-select
+          solc-select install $SOLC_VERSION
+          solc-select use $SOLC_VERSION
 
-  #     - name: Install Slither
-  #       env:
-  #         SLITHER_VERSION: 0.8.2
-  #       run: pip3 install slither-analyzer==$SLITHER_VERSION
+      - name: Install Slither
+        env:
+          SLITHER_VERSION: 0.8.3
+        run: pip3 install slither-analyzer==$SLITHER_VERSION
 
-  #     # We need this step because the `@keep-network/tbtc` which we update in
-  #     # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
-  #     # downloads one of its sub-dependencies via unathenticated `git://`
-  #     # protocol. That protocol is no longer supported. Thanks to this step
-  #     # `https://` is used instead of `git://`.
-  #     - name: Configure git to don't use unauthenticated protocol
-  #       run: git config --global url."https://".insteadOf git://
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
-  #     - name: Install dependencies
-  #       run: yarn install
+      - name: Install dependencies
+        run: yarn install
 
-  #     - name: Run Slither
-  #       run: slither --hardhat-artifacts-directory build .
+      - name: Run Slither
+        run: slither --hardhat-artifacts-directory build .

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -264,9 +264,11 @@ jobs:
 
   contracts-slither:
     needs: contracts-detect-changes
+    # TODO: remove 'pull_request' condition before merging PR to main
     if: |
       github.event_name == 'push'
         || needs.contracts-detect-changes.outputs.path-filter == 'true'
+        || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -250,7 +250,7 @@ library Deposit {
         deposit.treasuryFee = self.depositTreasuryFeeDivisor > 0
             ? fundingOutputAmount / self.depositTreasuryFeeDivisor
             : 0;
-
+        // slither-disable-next-line reentrancy-events
         emit DepositRevealed(
             fundingTxHash,
             reveal.fundingOutputIndex,

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -232,7 +232,7 @@ library Fraud {
 
         // Send the ether deposited by the challenger to the treasury
         /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls arbitrary-send
+        // slither-disable-next-line low-level-calls unchecked-lowlevel arbitrary-send
         self.treasury.call{gas: 100000, value: challenge.depositAmount}("");
         /* solhint-enable avoid-low-level-calls */
 

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -232,7 +232,7 @@ library Fraud {
 
         // Send the ether deposited by the challenger to the treasury
         /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls
+        // slither-disable-next-line low-level-calls arbitrary-send
         self.treasury.call{gas: 100000, value: challenge.depositAmount}("");
         /* solhint-enable avoid-low-level-calls */
 

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -155,7 +155,7 @@ library Fraud {
         /* solhint-disable-next-line not-rely-on-time */
         challenge.reportedAt = uint32(block.timestamp);
         challenge.resolved = false;
-
+        // slither-disable-next-line reentrancy-events
         emit FraudChallengeSubmitted(
             walletPubKeyHash,
             sighash,
@@ -232,7 +232,7 @@ library Fraud {
 
         // Send the ether deposited by the challenger to the treasury
         /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls unchecked-lowlevel arbitrary-send
+        // slither-disable-next-line low-level-calls,unchecked-lowlevel,arbitrary-send
         self.treasury.call{gas: 100000, value: challenge.depositAmount}("");
         /* solhint-enable avoid-low-level-calls */
 
@@ -241,7 +241,7 @@ library Fraud {
             walletPublicKey.slice32(32)
         );
         bytes20 walletPubKeyHash = compressedWalletPublicKey.hash160View();
-
+        // slither-disable-next-line reentrancy-events
         emit FraudChallengeDefeated(walletPubKeyHash, sighash);
     }
 
@@ -297,7 +297,7 @@ library Fraud {
 
         // Return the ether deposited by the challenger
         /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls unchecked-lowlevel
+        // slither-disable-next-line low-level-calls,unchecked-lowlevel
         challenge.challenger.call{gas: 100000, value: challenge.depositAmount}(
             ""
         );
@@ -308,7 +308,7 @@ library Fraud {
             walletPublicKey.slice32(32)
         );
         bytes20 walletPubKeyHash = compressedWalletPublicKey.hash160View();
-
+        // slither-disable-next-line reentrancy-events
         emit FraudChallengeDefeatTimedOut(walletPubKeyHash, sighash);
     }
 

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -297,7 +297,7 @@ library Fraud {
 
         // Return the ether deposited by the challenger
         /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls
+        // slither-disable-next-line low-level-calls unchecked-lowlevel
         challenge.challenger.call{gas: 100000, value: challenge.depositAmount}(
             ""
         );

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -268,7 +268,7 @@ library MovingFunds {
         );
 
         self.notifyWalletFundsMoved(walletPubKeyHash, targetWalletsHash);
-
+        // slither-disable-next-line reentrancy-events
         emit MovingFundsCompleted(walletPubKeyHash, movingFundsTxHash);
     }
 

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -841,7 +841,7 @@ library Redemption {
             // Propagate timeout consequences to the wallet
             self.notifyWalletTimedOutRedemption(walletPubKeyHash);
         }
-
+        // slither-disable-next-line reentrancy-events
         emit RedemptionTimedOut(walletPubKeyHash, redeemerOutputScript);
 
         // Return the requested amount of tokens to the redeemer

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -412,6 +412,8 @@ library Wallets {
     /// @param walletPubKeyHash 20-byte public key hash of the wallet
     /// @dev Requirements:
     ///      - Wallet must be in Live or MovingFunds state
+    ///
+    // slither-disable-next-line dead-code
     function notifyWalletFraud(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
@@ -440,6 +442,8 @@ library Wallets {
     /// @dev Requirements:
     ///      - The caller must make sure that the wallet is in the
     ///        Live or MovingFunds state.
+    ///
+    // slither-disable-next-line dead-code
     function terminateWallet(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash


### PR DESCRIPTION
Slither 0.8.3 fixes issues with false validation failures from
crytic/slither#1067.

TODO:

- [x] remove TODO from the workflow once slither errors get fixed