### PR TITLE
Transfer the entire TBTCVault Bank balance to a new vault during the upgrade

### DIFF
--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -207,8 +207,9 @@ contract TBTCVault is IVault, Ownable {
     /// @notice Allows the governance to finalize vault upgrade process. The
     ///         upgrade process needs to be first initiated with a call to
     ///         `initiateUpgrade` and the `UPGRADE_GOVERNANCE_DELAY` needs to
-    ///         pass. Once the upgrade is finalized, the new vault will become
-    ///         an owner of TBTC token.
+    ///         pass. Once the upgrade is finalized, the new vault becomes the
+    ///         owner of TBTC token and receives a whole Bank balance of this
+    ///         vault.
     function finalizeUpgrade()
         external
         onlyOwner
@@ -217,6 +218,7 @@ contract TBTCVault is IVault, Ownable {
         emit UpgradeFinalized(newVault);
         // slither-disable-next-line reentrancy-no-eth
         tbtcToken.transferOwnership(newVault);
+        bank.transferBalance(newVault, bank.balanceOf(address(this)));
         newVault = address(0);
         upgradeInitiatedTimestamp = 0;
     }

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -208,8 +208,8 @@ contract TBTCVault is IVault, Ownable {
     ///         upgrade process needs to be first initiated with a call to
     ///         `initiateUpgrade` and the `UPGRADE_GOVERNANCE_DELAY` needs to
     ///         pass. Once the upgrade is finalized, the new vault becomes the
-    ///         owner of TBTC token and receives a whole Bank balance of this
-    ///         vault.
+    ///         owner of the TBTC token and receives the whole Bank balance of
+    ///         this vault.
     function finalizeUpgrade()
         external
         onlyOwner

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -1015,6 +1015,14 @@ describe("TBTCVault", () => {
         before(async () => {
           await createSnapshot()
           await vault.connect(governance).initiateUpgrade(newVault)
+
+          // Mint some TBTC to increase the balance of TBTCVault
+          await bank
+            .connect(account1)
+            .approveBalanceAndCall(vault.address, initialBalance, [])
+          await bank
+            .connect(account2)
+            .approveBalanceAndCall(vault.address, initialBalance, [])
         })
 
         after(async () => {
@@ -1054,6 +1062,14 @@ describe("TBTCVault", () => {
 
           it("should transfer TBTC token ownership", async () => {
             expect(await tbtc.owner()).is.equal(newVault)
+          })
+
+          it("should transfer the entire bank balance", async () => {
+            expect(await bank.balanceOf(vault.address)).to.equal(0)
+            // In the setup, each account minted `initialBalance` of TBTC.
+            expect(await bank.balanceOf(newVault)).to.equal(
+              initialBalance.mul(2)
+            )
           })
 
           it("should emit UpgradeFinalized event", async () => {


### PR DESCRIPTION
~~Depends on #313. Keeping as a draft until #313 is not merged.~~
Refs #39

It is not enough to transfer TBTC token ownership. The entire Bank balance needs
to be transferred as well. Without the balance transfer, the new vault would not
be able to perform BTC redemption in the Bridge.