### PR TITLE
Allow the governance to recover ERC20 and ERC721 from TBTCVault 

### DIFF
--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -90,7 +90,7 @@ contract TBTCVault is IVault, Governable {
     /// @param token Address of the recovered ERC20 token contract.
     /// @param recipient Address the recovered token should be sent to.
     /// @param amount Recovered amount.
-    function recoverERC20(
+    function recoverERC20FromToken(
         IERC20 token,
         address recipient,
         uint256 amount
@@ -104,7 +104,7 @@ contract TBTCVault is IVault, Governable {
     /// @param recipient Address the recovered token should be sent to.
     /// @param tokenId Identifier of the recovered token.
     /// @param data Additional data.
-    function recoverERC721(
+    function recoverERC721FromToken(
         IERC721 token,
         address recipient,
         uint256 tokenId,

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -31,6 +31,8 @@ import "../GovernanceUtils.sol";
 /// @dev TBTC Vault is the owner of TBTC token contract and is the only contract
 ///      minting the token.
 contract TBTCVault is IVault, Governable {
+    using SafeERC20 for IERC20;
+
     /// @notice The time delay that needs to pass between initializing and
     ///         finalizing upgrade to a new vault. The time delay forces the
     ///         upgrading party to reflect on the vault address it is upgrading
@@ -83,34 +85,6 @@ contract TBTCVault is IVault, Governable {
         tbtcToken = _tbtcToken;
 
         _transferGovernance(msg.sender);
-    }
-
-    /// @notice Allows the governance of the TBTCVault to recover any ERC20
-    ///         token sent mistakenly to the TBTC token contract address.
-    /// @param token Address of the recovered ERC20 token contract.
-    /// @param recipient Address the recovered token should be sent to.
-    /// @param amount Recovered amount.
-    function recoverERC20FromToken(
-        IERC20 token,
-        address recipient,
-        uint256 amount
-    ) external onlyGovernance {
-        tbtcToken.recoverERC20(token, recipient, amount);
-    }
-
-    /// @notice Allows the governance of the TBTCVault to recover any ERC721
-    ///         token sent mistakenly to the TBTC token contract address.
-    /// @param token Address of the recovered ERC721 token contract.
-    /// @param recipient Address the recovered token should be sent to.
-    /// @param tokenId Identifier of the recovered token.
-    /// @param data Additional data.
-    function recoverERC721FromToken(
-        IERC721 token,
-        address recipient,
-        uint256 tokenId,
-        bytes calldata data
-    ) external onlyGovernance {
-        tbtcToken.recoverERC721(token, recipient, tokenId, data);
     }
 
     /// @notice Transfers the given `amount` of the Bank balance from caller
@@ -247,6 +221,64 @@ contract TBTCVault is IVault, Governable {
         tbtcToken.transferOwnership(newVault);
         newVault = address(0);
         upgradeInitiatedTimestamp = 0;
+    }
+
+    /// @notice Allows the governance of the TBTCVault to recover any ERC20
+    ///         token sent mistakenly to the TBTC token contract address.
+    /// @param token Address of the recovered ERC20 token contract.
+    /// @param recipient Address the recovered token should be sent to.
+    /// @param amount Recovered amount.
+    function recoverERC20FromToken(
+        IERC20 token,
+        address recipient,
+        uint256 amount
+    ) external onlyGovernance {
+        tbtcToken.recoverERC20(token, recipient, amount);
+    }
+
+    /// @notice Allows the governance of the TBTCVault to recover any ERC721
+    ///         token sent mistakenly to the TBTC token contract address.
+    /// @param token Address of the recovered ERC721 token contract.
+    /// @param recipient Address the recovered token should be sent to.
+    /// @param tokenId Identifier of the recovered token.
+    /// @param data Additional data.
+    function recoverERC721FromToken(
+        IERC721 token,
+        address recipient,
+        uint256 tokenId,
+        bytes calldata data
+    ) external onlyGovernance {
+        tbtcToken.recoverERC721(token, recipient, tokenId, data);
+    }
+
+    /// @notice Allows the governance of the TBTCVault to recover any ERC20
+    ///         token sent - mistakenly or not - to the vault address. This
+    ///         function should be used to withdraw TBTC v1 tokens transferred
+    ///         to TBTCVault as a result of VendingMachine > TBTCVault upgrade.
+    /// @param token Address of the recovered ERC20 token contract.
+    /// @param recipient Address the recovered token should be sent to.
+    /// @param amount Recovered amount.
+    function recoverERC20(
+        IERC20 token,
+        address recipient,
+        uint256 amount
+    ) external onlyGovernance {
+        token.safeTransfer(recipient, amount);
+    }
+
+    /// @notice Allows the governance of the TBTCVault to recover any ERC721
+    ///         token sent mistakenly to the vault address.
+    /// @param token Address of the recovered ERC721 token contract.
+    /// @param recipient Address the recovered token should be sent to.
+    /// @param tokenId Identifier of the recovered token.
+    /// @param data Additional data.
+    function recoverERC721(
+        IERC721 token,
+        address recipient,
+        uint256 tokenId,
+        bytes calldata data
+    ) external onlyGovernance {
+        token.safeTransferFrom(address(this), recipient, tokenId, data);
     }
 
     // slither-disable-next-line calls-loop

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -105,7 +105,7 @@ describe("TBTCVault", () => {
     })
   })
 
-  describe("recoverERC20", () => {
+  describe("recoverERC20FromToken", () => {
     let testToken: TestERC20
 
     before(async () => {
@@ -123,7 +123,7 @@ describe("TBTCVault", () => {
     context("when called not by the governance", () => {
       it("should revert", async () => {
         await expect(
-          vault.recoverERC20(testToken.address, account1.address, to1e18(800))
+          vault.recoverERC20FromToken(testToken.address, account1.address, to1e18(800))
         ).to.be.revertedWith("Caller is not the governance")
       })
     })
@@ -138,7 +138,7 @@ describe("TBTCVault", () => {
 
         await vault
           .connect(governance)
-          .recoverERC20(testToken.address, account1.address, to1e18(800))
+          .recoverERC20FromToken(testToken.address, account1.address, to1e18(800))
       })
 
       after(async () => {
@@ -154,7 +154,7 @@ describe("TBTCVault", () => {
     })
   })
 
-  describe("recoverERC721", () => {
+  describe("recoverERC721FromToken", () => {
     let testToken: TestERC721
 
     before(async () => {
@@ -172,7 +172,7 @@ describe("TBTCVault", () => {
     context("when called not by the governance", () => {
       it("should revert", async () => {
         await expect(
-          vault.recoverERC721(testToken.address, account1.address, 1, "0x01")
+          vault.recoverERC721FromToken(testToken.address, account1.address, 1, "0x01")
         ).to.be.revertedWith("Caller is not the governance")
       })
     })
@@ -188,7 +188,7 @@ describe("TBTCVault", () => {
 
         await vault
           .connect(governance)
-          .recoverERC721(testToken.address, account1.address, 1, "0x01")
+          .recoverERC721FromToken(testToken.address, account1.address, 1, "0x01")
       })
 
       after(async () => {


### PR DESCRIPTION
~~Depends on #309. Keeping as a draft until #309 is not merged.~~
Refs: https://github.com/keep-network/tbtc-v2/issues/39

ERC20 and ERC721 can be sent mistakenly to `TBTCVault`, two functions allow the
governance to recover them. Most importantly though, the governance can use
`recoverERC20` to recover TBTCv1 tokens sent by `VendingMachine` to `TBTCVault`
after the upgrade.