### PR TITLE
Donation vault

### DIFF
--- a/solidity/contracts/vault/DonationVault.sol
+++ b/solidity/contracts/vault/DonationVault.sol
@@ -25,9 +25,8 @@ import "../bank/Bank.sol";
 ///         allows making donations using existing Bank balances.
 ///
 ///         BEWARE: ALL BTC DEPOSITS TARGETING THIS VAULT ARE NOT REDEEMABLE
-///         AND THERE IS NO WAY TO RESTORE THE DONATED BALANCE! DO NOT DEPOSIT
-///         AGAINST THIS VAULT OR DONATE YOUR EXISTING BANK BALANCE UNLESS YOU
-///         REALLY KNOW WHAT YOU ARE DOING!
+///         AND THERE IS NO WAY TO RESTORE THE DONATED BALANCE.
+///         USE THIS VAULT ONLY WHEN YOU REALLY KNOW WHAT YOU ARE DOING!
 contract DonationVault is IVault {
     Bank public bank;
 

--- a/solidity/contracts/vault/DonationVault.sol
+++ b/solidity/contracts/vault/DonationVault.sol
@@ -20,12 +20,14 @@ import "../bank/Bank.sol";
 
 /// @title BTC donation vault
 /// @notice Vault that allows making BTC donations to the system. Upon deposit,
-///         this vault does not increase depositors' tBTC balances and always
-///         decreases its own tBTC balance in the same transaction.
+///         this vault does not increase depositors' balances and always
+///         decreases its own balance in the same transaction. The vault also
+///         allows making donations using existing Bank balances.
 ///
-///         BEWARE: ALL BTC DEPOSITS TARGETING THIS VAULT ARE NOT REDEEMABLE AND
-///         THERE IS NO WAY TO RESTORE THE TBTC BALANCE! DO NOT DEPOSIT AGAINST
-///         THIS VAULT UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!
+///         BEWARE: ALL BTC DEPOSITS TARGETING THIS VAULT ARE NOT REDEEMABLE
+///         AND THERE IS NO WAY TO RESTORE THE DONATED BALANCE! DO NOT DEPOSIT
+///         AGAINST THIS VAULT OR DONATE YOUR EXISTING BANK BALANCE UNLESS YOU
+///         REALLY KNOW WHAT YOU ARE DOING!
 contract DonationVault is IVault {
     Bank public bank;
 
@@ -96,7 +98,7 @@ contract DonationVault is IVault {
     }
 
     /// @notice Ignores the deposited amounts and does not increase depositors'
-    ///         individual tBTC balances. Decreases its own tBTC balance
+    ///         individual balances. The vault decreases its own tBTC balance
     ///         in the Bank by the total deposited amount.
     /// @param depositors Addresses of depositors whose deposits have been swept
     /// @param depositedAmounts Amounts deposited by individual depositors and

--- a/solidity/contracts/vault/DonationVault.sol
+++ b/solidity/contracts/vault/DonationVault.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import "./IVault.sol";
+import "../bank/Bank.sol";
+
+/// @title BTC donation vault
+/// @notice Vault that allows making BTC donations to the system. Upon deposit,
+///         this vault does not increase depositors' tBTC balances and always
+///         decreases its own tBTC balance in the same transaction.
+///
+///         BEWARE: ALL BTC DEPOSITS TARGETING THIS VAULT ARE NOT REDEEMABLE AND
+///         THERE IS NO WAY TO RESTORE THE TBTC BALANCE! DO NOT DEPOSIT AGAINST
+///         THIS VAULT UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!
+contract DonationVault is IVault {
+    Bank public bank;
+
+    event DonationReceived(address[] depositors, uint256[] depositedAmounts);
+
+    modifier onlyBank() {
+        require(msg.sender == address(bank), "Caller is not the Bank");
+        _;
+    }
+
+    constructor(Bank _bank) {
+        require(
+            address(_bank) != address(0),
+            "Bank can not be the zero address"
+        );
+
+        bank = _bank;
+    }
+
+    /// @notice Function not supported by the `DonationVault`. Always reverts.
+    function receiveBalanceApproval(address, uint256)
+        external
+        override
+        onlyBank
+    {
+        revert("Donation vault cannot receive balance approval");
+    }
+
+    /// @notice Ignores the deposited amounts and does not increase depositors'
+    ///         individual tBTC balances. Decreases its own tBTC balance
+    ///         in the Bank by the total deposited amount.
+    /// @dev Requirements:
+    ///      - Can only be called by the Bank after the Bridge swept deposits
+    ///        and Bank increased balance for the vault.
+    ///      - The `depositors` array must not be empty.
+    ///      - The `depositors` array length must be equal to the
+    ///        `depositedAmounts` array length.
+    function receiveBalanceIncrease(
+        address[] calldata depositors,
+        uint256[] calldata depositedAmounts
+    ) external override onlyBank {
+        require(depositors.length != 0, "No depositors specified");
+
+        uint256 totalAmount = 0;
+        for (uint256 i = 0; i < depositors.length; i++) {
+            totalAmount += depositedAmounts[i];
+        }
+
+        emit DonationReceived(depositors, depositedAmounts);
+
+        bank.decreaseBalance(totalAmount);
+    }
+}

--- a/solidity/contracts/vault/DonationVault.sol
+++ b/solidity/contracts/vault/DonationVault.sol
@@ -30,7 +30,7 @@ import "../bank/Bank.sol";
 contract DonationVault is IVault {
     Bank public bank;
 
-    event DonationReceived(address donator, uint256 donatedAmount);
+    event DonationReceived(address donor, uint256 donatedAmount);
 
     modifier onlyBank() {
         require(msg.sender == address(bank), "Caller is not the Bank");
@@ -56,16 +56,16 @@ contract DonationVault is IVault {
     ///      - Donation Vault must have an allowance for caller's balance in
     ///        the Bank for at least `amount`.
     function donate(uint256 amount) external {
-        address donator = msg.sender;
+        address donor = msg.sender;
 
         require(
-            bank.balanceOf(donator) >= amount,
+            bank.balanceOf(donor) >= amount,
             "Amount exceeds balance in the bank"
         );
 
-        emit DonationReceived(donator, amount);
+        emit DonationReceived(donor, amount);
 
-        bank.transferBalanceFrom(donator, address(this), amount);
+        bank.transferBalanceFrom(donor, address(this), amount);
         bank.decreaseBalance(amount);
     }
 

--- a/solidity/test/vault/DonationVault.test.ts
+++ b/solidity/test/vault/DonationVault.test.ts
@@ -128,7 +128,7 @@ describe("DonationVault", () => {
         await restoreSnapshot()
       })
 
-      it("should decrease donator's balance", async () => {
+      it("should decrease donor's balance", async () => {
         expect(await bank.balanceOf(account1.address)).to.be.equal(0)
       })
 
@@ -194,7 +194,7 @@ describe("DonationVault", () => {
         await restoreSnapshot()
       })
 
-      it("should decrease donator's balance", async () => {
+      it("should decrease donor's balance", async () => {
         expect(await bank.balanceOf(account1.address)).to.be.equal(0)
       })
 

--- a/solidity/test/vault/DonationVault.test.ts
+++ b/solidity/test/vault/DonationVault.test.ts
@@ -1,0 +1,149 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { ethers, helpers, waffle } from "hardhat"
+import { expect } from "chai"
+
+import { ContractTransaction } from "ethers"
+import type {
+  Bank,
+  Bank__factory,
+  DonationVault,
+  DonationVault__factory,
+} from "../../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+const fixture = async () => {
+  const [deployer, bridge, thirdParty1, thirdParty2] = await ethers.getSigners()
+
+  const Bank = await ethers.getContractFactory<Bank__factory>("Bank")
+  const bank = await Bank.deploy()
+  await bank.deployed()
+
+  await bank.connect(deployer).updateBridge(bridge.address)
+
+  const DonationVault = await ethers.getContractFactory<DonationVault__factory>(
+    "DonationVault"
+  )
+  const vault = await DonationVault.deploy(bank.address)
+  await vault.deployed()
+
+  return {
+    bridge,
+    thirdParty1,
+    thirdParty2,
+    bank,
+    vault,
+  }
+}
+
+describe("DonationVault", () => {
+  let bridge: SignerWithAddress
+  let thirdParty1: SignerWithAddress
+  let thirdParty2: SignerWithAddress
+  let bank: Bank
+  let vault: DonationVault
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ bridge, thirdParty1, thirdParty2, bank, vault } =
+      await waffle.loadFixture(fixture))
+  })
+
+  describe("constructor", () => {
+    context("when called with a 0-address bank", () => {
+      it("should revert", async () => {
+        const DonationVault = await ethers.getContractFactory("DonationVault")
+        await expect(
+          DonationVault.deploy(ethers.constants.AddressZero)
+        ).to.be.revertedWith("Bank can not be the zero address")
+      })
+    })
+
+    context("when called with correct parameters", () => {
+      it("should set the Bank field", async () => {
+        expect(await vault.bank()).to.equal(bank.address)
+      })
+    })
+  })
+
+  describe("receiveBalanceApproval", () => {
+    context("when called not by the bank", () => {
+      it("should revert", async () => {
+        await expect(
+          vault
+            .connect(bridge)
+            .receiveBalanceApproval(thirdParty1.address, 1000)
+        ).to.be.revertedWith("Caller is not the Bank")
+      })
+    })
+
+    context("when called by the bank", () => {
+      it("should revert", async () => {
+        await expect(
+          bank.connect(thirdParty1).approveBalanceAndCall(vault.address, 1000)
+        ).to.be.revertedWith("Donation vault cannot receive balance approval")
+      })
+    })
+  })
+
+  describe("receiveBalanceIncrease", () => {
+    context("when called not by the bank", () => {
+      it("should revert", async () => {
+        await expect(
+          vault
+            .connect(bridge)
+            .receiveBalanceIncrease([thirdParty1.address], [1000])
+        ).to.be.revertedWith("Caller is not the Bank")
+      })
+    })
+
+    context("when called with no depositors", () => {
+      it("should revert", async () => {
+        await expect(
+          bank.connect(bridge).increaseBalanceAndCall(vault.address, [], [])
+        ).to.be.revertedWith("No depositors specified")
+      })
+    })
+
+    context("when called with correct parameters", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await bank
+          .connect(bridge)
+          .increaseBalanceAndCall(
+            vault.address,
+            [thirdParty1.address, thirdParty2.address],
+            [1000, 2000]
+          )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not increase depositors' balances", async () => {
+        expect(await bank.balanceOf(thirdParty1.address)).to.be.equal(0)
+        expect(await bank.balanceOf(thirdParty2.address)).to.be.equal(0)
+      })
+
+      it("should not increase vault's balance", async () => {
+        expect(await bank.balanceOf(vault.address)).to.be.equal(0)
+      })
+
+      it("should emit BalanceDecreased event", async () => {
+        await expect(tx)
+          .to.emit(bank, "BalanceDecreased")
+          .withArgs(vault.address, 3000)
+      })
+
+      it("should emit DonationReceived event", async () => {
+        await expect(tx)
+          .to.emit(vault, "DonationReceived")
+          .withArgs([thirdParty1.address, thirdParty2.address], [1000, 2000])
+      })
+    })
+  })
+})

--- a/solidity/test/vault/DonationVault.test.ts
+++ b/solidity/test/vault/DonationVault.test.ts
@@ -116,10 +116,10 @@ describe("DonationVault", () => {
       before(async () => {
         await createSnapshot()
 
-        await bank.connect(bridge).increaseBalance(account1.address, 1000)
+        await bank.connect(bridge).increaseBalance(account1.address, 1100)
         await bank
           .connect(account1)
-          .increaseBalanceAllowance(vault.address, 1000)
+          .increaseBalanceAllowance(vault.address, 1100)
 
         tx = await vault.connect(account1).donate(1000)
       })
@@ -129,7 +129,7 @@ describe("DonationVault", () => {
       })
 
       it("should decrease donor's balance", async () => {
-        expect(await bank.balanceOf(account1.address)).to.be.equal(0)
+        expect(await bank.balanceOf(account1.address)).to.be.equal(100)
       })
 
       it("should not increase vault's balance", async () => {
@@ -183,7 +183,7 @@ describe("DonationVault", () => {
       before(async () => {
         await createSnapshot()
 
-        await bank.connect(bridge).increaseBalance(account1.address, 1000)
+        await bank.connect(bridge).increaseBalance(account1.address, 1100)
 
         tx = await bank
           .connect(account1)
@@ -195,7 +195,7 @@ describe("DonationVault", () => {
       })
 
       it("should decrease donor's balance", async () => {
-        expect(await bank.balanceOf(account1.address)).to.be.equal(0)
+        expect(await bank.balanceOf(account1.address)).to.be.equal(100)
       })
 
       it("should not increase vault's balance", async () => {


### PR DESCRIPTION
Closes: #237 

BTC donations are needed to re-balance the system in some rare cases when the BTC:tBTC peg can be breached. This change introduces a new `DonationVault` that is meant to handle BTC donations. That vault is plugged-in into the deposit flow. An external actor willing to make a BTC donation just makes a regular deposit targeting the `DonationVault`. Once that deposit is swept by the target wallet, the depositor's tBTC balance is not increased in the Bank, and the deposit is routed to the `DonationVault` which ignores it as well. In effect, deposited BTC remains swept by the wallet but no tBTC-related side effects take place.