### PR TITLE
Change the order of parameters

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -194,10 +194,10 @@ contract Bridge is Governable, EcdsaWalletOwner {
     );
 
     event FraudParametersUpdated(
-        uint96 fraudSlashingAmount,
-        uint256 fraudNotifierRewardMultiplier,
+        uint256 fraudChallengeDepositAmount,
         uint256 fraudChallengeDefeatTimeout,
-        uint256 fraudChallengeDepositAmount
+        uint96 fraudSlashingAmount,
+        uint256 fraudNotifierRewardMultiplier
     );
 
     constructor(
@@ -239,10 +239,10 @@ contract Bridge is Governable, EcdsaWalletOwner {
         self.movingFundsTimeout = 7 days;
         self.movingFundsTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
         self.movingFundsTimeoutNotifierRewardMultiplier = 100; //100%
+        self.fraudChallengeDepositAmount = 2 ether;
+        self.fraudChallengeDefeatTimeout = 7 days;
         self.fraudSlashingAmount = 10000 * 1e18; // 10000 T
         self.fraudNotifierRewardMultiplier = 100; // 100%
-        self.fraudChallengeDefeatTimeout = 7 days;
-        self.fraudChallengeDepositAmount = 2 ether;
         self.walletCreationPeriod = 1 weeks;
         self.walletCreationMinBtcBalance = 1e8; // 1 BTC
         self.walletCreationMaxBtcBalance = 100e8; // 100 BTC
@@ -1067,6 +1067,12 @@ contract Bridge is Governable, EcdsaWalletOwner {
     }
 
     /// @notice Updates parameters related to frauds.
+    /// @param fraudChallengeDepositAmount New value of the fraud challenge
+    ///        deposit amount in wei, it is the amount of ETH the party
+    ///        challenging the wallet for fraud needs to deposit
+    /// @param fraudChallengeDefeatTimeout New value of the challenge defeat
+    ///        timeout in seconds, it is the amount of time the wallet has to
+    ///        defeat a fraud challenge. The value must be greater than zero
     /// @param fraudSlashingAmount New value of the fraud slashing amount in T,
     ///        it is the amount slashed from each wallet member for committing
     ///        a fraud
@@ -1074,26 +1080,20 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///        reward multiplier as percentage, it determines the percentage of
     ///        the notifier reward from the staking contact the notifier of
     ///        a fraud receives. The value must be in the range [0, 100]
-    /// @param fraudChallengeDefeatTimeout New value of the challenge defeat
-    ///        timeout in seconds, it is the amount of time the wallet has to
-    ///        defeat a fraud challenge. The value must be greater than zero
-    /// @param fraudChallengeDepositAmount New value of the fraud challenge
-    ///        deposit amount in wei, it is the amount of ETH the party
-    ///        challenging the wallet for fraud needs to deposit
     /// @dev Requirements:
-    ///      - Fraud notifier reward multiplier must be in the range [0, 100]
     ///      - Fraud challenge defeat timeout must be greater than 0
+    ///      - Fraud notifier reward multiplier must be in the range [0, 100]
     function updateFraudParameters(
-        uint96 fraudSlashingAmount,
-        uint256 fraudNotifierRewardMultiplier,
+        uint256 fraudChallengeDepositAmount,
         uint256 fraudChallengeDefeatTimeout,
-        uint256 fraudChallengeDepositAmount
+        uint96 fraudSlashingAmount,
+        uint256 fraudNotifierRewardMultiplier
     ) external onlyGovernance {
         self.updateFraudParameters(
-            fraudSlashingAmount,
-            fraudNotifierRewardMultiplier,
+            fraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
-            fraudChallengeDepositAmount
+            fraudSlashingAmount,
+            fraudNotifierRewardMultiplier
         );
     }
 
@@ -1373,29 +1373,29 @@ contract Bridge is Governable, EcdsaWalletOwner {
     }
 
     /// @notice Returns the current values of Bridge fraud parameters.
+    /// @return fraudChallengeDepositAmount The amount of ETH in wei the party
+    ///         challenging the wallet for fraud needs to deposit.
+    /// @return fraudChallengeDefeatTimeout The amount of time the wallet has to
+    ///         defeat a fraud challenge.
     /// @return fraudSlashingAmount The amount slashed from each wallet member
     ///         for committing a fraud.
     /// @return fraudNotifierRewardMultiplier The percentage of the notifier
     ///         reward from the staking contract the notifier of a fraud
     ///         receives. The value is in the range [0, 100].
-    /// @return fraudChallengeDefeatTimeout The amount of time the wallet has to
-    ///         defeat a fraud challenge.
-    /// @return fraudChallengeDepositAmount The amount of ETH in wei the party
-    ///         challenging the wallet for fraud needs to deposit.
     function fraudParameters()
         external
         view
         returns (
-            uint96 fraudSlashingAmount,
-            uint256 fraudNotifierRewardMultiplier,
+            uint256 fraudChallengeDepositAmount,
             uint256 fraudChallengeDefeatTimeout,
-            uint256 fraudChallengeDepositAmount
+            uint96 fraudSlashingAmount,
+            uint256 fraudNotifierRewardMultiplier
         )
     {
+        fraudChallengeDepositAmount = self.fraudChallengeDepositAmount;
+        fraudChallengeDefeatTimeout = self.fraudChallengeDefeatTimeout;
         fraudSlashingAmount = self.fraudSlashingAmount;
         fraudNotifierRewardMultiplier = self.fraudNotifierRewardMultiplier;
-        fraudChallengeDefeatTimeout = self.fraudChallengeDefeatTimeout;
-        fraudChallengeDepositAmount = self.fraudChallengeDepositAmount;
     }
 
     /// @notice Returns the addresses of contracts Bridge is interacting with.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -177,10 +177,10 @@ contract Bridge is Governable, EcdsaWalletOwner {
 
     event MovingFundsParametersUpdated(
         uint64 movingFundsTxMaxTotalFee,
+        uint64 movingFundsDustThreshold,
         uint32 movingFundsTimeout,
         uint96 movingFundsTimeoutSlashingAmount,
-        uint256 movingFundsTimeoutNotifierRewardMultiplier,
-        uint64 movingFundsDustThreshold
+        uint256 movingFundsTimeoutNotifierRewardMultiplier
     );
 
     event WalletParametersUpdated(
@@ -235,10 +235,10 @@ contract Bridge is Governable, EcdsaWalletOwner {
         self.redemptionTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
         self.redemptionTimeoutNotifierRewardMultiplier = 100; // 100%
         self.movingFundsTxMaxTotalFee = 10000; // 10000 satoshi
+        self.movingFundsDustThreshold = 20000; // 20000 satoshi
         self.movingFundsTimeout = 7 days;
         self.movingFundsTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
         self.movingFundsTimeoutNotifierRewardMultiplier = 100; //100%
-        self.movingFundsDustThreshold = 20000; // 20000 satoshi
         self.fraudSlashingAmount = 10000 * 1e18; // 10000 T
         self.fraudNotifierRewardMultiplier = 100; // 100%
         self.fraudChallengeDefeatTimeout = 7 days;
@@ -979,6 +979,12 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///        BTC transaction fee that is acceptable in a single moving funds
     ///        transaction. This is a _total_ max fee for the entire moving
     ///        funds transaction.
+    /// @param movingFundsDustThreshold New value of the moving funds dust
+    ///        threshold. It is the minimal satoshi amount that makes sense to
+    //         be transferred during the moving funds process. Moving funds
+    //         wallets having their BTC balance below that value can begin
+    //         closing immediately as transferring such a low value may not be
+    //         possible due to BTC network fees.
     /// @param movingFundsTimeout New value of the moving funds timeout in
     ///        seconds. It is the time after which the moving funds process can
     ///        be reported as timed out. It is counted from the moment when the
@@ -992,31 +998,25 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///        it determines the percentage of the notifier reward from the
     ///        staking contact the notifier of a moving funds timeout receives.
     ///        The value must be in the range [0, 100]
-    /// @param movingFundsDustThreshold New value of the moving funds dust
-    ///        threshold. It is the minimal satoshi amount that makes sense to
-    //         be transferred during the moving funds process. Moving funds
-    //         wallets having their BTC balance below that value can begin
-    //         closing immediately as transferring such a low value may not be
-    //         possible due to BTC network fees.
     /// @dev Requirements:
     ///      - Moving funds transaction max total fee must be greater than zero
+    ///      - Moving funds dust threshold must be greater than zero
     ///      - Moving funds timeout must be greater than zero
     ///      - Moving funds timeout notifier reward multiplier must be in the
     ///        range [0, 100]
-    ///      - Moving funds dust threshold must be greater than zero
     function updateMovingFundsParameters(
         uint64 movingFundsTxMaxTotalFee,
+        uint64 movingFundsDustThreshold,
         uint32 movingFundsTimeout,
         uint96 movingFundsTimeoutSlashingAmount,
-        uint256 movingFundsTimeoutNotifierRewardMultiplier,
-        uint64 movingFundsDustThreshold
+        uint256 movingFundsTimeoutNotifierRewardMultiplier
     ) external onlyGovernance {
         self.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
+            movingFundsDustThreshold,
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
-            movingFundsTimeoutNotifierRewardMultiplier,
-            movingFundsDustThreshold
+            movingFundsTimeoutNotifierRewardMultiplier
         );
     }
 
@@ -1299,6 +1299,11 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///         transaction fee that is acceptable in a single moving funds
     ///         transaction. This is a _total_ max fee for the entire moving
     ///         funds transaction.
+    /// @return movingFundsDustThreshold The minimal satoshi amount that makes
+    ///         sense to be transferred during the moving funds process. Moving
+    ///         funds wallets having their BTC balance below that value can
+    ///         begin closing immediately as transferring such a low value may
+    ///         not be possible due to BTC network fees.
     /// @return movingFundsTimeout Time after which the moving funds process
     ///         can be reported as timed out. It is counted from the moment
     ///         when the wallet was requested to move their funds and switched
@@ -1308,29 +1313,24 @@ contract Bridge is Governable, EcdsaWalletOwner {
     /// @return movingFundsTimeoutNotifierRewardMultiplier The percentage of the
     ///         notifier reward from the staking contract the notifier of a
     ///         moving funds timeout receives. The value is in the range [0, 100].
-    /// @return movingFundsDustThreshold The minimal satoshi amount that makes
-    //          sense to be transferred during the moving funds process. Moving
-    //          funds wallets having their BTC balance below that value can
-    //          begin closing immediately as transferring such a low value may
-    //          not be possible due to BTC network fees.
     function movingFundsParameters()
         external
         view
         returns (
             uint64 movingFundsTxMaxTotalFee,
+            uint64 movingFundsDustThreshold,
             uint32 movingFundsTimeout,
             uint96 movingFundsTimeoutSlashingAmount,
-            uint256 movingFundsTimeoutNotifierRewardMultiplier,
-            uint64 movingFundsDustThreshold
+            uint256 movingFundsTimeoutNotifierRewardMultiplier
         )
     {
         movingFundsTxMaxTotalFee = self.movingFundsTxMaxTotalFee;
+        movingFundsDustThreshold = self.movingFundsDustThreshold;
         movingFundsTimeout = self.movingFundsTimeout;
         movingFundsTimeoutSlashingAmount = self
             .movingFundsTimeoutSlashingAmount;
         movingFundsTimeoutNotifierRewardMultiplier = self
             .movingFundsTimeoutNotifierRewardMultiplier;
-        movingFundsDustThreshold = self.movingFundsDustThreshold;
     }
 
     /// @return walletCreationPeriod Determines how frequently a new wallet

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -33,20 +33,20 @@ describe("Bridge - Fraud", () => {
   let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
 
+  let fraudChallengeDepositAmount: BigNumber
+  let fraudChallengeDefeatTimeout: BigNumber
   let fraudSlashingAmount: BigNumber
   let fraudNotifierRewardMultiplier: BigNumber
-  let fraudChallengeDefeatTimeout: BigNumber
-  let fraudChallengeDepositAmount: BigNumber
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ thirdParty, treasury, walletRegistry, bridge } =
       await waffle.loadFixture(bridgeFixture))
     ;({
+      fraudChallengeDepositAmount,
+      fraudChallengeDefeatTimeout,
       fraudSlashingAmount,
       fraudNotifierRewardMultiplier,
-      fraudChallengeDefeatTimeout,
-      fraudChallengeDepositAmount,
     } = await bridge.fraudParameters())
   })
 

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -319,13 +319,13 @@ describe("Bridge - Parameters", () => {
       context("when all new parameter values are correct", () => {
         const newMovingFundsTxMaxTotalFee =
           constants.movingFundsTxMaxTotalFee / 2
+        const newMovingFundsDustThreshold =
+          constants.movingFundsDustThreshold * 2
         const newMovingFundsTimeout = constants.movingFundsTimeout * 2
         const newMovingFundsTimeoutSlashingAmount =
           constants.movingFundsTimeoutSlashingAmount.mul(3)
         const newMovingFundsTimeoutNotifierRewardMultiplier =
           constants.movingFundsTimeoutNotifierRewardMultiplier / 2
-        const newMovingFundsDustThreshold =
-          constants.movingFundsDustThreshold * 2
 
         let tx: ContractTransaction
 
@@ -336,10 +336,10 @@ describe("Bridge - Parameters", () => {
             .connect(governance)
             .updateMovingFundsParameters(
               newMovingFundsTxMaxTotalFee,
+              newMovingFundsDustThreshold,
               newMovingFundsTimeout,
               newMovingFundsTimeoutSlashingAmount,
-              newMovingFundsTimeoutNotifierRewardMultiplier,
-              newMovingFundsDustThreshold
+              newMovingFundsTimeoutNotifierRewardMultiplier
             )
         })
 
@@ -353,15 +353,15 @@ describe("Bridge - Parameters", () => {
           expect(params.movingFundsTxMaxTotalFee).to.be.equal(
             newMovingFundsTxMaxTotalFee
           )
+          expect(params.movingFundsDustThreshold).to.be.equal(
+            newMovingFundsDustThreshold
+          )
           expect(params.movingFundsTimeout).to.be.equal(newMovingFundsTimeout)
           expect(params.movingFundsTimeoutSlashingAmount).to.be.equal(
             newMovingFundsTimeoutSlashingAmount
           )
           expect(params.movingFundsTimeoutNotifierRewardMultiplier).to.be.equal(
             newMovingFundsTimeoutNotifierRewardMultiplier
-          )
-          expect(params.movingFundsDustThreshold).to.be.equal(
-            newMovingFundsDustThreshold
           )
         })
 
@@ -370,10 +370,10 @@ describe("Bridge - Parameters", () => {
             .to.emit(bridge, "MovingFundsParametersUpdated")
             .withArgs(
               newMovingFundsTxMaxTotalFee,
+              newMovingFundsDustThreshold,
               newMovingFundsTimeout,
               newMovingFundsTimeoutSlashingAmount,
-              newMovingFundsTimeoutNotifierRewardMultiplier,
-              newMovingFundsDustThreshold
+              newMovingFundsTimeoutNotifierRewardMultiplier
             )
         })
       })
@@ -385,13 +385,31 @@ describe("Bridge - Parameters", () => {
               .connect(governance)
               .updateMovingFundsParameters(
                 0,
+                constants.movingFundsDustThreshold,
                 constants.movingFundsTimeout,
                 constants.movingFundsTimeoutSlashingAmount,
-                constants.movingFundsTimeoutNotifierRewardMultiplier,
-                constants.movingFundsDustThreshold
+                constants.movingFundsTimeoutNotifierRewardMultiplier
               )
           ).to.be.revertedWith(
             "Moving funds transaction max total fee must be greater than zero"
+          )
+        })
+      })
+
+      context("when new moving funds dust threshold is zero", () => {
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(governance)
+              .updateMovingFundsParameters(
+                constants.movingFundsTxMaxTotalFee,
+                0,
+                constants.movingFundsTimeout,
+                constants.movingFundsTimeoutSlashingAmount,
+                constants.movingFundsTimeoutNotifierRewardMultiplier
+              )
+          ).to.be.revertedWith(
+            "Moving funds dust threshold must be greater than zero"
           )
         })
       })
