### PR TITLE
Support vaults during deposit sweep

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -327,14 +327,14 @@ contract Bridge is Governable, EcdsaWalletOwner {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
-    /// @param vault Address of the vault where all swept deposits should
-    ///        be routed to. All deposits swept as part of the transaction
+    /// @param vault Optional address of the vault where all swept deposits
+    ///        should be routed to. All deposits swept as part of the transaction
     ///        must have their `vault` parameters set to the same address.
-    ///        If this parameter is set an address of a trusted vault, swept
+    ///        If this parameter is set to an address of a trusted vault, swept
     ///        deposits are routed to that vault.
     ///        If this parameter is set to the zero address or to an address
-    ///        of a non-trusted vault, swept deposits are not routed to any
-    ///        vault and depositors' balances are increased in the Bank
+    ///        of a non-trusted vault, swept deposits are not routed to a
+    ///        vault but depositors' balances are increased in the Bank
     ///        individually.
     /// @dev Requirements:
     ///      - `sweepTx` components must match the expected structure. See

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -327,6 +327,15 @@ contract Bridge is Governable, EcdsaWalletOwner {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
+    /// @param vault Address of the vault where all swept deposits should
+    ///        be routed to. All deposits swept as part of the transaction
+    ///        must have their `vault` parameters set to the same address.
+    ///        If this parameter is set an address of a trusted vault, swept
+    ///        deposits are routed to that vault.
+    ///        If this parameter is set to the zero address or to an address
+    ///        of a non-trusted vault, swept deposits are not routed to any
+    ///        vault and depositors' balances are increased in the Bank
+    ///        individually.
     /// @dev Requirements:
     ///      - `sweepTx` components must match the expected structure. See
     ///        `BitcoinTx.Info` docs for reference. Their values must exactly
@@ -340,6 +349,9 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///        revealed deposits UTXOs. That transaction must have only
     ///        one P2(W)PKH output locking funds on the 20-byte wallet public
     ///        key hash.
+    ///      - All revealed deposits that are swept by `sweepTx` must have
+    ///        their `vault` parameters set to the same address as the address
+    ///        passed in the `vault` function parameter.
     ///      - `sweepProof` components must match the expected structure. See
     ///        `BitcoinTx.Proof` docs for reference. The `bitcoinHeaders`
     ///        field must contain a valid number of block headers, not less
@@ -350,9 +362,10 @@ contract Bridge is Governable, EcdsaWalletOwner {
     function submitDepositSweepProof(
         BitcoinTx.Info calldata sweepTx,
         BitcoinTx.Proof calldata sweepProof,
-        BitcoinTx.UTXO calldata mainUtxo
+        BitcoinTx.UTXO calldata mainUtxo,
+        address vault
     ) external {
-        self.submitDepositSweepProof(sweepTx, sweepProof, mainUtxo);
+        self.submitDepositSweepProof(sweepTx, sweepProof, mainUtxo, vault);
     }
 
     /// @notice Requests redemption of the given amount from the specified

--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -57,7 +57,8 @@ library DepositSweep {
         BitcoinTx.UTXO mainUtxo;
         // Address of the vault where all swept deposits should be routed to.
         // It is used to validate whether all swept deposits have been revealed
-        // with the same `vault` parameter.
+        // with the same `vault` parameter. It is an optional parameter.
+        // Set to zero address if deposits are not routed to a vault.
         address vault;
     }
 
@@ -105,14 +106,14 @@ library DepositSweep {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
-    /// @param vault Address of the vault where all swept deposits should
-    ///        be routed to. All deposits swept as part of the transaction
+    /// @param vault Optional address of the vault where all swept deposits
+    ///        should be routed to. All deposits swept as part of the transaction
     ///        must have their `vault` parameters set to the same address.
-    ///        If this parameter is set an address of a trusted vault, swept
+    ///        If this parameter is set to an address of a trusted vault, swept
     ///        deposits are routed to that vault.
     ///        If this parameter is set to the zero address or to an address
-    ///        of a non-trusted vault, swept deposits are not routed to any
-    ///        vault and depositors' balances are increased in the Bank
+    ///        of a non-trusted vault, swept deposits are not routed to a
+    ///        vault but depositors' balances are increased in the Bank
     ///        individually.
     /// @dev Requirements:
     ///      - `sweepTx` components must match the expected structure. See
@@ -236,8 +237,9 @@ library DepositSweep {
                 inputsInfo.depositedAmounts
             );
         } else {
-            // If the `vault` address is zero or belongs to an non-trusted
-            // vault, increase balances in the Bank individually.
+            // If the `vault` address is zero or belongs to a non-trusted
+            // vault, increase balances in the Bank individually for each
+            // depositor.
             self.bank.increaseBalances(
                 inputsInfo.depositors,
                 inputsInfo.depositedAmounts
@@ -347,7 +349,6 @@ library DepositSweep {
     ///         if one of the inputs cannot be recognized as a pointer to a
     ///         revealed deposit or expected main UTXO.
     ///         This function also marks each processed deposit as swept.
-
     /// @return resultInfo Outcomes of the processing.
     function processDepositSweepTxInputs(
         BridgeState.Storage storage self,

--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -39,6 +39,28 @@ library DepositSweep {
 
     using BTCUtils for bytes;
 
+    /// @notice Represents temporary information needed during the processing
+    ///         of the deposit sweep Bitcoin transaction inputs. This structure
+    ///         is an internal one and should not be exported outside of the
+    ///         deposit sweep transaction processing code.
+    /// @dev Allows to mitigate "stack too deep" errors on EVM.
+    struct DepositSweepTxInputsProcessingInfo {
+        // Input vector of the deposit sweep Bitcoin transaction. It is
+        // assumed the vector's structure is valid so it must be validated
+        // using e.g. `BTCUtils.validateVin` function before being used
+        // during the processing. The validation is usually done as part
+        // of the `BitcoinTx.validateProof` call that checks the SPV proof.
+        bytes sweepTxInputVector;
+        // Data of the wallet's main UTXO. If no main UTXO exists for the given
+        // sweeping wallet, this parameter's fields should be zeroed to bypass
+        // the main UTXO validation
+        BitcoinTx.UTXO mainUtxo;
+        // Address of the vault where all swept deposits should be routed to.
+        // It is used to validate whether all swept deposits have been revealed
+        // with the same `vault` parameter.
+        address vault;
+    }
+
     /// @notice Represents an outcome of the sweep Bitcoin transaction
     ///         inputs processing.
     struct DepositSweepTxInputsInfo {
@@ -83,6 +105,15 @@ library DepositSweep {
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
     ///        the Ethereum chain. If no main UTXO exists for the given wallet,
     ///        this parameter is ignored
+    /// @param vault Address of the vault where all swept deposits should
+    ///        be routed to. All deposits swept as part of the transaction
+    ///        must have their `vault` parameters set to the same address.
+    ///        If this parameter is set an address of a trusted vault, swept
+    ///        deposits are routed to that vault.
+    ///        If this parameter is set to the zero address or to an address
+    ///        of a non-trusted vault, swept deposits are not routed to any
+    ///        vault and depositors' balances are increased in the Bank
+    ///        individually.
     /// @dev Requirements:
     ///      - `sweepTx` components must match the expected structure. See
     ///        `BitcoinTx.Info` docs for reference. Their values must exactly
@@ -96,6 +127,9 @@ library DepositSweep {
     ///        revealed deposits UTXOs. That transaction must have only
     ///        one P2(W)PKH output locking funds on the 20-byte wallet public
     ///        key hash.
+    ///      - All revealed deposits that are swept by `sweepTx` must have
+    ///        their `vault` parameters set to the same address as the address
+    ///        passed in the `vault` function parameter.
     ///      - `sweepProof` components must match the expected structure. See
     ///        `BitcoinTx.Proof` docs for reference. The `bitcoinHeaders`
     ///        field must contain a valid number of block headers, not less
@@ -107,7 +141,8 @@ library DepositSweep {
         BridgeState.Storage storage self,
         BitcoinTx.Info calldata sweepTx,
         BitcoinTx.Proof calldata sweepProof,
-        BitcoinTx.UTXO calldata mainUtxo
+        BitcoinTx.UTXO calldata mainUtxo,
+        address vault
     ) external {
         // The actual transaction proof is performed here. After that point, we
         // can assume the transaction happened on Bitcoin chain and has
@@ -132,8 +167,11 @@ library DepositSweep {
         DepositSweepTxInputsInfo
             memory inputsInfo = processDepositSweepTxInputs(
                 self,
-                sweepTx.inputVector,
-                resolvedMainUtxo
+                DepositSweepTxInputsProcessingInfo(
+                    sweepTx.inputVector,
+                    resolvedMainUtxo,
+                    vault
+                )
             );
 
         // Helper variable that will hold the sum of treasury fees paid by
@@ -189,15 +227,25 @@ library DepositSweep {
         // slither-disable-next-line reentrancy-events
         emit DepositsSwept(walletPubKeyHash, sweepTxHash);
 
-        // Update depositors balances in the Bank.
-        self.bank.increaseBalances(
-            inputsInfo.depositors,
-            inputsInfo.depositedAmounts
-        );
+        if (vault != address(0) && self.isVaultTrusted[vault]) {
+            // If the `vault` address is not zero and belongs to a trusted
+            // vault, route the deposits to that vault.
+            self.bank.increaseBalanceAndCall(
+                vault,
+                inputsInfo.depositors,
+                inputsInfo.depositedAmounts
+            );
+        } else {
+            // If the `vault` address is zero or belongs to an non-trusted
+            // vault, increase balances in the Bank individually.
+            self.bank.increaseBalances(
+                inputsInfo.depositors,
+                inputsInfo.depositedAmounts
+            );
+        }
+
         // Pass the treasury fee to the treasury address.
         self.bank.increaseBalance(self.treasury, totalTreasuryFee);
-
-        // TODO: Handle deposits having `vault` set.
     }
 
     /// @notice Resolves sweeping wallet based on the provided wallet public key
@@ -299,32 +347,24 @@ library DepositSweep {
     ///         if one of the inputs cannot be recognized as a pointer to a
     ///         revealed deposit or expected main UTXO.
     ///         This function also marks each processed deposit as swept.
-    /// @param sweepTxInputVector Bitcoin sweep transaction input vector.
-    ///        This function assumes vector's structure is valid so it must be
-    ///        validated using e.g. `BTCUtils.validateVin` function before
-    ///        it is passed here
-    /// @param mainUtxo Data of the wallet's main UTXO. If no main UTXO
-    ///        exists for the given the wallet, this parameter's fields should
-    ///        be zeroed to bypass the main UTXO validation
-    /// @return info Outcomes of the processing.
+
+    /// @return resultInfo Outcomes of the processing.
     function processDepositSweepTxInputs(
         BridgeState.Storage storage self,
-        bytes memory sweepTxInputVector,
-        BitcoinTx.UTXO memory mainUtxo
-    ) internal returns (DepositSweepTxInputsInfo memory info) {
+        DepositSweepTxInputsProcessingInfo memory processInfo
+    ) internal returns (DepositSweepTxInputsInfo memory resultInfo) {
         // If the passed `mainUtxo` parameter's values are zeroed, the main UTXO
         // for the given wallet doesn't exist and it is not expected to be
         // included in the sweep transaction input vector.
-        bool mainUtxoExpected = mainUtxo.txHash != bytes32(0);
+        bool mainUtxoExpected = processInfo.mainUtxo.txHash != bytes32(0);
         bool mainUtxoFound = false;
 
         // Determining the total number of sweep transaction inputs in the same
         // way as for number of outputs. See `BitcoinTx.inputVector` docs for
         // more details.
-        (
-            uint256 inputsCompactSizeUintLength,
-            uint256 inputsCount
-        ) = sweepTxInputVector.parseVarInt();
+        (uint256 inputsCompactSizeUintLength, uint256 inputsCount) = processInfo
+            .sweepTxInputVector
+            .parseVarInt();
 
         // To determine the first input starting index, we must jump over
         // the compactSize uint which prepends the input vector. One byte
@@ -346,11 +386,13 @@ library DepositSweep {
         // Determine the swept deposits count. If main UTXO is NOT expected,
         // all inputs should be deposits. If main UTXO is expected, one input
         // should point to that main UTXO.
-        info.depositors = new address[](
+        resultInfo.depositors = new address[](
             !mainUtxoExpected ? inputsCount : inputsCount - 1
         );
-        info.depositedAmounts = new uint256[](info.depositors.length);
-        info.treasuryFees = new uint256[](info.depositors.length);
+        resultInfo.depositedAmounts = new uint256[](
+            resultInfo.depositors.length
+        );
+        resultInfo.treasuryFees = new uint256[](resultInfo.depositors.length);
 
         // Initialize helper variables.
         uint256 processedDepositsCount = 0;
@@ -362,7 +404,7 @@ library DepositSweep {
                 uint32 outpointIndex,
                 uint256 inputLength
             ) = parseDepositSweepTxInputAt(
-                    sweepTxInputVector,
+                    processInfo.sweepTxInputVector,
                     inputStartingIndex
                 );
 
@@ -377,7 +419,12 @@ library DepositSweep {
                 // a revealed deposit.
                 require(deposit.sweptAt == 0, "Deposit already swept");
 
-                if (processedDepositsCount == info.depositors.length) {
+                require(
+                    deposit.vault == processInfo.vault,
+                    "Deposit should be routed to another vault"
+                );
+
+                if (processedDepositsCount == resultInfo.depositors.length) {
                     // If this condition is true, that means a deposit input
                     // took place of an expected main UTXO input.
                     // In other words, there is no expected main UTXO
@@ -390,22 +437,27 @@ library DepositSweep {
                 /* solhint-disable-next-line not-rely-on-time */
                 deposit.sweptAt = uint32(block.timestamp);
 
-                info.depositors[processedDepositsCount] = deposit.depositor;
-                info.depositedAmounts[processedDepositsCount] = deposit.amount;
-                info.inputsTotalValue += info.depositedAmounts[
+                resultInfo.depositors[processedDepositsCount] = deposit
+                    .depositor;
+                resultInfo.depositedAmounts[processedDepositsCount] = deposit
+                    .amount;
+                resultInfo.inputsTotalValue += resultInfo.depositedAmounts[
                     processedDepositsCount
                 ];
-                info.treasuryFees[processedDepositsCount] = deposit.treasuryFee;
+                resultInfo.treasuryFees[processedDepositsCount] = deposit
+                    .treasuryFee;
 
                 processedDepositsCount++;
             } else if (
                 mainUtxoExpected != mainUtxoFound &&
-                mainUtxo.txHash == outpointTxHash &&
-                mainUtxo.txOutputIndex == outpointIndex
+                processInfo.mainUtxo.txHash == outpointTxHash &&
+                processInfo.mainUtxo.txOutputIndex == outpointIndex
             ) {
                 // If we entered here, that means the input was identified as
                 // the expected main UTXO.
-                info.inputsTotalValue += mainUtxo.txOutputValue;
+                resultInfo.inputsTotalValue += processInfo
+                    .mainUtxo
+                    .txOutputValue;
                 mainUtxoFound = true;
 
                 // Main UTXO used as an input, mark it as spent.
@@ -426,7 +478,7 @@ library DepositSweep {
         }
 
         // Construction of the input processing loop guarantees that:
-        // `processedDepositsCount == info.depositors.length == info.depositedAmounts.length`
+        // `processedDepositsCount == resultInfo.depositors.length == resultInfo.depositedAmounts.length`
         // is always true at this point. We just use the first variable
         // to assert the total count of swept deposit is bigger than zero.
         require(
@@ -441,7 +493,7 @@ library DepositSweep {
             "Expected main UTXO not present in sweep transaction inputs"
         );
 
-        return info;
+        return resultInfo;
     }
 
     /// @notice Parses a Bitcoin transaction input starting at the given index.

--- a/solidity/test/bridge/Bridge.test.ts
+++ b/solidity/test/bridge/Bridge.test.ts
@@ -955,7 +955,8 @@ describe("Bridge", () => {
                               bridge.submitDepositSweepProof(
                                 data.sweepTx,
                                 data.sweepProof,
-                                mainUtxo
+                                mainUtxo,
+                                ethers.constants.AddressZero
                               )
                             ).to.be.revertedWith("Deposit already swept")
                           })
@@ -1006,7 +1007,8 @@ describe("Bridge", () => {
                             bridge.submitDepositSweepProof(
                               data.sweepTx,
                               data.sweepProof,
-                              NO_MAIN_UTXO
+                              NO_MAIN_UTXO,
+                              ethers.constants.AddressZero
                             )
                           ).to.be.revertedWith("Unknown input type")
                         })
@@ -1424,7 +1426,8 @@ describe("Bridge", () => {
                               bridge.submitDepositSweepProof(
                                 data.sweepTx,
                                 data.sweepProof,
-                                mainUtxo
+                                mainUtxo,
+                                ethers.constants.AddressZero
                               )
                             ).to.be.revertedWith("Deposit already swept")
                           })
@@ -1641,7 +1644,8 @@ describe("Bridge", () => {
                 bridge.submitDepositSweepProof(
                   sweepTx,
                   sweepProof,
-                  NO_MAIN_UTXO
+                  NO_MAIN_UTXO,
+                  ethers.constants.AddressZero
                 )
               ).to.be.revertedWith(
                 "Output's public key hash must have 20 bytes"
@@ -1702,7 +1706,12 @@ describe("Bridge", () => {
             }
 
             await expect(
-              bridge.submitDepositSweepProof(sweepTx, sweepProof, NO_MAIN_UTXO)
+              bridge.submitDepositSweepProof(
+                sweepTx,
+                sweepProof,
+                NO_MAIN_UTXO,
+                ethers.constants.AddressZero
+              )
             ).to.be.revertedWith("Sweep transaction must have a single output")
           })
         })
@@ -2095,7 +2104,8 @@ describe("Bridge", () => {
                 otherBridge.submitDepositSweepProof(
                   data.sweepTx,
                   data.sweepProof,
-                  data.mainUtxo
+                  data.mainUtxo,
+                  ethers.constants.AddressZero
                 )
               ).to.be.revertedWith(
                 "Insufficient accumulated difficulty in header chain"
@@ -2152,7 +2162,8 @@ describe("Bridge", () => {
           bridge.submitDepositSweepProof(
             data.sweepTx,
             data.sweepProof,
-            data.mainUtxo
+            data.mainUtxo,
+            ethers.constants.AddressZero
           )
         ).not.to.be.reverted
       })
@@ -2228,7 +2239,8 @@ describe("Bridge", () => {
               bridge.submitDepositSweepProof(
                 data.sweepTx,
                 data.sweepProof,
-                data.mainUtxo
+                data.mainUtxo,
+                ethers.constants.AddressZero
               )
             ).to.be.revertedWith("Wallet must be in Live or MovingFunds state")
           })
@@ -6176,7 +6188,8 @@ describe("Bridge", () => {
     return bridge.submitDepositSweepProof(
       data.sweepTx,
       data.sweepProof,
-      data.mainUtxo
+      data.mainUtxo,
+      ethers.constants.AddressZero
     )
   }
 

--- a/solidity/test/data/deposit-sweep.ts
+++ b/solidity/test/data/deposit-sweep.ts
@@ -34,6 +34,12 @@ export interface DepositSweepTestData {
   }[]
 
   /**
+   * Address that will be passed to the `submitDepositSweepProof` function
+   * as the `vault` parameter.
+   */
+  vault: string
+
+  /**
    * Main UTXO data which are used as `mainUtxo` parameter during
    * `submitDepositSweepProof` function call. If no main UTXO exists for given wallet,
    * `NO_MAIN_UTXO` constant should be used as value.
@@ -119,6 +125,8 @@ export const SingleP2SHDeposit: DepositSweepTestData = {
       },
     },
   ],
+
+  vault: "0x0000000000000000000000000000000000000000",
 
   mainUtxo: NO_MAIN_UTXO,
 
@@ -210,6 +218,8 @@ export const SingleP2WSHDeposit: DepositSweepTestData = {
     },
   ],
 
+  vault: "0x0000000000000000000000000000000000000000",
+
   mainUtxo: NO_MAIN_UTXO,
 
   // https://live.blockcypher.com/btc-testnet/tx/9efc9d555233e12e06378a35a7b988d54f7043b5c3156adc79c7af0a0fd6f1a0
@@ -264,6 +274,8 @@ export const SingleP2WSHDeposit: DepositSweepTestData = {
  */
 export const SingleMainUtxo: DepositSweepTestData = {
   deposits: [],
+
+  vault: "0x0000000000000000000000000000000000000000",
 
   // https://live.blockcypher.com/btc-testnet/tx/f5b9ad4e8cd5317925319ebc64dc923092bef3b56429c6b1bc2261bbdc73f351
   mainUtxo: {
@@ -458,6 +470,8 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
       },
     },
   ],
+
+  vault: "0x0000000000000000000000000000000000000000",
 
   mainUtxo: NO_MAIN_UTXO,
 
@@ -662,6 +676,8 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
     },
   ],
 
+  vault: "0x0000000000000000000000000000000000000000",
+
   // https://live.blockcypher.com/btc-testnet/tx/2a5d5f472e376dc28964e1b597b1ca5ee5ac042101b5199a3ca8dae2deec3538
   mainUtxo: {
     txHash:
@@ -742,6 +758,8 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
 export const SingleMainUtxoP2SHOutput: DepositSweepTestData = {
   // Not relevant in this test scenario.
   deposits: [],
+
+  vault: "0x0000000000000000000000000000000000000000",
 
   mainUtxo: {
     txHash:


### PR DESCRIPTION
Closes: #123 

This change adds the ability to support vault routing during deposit sweep. The routing can be done if all swept deposits point to the same trusted vault indicated by the `vault` parameter of the `submitDepositSweepFunction`. In that case, the `Bank` just increases the vault's balance by the sum of all swept deposits and the vault takes the responsibility for individual depositors' balances. If the `vault` parameter is the zero address or points to a non-trusted vault, no routing occurs and the depositor's balances are updated in the `Bank` individually.

Gas costs of `submitDepositSweepProof` before:
```
····················|··············································|·············|·············|··············|···············|··············
|  BridgeStub       ·  submitDepositSweepProof                     ·     187149  ·     341507  ·      260653  ·           15  ·          -  │
····················|··············································|·············|·············|··············|···············|··············
```
now:
```
····················|··············································|·············|·············|··············|···············|··············
|  BridgeStub       ·  submitDepositSweepProof                     ·     188082  ·     343137  ·      265778  ·           26  ·          -  │
····················|··············································|·············|·············|··············|···············|··············
```