### PR TITLE
Align wallet state revert messages

### DIFF
--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -280,7 +280,7 @@ library MovingFunds {
 
         require(
             wallet.state == Wallets.WalletState.MovingFunds,
-            "ECDSA wallet must be in MovingFunds state"
+            "Wallet must be in MovingFunds state"
         );
 
         // If the moving funds wallet already submitted their target wallets
@@ -554,7 +554,7 @@ library MovingFunds {
 
         require(
             wallet.state == Wallets.WalletState.MovingFunds,
-            "ECDSA wallet must be in MovingFunds state"
+            "Wallet must be in MovingFunds state"
         );
 
         require(
@@ -602,7 +602,7 @@ library MovingFunds {
 
         require(
             wallet.state == Wallets.WalletState.MovingFunds,
-            "ECDSA wallet must be in MovingFunds state"
+            "Wallet must be in MovingFunds state"
         );
 
         uint64 walletBtcBalance = self.getWalletBtcBalance(
@@ -1058,7 +1058,7 @@ library MovingFunds {
             walletState == Wallets.WalletState.Live ||
                 walletState == Wallets.WalletState.MovingFunds ||
                 walletState == Wallets.WalletState.Terminated,
-            "ECDSA wallet must be in Live or MovingFunds or Terminated state"
+            "Wallet must be in Live or MovingFunds or Terminated state"
         );
 
         sweepRequest.state = MovedFundsSweepRequestState.TimedOut;

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -982,7 +982,7 @@ library Redemption {
             wallet.state == Wallets.WalletState.Live ||
                 wallet.state == Wallets.WalletState.MovingFunds ||
                 wallet.state == Wallets.WalletState.Terminated,
-            "The wallet must be in Live, MovingFunds or Terminated state"
+            "Wallet must be in Live, MovingFunds or Terminated state"
         );
 
         // It is worth noting that there is no need to check if

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -287,7 +287,7 @@ library Wallets {
 
         require(
             self.registeredWallets[walletPubKeyHash].state == WalletState.Live,
-            "ECDSA wallet must be in Live state"
+            "Wallet must be in Live state"
         );
 
         moveFunds(self, walletPubKeyHash);
@@ -312,7 +312,7 @@ library Wallets {
         require(
             walletState == WalletState.Live ||
                 walletState == WalletState.MovingFunds,
-            "ECDSA wallet must be in Live or MovingFunds state"
+            "Wallet must be in Live or MovingFunds state"
         );
 
         if (walletState == WalletState.Live) {
@@ -348,7 +348,7 @@ library Wallets {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         require(
             wallet.state == WalletState.Live,
-            "ECDSA wallet must be in Live state"
+            "Wallet must be in Live state"
         );
 
         /* solhint-disable-next-line not-rely-on-time */
@@ -435,7 +435,7 @@ library Wallets {
 
         require(
             wallet.state == WalletState.Closing,
-            "ECDSA wallet must be in Closing state"
+            "Wallet must be in Closing state"
         );
 
         require(
@@ -527,7 +527,7 @@ library Wallets {
         // not reported yet.
         require(
             wallet.state == WalletState.MovingFunds,
-            "ECDSA wallet must be in MovingFunds state"
+            "Wallet must be in MovingFunds state"
         );
 
         bytes32 targetWalletsCommitmentHash = wallet

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -965,7 +965,7 @@ describe("Bridge - Moving funds", () => {
           it("should revert", async () => {
             await expect(
               bridge.resetMovingFundsTimeout(ecdsaWalletTestData.pubKeyHash160)
-            ).to.be.revertedWith("ECDSA wallet must be in MovingFunds state")
+            ).to.be.revertedWith("Wallet must be in MovingFunds state")
           })
         })
       })
@@ -1434,7 +1434,7 @@ describe("Bridge - Moving funds", () => {
 
                                         it("should revert", async () => {
                                           await expect(tx).to.be.revertedWith(
-                                            "ECDSA wallet must be in MovingFunds state"
+                                            "Wallet must be in MovingFunds state"
                                           )
                                         })
                                       })
@@ -2141,7 +2141,7 @@ describe("Bridge - Moving funds", () => {
                 ecdsaWalletTestData.pubKeyHash160,
                 []
               )
-            ).to.be.revertedWith("ECDSA wallet must be in MovingFunds state")
+            ).to.be.revertedWith("Wallet must be in MovingFunds state")
           })
         })
       })
@@ -2353,7 +2353,7 @@ describe("Bridge - Moving funds", () => {
                 ecdsaWalletTestData.pubKeyHash160,
                 NO_MAIN_UTXO
               )
-            ).to.be.revertedWith("ECDSA wallet must be in MovingFunds state")
+            ).to.be.revertedWith("Wallet must be in MovingFunds state")
           })
         })
       })
@@ -3787,7 +3787,7 @@ describe("Bridge - Moving funds", () => {
                       walletMembersIDs
                     )
                   ).to.be.revertedWith(
-                    "ECDSA wallet must be in Live or MovingFunds or Terminated state"
+                    "Wallet must be in Live or MovingFunds or Terminated state"
                   )
                 })
               })

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -4148,7 +4148,7 @@ describe("Bridge - Redemption", () => {
                         data.redemptionRequests[0].redeemerOutputScript
                       )
                   ).to.be.revertedWith(
-                    "The wallet must be in Live, MovingFunds or Terminated state"
+                    "Wallet must be in Live, MovingFunds or Terminated state"
                   )
                 })
               })

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -887,7 +887,7 @@ describe("Bridge - Wallets", () => {
                     ecdsaWalletTestData.publicKeyX,
                     ecdsaWalletTestData.publicKeyY
                   )
-              ).to.be.revertedWith("ECDSA wallet must be in Live state")
+              ).to.be.revertedWith("Wallet must be in Live state")
             })
           })
         })
@@ -1304,7 +1304,7 @@ describe("Bridge - Wallets", () => {
                     ecdsaWalletTestData.pubKeyHash160,
                     NO_MAIN_UTXO
                   )
-              ).to.be.revertedWith("ECDSA wallet must be in Live state")
+              ).to.be.revertedWith("Wallet must be in Live state")
             })
           })
         })
@@ -1497,7 +1497,7 @@ describe("Bridge - Wallets", () => {
               bridge.notifyWalletClosingPeriodElapsed(
                 ecdsaWalletTestData.pubKeyHash160
               )
-            ).to.be.revertedWith("ECDSA wallet must be in Closing state")
+            ).to.be.revertedWith("Wallet must be in Closing state")
           })
         })
       })


### PR DESCRIPTION
Refs https://github.com/keep-network/tbtc-v2/issues/255

Some revert messages were starting with `ECDSA wallet...` some others with
`Wallet...` and some others with `The wallet...`. This change aligns them using
the shortest version (:bytecodesavingsallthethings:).