### PR TITLE
Integrate moved funds sweeps with fraud mechanism

### DIFF
--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -22,6 +22,7 @@ import {CheckBitcoinSigs} from "@keep-network/bitcoin-spv-sol/contracts/CheckBit
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./BridgeState.sol";
+import "./MovingFunds.sol";
 import "./Wallets.sol";
 
 /// @title Bridge fraud
@@ -226,7 +227,10 @@ library Fraud {
 
         // Check that the UTXO key identifies a correctly spent UTXO.
         require(
-            self.deposits[utxoKey].sweptAt > 0 || self.spentMainUTXOs[utxoKey],
+            self.deposits[utxoKey].sweptAt > 0 ||
+                self.spentMainUTXOs[utxoKey] ||
+                self.movedFundsSweepRequests[utxoKey].state ==
+                MovingFunds.MovedFundsSweepRequestState.Processed,
             "Spent UTXO not found among correctly spent UTXOs"
         );
 

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -46,6 +46,17 @@ contract BridgeStub is Bridge {
         }
     }
 
+    function setProcessedMovedFundsSweepRequests(BitcoinTx.UTXO[] calldata utxos) external {
+        for (uint256 i = 0; i < utxos.length; i++) {
+            uint256 utxoKey = uint256(
+                keccak256(
+                    abi.encodePacked(utxos[i].txHash, utxos[i].txOutputIndex)
+                )
+            );
+            self.movedFundsSweepRequests[utxoKey].state = MovingFunds.MovedFundsSweepRequestState.Processed;
+        }
+    }
+
     function setActiveWallet(bytes20 activeWalletPubKeyHash) external {
         self.activeWalletPubKeyHash = activeWalletPubKeyHash;
     }

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -46,14 +46,18 @@ contract BridgeStub is Bridge {
         }
     }
 
