### PR TITLE
Removed unnecessary TODO

### DIFF
--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -6,8 +6,6 @@ import "../bridge/BitcoinTx.sol";
 import "../bridge/Bridge.sol";
 import "../bridge/Wallets.sol";
 
-// TODO: Try to create a separate BridgeStub for every test group (wallets,
-//       frauds, etc.) to decrease the size.
 contract BridgeStub is Bridge {
     constructor(
         address _bank,


### PR DESCRIPTION
Refs https://github.com/keep-network/tbtc-v2/issues/152
Since the size of the `BridgeStub` is no longer a problem, there is no point
in having multiple `BridgeStub` contracts for different test groups.