### PR TITLE
Reset moving funds timeout

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -112,6 +112,8 @@ contract Bridge is Governable, EcdsaWalletOwner {
         address submitter
     );
 
+    event MovingFundsTimeoutReset(bytes20 walletPubKeyHash);
+
     event MovingFundsCompleted(
         bytes20 walletPubKeyHash,
         bytes32 movingFundsTxHash
@@ -570,6 +572,19 @@ contract Bridge is Governable, EcdsaWalletOwner {
             walletMemberIndex,
             targetWallets
         );
+    }
+
+    /// @notice Resets the moving funds timeout for the given wallet if the
+    ///         target wallet commitment cannot be submitted due to a lack
+    ///         of live wallets in the system.
+    /// @param walletPubKeyHash 20-byte public key hash of the moving funds wallet
+    /// @dev Requirements:
+    ///      - The wallet must be in the MovingFunds state
+    ///      - The target wallets commitment must not be already submitted for
+    ///        the given moving funds wallet
+    ///      - Live wallets count must be zero
+    function resetMovingFundsTimeout(bytes20 walletPubKeyHash) external {
+        self.resetMovingFundsTimeout(walletPubKeyHash);
     }
 
     /// @notice Used by the wallet to prove the BTC moving funds transaction

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -93,6 +93,8 @@ library MovingFunds {
         address submitter
     );
 
+    event MovingFundsTimeoutReset(bytes20 walletPubKeyHash);
+
     event MovingFundsCompleted(
         bytes20 walletPubKeyHash,
         bytes32 movingFundsTxHash
@@ -206,10 +208,8 @@ library MovingFunds {
 
         // This requirement fails only when `liveWalletsCount` is zero. In
         // that case, the system cannot accept the commitment and must provide
-        // new wallets first.
-        //
-        // TODO: Expose separate function to reset the moving funds timeout
-        //       if no Live wallets exist in the system.
+        // new wallets first. However, the wallet supposed to submit the
+        // commitment can keep resetting the moving funds timeout until then.
         require(expectedTargetWalletsCount > 0, "No target wallets available");
 
         require(
@@ -250,6 +250,44 @@ library MovingFunds {
             targetWallets,
             msg.sender
         );
+    }
+
+    /// @notice Resets the moving funds timeout for the given wallet if the
+    ///         target wallet commitment cannot be submitted due to a lack
+    ///         of live wallets in the system.
+    /// @param walletPubKeyHash 20-byte public key hash of the moving funds wallet
+    /// @dev Requirements:
+    ///      - The wallet must be in the MovingFunds state
+    ///      - The target wallets commitment must not be already submitted for
+    ///        the given moving funds wallet
+    ///      - Live wallets count must be zero
+    function resetMovingFundsTimeout(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) external {
+        Wallets.Wallet storage wallet = self.registeredWallets[
+            walletPubKeyHash
+        ];
+
+        require(
+            wallet.state == Wallets.WalletState.MovingFunds,
+            "ECDSA wallet must be in MovingFunds state"
+        );
+
+        // If the moving funds wallet already submitted their target wallets
+        // commitment, there is no point to reset the timeout since the
+        // wallet can make the BTC transaction and submit the proof.
+        require(
+            wallet.movingFundsTargetWalletsCommitmentHash == bytes32(0),
+            "Target wallets commitment already submitted"
+        );
+
+        require(self.liveWalletsCount == 0, "Live wallets count must be zero");
+
+        /* solhint-disable-next-line not-rely-on-time */
+        wallet.movingFundsRequestedAt = uint32(block.timestamp);
+
+        emit MovingFundsTimeoutReset(walletPubKeyHash);
     }
 
     /// @notice Used by the wallet to prove the BTC moving funds transaction


### PR DESCRIPTION
Closes: #252 

This pull request introduces the `resetMovingFundsTimeout` function that allows resetting the moving funds timeout for a given wallet that has not yet submitted its commitment due to a lack of `Live` wallets in the system. This way, the moving funds wallet can avoid the punishment due to the system-caused timeout violation.