-    function setProcessedMovedFundsSweepRequests(BitcoinTx.UTXO[] calldata utxos) external {
+    function setProcessedMovedFundsSweepRequests(
+        BitcoinTx.UTXO[] calldata utxos
+    ) external {
         for (uint256 i = 0; i < utxos.length; i++) {
             uint256 utxoKey = uint256(
                 keccak256(
                     abi.encodePacked(utxos[i].txHash, utxos[i].txOutputIndex)
                 )
             );
-            self.movedFundsSweepRequests[utxoKey].state = MovingFunds.MovedFundsSweepRequestState.Processed;
+            self.movedFundsSweepRequests[utxoKey].state = MovingFunds
+                .MovedFundsSweepRequestState
+                .Processed;
         }
     }
 

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -559,6 +559,7 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
+                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
                     await bridge
                       .connect(thirdParty)
@@ -694,6 +695,7 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
+                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
                     await bridge
                       .connect(thirdParty)
@@ -831,6 +833,7 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
+                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
                     await bridge
                       .connect(thirdParty)
@@ -966,6 +969,7 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
+                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
                     await bridge
                       .connect(thirdParty)
@@ -1100,6 +1104,7 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
+            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
             await bridge
               .connect(thirdParty)
@@ -1150,6 +1155,7 @@ describe("Bridge - Fraud", () => {
           })
           await bridge.setSweptDeposits(data.deposits)
           await bridge.setSpentMainUtxos(data.spentMainUtxos)
+          await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
           await bridge
             .connect(thirdParty)
@@ -1199,6 +1205,7 @@ describe("Bridge - Fraud", () => {
           })
           await bridge.setSweptDeposits(data.deposits)
           await bridge.setSpentMainUtxos(data.spentMainUtxos)
+          await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
           await bridge
             .connect(thirdParty)
@@ -1569,6 +1576,7 @@ describe("Bridge - Fraud", () => {
 
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
+                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
                     await bridge
                       .connect(thirdParty)
@@ -1631,6 +1639,7 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
+            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
             await bridge
               .connect(thirdParty)
@@ -1685,6 +1694,7 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
+            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
             await bridge
               .connect(thirdParty)
@@ -1739,6 +1749,7 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
+            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
 
             await bridge
               .connect(thirdParty)

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -559,7 +559,9 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
-                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+                    await bridge.setProcessedMovedFundsSweepRequests(
+                      data.movedFundsSweepRequests
+                    )
 
                     await bridge
                       .connect(thirdParty)
@@ -695,7 +697,9 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
-                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+                    await bridge.setProcessedMovedFundsSweepRequests(
+                      data.movedFundsSweepRequests
+                    )
 
                     await bridge
                       .connect(thirdParty)
@@ -833,7 +837,9 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
-                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+                    await bridge.setProcessedMovedFundsSweepRequests(
+                      data.movedFundsSweepRequests
+                    )
 
                     await bridge
                       .connect(thirdParty)
@@ -969,7 +975,9 @@ describe("Bridge - Fraud", () => {
                     })
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
-                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+                    await bridge.setProcessedMovedFundsSweepRequests(
+                      data.movedFundsSweepRequests
+                    )
 
                     await bridge
                       .connect(thirdParty)
@@ -1104,7 +1112,9 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
-            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+            await bridge.setProcessedMovedFundsSweepRequests(
+              data.movedFundsSweepRequests
+            )
 
             await bridge
               .connect(thirdParty)
@@ -1155,7 +1165,9 @@ describe("Bridge - Fraud", () => {
           })
           await bridge.setSweptDeposits(data.deposits)
           await bridge.setSpentMainUtxos(data.spentMainUtxos)
-          await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+          await bridge.setProcessedMovedFundsSweepRequests(
+            data.movedFundsSweepRequests
+          )
 
           await bridge
             .connect(thirdParty)
@@ -1205,7 +1217,9 @@ describe("Bridge - Fraud", () => {
           })
           await bridge.setSweptDeposits(data.deposits)
           await bridge.setSpentMainUtxos(data.spentMainUtxos)
-          await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+          await bridge.setProcessedMovedFundsSweepRequests(
+            data.movedFundsSweepRequests
+          )
 
           await bridge
             .connect(thirdParty)
@@ -1576,7 +1590,9 @@ describe("Bridge - Fraud", () => {
 
                     await bridge.setSweptDeposits(data.deposits)
                     await bridge.setSpentMainUtxos(data.spentMainUtxos)
-                    await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+                    await bridge.setProcessedMovedFundsSweepRequests(
+                      data.movedFundsSweepRequests
+                    )
 
                     await bridge
                       .connect(thirdParty)
@@ -1639,7 +1655,9 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
-            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+            await bridge.setProcessedMovedFundsSweepRequests(
+              data.movedFundsSweepRequests
+            )
 
             await bridge
               .connect(thirdParty)
@@ -1694,7 +1712,9 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
-            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+            await bridge.setProcessedMovedFundsSweepRequests(
+              data.movedFundsSweepRequests
+            )
 
             await bridge
               .connect(thirdParty)
@@ -1749,7 +1769,9 @@ describe("Bridge - Fraud", () => {
             })
             await bridge.setSweptDeposits(data.deposits)
             await bridge.setSpentMainUtxos(data.spentMainUtxos)
-            await bridge.setProcessedMovedFundsSweepRequests(data.movedFundsSweepRequests)
+            await bridge.setProcessedMovedFundsSweepRequests(
+              data.movedFundsSweepRequests
+            )
 
             await bridge
               .connect(thirdParty)

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -3290,6 +3290,10 @@ describe("Bridge - Moving funds", () => {
                 before(async () => {
                   await createSnapshot()
 
+                  // We change the wallet state while preserving other fields.
+                  // We don't have an update function in the stub so we just use
+                  // the getter to get wallet fields and set them through the
+                  // setter with state field overwritten.
                   await bridge.setWallet(
                     movedFundsSweepRequest.walletPubKeyHash,
                     {

--- a/solidity/test/data/fraud.ts
+++ b/solidity/test/data/fraud.ts
@@ -4,20 +4,55 @@ import { BytesLike } from "ethers"
  * Represents a set of data used for given fraud scenario.
  */
 export interface FraudTestData {
+  /**
+   * The signature of the given sigash.
+   */
   signature: {
     v: number
     r: BytesLike
     s: BytesLike
   }
+
+  /**
+   * The preimage used to built the given sighash.
+   */
   preimage: BytesLike
+
+  /**
+   * The sighash used to create the fraud challenge.
+   */
   sighash: BytesLike
+
+  /**
+   * Determines whether the input the sighash refers to is witness or not.
+   */
   witness: boolean
+
+  /**
+   * Swept deposits that will be registered in the system during the test case
+   * execution.
+   */
   deposits: {
     txHash: BytesLike // little endian
     txOutputIndex: number
     txOutputValue: number
   }[]
+
+  /**
+   * Spent main UTXOs that will be registered in the system during the test case
+   * execution.
+   */
   spentMainUtxos: {
+    txHash: BytesLike // little endian
+    txOutputIndex: number
+    txOutputValue: number
+  }[]
+
+  /**
+   * Processed moved funds sweep requests that will be registered in the system
+   * during the test case execution.
+   */
+  movedFundsSweepRequests: {
     txHash: BytesLike // little endian
     txOutputIndex: number
     txOutputValue: number
@@ -51,7 +86,9 @@ export const nonWitnessSignSingleInputTx: FraudTestData = {
     "a90f738986f60000000001000000",
   sighash: "0x5d09cd07392c7163335b67eacc999491a3794c15b88e2b59094be5c5b157064b",
   witness: false,
-  deposits: [
+  deposits: [],
+  spentMainUtxos: [],
+  movedFundsSweepRequests: [
     {
       txHash:
         "0xfb26e52365437fc4fce01864d1303e0e1ed2824ef83345ea6e85174060778acb",
@@ -59,7 +96,6 @@ export const nonWitnessSignSingleInputTx: FraudTestData = {
       txOutputValue: 11000,
     },
   ],
-  spentMainUtxos: [],
 }
 
 // Test data comes from the input at index 5 of transaction:
@@ -93,6 +129,7 @@ export const nonWitnessSignMultipleInputsTx: FraudTestData = {
     },
   ],
   spentMainUtxos: [],
+  movedFundsSweepRequests: [],
 }
 
 // Test data comes from the (only) input of transaction:
@@ -123,6 +160,7 @@ export const witnessSignSingleInputTx: FraudTestData = {
     },
   ],
   spentMainUtxos: [],
+  movedFundsSweepRequests: [],
 }
 
 // Test data comes from the input at index 4 of transaction:
@@ -151,6 +189,7 @@ export const witnessSignMultipleInputTx: FraudTestData = {
       txOutputValue: 8400,
     },
   ],
+  movedFundsSweepRequests: [],
 }
 
 // Test data comes from the input at index 1 of transaction:
@@ -181,4 +220,5 @@ export const wrongSighashType: FraudTestData = {
     },
   ],
   spentMainUtxos: [],
+  movedFundsSweepRequests: [],
 }


### PR DESCRIPTION
Closes: #243 
Depends on: #262

Signatures that unlock main UTXOs being subject of processed moved funds sweep request can be challenged as frauds. Wallets must be able to defeat those challenges. This change adds a path to the `defeatFraudChallenge` function which makes such defeats possible.