### PR TITLE
Disambiguate sweeps

### DIFF
--- a/typescript/src/bridge.ts
+++ b/typescript/src/bridge.ts
@@ -9,12 +9,12 @@ import {
  */
 export interface Bridge {
   /**
-   * Submits a sweep transaction proof to the on-chain contract.
+   * Submits a deposit sweep transaction proof to the on-chain contract.
    * @param sweepTx - Sweep transaction data.
    * @param sweepProof - Sweep proof data.
    * @param mainUtxo - Data of the wallets main UTXO.
    */
-  submitSweepProof(
+  submitDepositSweepProof(
     sweepTx: DecomposedRawTransaction,
     sweepProof: Proof,
     mainUtxo: UnspentTransactionOutput

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -7,7 +7,11 @@ import {
   makeDeposit,
   revealDeposit,
 } from "./deposit"
-import { createSweepTransaction, sweepDeposits, proveSweep } from "./sweep"
+import {
+  createDepositSweepTransaction,
+  sweepDeposits,
+  proveDepositSweep,
+} from "./deposit-sweep"
 import { Bridge } from "./bridge"
 import {
   Client as BitcoinClient,
@@ -91,31 +95,8 @@ export interface TBTC {
   revealDeposit(): Promise<void>
 
   /**
-   * Creates a Bitcoin P2WPKH sweep transaction.
-   * @dev The caller is responsible for ensuring the provided UTXOs are correctly
-   *      formed, can be spent by the wallet and their combined value is greater
-   *      then the fee.
-   * @param fee - the value that should be subtracted from the sum of the UTXOs
-   *              values and used as the transaction fee.
-   * @param walletPrivateKey - Bitcoin private key of the wallet in WIF format.
-   * @param utxos - UTXOs from new deposit transactions. Must be P2(W)SH.
-   * @param depositData - data on deposits. Each element corresponds to UTXO.
-   *                      The number of UTXOs and deposit data elements must equal.
-   * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
-   *                   from the previous sweep transaction (optional).
-   * @returns Bitcoin sweep transaction in raw format.
-   */
-  createSweepTransaction(
-    fee: BigNumber,
-    walletPrivateKey: string,
-    utxos: (UnspentTransactionOutput & RawTransaction)[],
-    depositData: DepositData[],
-    mainUtxo?: UnspentTransactionOutput & RawTransaction
-  ): Promise<RawTransaction>
-
-  /**
-   * Sweeps P2(W)SH UTXOs by combining all the provided UTXOs and broadcasting
-   * a Bitcoin P2WPKH sweep transaction.
+   * Sweeps deposits P2(W)SH UTXOs by combining all the provided UTXOs and
+   * broadcasting a Bitcoin P2WPKH deposit sweep transaction.
    * @dev The caller is responsible for ensuring the provided UTXOs are correctly
    *      formed, can be spent by the wallet and their combined value is greater
    *      then the fee. Note that broadcasting transaction may fail silently (e.g.
@@ -129,7 +110,7 @@ export interface TBTC {
    *                      The number of UTXOs and deposit data elements must
    *                      equal.
    * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
-   *                   from the previous sweep transaction (optional).
+   *                   from the previous wallet transaction (optional).
    * @returns Empty promise.
    */
   sweepDeposits(
@@ -142,15 +123,38 @@ export interface TBTC {
   ): Promise<void>
 
   /**
-   * Prepares the proof of a sweep transaction and submits it to the Bridge
-   * on-chain contract.
+   * Creates a Bitcoin P2WPKH deposit sweep transaction.
+   * @dev The caller is responsible for ensuring the provided UTXOs are correctly
+   *      formed, can be spent by the wallet and their combined value is greater
+   *      then the fee.
+   * @param fee - the value that should be subtracted from the sum of the UTXOs
+   *              values and used as the transaction fee.
+   * @param walletPrivateKey - Bitcoin private key of the wallet in WIF format.
+   * @param utxos - UTXOs from new deposit transactions. Must be P2(W)SH.
+   * @param depositData - data on deposits. Each element corresponds to UTXO.
+   *                      The number of UTXOs and deposit data elements must equal.
+   * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
+   *                   from the previous wallet transaction (optional).
+   * @returns Bitcoin deposit sweep transaction in raw format.
+   */
+  createDepositSweepTransaction(
+    fee: BigNumber,
+    walletPrivateKey: string,
+    utxos: (UnspentTransactionOutput & RawTransaction)[],
+    depositData: DepositData[],
+    mainUtxo?: UnspentTransactionOutput & RawTransaction
+  ): Promise<RawTransaction>
+
+  /**
+   * Prepares the proof of a deposit sweep transaction and submits it to the
+   * Bridge on-chain contract.
    * @param transactionHash - Hash of the transaction being proven.
    * @param mainUtxo - Recent main UTXO of the wallet as currently known on-chain.
    * @param bridge - Interface to the Bridge on-chain contract.
    * @param bitcoinClient - Bitcoin client used to interact with the network.
    * @returns Empty promise.
    */
-  proveSweep(
+  proveDepositSweep(
     transactionHash: string,
     mainUtxo: UnspentTransactionOutput,
     bridge: Bridge,
@@ -165,9 +169,9 @@ const tbtc: TBTC = {
   createDepositScriptHash,
   createDepositAddress,
   revealDeposit,
-  createSweepTransaction,
   sweepDeposits,
-  proveSweep,
+  createDepositSweepTransaction,
+  proveDepositSweep,
 }
 
 export default tbtc

--- a/typescript/test/data/deposit-sweep.ts
+++ b/typescript/test/data/deposit-sweep.ts
@@ -17,9 +17,9 @@ export const NO_MAIN_UTXO = {
 }
 
 /**
- * Represents data for tests of assembling sweep transactions.
+ * Represents data for tests of assembling deposit sweep transactions.
  */
-export interface SweepTestData {
+export interface DepositSweepTestData {
   deposits: {
     utxo: UnspentTransactionOutput & RawTransaction
     data: DepositData
@@ -31,7 +31,7 @@ export interface SweepTestData {
   }
 }
 
-export const sweepWithNoMainUtxo: SweepTestData = {
+export const depositSweepWithNoMainUtxo: DepositSweepTestData = {
   deposits: [
     {
       utxo: {
@@ -112,7 +112,7 @@ export const sweepWithNoMainUtxo: SweepTestData = {
   },
 }
 
-export const sweepWithMainUtxo: SweepTestData = {
+export const depositSweepWithMainUtxo: DepositSweepTestData = {
   deposits: [
     {
       // P2SH deposit
@@ -224,9 +224,9 @@ export const sweepWithMainUtxo: SweepTestData = {
 }
 
 /**
- * Represents data for tests of assembling sweep proofs.
+ * Represents data for tests of assembling deposit sweep proofs.
  */
-export interface SweepProofTestData {
+export interface DepositSweepProofTestData {
   bitcoinChainData: {
     transaction: Transaction
     rawTransaction: RawTransaction
@@ -246,7 +246,7 @@ export interface SweepProofTestData {
  * Test data that is based on a Bitcoin testnet transaction with multiple inputs
  * https://live.blockcypher.com/btc-testnet/tx/5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753/
  */
-export const sweepProof: SweepProofTestData = {
+export const depositSweepProof: DepositSweepProofTestData = {
   bitcoinChainData: {
     transaction: {
       transactionHash:

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -16,18 +16,18 @@ interface BridgeLog {
  */
 export class MockBridge implements Bridge {
   private _difficultyFactor = 6
-  private _sweepProofLog: BridgeLog[] = []
+  private _depositSweepProofLog: BridgeLog[] = []
 
-  get sweepProofLog(): BridgeLog[] {
-    return this._sweepProofLog
+  get depositSweepProofLog(): BridgeLog[] {
+    return this._depositSweepProofLog
   }
 
-  submitSweepProof(
+  submitDepositSweepProof(
     sweepTx: DecomposedRawTransaction,
     sweepProof: Proof,
     mainUtxo: UnspentTransactionOutput
   ): Promise<void> {
-    this._sweepProofLog.push({ sweepTx, sweepProof, mainUtxo })
+    this._depositSweepProofLog.push({ sweepTx, sweepProof, mainUtxo })
     return new Promise<void>((resolve, _) => {
       resolve()
     })


### PR DESCRIPTION
The `Bridge` contract has no longer a single sweep functionality and now supports deposits and moved funds sweep. The `typescript` library supports just deposit sweeps but a general sweep-based nomenclature is used. Here we disambiguate that by adding the "deposit" prefix where applicable.