### PR TITLE
Replace Ethereum addresses with chain identifiers

### DIFF
--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -5,6 +5,16 @@ import {
 } from "./bitcoin"
 
 /**
+ * Represents a generic chain identifier.
+ */
+export interface Identifier {
+  /**
+   * Identifier as an un-prefixed hex string.
+   */
+  identifierHex: string
+}
+
+/**
  * Interface for communication with the Bridge on-chain contract.
  */
 export interface Bridge {

--- a/typescript/src/deposit-sweep.ts
+++ b/typescript/src/deposit-sweep.ts
@@ -11,7 +11,7 @@ import {
   isCompressedPublicKey,
 } from "./bitcoin"
 import { createDepositScript, DepositData } from "./deposit"
-import { Bridge } from "./bridge"
+import { Bridge } from "./chain"
 import { createTransactionProof } from "./proof"
 
 /**

--- a/typescript/src/deposit.ts
+++ b/typescript/src/deposit.ts
@@ -13,15 +13,16 @@ import {
   RawTransaction,
   UnspentTransactionOutput,
 } from "./bitcoin"
+import { Identifier } from "./chain"
 
 /**
  * Contains deposit data.
  */
 export interface DepositData {
   /**
-   * Ethereum address prefixed with '0x' that should be used for TBTC accounting.
+   * Depositor's chain identifier.
    */
-  ethereumAddress: string
+  depositor: Identifier
 
   /**
    * Deposit amount in satoshis.
@@ -155,12 +156,7 @@ export async function createDepositTransaction(
 export async function createDepositScript(
   depositData: DepositData
 ): Promise<string> {
-  // Make sure Ethereum address is prefixed since the prefix is removed
-  // while constructing the script.
-  const ethereumAddress = depositData.ethereumAddress
-  if (ethereumAddress.substring(0, 2) !== "0x") {
-    throw new Error("Ethereum address must be prefixed with 0x")
-  }
+  const depositor = depositData.depositor
 
   // Blinding factor should be an 8 bytes number.
   const blindingFactor = depositData.blindingFactor
@@ -185,7 +181,7 @@ export async function createDepositScript(
   // All HEXes pushed to the script must be un-prefixed.
   const script = new bcoin.Script()
   script.clear()
-  script.pushData(Buffer.from(ethereumAddress.substring(2), "hex"))
+  script.pushData(Buffer.from(depositor.identifierHex, "hex"))
   script.pushOp(opcodes.OP_DROP)
   script.pushData(Buffer.from(blindingFactor.toHexString().substring(2), "hex"))
   script.pushOp(opcodes.OP_DROP)

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -12,7 +12,7 @@ import {
   sweepDeposits,
   proveDepositSweep,
 } from "./deposit-sweep"
-import { Bridge } from "./bridge"
+import { Bridge } from "./chain"
 import {
   Client as BitcoinClient,
   RawTransaction,

--- a/typescript/test/data/deposit-sweep.ts
+++ b/typescript/test/data/deposit-sweep.ts
@@ -49,7 +49,9 @@ export const depositSweepWithNoMainUtxo: DepositSweepTestData = {
           "db60231d117aeede04e7bc11907bfa00000000",
       },
       data: {
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        depositor: {
+          identifierHex: "934b98637ca318a4d6e7ca6ffd1690b8e77df637",
+        },
         amount: BigNumber.from(25000),
         walletPublicKey:
           "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
@@ -75,7 +77,9 @@ export const depositSweepWithNoMainUtxo: DepositSweepTestData = {
           "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
       },
       data: {
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        depositor: {
+          identifierHex: "934b98637ca318a4d6e7ca6ffd1690b8e77df637",
+        },
         amount: BigNumber.from(12000),
         walletPublicKey:
           "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
@@ -131,7 +135,9 @@ export const depositSweepWithMainUtxo: DepositSweepTestData = {
           "08db60231d117aeede04e7bc11907bfa00000000",
       },
       data: {
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        depositor: {
+          identifierHex: "934b98637ca318a4d6e7ca6ffd1690b8e77df637",
+        },
         amount: BigNumber.from(17000),
         walletPublicKey:
           "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
@@ -158,7 +164,9 @@ export const depositSweepWithMainUtxo: DepositSweepTestData = {
           "8d3f8550d22eb90b4af908db60231d117aeede04e7bc11907bfa00000000",
       },
       data: {
-        ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+        depositor: {
+          identifierHex: "934b98637ca318a4d6e7ca6ffd1690b8e77df637",
+        },
         amount: BigNumber.from(10000),
         walletPublicKey:
           "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",

--- a/typescript/test/deposit.test.ts
+++ b/typescript/test/deposit.test.ts
@@ -14,10 +14,11 @@ import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
 import bcoin from "bcoin"
 // @ts-ignore
 import hash160 from "bcrypto/lib/hash160"
+import { DepositData } from "../src/deposit"
 
 describe("Deposit", () => {
-  const depositData = {
-    ethereumAddress: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+  const depositData: DepositData = {
+    depositor: { identifierHex: "934b98637ca318a4d6e7ca6ffd1690b8e77df637" },
     amount: BigNumber.from(10000), // 0.0001 BTC
     walletPublicKey:
       "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
@@ -305,14 +306,14 @@ describe("Deposit", () => {
 
       expect(script.length).to.be.equal(expectedDepositScript.length)
 
-      // Assert the Ethereum address is encoded correctly.
+      // Assert the depositor identifier is encoded correctly.
       // According the Bitcoin script format, the first byte before arbitrary
       // data must determine the length of those data. In this case the first
       // byte is 0x14 which is 20 in decimal, and this is correct because we
-      // have a 20 bytes Ethereum address as subsequent data.
+      // have a 20 bytes depositor identifier as subsequent data.
       expect(script.substring(0, 2)).to.be.equal("14")
       expect(script.substring(2, 42)).to.be.equal(
-        depositData.ethereumAddress.substring(2).toLowerCase()
+        depositData.depositor.identifierHex
       )
 
       // According to https://en.bitcoin.it/wiki/Script#Constants, the

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -1,4 +1,4 @@
-import { Bridge } from "../../src/bridge"
+import { Bridge } from "../../src/chain"
 import {
   DecomposedRawTransaction,
   Proof,


### PR DESCRIPTION
Here we introduce the `Identifier` interface that is meant to represent a generic chain identifier. This way, we can decouple deposits from Ethereum addresses and their parsing and validation rules thus making the `typescript` library more friendly for potential multichain support.