### PR TITLE
Removed three TODOs from Bridge contract

### DIFF
--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -27,7 +27,6 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
-    // TODO: Make parameters governable
     struct Storage {
         // Address of the Bank the Bridge belongs to.
         Bank bank;

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -162,8 +162,6 @@ library Deposit {
             "Vault is not trusted"
         );
 
-        // TODO: Should we enforce a specific locktime at contract level?
-
         bytes memory expectedScript = abi.encodePacked(
             hex"14", // Byte length of depositor Ethereum address.
             reveal.depositor,

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -292,14 +292,6 @@ library Redemption {
             "Invalid main UTXO data"
         );
 
-        // TODO: Confirm if `walletPubKeyHash` should be validated by checking
-        //       if it is the oldest one who can handle the request. This will
-        //       be suggested by the dApp but may not be respected by users who
-        //       interact directly with the contract. Do we need to enforce it
-        //       here? One option is not to enforce it, to save on gas, but if
-        //       we see this rule is not respected, upgrade Bridge contract to
-        //       require it.
-
         // Validate if redeemer output script is a correct standard type
         // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by building a stub
         // output with 0 as value and using `BTCUtils.extractHash` on it. Such


### PR DESCRIPTION
Refs #152 

[Removed TODO about making BridgeState parameters governable](https://github.com/keep-network/tbtc-v2/commit/af2970c796950aaa2b7942cf655032e9c3926a19). All those parameters are already governable - we have an entire set of `update*` functions in `BridgeState`.

[Removed TODO about enforcing a specific locktime of revealed deposits](https://github.com/keep-network/tbtc-v2/commit/dad4f7049d053937a80de0d2b0ed8c29e99fd14a). Off-chain clients need to validate revealed deposits anyway. Validation of locktime can be just another off-chain step. This way, `revealDeposit` transaction can be cheaper.

[Removed TODO about validating the wallet used for redemption](https://github.com/keep-network/tbtc-v2/commit/05a3700b0b55a437718ce729fb9e0dd6dcc6d77c). The oldest wallet should be used for redemptions and this will be suggested by the dApp. It does not feel like something we need to enforce on-chain. If we observe that users notoriously bypass the recommendation, we can always update Bridge contract to require it. For now, we are optimistic and try to save on gas.

