### PR TITLE
Defeat against fraud challenge with a heartbeat sighash

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -918,7 +918,7 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///         deposited by the challenger is sent to the treasury.
     /// @param walletPublicKey The public key of the wallet in the uncompressed
     ///        and unprefixed format (64 bytes)
-    /// @param heartbeatMessage Off-chain heartbeat message meeting the hearteat
+    /// @param heartbeatMessage Off-chain heartbeat message meeting the heartbeat
     ///        message format requirements which produces sighash used to
     ///        generate the ECDSA signature that is the subject of the fraud
     ///        claim

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -844,8 +844,8 @@ contract Bridge is Governable, EcdsaWalletOwner {
     ///         to protocol rules. To prevent spurious allegations, the caller
     ///         must deposit ETH that is returned back upon justified fraud
     ///         challenge or confiscated otherwise.
-    ///@param walletPublicKey The public key of the wallet in the uncompressed
-    ///       and unprefixed format (64 bytes)
+    /// @param walletPublicKey The public key of the wallet in the uncompressed
+    ///        and unprefixed format (64 bytes)
     /// @param sighash The hash that was used to produce the ECDSA signature
     ///        that is the subject of the fraud claim. This hash is constructed
     ///        by applying double SHA-256 over a serialized subset of the
@@ -903,6 +903,38 @@ contract Bridge is Governable, EcdsaWalletOwner {
         bool witness
     ) external {
         self.defeatFraudChallenge(walletPublicKey, preimage, witness);
+    }
+
+    /// @notice Allows to defeat a pending fraud challenge against a wallet by
+    ///         proving the sighash and signature were produced for an off-chain
+    ///         wallet heartbeat message following a strict format.
+    ///         In order to defeat the challenge the same `walletPublicKey` and
+    ///         signature (represented by `r`, `s` and `v`) must be provided as
+    ///         were used to calculate the sighash during heartbeat message
+    ///         signing. The fraud challenge defeat attempt will only succeed if
+    ///         the signed message follows a strict format required for
+    ///         heartbeat messages. If successfully defeated, the fraud
+    ///         challenge is marked as resolved and the amount of ether
+    ///         deposited by the challenger is sent to the treasury.
+    /// @param walletPublicKey The public key of the wallet in the uncompressed
+    ///        and unprefixed format (64 bytes)
+    /// @param heartbeatMessage Off-chain heartbeat message meeting the hearteat
+    ///        message format requirements which produces sighash used to
+    ///        generate the ECDSA signature that is the subject of the fraud
+    ///        claim
+    /// @dev Requirements:
+    ///      - `walletPublicKey` and `sighash` calculated as
+    ///        `hash256(heartbeatMessage)` must identify an open fraud challenge
+    ///      - `heartbeatMessage` must follow a strict format of heartbeat
+    ///        messages
+    function defeatFraudChallengeWithHeartbeat(
+        bytes calldata walletPublicKey,
+        bytes calldata heartbeatMessage
+    ) external {
+        self.defeatFraudChallengeWithHeartbeat(
+            walletPublicKey,
+            heartbeatMessage
+        );
     }
 
     /// @notice Notifies about defeat timeout for the given fraud challenge.

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -263,7 +263,7 @@ library Fraud {
     ///         deposited by the challenger is sent to the treasury.
     /// @param walletPublicKey The public key of the wallet in the uncompressed
     ///        and unprefixed format (64 bytes)
-    /// @param heartbeatMessage Off-chain heartbeat message meeting the hearteat
+    /// @param heartbeatMessage Off-chain heartbeat message meeting the heartbeat
     ///        message format requirements which produces sighash used to
     ///        generate the ECDSA signature that is the subject of the fraud
     ///        claim

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -22,6 +22,7 @@ import {CheckBitcoinSigs} from "@keep-network/bitcoin-spv-sol/contracts/CheckBit
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./BridgeState.sol";
+import "./Heartbeat.sol";
 import "./MovingFunds.sol";
 import "./Wallets.sol";
 
@@ -38,10 +39,18 @@ import "./Wallets.sol";
 ///      signature must be provided as were used to calculate the sighash during
 ///      the challenge. The wallet provides the preimage which produces sighash
 ///      used to generate the ECDSA signature that is the subject of the fraud
-///      claim. The fraud challenge defeat attempt will only succeed if the
-///      inputs in the preimage are considered honestly spent by the wallet.
-///      Therefore the transaction spending the UTXO must be proven in the
-///      Bridge before a challenge defeat is called.
+///      claim.
+///
+///      The fraud challenge defeat attempt will succeed if the inputs in the
+///      preimage are considered honestly spent by the wallet. Therefore the
+///      transaction spending the UTXO must be proven in the Bridge before
+///      a challenge defeat is called.
+///
+///      Another option is when a malicious wallet member used a signed heartbeat
+///      message periodically produced by the wallet off-chain to challenge the
+///      wallet for a fraud. Anyone from the wallet can defeat the challenge by
+///      proving the sighash and signature were produced for a heartbeat message
+///      following a strict format.
 library Fraud {
     using Wallets for BridgeState.Storage;
 
@@ -73,6 +82,10 @@ library Fraud {
 
     event FraudChallengeDefeatTimedOut(
         bytes20 walletPubKeyHash,
+        // Sighash calculated as a Bitcoin's hash256 (double sha2) of:
+        // - a preimage of a transaction spending UTXO according to the protocol
+        //   rules OR
+        // - a valid heartbeat message produced by the wallet off-chain.
         bytes32 sighash
     );
 
@@ -234,6 +247,69 @@ library Fraud {
             "Spent UTXO not found among correctly spent UTXOs"
         );
 
+        resolveFraudChallenge(self, walletPublicKey, challenge, sighash);
+    }
+
+    /// @notice Allows to defeat a pending fraud challenge against a wallet by
+    ///         proving the sighash and signature were produced for an off-chain
+    ///         wallet heartbeat message following a strict format.
+    ///         In order to defeat the challenge the same `walletPublicKey` and
+    ///         signature (represented by `r`, `s` and `v`) must be provided as
+    ///         were used to calculate the sighash during heartbeat message
+    ///         signing. The fraud challenge defeat attempt will only succeed if
+    ///         the signed message follows a strict format required for
+    ///         heartbeat messages. If successfully defeated, the fraud
+    ///         challenge is marked as resolved and the amount of ether
+    ///         deposited by the challenger is sent to the treasury.
+    /// @param walletPublicKey The public key of the wallet in the uncompressed
+    ///        and unprefixed format (64 bytes)
+    /// @param heartbeatMessage Off-chain heartbeat message meeting the hearteat
+    ///        message format requirements which produces sighash used to
+    ///        generate the ECDSA signature that is the subject of the fraud
+    ///        claim
+    /// @dev Requirements:
+    ///      - `walletPublicKey` and `sighash` calculated as
+    ///        `hash256(heartbeatMessage)` must identify an open fraud challenge
+    ///      - `heartbeatMessage` must follow a strict format of heartbeat
+    ///        messages
+    function defeatFraudChallengeWithHeartbeat(
+        BridgeState.Storage storage self,
+        bytes calldata walletPublicKey,
+        bytes calldata heartbeatMessage
+    ) external {
+        bytes32 sighash = heartbeatMessage.hash256();
+
+        uint256 challengeKey = uint256(
+            keccak256(abi.encodePacked(walletPublicKey, sighash))
+        );
+
+        FraudChallenge storage challenge = self.fraudChallenges[challengeKey];
+
+        require(challenge.reportedAt > 0, "Fraud challenge does not exist");
+        require(
+            !challenge.resolved,
+            "Fraud challenge has already been resolved"
+        );
+
+        require(
+            Heartbeat.isValidHeartbeatMessage(heartbeatMessage),
+            "Not a valid heartbeat message"
+        );
+
+        resolveFraudChallenge(self, walletPublicKey, challenge, sighash);
+    }
+
+    /// @notice Called only for successfully defeated fraud challenges.
+    ///         The fraud challenge is marked as resolved and the amount of
+    ///         ether deposited by the challenger is sent to the treasury.
+    /// @dev Requirements:
+    ///      - Must be called only for successfully defeated fraud challenges.
+    function resolveFraudChallenge(
+        BridgeState.Storage storage self,
+        bytes calldata walletPublicKey,
+        FraudChallenge storage challenge,
+        bytes32 sighash
+    ) internal {
         // Mark the challenge as resolved as it was successfully defeated
         challenge.resolved = true;
 
@@ -248,6 +324,7 @@ library Fraud {
             walletPublicKey.slice32(32)
         );
         bytes20 walletPubKeyHash = compressedWalletPublicKey.hash160View();
+
         // slither-disable-next-line reentrancy-events
         emit FraudChallengeDefeated(walletPubKeyHash, sighash);
     }

--- a/solidity/contracts/bridge/Heartbeat.sol
+++ b/solidity/contracts/bridge/Heartbeat.sol
@@ -80,7 +80,7 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 ///      example, the last Ethereum block hash).
 ///
 ///      The message being signed by the wallet when executing the heartbeat
-///      protocol should be Bitcoin's hash256 (double sha2) of the heartbeat
+///      protocol should be Bitcoin's hash256 (double SHA-256) of the heartbeat
 ///      message:
 ///        heartbeat_sighash = hash256(heartbeat_message)
 library Heartbeat {

--- a/solidity/contracts/bridge/Heartbeat.sol
+++ b/solidity/contracts/bridge/Heartbeat.sol
@@ -78,6 +78,11 @@ import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 ///      message. The first 8 bytes are 0xffffffffffffffff. The last 8 bytes
 ///      are for an arbitrary uint64, being a signed heartbeat nonce (for
 ///      example, the last Ethereum block hash).
+///
+///      The message being signed by the wallet when executing the heartbeat
+///      protocol should be Bitcoin's hash256 (double sha2) of the heartbeat
+///      message:
+///        heartbeat_sighash = hash256(heartbeat_message)
 library Heartbeat {
     using BytesLib for bytes;
 

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -871,9 +871,7 @@ describe("Bank", () => {
         )
       )
 
-      return ethers.utils.splitSignature(
-        await signingKey.signDigest(approvalDigest)
-      )
+      return ethers.utils.splitSignature(signingKey.signDigest(approvalDigest))
     }
 
     context("when permission expired", () => {

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -811,7 +811,7 @@ describe("Bank", () => {
     before(async () => {
       await createSnapshot()
 
-      owner = await ethers.Wallet.createRandom()
+      owner = ethers.Wallet.createRandom()
       await bank.connect(bridge).increaseBalance(owner.address, initialBalance)
 
       const accounts = await getUnnamedAccounts()

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -548,7 +548,7 @@ describe("Bridge - Fraud", () => {
       // message changes or in case we want to add more unit tests, we can simply
       // call appropriate function to compute another signature. Also, we do not
       // use any BTC-specific data for this set of unit tests.
-      const wallet = await ethers.Wallet.createRandom()
+      const wallet = ethers.Wallet.createRandom()
       // We use `ethers.utils.SigningKey` for a `Wallet` instead of
       // `Signer.signMessage` to do not add '\x19Ethereum Signed Message:\n'
       // prefix to the signed message. The format of the heartbeat message is

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -587,7 +587,7 @@ describe("Bridge - Fraud", () => {
             await createSnapshot()
 
             const signature = ethers.utils.splitSignature(
-              await heartbeatWalletSigningKey.signDigest(sighash)
+              heartbeatWalletSigningKey.signDigest(sighash)
             )
 
             await bridge
@@ -648,7 +648,7 @@ describe("Bridge - Fraud", () => {
             await createSnapshot()
 
             const signature = ethers.utils.splitSignature(
-              await heartbeatWalletSigningKey.signDigest(sighash)
+              heartbeatWalletSigningKey.signDigest(sighash)
             )
 
             await bridge
@@ -688,7 +688,7 @@ describe("Bridge - Fraud", () => {
           await createSnapshot()
 
           const signature = ethers.utils.splitSignature(
-            await heartbeatWalletSigningKey.signDigest(sighash)
+            heartbeatWalletSigningKey.signDigest(sighash)
           )
 
           await bridge
@@ -734,7 +734,7 @@ describe("Bridge - Fraud", () => {
           await createSnapshot()
 
           const signature = ethers.utils.splitSignature(
-            await heartbeatWalletSigningKey.signDigest(sighash)
+            heartbeatWalletSigningKey.signDigest(sighash)
           )
 
           await bridge
@@ -784,7 +784,7 @@ describe("Bridge - Fraud", () => {
         await createSnapshot()
 
         const signature = ethers.utils.splitSignature(
-          await heartbeatWalletSigningKey.signDigest(sighash)
+          heartbeatWalletSigningKey.signDigest(sighash)
         )
 
         await bridge

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -3,6 +3,7 @@
 
 import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { SigningKey } from "ethers/lib/utils"
 import chai, { expect } from "chai"
 import { BigNumber, ContractTransaction } from "ethers"
 import { BytesLike } from "@ethersproject/bytes"
@@ -532,9 +533,9 @@ describe("Bridge - Fraud", () => {
   })
 
   describe("defeatFraudChallengeWithHeartbeat", () => {
-    let heartbeatWalletPublicKey
-    let heartbeatWalletPublicKeyHash
-    let heartbeatWalletSigningKey
+    let heartbeatWalletPublicKey: string
+    let heartbeatWalletPublicKeyHash: string
+    let heartbeatWalletSigningKey: SigningKey
 
     before(async () => {
       await createSnapshot()

--- a/solidity/test/bridge/Bridge.Frauds.test.ts
+++ b/solidity/test/bridge/Bridge.Frauds.test.ts
@@ -25,6 +25,7 @@ chai.use(smock.matchers)
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 const { lastBlockTime, increaseTime } = helpers.time
+const { keccak256, sha256 } = ethers.utils
 
 describe("Bridge - Fraud", () => {
   let thirdParty: SignerWithAddress
@@ -528,6 +529,283 @@ describe("Bridge - Fraud", () => {
         })
       }
     )
+  })
+
+  describe("defeatFraudChallengeWithHeartbeat", () => {
+    let heartbeatWalletPublicKey
+    let heartbeatWalletPublicKeyHash
+    let heartbeatWalletSigningKey
+
+    before(async () => {
+      await createSnapshot()
+
+      // For `defeatFraudChallengeWithHeartbeat` unit tests we do not use test
+      // data from `fraud.ts`. Instead, we create random wallet and use its
+      // SigningKey.
+      //
+      // This approach is better long-term. In case the format of the heartbeat
+      // message changes or in case we want to add more unit tests, we can simply
+      // call appropriate function to compute another signature. Also, we do not
+      // use any BTC-specific data for this set of unit tests.
+      const wallet = await ethers.Wallet.createRandom()
+      // We use `ethers.utils.SigningKey` for a `Wallet` instead of
+      // `Signer.signMessage` to do not add '\x19Ethereum Signed Message:\n'
+      // prefix to the signed message. The format of the heartbeat message is
+      // the same no matter on which host chain TBTC is deployed.
+      heartbeatWalletSigningKey = new ethers.utils.SigningKey(wallet.privateKey)
+      // Public key obtained as `wallet.publicKey` is an uncompressed key,
+      // prefixed with `0x04`. To compute raw ECDSA key, we need to drop `0x04`.
+      heartbeatWalletPublicKey = `0x${wallet.publicKey.substring(4)}`
+
+      const walletID = keccak256(heartbeatWalletPublicKey)
+      const walletPublicKeyX = `0x${heartbeatWalletPublicKey.substring(2, 66)}`
+      const walletPublicKeyY = `0x${heartbeatWalletPublicKey.substring(66)}`
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          walletID,
+          walletPublicKeyX,
+          walletPublicKeyY
+        )
+      heartbeatWalletPublicKeyHash = await bridge.activeWalletPubKeyHash()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when the challenge exists", () => {
+      context("when the challenge is open", () => {
+        context("when the heartbeat message has correct format", () => {
+          const heartbeatMessage = "0xFFFFFFFFFFFFFFFF0000000000E0EED7"
+          const sighash = sha256(sha256(heartbeatMessage))
+
+          let tx: ContractTransaction
+
+          before(async () => {
+            await createSnapshot()
+
+            const signature = ethers.utils.splitSignature(
+              await heartbeatWalletSigningKey.signDigest(sighash)
+            )
+
+            await bridge
+              .connect(thirdParty)
+              .submitFraudChallenge(
+                heartbeatWalletPublicKey,
+                sighash,
+                signature,
+                {
+                  value: fraudChallengeDepositAmount,
+                }
+              )
+
+            tx = await bridge
+              .connect(thirdParty)
+              .defeatFraudChallengeWithHeartbeat(
+                heartbeatWalletPublicKey,
+                heartbeatMessage
+              )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should mark the challenge as resolved", async () => {
+            const challengeKey = buildChallengeKey(
+              heartbeatWalletPublicKey,
+              sighash
+            )
+            const fraudChallenge = await bridge.fraudChallenges(challengeKey)
+            expect(fraudChallenge.resolved).to.equal(true)
+          })
+
+          it("should send the ether deposited by the challenger to the treasury", async () => {
+            await expect(tx).to.changeEtherBalance(
+              bridge,
+              fraudChallengeDepositAmount.mul(-1)
+            )
+            await expect(tx).to.changeEtherBalance(
+              treasury,
+              fraudChallengeDepositAmount
+            )
+          })
+
+          it("should emit FraudChallengeDefeated event", async () => {
+            await expect(tx)
+              .to.emit(bridge, "FraudChallengeDefeated")
+              .withArgs(heartbeatWalletPublicKeyHash, sighash)
+          })
+        })
+
+        context("when the heartbeat message has no correct format", () => {
+          const notHeartbeatMessage = "0xAAFFFFFFFFFFFFFF0000000000E0EED7"
+          const sighash = sha256(sha256(notHeartbeatMessage))
+
+          before(async () => {
+            await createSnapshot()
+
+            const signature = ethers.utils.splitSignature(
+              await heartbeatWalletSigningKey.signDigest(sighash)
+            )
+
+            await bridge
+              .connect(thirdParty)
+              .submitFraudChallenge(
+                heartbeatWalletPublicKey,
+                sighash,
+                signature,
+                {
+                  value: fraudChallengeDepositAmount,
+                }
+              )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(thirdParty)
+                .defeatFraudChallengeWithHeartbeat(
+                  heartbeatWalletPublicKey,
+                  notHeartbeatMessage
+                )
+            ).to.be.revertedWith("Not a valid heartbeat message")
+          })
+        })
+      })
+
+      context("when the challenge is resolved by defeat", () => {
+        const heartbeatMessage = "0xFFFFFFFFFFFFFFFF0000000000E0EED7"
+        const sighash = sha256(sha256(heartbeatMessage))
+
+        before(async () => {
+          await createSnapshot()
+
+          const signature = ethers.utils.splitSignature(
+            await heartbeatWalletSigningKey.signDigest(sighash)
+          )
+
+          await bridge
+            .connect(thirdParty)
+            .submitFraudChallenge(
+              heartbeatWalletPublicKey,
+              sighash,
+              signature,
+              {
+                value: fraudChallengeDepositAmount,
+              }
+            )
+
+          await bridge
+            .connect(thirdParty)
+            .defeatFraudChallengeWithHeartbeat(
+              heartbeatWalletPublicKey,
+              heartbeatMessage
+            )
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(thirdParty)
+              .defeatFraudChallengeWithHeartbeat(
+                heartbeatWalletPublicKey,
+                heartbeatMessage
+              )
+          ).to.be.revertedWith("Fraud challenge has already been resolved")
+        })
+      })
+
+      context("when the challenge is resolved by timeout", () => {
+        const heartbeatMessage = "0xFFFFFFFFFFFFFFFF0000000000E0EED7"
+        const sighash = sha256(sha256(heartbeatMessage))
+
+        before(async () => {
+          await createSnapshot()
+
+          const signature = ethers.utils.splitSignature(
+            await heartbeatWalletSigningKey.signDigest(sighash)
+          )
+
+          await bridge
+            .connect(thirdParty)
+            .submitFraudChallenge(
+              heartbeatWalletPublicKey,
+              sighash,
+              signature,
+              {
+                value: fraudChallengeDepositAmount,
+              }
+            )
+
+          await increaseTime(fraudChallengeDefeatTimeout)
+
+          await bridge
+            .connect(thirdParty)
+            .notifyFraudChallengeDefeatTimeout(
+              heartbeatWalletPublicKey,
+              [],
+              sighash
+            )
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(thirdParty)
+              .defeatFraudChallengeWithHeartbeat(
+                heartbeatWalletPublicKey,
+                heartbeatMessage
+              )
+          ).to.be.revertedWith("Fraud challenge has already been resolved")
+        })
+      })
+    })
+
+    context("when the challenge does not exist", () => {
+      const heartbeatMessage = "0xFFFFFFFFFFFFFFFF0000000000E0EED7"
+      const sighash = sha256(sha256(heartbeatMessage))
+
+      before(async () => {
+        await createSnapshot()
+
+        const signature = ethers.utils.splitSignature(
+          await heartbeatWalletSigningKey.signDigest(sighash)
+        )
+
+        await bridge
+          .connect(thirdParty)
+          .submitFraudChallenge(heartbeatWalletPublicKey, sighash, signature, {
+            value: fraudChallengeDepositAmount,
+          })
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          bridge.connect(thirdParty).defeatFraudChallengeWithHeartbeat(
+            heartbeatWalletPublicKey,
+            "0xFFFFFFFFFFFFFFFF0000000000E0EED8" // ...D7 -> ...D8
+          )
+        ).to.be.revertedWith("Fraud challenge does not exist")
+      })
+    })
   })
 
   describe("defeatFraudChallenge", () => {


### PR DESCRIPTION
~~Depends on #263. Keeping as a draft until #263 is not merged.~~
Refs https://github.com/keep-network/tbtc-v2/issues/254

Malicious wallet member can accuse wallet for a fraud using off-chain
heartbeat message signed by wallet members periodically.
`defeatFraudChallengeWithHearbeat` function allows wallet members to
defeat such challenge.

`defeatFraudChallengeWithHeartbeat` function added to `Fraud` library
allows to defeat a pending fraud challenge against a wallet by proving the
sighash and signature were produced for an off-chain wallet heartbeat message
following a strict format. In order to defeat the challenge the same
`walletPublicKey` and signature (represented by `r`, `s` and `v`) must be
provided as were used to calculate the sighash during heartbeat message
signing. The fraud challenge defeat attempt will only succeed if the signed
message follows a strict format required for heartbeat messages. If successfully
defeated, the fraud challenge is marked as resolved and the amount of ether
deposited by the challenger is sent to the treasury.