### PR TITLE
One-transaction TBTC to BTC

### DIFF
--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -7,6 +7,8 @@ import type {
   BridgeStub,
   IWalletRegistry,
   TestRelay,
+  TBTC,
+  TBTCVault,
 } from "../../typechain"
 
 /**
@@ -18,6 +20,10 @@ export default async function bridgeFixture() {
   const { deployer, governance, treasury } =
     await helpers.signers.getNamedSigners()
   const [thirdParty] = await helpers.signers.getUnnamedSigners()
+
+  const tbtc: TBTC = await helpers.contracts.getContract("TBTC")
+
+  const tbtcVault: TBTCVault = await helpers.contracts.getContract("TBTCVault")
 
   const bank: Bank & BankStub = await helpers.contracts.getContract("Bank")
 
@@ -58,6 +64,8 @@ export default async function bridgeFixture() {
     governance,
     thirdParty,
     treasury,
+    tbtc,
+    tbtcVault,
     bank,
     relay,
     walletRegistry,

--- a/solidity/test/vault/TBTCVault.Redemption.test.ts
+++ b/solidity/test/vault/TBTCVault.Redemption.test.ts
@@ -1,0 +1,580 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import { expect } from "chai"
+import { ContractTransaction } from "ethers"
+import { BytesLike } from "@ethersproject/bytes"
+
+import { walletState } from "../fixtures"
+import bridgeFixture from "../fixtures/bridge"
+
+import type {
+  Bank,
+  BankStub,
+  Bridge,
+  BridgeStub,
+  TBTC,
+  TBTCVault,
+  VendingMachine,
+} from "../../typechain"
+
+const { to1e18 } = helpers.number
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { increaseTime, lastBlockTime } = helpers.time
+const { defaultAbiCoder } = ethers.utils
+
+describe("TBTCVault - Redemption", () => {
+  const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+  const mainUtxo = {
+    txHash:
+      "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
+    txOutputIndex: 0,
+    txOutputValue: 10000000,
+  }
+
+  let bridge: Bridge & BridgeStub
+  let bank: Bank & BankStub
+  let tbtc: TBTC
+  let tbtcVault: TBTCVault
+
+  let deployer: SignerWithAddress
+  let account1: SignerWithAddress
+  let account2: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ deployer } = await helpers.signers.getNamedSigners())
+
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ bridge, bank, tbtcVault, tbtc } = await waffle.loadFixture(
+      bridgeFixture
+    ))
+
+    // Deployment scripts deploy both `VendingMachine` and `TBTCVault` but they
+    // do not transfer the ownership of `TBTC` token to `TBTCVault`.
+    // We need to do it manually in tests covering `TBTCVault` behavior.
+    // Also, please note that `03_transfer_roles.ts` assigning `VendingMachine`
+    // upgrade initiator role to Keep Technical Wallet is skipped for Hardhat
+    // env deployment. That's why the upgrade initiator and `VendingMachine`
+    // owner is the deployer.
+    const vendingMachine: VendingMachine = await helpers.contracts.getContract(
+      "VendingMachine"
+    )
+    await vendingMachine
+      .connect(deployer)
+      .initiateVendingMachineUpgrade(tbtcVault.address)
+    await increaseTime(await vendingMachine.GOVERNANCE_DELAY())
+    await vendingMachine.connect(deployer).finalizeVendingMachineUpgrade()
+
+    const accounts = await getUnnamedAccounts()
+    account1 = await ethers.getSigner(accounts[0])
+    account2 = await ethers.getSigner(accounts[1])
+
+    const initialBankBalance = to1e18(100)
+    await bank.setBalance(account1.address, initialBankBalance)
+    await bank.setBalance(account2.address, initialBankBalance)
+    await bank
+      .connect(account1)
+      .approveBalance(tbtcVault.address, initialBankBalance)
+    await bank
+      .connect(account2)
+      .approveBalance(tbtcVault.address, initialBankBalance)
+
+    await bridge.setWallet(walletPubKeyHash, {
+      ecdsaWalletID: ethers.constants.HashZero,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+    await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+  })
+
+  describe("redeem", () => {
+    const requestRedemption = async (
+      redeemer: SignerWithAddress,
+      redeemerOutputScript: string,
+      amount: number
+    ): Promise<ContractTransaction> => {
+      const data = defaultAbiCoder.encode(
+        ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
+        [
+          redeemer.address,
+          walletPubKeyHash,
+          mainUtxo.txHash,
+          mainUtxo.txOutputIndex,
+          mainUtxo.txOutputValue,
+          redeemerOutputScript,
+        ]
+      )
+
+      return tbtcVault.connect(redeemer).redeem(amount, data)
+    }
+
+    context("when the redeemer has no TBTC", () => {
+      const amount = to1e18(1)
+      before(async () => {
+        await createSnapshot()
+
+        await tbtc.connect(account1).approve(tbtcVault.address, amount)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).redeem(to1e18(1), [])
+        ).to.be.revertedWith("Burn amount exceeds balance")
+      })
+    })
+
+    context("when the redeemer has not enough TBTC", () => {
+      const mintedAmount = to1e18(1)
+      const redeemedAmount = mintedAmount.add(1)
+
+      before(async () => {
+        await createSnapshot()
+
+        await tbtcVault.connect(account1).mint(mintedAmount)
+        await tbtc.connect(account1).approve(tbtcVault.address, redeemedAmount)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).redeem(redeemedAmount, [])
+        ).to.be.revertedWith("Burn amount exceeds balance")
+      })
+    })
+
+    context("when there is a single redeemer", () => {
+      const redeemerOutputScriptP2WPKH =
+        "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+      const redeemerOutputScriptP2WSH =
+        "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
+      const redeemerOutputScriptP2PKH =
+        "0x1976a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
+
+      const mintedAmount = 10000000
+      const redeemedAmount1 = 1000000
+      const redeemedAmount2 = 2000000
+      const redeemedAmount3 = 3000000
+      const totalRedeemedAmount =
+        redeemedAmount1 + redeemedAmount2 + redeemedAmount3
+      const notRedeemedAmount = mintedAmount - totalRedeemedAmount
+
+      const transactions: ContractTransaction[] = []
+
+      before(async () => {
+        await createSnapshot()
+
+        await tbtcVault.connect(account1).mint(mintedAmount)
+        await tbtc.connect(account1).approve(tbtcVault.address, mintedAmount)
+
+        transactions.push(
+          await requestRedemption(
+            account1,
+            redeemerOutputScriptP2WPKH,
+            redeemedAmount1
+          )
+        )
+        transactions.push(
+          await requestRedemption(
+            account1,
+            redeemerOutputScriptP2WSH,
+            redeemedAmount2
+          )
+        )
+        transactions.push(
+          await requestRedemption(
+            account1,
+            redeemerOutputScriptP2PKH,
+            redeemedAmount3
+          )
+        )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should transfer balances to Bridge", async () => {
+        expect(await bank.balanceOf(tbtcVault.address)).to.equal(
+          notRedeemedAmount
+        )
+        expect(await bank.balanceOf(bridge.address)).to.equal(
+          totalRedeemedAmount
+        )
+      })
+
+      it("should request redemptions in Bridge", async () => {
+        const redemptionRequest1 = await bridge.pendingRedemptions(
+          buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WPKH)
+        )
+        expect(redemptionRequest1.redeemer).to.be.equal(account1.address)
+        expect(redemptionRequest1.requestedAmount).to.be.equal(redeemedAmount1)
+
+        const redemptionRequest2 = await bridge.pendingRedemptions(
+          buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WSH)
+        )
+        expect(redemptionRequest2.redeemer).to.be.equal(account1.address)
+        expect(redemptionRequest2.requestedAmount).to.be.equal(redeemedAmount2)
+
+        const redemptionRequest3 = await bridge.pendingRedemptions(
+          buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2PKH)
+        )
+        expect(redemptionRequest3.redeemer).to.be.equal(account1.address)
+        expect(redemptionRequest3.requestedAmount).to.be.equal(redeemedAmount3)
+      })
+
+      it("should burn TBTC", async () => {
+        expect(await tbtc.balanceOf(account1.address)).to.equal(
+          notRedeemedAmount
+        )
+        expect(await tbtc.totalSupply()).to.be.equal(notRedeemedAmount)
+      })
+
+      it("should emit Unminted events", async () => {
+        await expect(transactions[0])
+          .to.emit(tbtcVault, "Unminted")
+          .withArgs(account1.address, redeemedAmount1)
+        await expect(transactions[1])
+          .to.emit(tbtcVault, "Unminted")
+          .withArgs(account1.address, redeemedAmount2)
+        await expect(transactions[2])
+          .to.emit(tbtcVault, "Unminted")
+          .withArgs(account1.address, redeemedAmount3)
+      })
+    })
+
+    context("when there are multiple redeemers", () => {
+      const redeemerOutputScriptP2WPKH =
+        "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+      const redeemerOutputScriptP2WSH =
+        "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
+
+      const mintedAmount1 = 10000000
+      const mintedAmount2 = 20000000
+      const redeemedAmount1 = 1000000
+      const redeemedAmount2 = 2000000
+
+      const totalMintedAmount = mintedAmount1 + mintedAmount2
+      const totalRedeemedAmount = redeemedAmount1 + redeemedAmount2
+      const totalNotRedeemedAmount = totalMintedAmount - totalRedeemedAmount
+
+      const transactions: ContractTransaction[] = []
+
+      before(async () => {
+        await createSnapshot()
+
+        await tbtcVault.connect(account1).mint(mintedAmount1)
+        await tbtc.connect(account1).approve(tbtcVault.address, mintedAmount1)
+
+        await tbtcVault.connect(account2).mint(mintedAmount2)
+        await tbtc.connect(account2).approve(tbtcVault.address, mintedAmount2)
+
+        transactions.push(
+          await requestRedemption(
+            account1,
+            redeemerOutputScriptP2WPKH,
+            redeemedAmount1
+          )
+        )
+        transactions.push(
+          await requestRedemption(
+            account2,
+            redeemerOutputScriptP2WSH,
+            redeemedAmount2
+          )
+        )
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should transfer balances to Bridge", async () => {
+        expect(await bank.balanceOf(tbtcVault.address)).to.equal(
+          totalNotRedeemedAmount
+        )
+        expect(await bank.balanceOf(bridge.address)).to.equal(
+          totalRedeemedAmount
+        )
+      })
+
+      it("should request redemptions in Bridge", async () => {
+        const redemptionRequest1 = await bridge.pendingRedemptions(
+          buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WPKH)
+        )
+        expect(redemptionRequest1.redeemer).to.be.equal(account1.address)
+        expect(redemptionRequest1.requestedAmount).to.be.equal(redeemedAmount1)
+
+        const redemptionRequest2 = await bridge.pendingRedemptions(
+          buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WSH)
+        )
+        expect(redemptionRequest2.redeemer).to.be.equal(account2.address)
+        expect(redemptionRequest2.requestedAmount).to.be.equal(redeemedAmount2)
+      })
+
+      it("should burn TBTC", async () => {
+        expect(await tbtc.balanceOf(account1.address)).to.equal(
+          mintedAmount1 - redeemedAmount1
+        )
+        expect(await tbtc.balanceOf(account2.address)).to.equal(
+          mintedAmount2 - redeemedAmount2
+        )
+        expect(await tbtc.totalSupply()).to.be.equal(totalNotRedeemedAmount)
+      })
+
+      it("should emit Unminted events", async () => {
+        await expect(transactions[0])
+          .to.emit(tbtcVault, "Unminted")
+          .withArgs(account1.address, redeemedAmount1)
+        await expect(transactions[1])
+          .to.emit(tbtcVault, "Unminted")
+          .withArgs(account2.address, redeemedAmount2)
+      })
+    })
+  })
+
+  describe("receiveApproval", () => {
+    const requestRedemption = async (
+      redeemer: SignerWithAddress,
+      redeemerOutputScript: string,
+      amount: number
+    ): Promise<ContractTransaction> => {
+      const data = defaultAbiCoder.encode(
+        ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
+        [
+          redeemer.address,
+          walletPubKeyHash,
+          mainUtxo.txHash,
+          mainUtxo.txOutputIndex,
+          mainUtxo.txOutputValue,
+          redeemerOutputScript,
+        ]
+      )
+
+      return tbtc
+        .connect(redeemer)
+        .approveAndCall(tbtcVault.address, amount, data)
+    }
+
+    context("when called via approveAndCall", () => {
+      context("when called with non-empty extraData", () => {
+        context("when there is a single redeemer", () => {
+          const redeemerOutputScriptP2WPKH =
+            "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+          const redeemerOutputScriptP2WSH =
+            "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
+          const redeemerOutputScriptP2PKH =
+            "0x1976a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
+
+          const mintedAmount = 10000000
+          const redeemedAmount1 = 1000000
+          const redeemedAmount2 = 2000000
+          const redeemedAmount3 = 3000000
+          const totalRedeemedAmount =
+            redeemedAmount1 + redeemedAmount2 + redeemedAmount3
+          const notRedeemedAmount = mintedAmount - totalRedeemedAmount
+
+          const transactions: ContractTransaction[] = []
+
+          before(async () => {
+            await createSnapshot()
+
+            await tbtcVault.connect(account1).mint(mintedAmount)
+
+            transactions.push(
+              await requestRedemption(
+                account1,
+                redeemerOutputScriptP2WPKH,
+                redeemedAmount1
+              )
+            )
+            transactions.push(
+              await requestRedemption(
+                account1,
+                redeemerOutputScriptP2WSH,
+                redeemedAmount2
+              )
+            )
+            transactions.push(
+              await requestRedemption(
+                account1,
+                redeemerOutputScriptP2PKH,
+                redeemedAmount3
+              )
+            )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should transfer balances to Bridge", async () => {
+            expect(await bank.balanceOf(tbtcVault.address)).to.equal(
+              notRedeemedAmount
+            )
+            expect(await bank.balanceOf(bridge.address)).to.equal(
+              totalRedeemedAmount
+            )
+          })
+
+          it("should request redemptions in Bridge", async () => {
+            const redemptionRequest1 = await bridge.pendingRedemptions(
+              buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WPKH)
+            )
+            expect(redemptionRequest1.redeemer).to.be.equal(account1.address)
+            expect(redemptionRequest1.requestedAmount).to.be.equal(
+              redeemedAmount1
+            )
+
+            const redemptionRequest2 = await bridge.pendingRedemptions(
+              buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WSH)
+            )
+            expect(redemptionRequest2.redeemer).to.be.equal(account1.address)
+            expect(redemptionRequest2.requestedAmount).to.be.equal(
+              redeemedAmount2
+            )
+
+            const redemptionRequest3 = await bridge.pendingRedemptions(
+              buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2PKH)
+            )
+            expect(redemptionRequest3.redeemer).to.be.equal(account1.address)
+            expect(redemptionRequest3.requestedAmount).to.be.equal(
+              redeemedAmount3
+            )
+          })
+
+          it("should burn TBTC", async () => {
+            expect(await tbtc.balanceOf(account1.address)).to.equal(
+              notRedeemedAmount
+            )
+            expect(await tbtc.totalSupply()).to.be.equal(notRedeemedAmount)
+          })
+
+          it("should emit Unminted events", async () => {
+            await expect(transactions[0])
+              .to.emit(tbtcVault, "Unminted")
+              .withArgs(account1.address, redeemedAmount1)
+            await expect(transactions[1])
+              .to.emit(tbtcVault, "Unminted")
+              .withArgs(account1.address, redeemedAmount2)
+            await expect(transactions[2])
+              .to.emit(tbtcVault, "Unminted")
+              .withArgs(account1.address, redeemedAmount3)
+          })
+        })
+
+        context("when there are multiple redeemers", () => {
+          const redeemerOutputScriptP2WPKH =
+            "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+          const redeemerOutputScriptP2WSH =
+            "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
+
+          const mintedAmount1 = 10000000
+          const mintedAmount2 = 20000000
+          const redeemedAmount1 = 1000000
+          const redeemedAmount2 = 2000000
+
+          const totalMintedAmount = mintedAmount1 + mintedAmount2
+          const totalRedeemedAmount = redeemedAmount1 + redeemedAmount2
+          const totalNotRedeemedAmount = totalMintedAmount - totalRedeemedAmount
+
+          const transactions: ContractTransaction[] = []
+
+          before(async () => {
+            await createSnapshot()
+
+            await tbtcVault.connect(account1).mint(mintedAmount1)
+            await tbtcVault.connect(account2).mint(mintedAmount2)
+
+            transactions.push(
+              await requestRedemption(
+                account1,
+                redeemerOutputScriptP2WPKH,
+                redeemedAmount1
+              )
+            )
+            transactions.push(
+              await requestRedemption(
+                account2,
+                redeemerOutputScriptP2WSH,
+                redeemedAmount2
+              )
+            )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should transfer balances to Bridge", async () => {
+            expect(await bank.balanceOf(tbtcVault.address)).to.equal(
+              totalNotRedeemedAmount
+            )
+            expect(await bank.balanceOf(bridge.address)).to.equal(
+              totalRedeemedAmount
+            )
+          })
+
+          it("should request redemptions in Bridge", async () => {
+            const redemptionRequest1 = await bridge.pendingRedemptions(
+              buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WPKH)
+            )
+            expect(redemptionRequest1.redeemer).to.be.equal(account1.address)
+            expect(redemptionRequest1.requestedAmount).to.be.equal(
+              redeemedAmount1
+            )
+
+            const redemptionRequest2 = await bridge.pendingRedemptions(
+              buildRedemptionKey(walletPubKeyHash, redeemerOutputScriptP2WSH)
+            )
+            expect(redemptionRequest2.redeemer).to.be.equal(account2.address)
+            expect(redemptionRequest2.requestedAmount).to.be.equal(
+              redeemedAmount2
+            )
+          })
+
+          it("should burn TBTC", async () => {
+            expect(await tbtc.balanceOf(account1.address)).to.equal(
+              mintedAmount1 - redeemedAmount1
+            )
+            expect(await tbtc.balanceOf(account2.address)).to.equal(
+              mintedAmount2 - redeemedAmount2
+            )
+            expect(await tbtc.totalSupply()).to.be.equal(totalNotRedeemedAmount)
+          })
+
+          it("should emit Unminted events", async () => {
+            await expect(transactions[0])
+              .to.emit(tbtcVault, "Unminted")
+              .withArgs(account1.address, redeemedAmount1)
+            await expect(transactions[1])
+              .to.emit(tbtcVault, "Unminted")
+              .withArgs(account2.address, redeemedAmount2)
+          })
+        })
+      })
+    })
+  })
+})
+
+function buildRedemptionKey(
+  walletPubKeyHash: BytesLike,
+  redeemerOutputScript: BytesLike
+): string {
+  return ethers.utils.solidityKeccak256(
+    ["bytes20", "bytes"],
+    [walletPubKeyHash, redeemerOutputScript]
+  )
+}

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -505,44 +505,47 @@ describe("TBTCVault", () => {
     })
 
     context("when called via approveAndCall", () => {
-      const mintedAmount = to1e18(10)
-      const unmintedAmount = to1e18(4)
-      const notUnmintedAmount = mintedAmount.sub(unmintedAmount)
+      context("when called with an empty extraData", () => {
+        const mintedAmount = to1e18(10)
+        const unmintedAmount = to1e18(4)
+        const notUnmintedAmount = mintedAmount.sub(unmintedAmount)
 
-      let tx
+        let tx: ContractTransaction
 
-      before(async () => {
-        await createSnapshot()
+        before(async () => {
+          await createSnapshot()
 
-        await vault.connect(account1).mint(mintedAmount)
-        await tbtc.connect(account1).approve(vault.address, unmintedAmount)
-        tx = await tbtc
-          .connect(account1)
-          .approveAndCall(vault.address, unmintedAmount, [])
-      })
+          await vault.connect(account1).mint(mintedAmount)
+          tx = await tbtc
+            .connect(account1)
+            .approveAndCall(vault.address, unmintedAmount, [])
+        })
 
-      after(async () => {
-        await restoreSnapshot()
-      })
+        after(async () => {
+          await restoreSnapshot()
+        })
 
-      it("should transfer balance to the unminter", async () => {
-        expect(await bank.balanceOf(vault.address)).to.equal(notUnmintedAmount)
-        expect(await bank.balanceOf(account1.address)).to.equal(
-          initialBalance.sub(notUnmintedAmount)
-        )
-      })
+        it("should transfer balance to the unminter", async () => {
+          expect(await bank.balanceOf(vault.address)).to.equal(
+            notUnmintedAmount
+          )
+          expect(await bank.balanceOf(account1.address)).to.equal(
+            initialBalance.sub(notUnmintedAmount)
+          )
+        })
 
-      it("should burn TBTC", async () => {
-        expect(await tbtc.balanceOf(account1.address)).to.equal(
-          notUnmintedAmount
-        )
-        expect(await tbtc.totalSupply()).to.be.equal(notUnmintedAmount)
-      })
+        it("should burn TBTC", async () => {
+          expect(await tbtc.balanceOf(account1.address)).to.equal(
+            notUnmintedAmount
+          )
+          expect(await tbtc.totalSupply()).to.be.equal(notUnmintedAmount)
+        })
 
-      it("should emit Unminted event", async () => {
-        await expect(tx)
-          .to.emit(vault, "Unminted")
-          .withArgs(account1.address, unmintedAmount)
+        it("should emit Unminted event", async () => {
+          await expect(tx)
+            .to.emit(vault, "Unminted")
+            .withArgs(account1.address, unmintedAmount)
+        })
       })
     })
   })


### PR DESCRIPTION
Closes #256 

Modified `TBTCVault.receiveApproval` function to allow unminting TBTC and
requesting Bank balance redemption in the Bridge in a single transaction via
`TBTC.approveAndCall`. Also, added `TBTCVault.redeem` function allowing to
unmint TBTC and request redemption in the `Bridge` on an already approved TBTC
balance.

During the work on this feature, I have been exploring different options,
including exposing `IBridge` interface that would be called from `Bank` or
`TBTCVault` to redeem balance. The current version won because it does not
tightly-couple vault implementations with the specific `Bridge` implementation.
For example, the second version of the `Bridge` may not even have a concept of
a wallet or a main wallet UTXO. Passing parameters as bytes is more flexible and
uses an existing `Bank` mechanism of `receiveBalanceApproval`.