@@ -403,10 +421,10 @@ describe("Bridge - Parameters", () => {
               .connect(governance)
               .updateMovingFundsParameters(
                 constants.movingFundsTxMaxTotalFee,
+                constants.movingFundsDustThreshold,
                 0,
                 constants.movingFundsTimeoutSlashingAmount,
-                constants.movingFundsTimeoutNotifierRewardMultiplier,
-                constants.movingFundsDustThreshold
+                constants.movingFundsTimeoutNotifierRewardMultiplier
               )
           ).to.be.revertedWith("Moving funds timeout must be greater than zero")
         })
@@ -421,10 +439,10 @@ describe("Bridge - Parameters", () => {
                 .connect(governance)
                 .updateMovingFundsParameters(
                   constants.movingFundsTxMaxTotalFee,
+                  constants.movingFundsDustThreshold,
                   constants.movingFundsTimeout,
                   constants.movingFundsTimeoutSlashingAmount,
-                  101,
-                  constants.movingFundsDustThreshold
+                  101
                 )
             ).to.be.revertedWith(
               "Moving funds timeout notifier reward multiplier must be in the range [0, 100]"
@@ -432,23 +450,6 @@ describe("Bridge - Parameters", () => {
           })
         }
       )
-      context("when new moving funds dust threshold is zero", () => {
-        it("should revert", async () => {
-          await expect(
-            bridge
-              .connect(governance)
-              .updateMovingFundsParameters(
-                constants.movingFundsTxMaxTotalFee,
-                constants.movingFundsTimeout,
-                constants.movingFundsTimeoutSlashingAmount,
-                constants.movingFundsTimeoutNotifierRewardMultiplier,
-                0
-              )
-          ).to.be.revertedWith(
-            "Moving funds dust threshold must be greater than zero"
-          )
-        })
-      })
     })
 
     context("when caller is not the contract guvnor", () => {
@@ -458,10 +459,10 @@ describe("Bridge - Parameters", () => {
             .connect(thirdParty)
             .updateMovingFundsParameters(
               constants.movingFundsTxMaxTotalFee,
+              constants.movingFundsDustThreshold,
               constants.movingFundsTimeout,
               constants.movingFundsTimeoutSlashingAmount,
-              constants.movingFundsTimeoutNotifierRewardMultiplier,
-              constants.movingFundsDustThreshold
+              constants.movingFundsTimeoutNotifierRewardMultiplier
             )
         ).to.be.revertedWith("Caller is not the governance")
       })

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -648,13 +648,13 @@ describe("Bridge - Parameters", () => {
   describe("updateFraudParameters", () => {
     context("when caller is the contract guvnor", () => {
       context("when all new parameter values are correct", () => {
+        const newFraudChallengeDepositAmount =
+          constants.fraudChallengeDepositAmount.mul(4)
+        const newFraudChallengeDefeatTimeout =
+          constants.fraudChallengeDefeatTimeout * 3
         const newFraudSlashingAmount = constants.fraudSlashingAmount.mul(2)
         const newFraudNotifierRewardMultiplier =
           constants.fraudNotifierRewardMultiplier / 4
-        const newFraudChallengeDefeatTimeout =
-          constants.fraudChallengeDefeatTimeout * 3
-        const newFraudChallengeDepositAmount =
-          constants.fraudChallengeDepositAmount.mul(4)
 
         let tx: ContractTransaction
 
@@ -664,10 +664,10 @@ describe("Bridge - Parameters", () => {
           tx = await bridge
             .connect(governance)
             .updateFraudParameters(
-              newFraudSlashingAmount,
-              newFraudNotifierRewardMultiplier,
+              newFraudChallengeDepositAmount,
               newFraudChallengeDefeatTimeout,
-              newFraudChallengeDepositAmount
+              newFraudSlashingAmount,
+              newFraudNotifierRewardMultiplier
             )
         })
 
@@ -678,15 +678,15 @@ describe("Bridge - Parameters", () => {
         it("should set correct values", async () => {
           const params = await bridge.fraudParameters()
 
-          expect(params.fraudSlashingAmount).to.be.equal(newFraudSlashingAmount)
-          expect(params.fraudNotifierRewardMultiplier).to.be.equal(
-            newFraudNotifierRewardMultiplier
+          expect(params.fraudChallengeDepositAmount).to.be.equal(
+            newFraudChallengeDepositAmount
           )
           expect(params.fraudChallengeDefeatTimeout).to.be.equal(
             newFraudChallengeDefeatTimeout
           )
-          expect(params.fraudChallengeDepositAmount).to.be.equal(
-            newFraudChallengeDepositAmount
+          expect(params.fraudSlashingAmount).to.be.equal(newFraudSlashingAmount)
+          expect(params.fraudNotifierRewardMultiplier).to.be.equal(
+            newFraudNotifierRewardMultiplier
           )
         })
 
@@ -694,11 +694,28 @@ describe("Bridge - Parameters", () => {
           await expect(tx)
             .to.emit(bridge, "FraudParametersUpdated")
             .withArgs(
-              newFraudSlashingAmount,
-              newFraudNotifierRewardMultiplier,
+              newFraudChallengeDepositAmount,
               newFraudChallengeDefeatTimeout,
-              newFraudChallengeDepositAmount
+              newFraudSlashingAmount,
+              newFraudNotifierRewardMultiplier
             )
+        })
+      })
+
+      context("when new fraud challenge defeat timeout is zero", () => {
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(governance)
+              .updateFraudParameters(
+                constants.fraudChallengeDepositAmount,
+                0,
+                constants.fraudSlashingAmount,
+                constants.fraudNotifierRewardMultiplier
+              )
+          ).to.be.revertedWith(
+            "Fraud challenge defeat timeout must be greater than zero"
+          )
         })
       })
 
@@ -710,10 +727,10 @@ describe("Bridge - Parameters", () => {
               bridge
                 .connect(governance)
                 .updateFraudParameters(
-                  constants.fraudSlashingAmount,
-                  101,
+                  constants.fraudChallengeDepositAmount,
                   constants.fraudChallengeDefeatTimeout,
-                  constants.fraudChallengeDepositAmount
+                  constants.fraudSlashingAmount,
+                  101
                 )
             ).to.be.revertedWith(
               "Fraud notifier reward multiplier must be in the range [0, 100]"
@@ -721,23 +738,6 @@ describe("Bridge - Parameters", () => {
           })
         }
       )
-
-      context("when new fraud challenge defeat timeout is zero", () => {
-        it("should revert", async () => {
-          await expect(
-            bridge
-              .connect(governance)
-              .updateFraudParameters(
-                constants.fraudSlashingAmount,
-                constants.fraudNotifierRewardMultiplier,
-                0,
-                constants.fraudChallengeDepositAmount
-              )
-          ).to.be.revertedWith(
-            "Fraud challenge defeat timeout must be greater than zero"
-          )
-        })
-      })
     })
 
     context("when caller is not the contract guvnor", () => {
@@ -746,10 +746,10 @@ describe("Bridge - Parameters", () => {
           bridge
             .connect(thirdParty)
             .updateFraudParameters(
-              constants.fraudSlashingAmount,
-              constants.fraudNotifierRewardMultiplier,
+              constants.fraudChallengeDepositAmount,
               constants.fraudChallengeDefeatTimeout,
-              constants.fraudChallengeDepositAmount
+              constants.fraudSlashingAmount,
+              constants.fraudNotifierRewardMultiplier
             )
         ).to.be.revertedWith("Caller is not the governance")
       })

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -23,10 +23,10 @@ export const constants = {
   walletMaxAge: 8 * 604800, // 8 weeks,
   walletMaxBtcTransfer: to1ePrecision(10, 8), // 10 BTC
   walletClosingPeriod: 3456000, // 40 days
+  fraudChallengeDepositAmount: to1ePrecision(2, 18), // 2 ethers
+  fraudChallengeDefeatTimeout: 604800, // 1 week
   fraudSlashingAmount: to1ePrecision(10000, 18), // 10000 T
   fraudNotifierRewardMultiplier: 100, // 100%
-  fraudChallengeDefeatTimeout: 604800, // 1 week
-  fraudChallengeDepositAmount: to1ePrecision(2, 18), // 2 ethers
 }
 
 export const walletState = {

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -12,10 +12,10 @@ export const constants = {
   redemptionTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
   redemptionTimeoutNotifierRewardMultiplier: 100, // 100%
   movingFundsTxMaxTotalFee: 10000, // 10000 satoshi
+  movingFundsDustThreshold: 20000, // 20000 satoshi
   movingFundsTimeout: 604800, // 1 week
   movingFundsTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
   movingFundsTimeoutNotifierRewardMultiplier: 100, // 100%
-  movingFundsDustThreshold: 20000, // 20000 satoshi
   walletCreationPeriod: 604800, // 1 week
   walletCreationMinBtcBalance: to1ePrecision(1, 8), // 1 BTC
   walletCreationMaxBtcBalance: to1ePrecision(100, 8), // 100 BTC


### PR DESCRIPTION
This PR addresses [this review comment](https://github.com/keep-network/tbtc-v2/pull/236#discussion_r863557924).
Timeout-related parameters are moved to the end in functions that update and return parameters as well as events and declarations.