### PR TITLE
Indexed fields of Bridge events

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -79,7 +79,7 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
         address depositor,
         uint64 amount,
         bytes8 blindingFactor,
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes20 refundPubKeyHash,
         bytes4 refundLocktime,
         address vault
@@ -88,7 +88,7 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     event DepositsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
 
     event RedemptionRequested(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript,
         address redeemer,
         uint64 requestedAmount,
@@ -97,12 +97,12 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     );
 
     event RedemptionsCompleted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 redemptionTxHash
     );
 
     event RedemptionTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript
     );
 
@@ -112,26 +112,29 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     );
 
     event MovingFundsCommitmentSubmitted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes20[] targetWallets,
         address submitter
     );
 
-    event MovingFundsTimeoutReset(bytes20 walletPubKeyHash);
+    event MovingFundsTimeoutReset(bytes20 indexed walletPubKeyHash);
 
     event MovingFundsCompleted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 movingFundsTxHash
     );
 
-    event MovingFundsTimedOut(bytes20 walletPubKeyHash);
+    event MovingFundsTimedOut(bytes20 indexed walletPubKeyHash);
 
-    event MovingFundsBelowDustReported(bytes20 walletPubKeyHash);
+    event MovingFundsBelowDustReported(bytes20 indexed walletPubKeyHash);
 
-    event MovedFundsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
+    event MovedFundsSwept(
+        bytes20 indexed walletPubKeyHash,
+        bytes32 sweepTxHash
+    );
 
     event MovedFundsSweepTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 movingFundsTxHash,
         uint32 movingFundsTxOutputIndex
     );
@@ -159,17 +162,20 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     );
 
     event FraudChallengeSubmitted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 sighash,
         uint8 v,
         bytes32 r,
         bytes32 s
     );
 
-    event FraudChallengeDefeated(bytes20 walletPubKeyHash, bytes32 sighash);
+    event FraudChallengeDefeated(
+        bytes20 indexed walletPubKeyHash,
+        bytes32 sighash
+    );
 
     event FraudChallengeDefeatTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 sighash
     );
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -59,7 +59,6 @@ import "../bank/Bank.sol";
 ///      functionalities in this contract is: deposit, sweep, redemption,
 ///      moving funds, wallet lifecycle, frauds, parameters.
 ///
-/// TODO: Revisit all events and look which parameters should be indexed.
 /// TODO: Align the convention around `param` and `dev` endings. They should
 ///       not have a punctuation mark.
 contract Bridge is Governable, EcdsaWalletOwner, Initializable {
@@ -76,7 +75,7 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     event DepositRevealed(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex,
-        address depositor,
+        address indexed depositor,
         uint64 amount,
         bytes8 blindingFactor,
         bytes20 indexed walletPubKeyHash,
@@ -90,7 +89,7 @@ contract Bridge is Governable, EcdsaWalletOwner, Initializable {
     event RedemptionRequested(
         bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript,
-        address redeemer,
+        address indexed redeemer,
         uint64 requestedAmount,
         uint64 treasuryFee,
         uint64 txMaxFee

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -103,7 +103,7 @@ library Deposit {
     event DepositRevealed(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex,
-        address depositor,
+        address indexed depositor,
         uint64 amount,
         bytes8 blindingFactor,
         bytes20 indexed walletPubKeyHash,

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -106,7 +106,7 @@ library Deposit {
         address depositor,
         uint64 amount,
         bytes8 blindingFactor,
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes20 refundPubKeyHash,
         bytes4 refundLocktime,
         address vault

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -74,17 +74,20 @@ library Fraud {
     }
 
     event FraudChallengeSubmitted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 sighash,
         uint8 v,
         bytes32 r,
         bytes32 s
     );
 
-    event FraudChallengeDefeated(bytes20 walletPubKeyHash, bytes32 sighash);
+    event FraudChallengeDefeated(
+        bytes20 indexed walletPubKeyHash,
+        bytes32 sighash
+    );
 
     event FraudChallengeDefeatTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         // Sighash calculated as a Bitcoin's hash256 (double sha2) of:
         // - a preimage of a transaction spending UTXO according to the protocol
         //   rules OR

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -93,26 +93,29 @@ library MovingFunds {
     }
 
     event MovingFundsCommitmentSubmitted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes20[] targetWallets,
         address submitter
     );
 
-    event MovingFundsTimeoutReset(bytes20 walletPubKeyHash);
+    event MovingFundsTimeoutReset(bytes20 indexed walletPubKeyHash);
 
     event MovingFundsCompleted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 movingFundsTxHash
     );
 
-    event MovingFundsTimedOut(bytes20 walletPubKeyHash);
+    event MovingFundsTimedOut(bytes20 indexed walletPubKeyHash);
 
-    event MovingFundsBelowDustReported(bytes20 walletPubKeyHash);
+    event MovingFundsBelowDustReported(bytes20 indexed walletPubKeyHash);
 
-    event MovedFundsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
+    event MovedFundsSwept(
+        bytes20 indexed walletPubKeyHash,
+        bytes32 sweepTxHash
+    );
 
     event MovedFundsSweepTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 movingFundsTxHash,
         uint32 movingFundsTxOutputIndex
     );

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -213,7 +213,7 @@ library Redemption {
     }
 
     event RedemptionRequested(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript,
         address redeemer,
         uint64 requestedAmount,
@@ -222,12 +222,12 @@ library Redemption {
     );
 
     event RedemptionsCompleted(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes32 redemptionTxHash
     );
 
     event RedemptionTimedOut(
-        bytes20 walletPubKeyHash,
+        bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript
     );
 

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -215,7 +215,7 @@ library Redemption {
     event RedemptionRequested(
         bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript,
-        address redeemer,
+        address indexed redeemer,
         uint64 requestedAmount,
         uint64 treasuryFee,
         uint64 txMaxFee


### PR DESCRIPTION
Refs: #152 

All `walletPubKeyHash` fields in events are indexed now. It is essential for the wallet to be able to easily manage its lifecycle and react to events it is interested in. 

Also, redeemer and depositor fields in `DepositRevealed` and `RedemptionRequested ` events are indexed now. This will let the depositor and redeemer easily find their revealed deposits and redemption requests in the system. Should be helpful, especially for the dApp.

This change does not increase gas consumption significantly. Before/after comparison for selected functions is available in commit messages.