### PR TITLE
Replace hardhat-deploy-ethers with @keep-network/hardhat-helpers

### DIFF
--- a/solidity/deploy/09_transfer_proxy_admin_ownership.ts
+++ b/solidity/deploy/09_transfer_proxy_admin_ownership.ts
@@ -2,9 +2,9 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { ethers, getNamedAccounts, upgrades, deployments } = hre
+  const { ethers, helpers, getNamedAccounts, upgrades, deployments } = hre
   const { esdm } = await getNamedAccounts()
-  const { deployer } = await ethers.getNamedSigners()
+  const { deployer } = await helpers.signers.getNamedSigners()
 
   // TODO: Once a DAO is established we want to switch to ProxyAdminWithDeputy and
   // use the DAO as the proxy admin owner and ESDM as the deputy. Until then we

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.5.0",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.5",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
-    "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers",
+    "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
     "@openzeppelin/hardhat-upgrades": "^1.17.0",

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -3,7 +3,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
 
 import { ContractTransaction, Signature, Wallet } from "ethers"
-import type { Bank, Bank__factory } from "../../typechain"
+import type { Bank } from "../../typechain"
 
 const { to1e18 } = helpers.number
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
@@ -16,7 +16,7 @@ const MAX_UINT256 = ethers.constants.MaxUint256
 const fixture = async () => {
   const [deployer, governance, bridge, thirdParty] = await ethers.getSigners()
 
-  const Bank = await ethers.getContractFactory<Bank__factory>("Bank")
+  const Bank = await ethers.getContractFactory("Bank")
   const bank = await Bank.deploy()
   await bank.deployed()
 

--- a/solidity/test/bridge/Bridge.Deployment.test.ts
+++ b/solidity/test/bridge/Bridge.Deployment.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
-import { deployments, ethers, upgrades } from "hardhat"
+import { deployments, ethers, helpers, upgrades } from "hardhat"
 import chai, { expect } from "chai"
 import chaiAsPromised from "chai-as-promised"
 
@@ -22,11 +22,11 @@ describe("Bridge - Deployment", async () => {
 
   before(async () => {
     await deployments.fixture()
-    ;({ deployer, governance, esdm } = await ethers.getNamedSigners())
+    ;({ deployer, governance, esdm } = await helpers.signers.getNamedSigners())
 
-    bridge = await ethers.getContract<Bridge>("Bridge")
+    bridge = await helpers.contracts.getContract("Bridge")
 
-    bridgeProxy = await ethers.getContractAt<TransparentUpgradeableProxy>(
+    bridgeProxy = await ethers.getContractAt(
       "TransparentUpgradeableProxy",
       bridge.address
     )

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -1,7 +1,7 @@
 import { helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
-import { ContractTransaction, BigNumber } from "ethers"
+import { ContractTransaction } from "ethers"
 import type { Bridge, BridgeStub } from "../../typechain"
 import { constants } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"

--- a/solidity/test/bridge/EcdsaLib.test.ts
+++ b/solidity/test/bridge/EcdsaLib.test.ts
@@ -1,14 +1,12 @@
 import { expect } from "chai"
 import { ethers } from "hardhat"
-import { TestEcdsaLib, TestEcdsaLib__factory } from "../../typechain"
+import { TestEcdsaLib } from "../../typechain"
 
 describe("EcdsaLib", () => {
   let ecdsaLib: TestEcdsaLib
 
   before(async () => {
-    const EcdsaLib = await ethers.getContractFactory<TestEcdsaLib__factory>(
-      "TestEcdsaLib"
-    )
+    const EcdsaLib = await ethers.getContractFactory("TestEcdsaLib")
     ecdsaLib = await EcdsaLib.deploy()
   })
 

--- a/solidity/test/bridge/Heartbeat.test.ts
+++ b/solidity/test/bridge/Heartbeat.test.ts
@@ -2,14 +2,13 @@
 
 import { expect } from "chai"
 import { ethers } from "hardhat"
-import type { HeartbeatStub, HeartbeatStub__factory } from "../../typechain"
+import type { HeartbeatStub } from "../../typechain"
 
 describe("Heartbeat", () => {
   let heartbeat: HeartbeatStub
 
   before(async () => {
-    const HeartbeatStub =
-      await ethers.getContractFactory<HeartbeatStub__factory>("HeartbeatStub")
+    const HeartbeatStub = await ethers.getContractFactory("HeartbeatStub")
     heartbeat = await HeartbeatStub.deploy()
   })
 

--- a/solidity/test/bridge/VendingMachine.test.ts
+++ b/solidity/test/bridge/VendingMachine.test.ts
@@ -31,7 +31,7 @@ describe("VendingMachine", () => {
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;({ deployer, governance } = await ethers.getNamedSigners())
+    ;({ deployer, governance } = await helpers.signers.getNamedSigners())
 
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;[
@@ -39,7 +39,7 @@ describe("VendingMachine", () => {
       vendingMachineUpgradeInitiator,
       tokenHolder,
       thirdParty,
-    ] = await ethers.getUnnamedSigners()
+    ] = await helpers.signers.getUnnamedSigners()
 
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ tbtcV1, tbtcV2, vendingMachine } = await waffle.loadFixture(

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -1,4 +1,4 @@
-import { deployments, ethers } from "hardhat"
+import { deployments, ethers, helpers } from "hardhat"
 import { smock } from "@defi-wonderland/smock"
 import type {
   Bank,
@@ -6,7 +6,6 @@ import type {
   Bridge,
   BridgeStub,
   IWalletRegistry,
-  BridgeStub__factory,
   TestRelay,
 } from "../../typechain"
 
@@ -16,12 +15,15 @@ import type {
 export default async function bridgeFixture() {
   await deployments.fixture()
 
-  const { deployer, governance, treasury } = await ethers.getNamedSigners()
-  const [thirdParty] = await ethers.getUnnamedSigners()
+  const { deployer, governance, treasury } =
+    await helpers.signers.getNamedSigners()
+  const [thirdParty] = await helpers.signers.getUnnamedSigners()
 
-  const bank: Bank & BankStub = await ethers.getContract("Bank")
+  const bank: Bank & BankStub = await helpers.contracts.getContract("Bank")
 
-  const bridge: Bridge & BridgeStub = await ethers.getContract("Bridge")
+  const bridge: Bridge & BridgeStub = await helpers.contracts.getContract(
+    "Bridge"
+  )
 
   const walletRegistry = await smock.fake<IWalletRegistry>("IWalletRegistry", {
     address: await (await bridge.contractReferences()).ecdsaWalletRegistry,
@@ -39,19 +41,18 @@ export default async function bridgeFixture() {
 
   await bank.connect(governance).updateBridge(bridge.address)
 
-  const BridgeFactory = await ethers.getContractFactory<BridgeStub__factory>(
-    "BridgeStub",
-    {
-      libraries: {
-        Deposit: (await ethers.getContract("Deposit")).address,
-        DepositSweep: (await ethers.getContract("DepositSweep")).address,
-        Redemption: (await ethers.getContract("Redemption")).address,
-        Wallets: (await ethers.getContract("Wallets")).address,
-        Fraud: (await ethers.getContract("Fraud")).address,
-        MovingFunds: (await ethers.getContract("MovingFunds")).address,
-      },
-    }
-  )
+  const BridgeFactory = await ethers.getContractFactory("BridgeStub", {
+    libraries: {
+      Deposit: (await helpers.contracts.getContract("Deposit")).address,
+      DepositSweep: (
+        await helpers.contracts.getContract("DepositSweep")
+      ).address,
+      Redemption: (await helpers.contracts.getContract("Redemption")).address,
+      Wallets: (await helpers.contracts.getContract("Wallets")).address,
+      Fraud: (await helpers.contracts.getContract("Fraud")).address,
+      MovingFunds: (await helpers.contracts.getContract("MovingFunds")).address,
+    },
+  })
 
   return {
     governance,

--- a/solidity/test/fixtures/vendingMachine.ts
+++ b/solidity/test/fixtures/vendingMachine.ts
@@ -1,4 +1,4 @@
-import { deployments, ethers } from "hardhat"
+import { deployments, helpers } from "hardhat"
 import { TestERC20, TBTC, VendingMachine } from "../../typechain"
 
 // eslint-disable-next-line import/prefer-default-export
@@ -9,10 +9,10 @@ export default async function vendingMachineFixture(): Promise<{
 }> {
   await deployments.fixture("VendingMachine")
 
-  const tbtcV1: TestERC20 = await ethers.getContract("TBTCToken")
-  const tbtcV2: TBTC = await ethers.getContract("TBTC")
+  const tbtcV1: TestERC20 = await helpers.contracts.getContract("TBTCToken")
+  const tbtcV2: TBTC = await helpers.contracts.getContract("TBTC")
 
-  const vendingMachine: VendingMachine = await ethers.getContract(
+  const vendingMachine: VendingMachine = await helpers.contracts.getContract(
     "VendingMachine"
   )
 

--- a/solidity/test/vault/DonationVault.test.ts
+++ b/solidity/test/vault/DonationVault.test.ts
@@ -3,27 +3,20 @@ import { ethers, helpers, waffle } from "hardhat"
 import { expect } from "chai"
 
 import { ContractTransaction } from "ethers"
-import type {
-  Bank,
-  Bank__factory,
-  DonationVault,
-  DonationVault__factory,
-} from "../../typechain"
+import type { Bank, DonationVault } from "../../typechain"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
 const fixture = async () => {
   const [deployer, bridge, account1, account2] = await ethers.getSigners()
 
-  const Bank = await ethers.getContractFactory<Bank__factory>("Bank")
+  const Bank = await ethers.getContractFactory("Bank")
   const bank = await Bank.deploy()
   await bank.deployed()
 
   await bank.connect(deployer).updateBridge(bridge.address)
 
-  const DonationVault = await ethers.getContractFactory<DonationVault__factory>(
-    "DonationVault"
-  )
+  const DonationVault = await ethers.getContractFactory("DonationVault")
   const vault = await DonationVault.deploy(bank.address)
   await vault.deployed()
 

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -5,15 +5,11 @@ import { expect } from "chai"
 import { ContractTransaction } from "ethers"
 import type {
   Bank,
-  Bank__factory,
   TBTC,
   TBTCVault,
-  TBTCVault__factory,
-  TBTC__factory,
   TestERC20,
   TestERC721,
 } from "../../typechain"
-import { TestERC20__factory, TestERC721__factory } from "../../typechain"
 
 const { to1e18 } = helpers.number
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
@@ -23,19 +19,17 @@ const ZERO_ADDRESS = ethers.constants.AddressZero
 const fixture = async () => {
   const [deployer, bridge, governance] = await ethers.getSigners()
 
-  const Bank = await ethers.getContractFactory<Bank__factory>("Bank")
+  const Bank = await ethers.getContractFactory("Bank")
   const bank = await Bank.deploy()
   await bank.deployed()
 
   await bank.connect(deployer).updateBridge(bridge.address)
 
-  const TBTC = await ethers.getContractFactory<TBTC__factory>("TBTC")
+  const TBTC = await ethers.getContractFactory("TBTC")
   const tbtc = await TBTC.deploy()
   await tbtc.deployed()
 
-  const TBTCVault = await ethers.getContractFactory<TBTCVault__factory>(
-    "TBTCVault"
-  )
+  const TBTCVault = await ethers.getContractFactory("TBTCVault")
   const vault = await TBTCVault.deploy(bank.address, tbtc.address)
   await vault.deployed()
 
@@ -116,9 +110,7 @@ describe("TBTCVault", () => {
     before(async () => {
       await createSnapshot()
 
-      const TestToken = await ethers.getContractFactory<TestERC20__factory>(
-        "TestERC20"
-      )
+      const TestToken = await ethers.getContractFactory("TestERC20")
       testToken = await TestToken.deploy()
       await testToken.deployed()
     })
@@ -167,9 +159,7 @@ describe("TBTCVault", () => {
     before(async () => {
       await createSnapshot()
 
-      const TestToken = await ethers.getContractFactory<TestERC721__factory>(
-        "TestERC721"
-      )
+      const TestToken = await ethers.getContractFactory("TestERC721")
       testToken = await TestToken.deploy()
       await testToken.deployed()
     })

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1519,10 +1519,10 @@
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" ">1.2.0-dev <1.2.0-ropsten"
 
-"@keep-network/hardhat-helpers@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.5.0.tgz#9ff1849fc6786191e29e23751729fca34a8a7faa"
-  integrity sha512-okQ6Pa9Wz0cT6rKik3CVEkhTdmmDGJY3C0RjgjO9AePfy6tJpYinHxTkMJxErux+HeN8gUTTHa+j66/fyu+7Gg==
+"@keep-network/hardhat-helpers@^0.6.0-pre.5":
+  version "0.6.0-pre.5"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.5.tgz#81cc010d1afac08ec29a09e5846c9f8da28173b6"
+  integrity sha512-hRgQmvhmcayL9kto8xcK3lsfyRMvq/XG+EfQjPM731DOwPJ79kFk6PK3UMw7I+uKIgnZEkh29B+JizDR80Vr2g==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"
@@ -1695,10 +1695,10 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers":
-  version "0.3.0-beta.13"
-  resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz#b96086ff768ddf69928984d5eb0a8d78cfca9366"
-  integrity sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==
+"@nomiclabs/hardhat-ethers@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.6.tgz#1c695263d5b46a375dcda48c248c4fba9dfe2fc2"
+  integrity sha512-q2Cjp20IB48rEn2NPjR1qxsIQBvFVYW9rFRCFq+bC4RUrn1Ljz3g4wM8uSlgIBZYBi2JMXxmOzFqHraczxq4Ng==
 
 "@nomiclabs/hardhat-etherscan@^2.1.4":
   version "2.1.4"


### PR DESCRIPTION
We noticed problems with hardhat-deploy-ethers breaking functionalities
of other plugins that don't use it, e.g. @openzeppelin/hardhat-upgrades.

We use plain @nomiclabs/hardhat-ethers instead.

Refs https://github.com/keep-network/tbtc-v2/issues/250
Refs https://github.com/keep-network/tbtc-v2/issues/267