### PR TITLE
Moved funds sweep timeout

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -708,15 +708,14 @@ contract Bridge is Governable, EcdsaWalletOwner {
     /// @notice Notifies about a timed out moved funds sweep process. If the
     ///         wallet is not terminated yet, that function terminates
     ///         the wallet and slashes signing group members as a result.
-    ///         Marks the given request as resolved.
+    ///         Marks the given sweep request as TimedOut.
     /// @param movingFundsTxHash 32-byte hash of the moving funds transaction
     ///        that caused the sweep request to be created
     /// @param movingFundsTxOutputIndex Index of the moving funds transaction
     ///        output that is subject of the sweep request.
     /// @param walletMembersIDs Identifiers of the wallet signing group members
     /// @dev Requirements:
-    ///      - The moved funds sweep request must exist
-    ///      - The moved funds sweep not be already processed
+    ///      - The moved funds sweep request must be in the Pending state
     ///      - The moved funds sweep timeout must be actually exceeded
     ///      - The wallet must be either in the Live or MovingFunds or
     ///        Terminated state

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -123,7 +123,7 @@ contract Bridge is Governable, EcdsaWalletOwner {
 
     event MovedFundsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
 
-    event MovedFundsSweepRequestTimedOut(
+    event MovedFundsSweepTimedOut(
         bytes20 walletPubKeyHash,
         bytes32 movingFundsTxHash,
         uint32 movingFundsTxOutputIndex

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -113,14 +113,14 @@ library BridgeState {
         // Time after which the moved funds merge process can be reported as
         // timed out. It is counted from the moment when the recipient wallet
         // was requested to merge the received funds. Value in seconds.
-        uint32  movedFundsMergeTimeout;
+        uint32 movedFundsMergeTimeout;
         // The amount of stake slashed from each member of a wallet for a moved
         // funds merge timeout.
-        uint96  movedFundsMergeTimeoutSlashingAmount;
+        uint96 movedFundsMergeTimeoutSlashingAmount;
         // The percentage of the notifier reward from the staking contract
         // the notifier of a moved funds merge timeout receives. The value is
         // in the range [0, 100].
-        uint256  movedFundsMergeTimeoutNotifierRewardMultiplier;
+        uint256 movedFundsMergeTimeoutNotifierRewardMultiplier;
         // Collection of all moved funds merge requests indexed by
         // `keccak256(movingFundsTxHash | movingFundsOutputIndex)`.
         // The `movingFundsTxHash` is `bytes32` (ordered as in Bitcoin
@@ -559,8 +559,10 @@ library BridgeState {
             .movingFundsTimeoutNotifierRewardMultiplier = _movingFundsTimeoutNotifierRewardMultiplier;
         self.movedFundsMergeTxMaxTotalFee = _movedFundsMergeTxMaxTotalFee;
         self.movedFundsMergeTimeout = _movedFundsMergeTimeout;
-        self.movedFundsMergeTimeoutSlashingAmount = _movedFundsMergeTimeoutSlashingAmount;
-        self.movedFundsMergeTimeoutNotifierRewardMultiplier = _movedFundsMergeTimeoutNotifierRewardMultiplier;
+        self
+            .movedFundsMergeTimeoutSlashingAmount = _movedFundsMergeTimeoutSlashingAmount;
+        self
+            .movedFundsMergeTimeoutNotifierRewardMultiplier = _movedFundsMergeTimeoutNotifierRewardMultiplier;
 
         emit MovingFundsParametersUpdated(
             _movingFundsTxMaxTotalFee,

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -104,7 +104,7 @@ library MovingFunds {
 
     event MovedFundsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
 
-    event MovedFundsSweepRequestTimedOut(
+    event MovedFundsSweepTimedOut(
         bytes20 walletPubKeyHash,
         bytes32 movingFundsTxHash,
         uint32 movingFundsTxOutputIndex
@@ -1025,7 +1025,7 @@ library MovingFunds {
         }
 
         // slither-disable-next-line reentrancy-events
-        emit MovedFundsSweepRequestTimedOut(
+        emit MovedFundsSweepTimedOut(
             walletPubKeyHash,
             movingFundsTxHash,
             movingFundsTxOutputIndex

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -62,7 +62,7 @@ library MovingFunds {
     enum MovedFundsSweepRequestState {
         /// @dev The request is unknown to the Bridge.
         Unknown,
-        /// @dev Request is pending and can be either processed or timed out.
+        /// @dev Request is pending and can become either processed or timed out.
         Pending,
         /// @dev Request was processed by the target wallet.
         Processed,
@@ -83,7 +83,7 @@ library MovingFunds {
         uint64 value;
         // UNIX timestamp the request was created at.
         uint32 createdAt;
-        // Current state of the request.
+        // The current state of the request.
         MovedFundsSweepRequestState state;
     }
 

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -998,6 +998,7 @@ library MovingFunds {
         );
 
         sweepRequest.state = MovedFundsSweepRequestState.TimedOut;
+        wallet.pendingMovedFundsSweepRequestsCount--;
 
         if (
             walletState == Wallets.WalletState.Live ||

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -113,7 +113,7 @@ contract BridgeStub is Bridge {
                 utxo.txOutputValue,
                 /* solhint-disable-next-line not-rely-on-time */
                 uint32(block.timestamp),
-                0
+                false
             );
 
         self
@@ -133,9 +133,9 @@ contract BridgeStub is Bridge {
             .movedFundsMergeRequests[requestKey];
 
         require(request.createdAt != 0, "Stub merge request does not exist");
+        require(!request.processed, "Stub merge request already processed");
 
-        /* solhint-disable-next-line not-rely-on-time */
-        request.mergedAt = uint32(block.timestamp);
+        request.processed = true;
 
         self
             .registeredWallets[walletPubKeyHash]

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -144,6 +144,29 @@ contract BridgeStub is Bridge {
             .pendingMovedFundsSweepRequestsCount--;
     }
 
+    function timeoutPendingMovedFundsSweepRequest(
+        bytes20 walletPubKeyHash,
+        BitcoinTx.UTXO calldata utxo
+    ) external {
+        uint256 requestKey = uint256(
+            keccak256(abi.encodePacked(utxo.txHash, utxo.txOutputIndex))
+        );
+
+        MovingFunds.MovedFundsSweepRequest storage request = self
+            .movedFundsSweepRequests[requestKey];
+
+        require(
+            request.state == MovingFunds.MovedFundsSweepRequestState.Pending,
+            "Stub sweep request must be in Pending state"
+        );
+
+        request.state = MovingFunds.MovedFundsSweepRequestState.TimedOut;
+
+        self
+            .registeredWallets[walletPubKeyHash]
+            .pendingMovedFundsSweepRequestsCount--;
+    }
+
     function setMovedFundsSweepTxMaxTotalFee(
         uint64 _movedFundsSweepTxMaxTotalFee
     ) external {

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -113,7 +113,7 @@ contract BridgeStub is Bridge {
                 utxo.txOutputValue,
                 /* solhint-disable-next-line not-rely-on-time */
                 uint32(block.timestamp),
-                false
+                MovingFunds.MovedFundsSweepRequestState.Pending
             );
 
         self
@@ -132,10 +132,12 @@ contract BridgeStub is Bridge {
         MovingFunds.MovedFundsSweepRequest storage request = self
             .movedFundsSweepRequests[requestKey];
 
-        require(request.createdAt != 0, "Stub sweep request does not exist");
-        require(!request.processed, "Stub sweep request already processed");
+        require(
+            request.state == MovingFunds.MovedFundsSweepRequestState.Pending,
+            "Stub sweep request must be in Pending state"
+        );
 
-        request.processed = true;
+        request.state = MovingFunds.MovedFundsSweepRequestState.Processed;
 
         self
             .registeredWallets[walletPubKeyHash]

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -879,10 +879,10 @@ describe("Bridge - Moving funds", () => {
                                                     )
 
                                                     expect(
-                                                      actualMovedFundsMergeRequest.mergedAt
+                                                      actualMovedFundsMergeRequest.processed
                                                     ).to.be.equal(
-                                                      0,
-                                                      `Unexpected merged timestamp for merge request ${i}`
+                                                      false,
+                                                      `Unexpected processed flag for merge request ${i}`
                                                     )
 
                                                     /* eslint-disable no-await-in-loop */
@@ -2103,10 +2103,11 @@ describe("Bridge - Moving funds", () => {
                                     ]
                                   )
 
+                                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
                                   expect(
                                     (await bridge.movedFundsMergeRequests(key))
-                                      .mergedAt
-                                  ).to.be.equal(await lastBlockTime())
+                                      .processed
+                                  ).to.be.true
                                 })
 
                                 it("should decrease the merging wallet's pending requests count", async () => {
@@ -2321,10 +2322,11 @@ describe("Bridge - Moving funds", () => {
                                     ]
                                   )
 
+                                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
                                   expect(
                                     (await bridge.movedFundsMergeRequests(key))
-                                      .mergedAt
-                                  ).to.be.equal(await lastBlockTime())
+                                      .processed
+                                  ).to.be.true
                                 })
 
                                 it("should decrease the merging wallet's pending requests count", async () => {

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -3377,9 +3377,9 @@ describe("Bridge - Moving funds", () => {
                   )
                 })
 
-                it("should emit MovedFundsSweepRequestTimedOut event", async () => {
+                it("should emit MovedFundsSweepTimedOut event", async () => {
                   await expect(tx)
-                    .to.emit(bridge, "MovedFundsSweepRequestTimedOut")
+                    .to.emit(bridge, "MovedFundsSweepTimedOut")
                     .withArgs(
                       movedFundsSweepRequest.walletPubKeyHash,
                       movedFundsSweepRequest.txHash,

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -3170,7 +3170,7 @@ describe("Bridge - Moving funds", () => {
     })
   })
 
-  describe.only("notifyMovedFundsSweepTimeout", () => {
+  describe("notifyMovedFundsSweepTimeout", () => {
     const walletDraft = {
       ecdsaWalletID: ecdsaWalletTestData.walletID,
       mainUtxoHash: ethers.constants.HashZero,

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -557,7 +557,7 @@ describe("Bridge - Parameters", () => {
                   constants.movedFundsMergeTxMaxTotalFee,
                   constants.movedFundsMergeTimeout,
                   constants.movedFundsMergeTimeoutSlashingAmount,
-                  0
+                  101
                 )
             ).to.be.revertedWith(
               "Moved funds merge timeout notifier reward multiplier must be in the range [0, 100]"

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -328,6 +328,11 @@ describe("Bridge - Parameters", () => {
           constants.movingFundsTimeoutNotifierRewardMultiplier / 2
         const newMovedFundsMergeTxMaxTotalFee =
           constants.movedFundsMergeTxMaxTotalFee * 2
+        const newMovedFundsMergeTimeout = constants.movedFundsMergeTimeout * 4
+        const newMovedFundsMergeTimeoutSlashingAmount =
+          constants.movedFundsMergeTimeoutSlashingAmount.mul(6)
+        const newMovedFundsMergeTimeoutNotifierRewardMultiplier =
+          constants.movedFundsMergeTimeoutNotifierRewardMultiplier / 4
 
         let tx: ContractTransaction
 
@@ -342,7 +347,10 @@ describe("Bridge - Parameters", () => {
               newMovingFundsTimeout,
               newMovingFundsTimeoutSlashingAmount,
               newMovingFundsTimeoutNotifierRewardMultiplier,
-              newMovedFundsMergeTxMaxTotalFee
+              newMovedFundsMergeTxMaxTotalFee,
+              newMovedFundsMergeTimeout,
+              newMovedFundsMergeTimeoutSlashingAmount,
+              newMovedFundsMergeTimeoutNotifierRewardMultiplier
             )
         })
 
@@ -369,6 +377,15 @@ describe("Bridge - Parameters", () => {
           expect(params.movedFundsMergeTxMaxTotalFee).to.be.equal(
             newMovedFundsMergeTxMaxTotalFee
           )
+          expect(params.movedFundsMergeTimeout).to.be.equal(
+            newMovedFundsMergeTimeout
+          )
+          expect(params.movedFundsMergeTimeoutSlashingAmount).to.be.equal(
+            newMovedFundsMergeTimeoutSlashingAmount
+          )
+          expect(
+            params.movedFundsMergeTimeoutNotifierRewardMultiplier
+          ).to.be.equal(newMovedFundsMergeTimeoutNotifierRewardMultiplier)
         })
 
         it("should emit MovingFundsParametersUpdated event", async () => {
@@ -380,7 +397,10 @@ describe("Bridge - Parameters", () => {
               newMovingFundsTimeout,
               newMovingFundsTimeoutSlashingAmount,
               newMovingFundsTimeoutNotifierRewardMultiplier,
-              newMovedFundsMergeTxMaxTotalFee
+              newMovedFundsMergeTxMaxTotalFee,
+              newMovedFundsMergeTimeout,
+              newMovedFundsMergeTimeoutSlashingAmount,
+              newMovedFundsMergeTimeoutNotifierRewardMultiplier
             )
         })
       })
@@ -396,7 +416,10 @@ describe("Bridge - Parameters", () => {
                 constants.movingFundsTimeout,
                 constants.movingFundsTimeoutSlashingAmount,
                 constants.movingFundsTimeoutNotifierRewardMultiplier,
-                constants.movedFundsMergeTxMaxTotalFee
+                constants.movedFundsMergeTxMaxTotalFee,
+                constants.movedFundsMergeTimeout,
+                constants.movedFundsMergeTimeoutSlashingAmount,
+                constants.movedFundsMergeTimeoutNotifierRewardMultiplier
               )
           ).to.be.revertedWith(
             "Moving funds transaction max total fee must be greater than zero"
@@ -415,7 +438,10 @@ describe("Bridge - Parameters", () => {
                 constants.movingFundsTimeout,
                 constants.movingFundsTimeoutSlashingAmount,
                 constants.movingFundsTimeoutNotifierRewardMultiplier,
-                constants.movedFundsMergeTxMaxTotalFee
+                constants.movedFundsMergeTxMaxTotalFee,
+                constants.movedFundsMergeTimeout,
+                constants.movedFundsMergeTimeoutSlashingAmount,
+                constants.movedFundsMergeTimeoutNotifierRewardMultiplier
               )
           ).to.be.revertedWith(
             "Moving funds dust threshold must be greater than zero"
@@ -434,7 +460,10 @@ describe("Bridge - Parameters", () => {
                 0,
                 constants.movingFundsTimeoutSlashingAmount,
                 constants.movingFundsTimeoutNotifierRewardMultiplier,
-                constants.movedFundsMergeTxMaxTotalFee
+                constants.movedFundsMergeTxMaxTotalFee,
+                constants.movedFundsMergeTimeout,
+                constants.movedFundsMergeTimeoutSlashingAmount,
+                constants.movedFundsMergeTimeoutNotifierRewardMultiplier
               )
           ).to.be.revertedWith("Moving funds timeout must be greater than zero")
         })
@@ -453,7 +482,10 @@ describe("Bridge - Parameters", () => {
                   constants.movingFundsTimeout,
                   constants.movingFundsTimeoutSlashingAmount,
                   101,
-                  constants.movedFundsMergeTxMaxTotalFee
+                  constants.movedFundsMergeTxMaxTotalFee,
+                  constants.movedFundsMergeTimeout,
+                  constants.movedFundsMergeTimeoutSlashingAmount,
+                  constants.movedFundsMergeTimeoutNotifierRewardMultiplier
                 )
             ).to.be.revertedWith(
               "Moving funds timeout notifier reward multiplier must be in the range [0, 100]"
@@ -475,10 +507,60 @@ describe("Bridge - Parameters", () => {
                   constants.movingFundsTimeout,
                   constants.movingFundsTimeoutSlashingAmount,
                   constants.movingFundsTimeoutNotifierRewardMultiplier,
-                  0
+                  0,
+                  constants.movedFundsMergeTimeout,
+                  constants.movedFundsMergeTimeoutSlashingAmount,
+                  constants.movedFundsMergeTimeoutNotifierRewardMultiplier
                 )
             ).to.be.revertedWith(
               "Moved funds merge transaction max total fee must be greater than zero"
+            )
+          })
+        }
+      )
+
+      context("when new moved funds merge timeout is zero", () => {
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(governance)
+              .updateMovingFundsParameters(
+                constants.movingFundsTxMaxTotalFee,
+                constants.movingFundsDustThreshold,
+                constants.movingFundsTimeout,
+                constants.movingFundsTimeoutSlashingAmount,
+                constants.movingFundsTimeoutNotifierRewardMultiplier,
+                constants.movedFundsMergeTxMaxTotalFee,
+                0,
+                constants.movedFundsMergeTimeoutSlashingAmount,
+                constants.movedFundsMergeTimeoutNotifierRewardMultiplier
+              )
+          ).to.be.revertedWith(
+            "Moved funds merge timeout must be greater than zero"
+          )
+        })
+      })
+
+      context(
+        "when new moved funds merge timeout notifier reward multiplier is greater than 100",
+        () => {
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(governance)
+                .updateMovingFundsParameters(
+                  constants.movingFundsTxMaxTotalFee,
+                  constants.movingFundsDustThreshold,
+                  constants.movingFundsTimeout,
+                  constants.movingFundsTimeoutSlashingAmount,
+                  constants.movingFundsTimeoutNotifierRewardMultiplier,
+                  constants.movedFundsMergeTxMaxTotalFee,
+                  constants.movedFundsMergeTimeout,
+                  constants.movedFundsMergeTimeoutSlashingAmount,
+                  0
+                )
+            ).to.be.revertedWith(
+              "Moved funds merge timeout notifier reward multiplier must be in the range [0, 100]"
             )
           })
         }
@@ -496,7 +578,10 @@ describe("Bridge - Parameters", () => {
               constants.movingFundsTimeout,
               constants.movingFundsTimeoutSlashingAmount,
               constants.movingFundsTimeoutNotifierRewardMultiplier,
-              constants.movedFundsMergeTxMaxTotalFee
+              constants.movedFundsMergeTxMaxTotalFee,
+              constants.movedFundsMergeTimeout,
+              constants.movedFundsMergeTimeoutSlashingAmount,
+              constants.movedFundsMergeTimeoutNotifierRewardMultiplier
             )
         ).to.be.revertedWith("Caller is not the governance")
       })

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -17,6 +17,9 @@ export const constants = {
   movingFundsTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
   movingFundsTimeoutNotifierRewardMultiplier: 100, // 100%
   movedFundsMergeTxMaxTotalFee: 10000, // 10000 satoshi
+  movedFundsMergeTimeout: 604800, // 1 week
+  movedFundsMergeTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
+  movedFundsMergeTimeoutNotifierRewardMultiplier: 100, // 100%
   walletCreationPeriod: 604800, // 1 week
   walletCreationMinBtcBalance: to1ePrecision(1, 8), // 1 BTC
   walletCreationMaxBtcBalance: to1ePrecision(100, 8), // 100 BTC

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -48,3 +48,10 @@ export const ecdsaDkgState = {
   AWAITING_RESULT: 2,
   CHALLENGE: 3,
 }
+
+export const movedFundsSweepRequestState = {
+  Unknown: 0,
+  Pending: 1,
+  Processed: 2,
+  TimedOut: 3,
+}


### PR DESCRIPTION
Refs: #243
Depends on: #261 

Here we introduce the `notifyMovedFundsSweepTimeout` function that is meant to be used to notify about a timed out moved funds sweep process. Just like in the moving funds process, the recipient wallet must sweep the obtained funds with their own main UTXO in a finite time window. In case this time is exceeded, a third party can notify about this fact thus cause the wallet termination and a severe slashing of wallet operators' stakes.