### PR TITLE
Introduced resolveRedeemingWallet, removed main UTXO validation from OutboundTx

### DIFF
--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -149,6 +149,9 @@ library DepositSweep {
         BitcoinTx.UTXO calldata mainUtxo,
         address vault
     ) external {
+        // Wallet state validation is performed in the
+        // `resolveDepositSweepingWallet` function.
+
         // The actual transaction proof is performed here. After that point, we
         // can assume the transaction happened on Bitcoin chain and has
         // a sufficient number of confirmations as determined by


### PR DESCRIPTION
Refs: #255 

Main UTXO validation was a part of `OutboundTx.processWalletOutboundTxInput`. This change removes the main UTXO validation from there. For `submitRedemptionProof`, the validation happens in the newly introduced `resolveRedeemingWallet`. For `submitMovingFundsProof`, the validation happens inside `submitMovingFundsProof`.

First, this change allows saving gas on `submitMovingFundsProof` and `submitRedemptionProof` given we do not fetch wallet pointer twice from the mapping. Before/after:
```
| Bridge · submitMovingFundsProof · 200904 · 356450 · 304175 │
| Bridge · submitRedemptionProof  · 130155 · 208356 · 176074 │

| Bridge · submitMovingFundsProof · 200900 · 356446 · 304171 │
| Bridge · submitRedemptionProof  · 130103 · 208304 · 176025 │
```

Second, it allows to align wallet state validation rules.

If the function is not performing a state transition, the wallet state should be validated inside that function. For most functions (for example `Deposit.revealDeposit`, `Redemption.requestRedemption`) this will be the very first line of the logic.

There are three exceptions to this rule: `submitDepositSweepProof`, `submitRedemptionProof`, `submitMovedFundsSweepProof`. For `DepositSweep.submitDepositSweepProof` validating wallet state inside `submitDepositSweepProof` leads to stack too deep problems. Extracting it to a separate function helps. `Redemption.submitRedemptionProof` and `submitMovedFundsSweepProof` are aligned and they also perform the validation when resolving the wallet. To make it easier for future-us and external contributors, all three functions have now a comment informing where the state is validated.

State validations in functions not modifying the state of the wallet:

Bridge function | Allowed wallet states | Wallet state validation
-- | -- | --
revealDeposit | Live | Deposit.revealDeposit
submitFraudChallenge | Live, MovingFunds, Closing | Frauds.submitFraudChallenge
requestRedemption | Live | Redemption.requestRedemption
receiveBalanceApproval | Live | Redemption.requestRedemption
submitMovingFundsCommitment | MovingFunds | MovingFunds.submitMovingFundsCommitment
resetMovingFundsTimeout | MovingFunds | MovingFunds.resetMovingFundsTimeout
submitRedemptionProof | Live, MovingFunds | Redemption.resolveRedeemingWallet
submitDepositSweepProof | Live, MovingFunds | DepositSweep.resolveDepositSweepingWallet
submitMovedFundsSweepProof | Live, MovingFunds | MovingFunds.resolveMovedFundsSweepingWallet


