### PR TITLE
Line up the bridge params with the documentation

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -568,7 +568,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |`7 days`
 
 |movedFundsSweepTimeoutNotifierRewardMultiplier 
-|The percentage of the slashed stake that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds. 
+|The percentage of the staking contract notifier reward that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds. 
 |Yes 
 |`100%`
 
@@ -593,7 +593,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |`7 days`
 
 |movingFundsTimeoutNotifierRewardMultiplier 
-|The percentage of the slashed stake that the notifier receives when they notify the system about a wallet that has failed to fulfill a moving funds request. 
+|The percentage of the staking contract notifier reward that the notifier receives when they notify the system about a wallet that has failed to fulfill a moving funds request. 
 |Yes 
 |`100%`
 
@@ -618,7 +618,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |`40 days`
 
 |walletClosureMinBtcBalance 
-|The minimum amount of satoshis at which a non-active wallet is eligible to begin closing. 
+|The minimum amount of satoshis at which a non-active wallet is eligible to begin closing, regardless of the wallet's age.
 |Yes 
 |`5e7 satoshis = 0.5 BTC`
 
@@ -643,7 +643,6 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 
 |depositTreasuryFeeDivisor 
 |A divisor used to compute the treasury fee taken from each deposit and transferred to the treasury upon sweep proof submission.
-|The deposit fee divisor of one BTC to take as a treasury fee. 
 |Yes 
 |`1/2_000 = 0.05%`
 
@@ -665,7 +664,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |`5 days`
 
 |redemptionTimeoutNotifierRewardMultiplier 
-|The percentage of the slashed stake from a redemption timeout that the notifier receives as a reward. 
+|The percentage of the staking contract notifier reward that the notifier receives when they notify the system about a wallet that has failed to fulfill a redemption request.
 |Yes 
 |`100%`
 
@@ -697,7 +696,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |`5 ether`
 
 |fraudNotifierRewardMultiplier 
-|The percentage of the slashed stake from a fraud challenge that the challenger receives as a reward. 
+|The percentage of the staking contract notifier reward that the fraud challenger receives as a reward if the wallet did not defeat the challenge.
 |Yes 
 |`100%`
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -389,19 +389,19 @@ entirely, they can save a transaction and gas by calling
 4+s|Wallet Creation
 
 |walletCreationPeriod      
-|Length of time a wallet needs to exist for before a new one can be created
+|The length of time a wallet needs to exist for before a new one can be created
 |Yes
 |`1 week`
 
 |walletCreationMinBtcBalance
-|The minimum amount of satoshis an active wallet needs to have before we allow for
+|The minimum amount of satoshis an active wallet needs to hold before we allow for
 the creation of a new active wallet.
 |Yes
 |`1e8 satoshis`
 
 |walletCreationMaxBtcBalance
-|The amount of satoshis an active wallet needs to have before we allow for the
-creation of a new active wallet regardless of age.
+|The minimum amount of satoshis an active wallet needs to have before we allow
+for the creation of a new active wallet regardless of age.
 |Yes
 |`100e8 satoshis = 100 BTC`
 
@@ -413,72 +413,85 @@ creation of a new active wallet regardless of age.
 |`1 week`
 
 |walletMaxBtcTransfer
-|The amount of satoshis at which we try to divide up a closing wallet into multiple target wallets.
+|The amount of satoshis held by the closing wallet at which it should try to
+split the moved funds to multiple target wallets.
 |Yes
 |`10e8 = 10 BTC`
 
 |walletClosingPeriod
-|The amount of time the wallet remains in the `Closing` state before it is closed.
+|The amount of time the wallet remains in the `Closing` state before it can be closed.
 |Yes
 |`40 days`
 
 |walletClosureMinBtcBalance
-|The minimum amount of satoshis at which a wallet is eligible to begin closing.
+|The minimum amount of satoshis at which a non-active wallet is eligible to
+begin closing.
 |Yes
 |`5e7 = 0.5 BTC`
 
 |walletMaxAge
-|The age at which a wallet is eligible to begin closing.
+|The age at which a non-active wallet is eligible to begin closing.
 |Yes
 |`26 weeks`
 
 |movingFundsTxMaxTotalFee
-|The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction.
+|The max amount of satoshis that the wallet is allowed to pay miners for a
+moving funds transaction.
 |Yes
 |`10_000 satoshis`
 
 |movingFundsDustThreshold
-|The minimum amount of satoshis that we move from wallet to wallet when closing a wallet.
+|The minimum amount of satoshis held by a closing wallet that needs to be moved
+to a different wallet before closing.
 |Yes
 |`20_000 satoshis`
 
 |movingFundsTimeoutResetDelay
-|The amount of time one must wait to request a timeout reset on moving funds when there is no active wallet.
+|The amount of time operators must wait to request a moving funds timeout reset
+when there is no active wallet to move the funds to.
 |Yes
 |`6 days`
 
 |movingFundsTimeout
-|The amount of time group members have to move their wallet's funds to another live wallet(s).
+|The amount of time the operators have to move their wallet's funds to another
+live wallet(s).
 |Yes
 |`7 days`
 
 |movingFundsTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member loses if they do not fulfill a moving funds request.
+|The amount of stake in T tokens that each group member loses if they do not
+fulfill a moving funds request.
 |Yes
 |`10_000 * 1e18 = 10_000 T`
 
 |movingFundsTimeoutNotifierRewardMultiplier
-|The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed fulfill a moving funds request.
+|The percentage of the slashed stake that the notifier receives when they
+notify the system about a wallet that has failed to fulfill a moving funds
+request.
 |Yes
 |`100%`
 
 |movedFundsSweepTxMaxTotalFee
-|The max amount of satoshis that the target wallet is allowed to pay miners to sweep a moving funds transaction.
+|The max amount of satoshis that the target wallet is allowed to pay miners to
+process a moved funds sweep transaction.
 |Yes
 |`10_000 satoshis`
 
 |movedFundsSweepTimeout
-|The amount of time that the target wallet has to sweep the moved funds once they arrive.
+|The amount of time that the target wallet has to sweep the moved funds once
+they arrive.
 |Yes
 |`7 days`
 
 |movedFundsSweepTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member of the target wallet loses if they do not sweep moved funds.
+|The amount of stake in T tokens that each group member of the target wallet
+loses if they do not sweep moved funds.
 |Yes
 |`7 days`
 
 |movedFundsSweepTimeoutNotifierRewardMultiplier
-|The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds.
+|The percentage of the slashed stake that the notifier receives when they
+notify the system about a wallet that has failed to sweep the moved funds.
 |Yes
 |`100%`
 
@@ -497,7 +510,8 @@ creation of a new active wallet regardless of age.
 |`2_000 => 1/2_000 = 5 BPS`
 
 |depositTxMaxFee
-|The max amount of satoshis per deposit that the wallet is allowed to pay to miners.
+|The max amount of satoshis per deposit that the wallet is allowed to pay to
+miners for processing the sweep transaction.
 |Yes
 |`10_000 satoshis`
 
@@ -509,49 +523,56 @@ creation of a new active wallet regardless of age.
 |`1_000_000 satoshis`
 
 |redemptionTreasuryFeeDivisor
-|The redemption fee divisor of one BTC to take as a treasury fee.
+|A divisor used to compute the treasury fee taken from each redemption request
+and transferred to the treasury upon successful request finalization.
 |Yes
 |`2_000 => 1/2_000 = 5 BPS`
 
 |redemptionTxMaxFee
-|The max amount of satoshis per redemption that the wallet is allowed to pay miners.
+|The max amount of satoshis per redemption that the wallet is allowed to pay
+miners for processing the redemption transaction.
 |Yes
 |`10_000 satoshis`
 
 |redemptionTimeout
-|The amount of seconds a wallet has to fulfill a redemption request.
+|The amount of time a wallet has to fulfill a redemption request.
 |Yes
 |`172_800 seconds = 48 hours`
 
 |redemptionTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member will lose if they do not fulfill a redemption request.
+|The amount of stake in T tokens that each group member will lose if they do
+not fulfill a redemption request.
 |Yes
 |`10_000 * 1e18 = 10_000 T tokens` 
 
 |redemptionTimeoutNotifierRewardMultiplier 
-|The percentage of slashed stake from a redemption timeout that the notifier receives as a reward.
+|The percentage of the slashed stake from a redemption timeout that the
+notifier receives as a reward.
 |Yes
 |`100%`
 
 4+s|Fraud 
 
 |fraudChallengeDepositAmount
-|The amount of ether a challenger must deposit in order to make a wallet prove honesty.
+|The amount of ether a challenger must deposit in order to make a wallet prove
+its honesty.
 |Yes
 |`2 ether`
 
 |fraudChallengeDefeatTimeout
-|The amount of time wallet has to wallet has to defend itself from a fraud challenge.
+|The amount of time a wallet has to defend itself from a fraud challenge.
 |Yes
 |`7 days`
 
 |fraudSlashingAmount
-|The amount of T tokens that the each group member of a wallet will lose if they are defeated by a fraud challenge.
+|The amount of T tokens that the operators of a wallet lose if the fraud
+challenge does not get defeated.
 |Yes
 |`10_000 * 1e18 = 10_000 T`
 
 |fraudNotifierRewardMultiplier
-|The percentage of slashed stake from a fraud challenge that the challenger receives as a reward.
+|The percentage of the slashed stake from a fraud challenge that the challenger
+receives as a reward.
 |Yes
 |`100%`
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -376,16 +376,16 @@ entirely, they can save a transaction and gas by calling
 |`1 week`
 
 |walletCreationMinBtcBalance
-|The minimum amount of BTC an active wallet needs to have before we allow for
+|The minimum amount of satoshis an active wallet needs to have before we allow for
 the creation of a new active wallet.
 |Yes
-|`5 BTC`
+|`1e8 satoshis`
 
 |walletCreationMaxBtcBalance
-|The amount of BTC an active wallet needs to have where we allow for the
+|The amount of satoshis an active wallet needs to have before we allow for the
 creation of a new active wallet regardless of age.
 |Yes
-|`25 BTC`
+|`100e8 satoshis`
 
 4+s|Wallet Closure
 
@@ -394,25 +394,87 @@ creation of a new active wallet regardless of age.
 |Yes
 |`1 week`
 
-|movedFundsSweepTimeoutSlashingAmount
-|The amount of stake to slash if the wallet does not move its funds in time.
-|Yes
-|`100% of min-stake`
-
 |movedFundsSweepTimeoutNotifierRewardMultiplier
 |The the percentage of the slashed stake that the notifier receives as a reward.
 |Yes
 |`5%`
 
 |walletMaxBtcTransfer
-|The threshold at which we try to divide up a closing wallet into multiple target wallets
+|The amount of satoshis at which we try to divide up a closing wallet into multiple target wallets.
 |Yes
-|`50 BTC`
+|`10e8`
 
 |walletClosingPeriod
 |The amount of time the wallet remains in the `Closing` state before it is closed.
 |Yes
-|`3 days`
+|`40 days`
+
+|walletClosureMinBtcBalance
+|The minimum amount of satoshis at which a wallet is eligible to begin closing.
+|Yes
+|`5 * 1e7`
+
+|walletMaxAge
+|The age at which a wallet is eligible to begin closing.
+|Yes
+|`26 weeks`
+
+|movingFundsTxMaxTotalFee
+|The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction.
+|Yes
+|`10000 satoshis`
+
+|movingFundsDustThreshold
+|The minimum amount of satoshis that we move from wallet to wallet when closing a wallet.
+|Yes
+|`20000 satoshis`
+
+|movingFundsTimeoutResetDelay
+|The amount of time operators must wait to request a timeout reset on moving funds when there is no active wallet.
+|Yes
+|`6 days`
+
+|movingFundsTimeout
+|The amount of time operators have to move their wallet's funds to another live wallet(s).
+|Yes
+|`7 days`
+
+|movingFundsTimeoutSlashingAmount
+|The amount of stake in T tokens that operators lose if they do not move fulfill a moving funds request.
+|Yes
+|`10000 * 1e18`
+
+|movingFundsTimeoutNotifierRewardMultiplier
+|The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed fulfill a moving funds request.
+|Yes
+|`100`
+
+|movedFundsSweepTxMaxTotalFee
+|The max amount of satoshis that the target wallet is allowed to pay miners to sweep a moving funds transaction.
+|Yes
+|`10000`
+
+|movedFundsSweepTimeout
+|The amount of time that the target wallet has to sweep the moved funds once they arrive.
+|Yes
+|`7 days`
+
+|movedFundsSweepTimeoutSlashingAmount
+|The amount of stake in T tokens that operators of the target wallet lose if they do not sweep moved funds.
+|Yes
+|`7 days`
+
+|movedFundsSweepTimeoutNotifierRewardMultiplier
+|The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds.
+|Yes
+|`100`
+
+4+s|Depositing
+
+|depositDustThreshold
+|The minimum amount of satoshis in a valid deposit.
+|Yes
+|`1000000 satoshis`
 
 4+s|Sweeping
 
@@ -424,9 +486,14 @@ creation of a new active wallet regardless of age.
 |depositTxMaxFee
 |The max amount of satoshis per deposit that the wallet is allowed to pay to miners.
 |Yes
-|`10000 sats`
+|`10000 satoshis`
 
 4+s|Redeeming
+
+|redemptionDustThreshold
+|The minimum amount of satoshis in a valid redemption.
+|Yes
+|`1000000 satoshis`
 
 |redemptionTreasuryFeeDivisor
 |The redemption fee divisor of one BTC to take as a treasury fee.
@@ -437,3 +504,46 @@ creation of a new active wallet regardless of age.
 |Length of time a wallet has to fulfill a redemption.
 |Yes
 |`48 hours`
+
+|redemptionTxMaxFee
+|The max amount of satoshis per redemption that the wallet is allowed to pay miners.
+|Yes
+|`10000 satoshis`
+
+|redemptionTimeout
+|The amount of seconds a wallet has to fulfill a redemption request.
+|Yes
+|`172800 seconds = 48 hours`
+
+|redemptionTimeoutSlashingAmount
+|The amount of stake in T tokens that operators will lose if they do not fulfill a redemption request.
+|Yes
+|`10000 * 1e18` 
+
+|redemptionTimeoutNotifierRewardMultiplier 
+|The percentage of slashed stake from a redemption timeout that the notifier receives as a reward.
+|Yes
+|`100`
+
+4+s|Fraud 
+
+|fraudChallengeDepositAmount
+|The amount of ether a challenger must deposit in order to make a wallet prove honesty.
+|Yes
+|`2 ether`
+
+|fraudChallengeDefeatTimeout
+|The amount of time wallet has to wallet has to defend itself from a fraud challenge.
+|Yes
+|`7 days`
+
+|fraudSlashingAmount
+|The amount of T tokens that the operators of a wallet lose if they are defeated by a fraud challenge.
+|Yes
+|`10000 * 1e18`
+
+|fraudNotifierRewardMultiplier
+|The percentage of slashed stake from a fraud challenge that the challenger receives as a reward.
+|Yes
+|`100`
+

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -388,107 +388,92 @@ entirely, they can save a transaction and gas by calling
 
 4+s|Wallet Creation
 
-|walletCreationPeriod      
-|The length of time a wallet needs to exist for before a new one can be created
-|Yes
-|`1 week`
+|walletCreationMaxBtcBalance 
+|The minimum amount of satoshis an active wallet needs to have before we allow for the creation of a new active wallet regardless of age. 
+|Yes 
+|`100e8 satoshis = 100 BTC`
 
-|walletCreationMinBtcBalance
-|The minimum amount of satoshis an active wallet needs to hold before we allow for
-the creation of a new active wallet.
-|Yes
+|walletCreationMinBtcBalance 
+|The minimum amount of satoshis an active wallet needs to hold before we allow for the creation of a new active wallet. 
+|Yes 
 |`1e8 satoshis`
 
-|walletCreationMaxBtcBalance
-|The minimum amount of satoshis an active wallet needs to have before we allow
-for the creation of a new active wallet regardless of age.
-|Yes
-|`100e8 satoshis = 100 BTC`
+|walletCreationPeriod      
+|The length of time a wallet needs to exist for before a new one can be created 
+|Yes 
+|`1 week`
 
 4+s|Wallet Closure
 
-|walletMaxBtcTransfer
-|The amount of satoshis held by the closing wallet at which it should try to
-split the moved funds to multiple target wallets.
-|Yes
-|`10e8 = 10 BTC`
+|movedFundsSweepTimeout 
+|The amount of time that the target wallet has to sweep the moved funds once they arrive. 
+|Yes 
+|`7 days`
 
-|walletClosingPeriod
-|The amount of time the wallet remains in the `Closing` state before it can be closed.
-|Yes
-|`40 days`
+|movedFundsSweepTimeoutNotifierRewardMultiplier 
+|The percentage of the slashed stake that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds. 
+|Yes 
+|`100%`
 
-|walletClosureMinBtcBalance
-|The minimum amount of satoshis at which a non-active wallet is eligible to
-begin closing.
-|Yes
-|`5e7 = 0.5 BTC`
+|movedFundsSweepTimeoutSlashingAmount 
+|The amount of stake in T tokens that each group member of the target wallet loses if they do not sweep moved funds. 
+|Yes 
+|`7 days`
 
-|walletMaxAge
-|The age at which a non-active wallet is eligible to begin closing.
-|Yes
-|`26 weeks`
-
-|movingFundsTxMaxTotalFee
-|The max amount of satoshis that the wallet is allowed to pay miners for a
-moving funds transaction.
-|Yes
+|movedFundsSweepTxMaxTotalFee 
+|The max amount of satoshis that the target wallet is allowed to pay miners to process a moved funds sweep transaction. 
+|Yes 
 |`10_000 satoshis`
 
-|movingFundsDustThreshold
-|The minimum amount of satoshis held by a closing wallet that needs to be moved
-to a different wallet before closing.
-|Yes
+|movingFundsDustThreshold 
+|The minimum amount of satoshis held by a closing wallet that needs to be moved to a different wallet before closing. 
+|Yes 
 |`20_000 satoshis`
 
-|movingFundsTimeoutResetDelay
-|The amount of time operators must wait to request a moving funds timeout reset
-when there is no active wallet to move the funds to.
-|Yes
+|movingFundsTimeout 
+|The amount of time the operators have to move their wallet's funds to another live wallet(s). 
+|Yes 
+|`7 days`
+
+|movingFundsTimeoutNotifierRewardMultiplier 
+|The percentage of the slashed stake that the notifier receives when they notify the system about a wallet that has failed to fulfill a moving funds request. 
+|Yes 
+|`100%`
+
+|movingFundsTimeoutResetDelay 
+|The amount of time operators must wait to request a moving funds timeout reset when there is no active wallet to move the funds to. 
+|Yes 
 |`6 days`
 
-|movingFundsTimeout
-|The amount of time the operators have to move their wallet's funds to another
-live wallet(s).
-|Yes
-|`7 days`
-
-|movingFundsTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member loses if they do not
-fulfill a moving funds request.
-|Yes
+|movingFundsTimeoutSlashingAmount 
+|The amount of stake in T tokens that each group member loses if they do not fulfill a moving funds request. 
+|Yes 
 |`10_000 * 1e18 = 10_000 T`
 
-|movingFundsTimeoutNotifierRewardMultiplier
-|The percentage of the slashed stake that the notifier receives when they
-notify the system about a wallet that has failed to fulfill a moving funds
-request.
-|Yes
-|`100%`
-
-|movedFundsSweepTxMaxTotalFee
-|The max amount of satoshis that the target wallet is allowed to pay miners to
-process a moved funds sweep transaction.
-|Yes
+|movingFundsTxMaxTotalFee 
+|The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction. 
+|Yes 
 |`10_000 satoshis`
 
-|movedFundsSweepTimeout
-|The amount of time that the target wallet has to sweep the moved funds once
-they arrive.
-|Yes
-|`7 days`
+|walletClosingPeriod 
+|The amount of time the wallet remains in the `Closing` state before it can be closed. 
+|Yes 
+|`40 days`
 
-|movedFundsSweepTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member of the target wallet
-loses if they do not sweep moved funds.
-|Yes
-|`7 days`
+|walletClosureMinBtcBalance 
+|The minimum amount of satoshis at which a non-active wallet is eligible to begin closing. 
+|Yes 
+|`5e7 = 0.5 BTC`
 
-|movedFundsSweepTimeoutNotifierRewardMultiplier
-|The percentage of the slashed stake that the notifier receives when they
-notify the system about a wallet that has failed to sweep the moved funds.
-|Yes
-|`100%`
+|walletMaxAge 
+|The age at which a non-active wallet is eligible to begin closing. 
+|Yes 
+|`26 weeks`
+
+|walletMaxBtcTransfer 
+|The amount of satoshis held by the closing wallet at which it should try to split the moved funds to multiple target wallets. 
+|Yes 
+|`10e8 = 10 BTC`
 
 4+s|Depositing
 
@@ -499,75 +484,66 @@ notify the system about a wallet that has failed to sweep the moved funds.
 
 4+s|Sweeping
 
-|depositTreasuryFeeDivisor
-|The deposit fee divisor of one BTC to take as a treasury fee.
-|Yes
+|depositTreasuryFeeDivisor 
+|The deposit fee divisor of one BTC to take as a treasury fee. 
+|Yes 
 |`2_000 => 1/2_000 = 5 BPS`
 
-|depositTxMaxFee
-|The max amount of satoshis per deposit that the wallet is allowed to pay to
-miners for processing the sweep transaction.
-|Yes
+|depositTxMaxFee 
+|The max amount of satoshis per deposit that the wallet is allowed to pay to miners for processing the sweep transaction. 
+|Yes 
 |`10_000 satoshis`
 
 4+s|Redeeming
 
-|redemptionDustThreshold
-|The minimum amount of satoshis in a valid redemption.
-|Yes
+|redemptionDustThreshold 
+|The minimum amount of satoshis in a valid redemption. 
+|Yes 
 |`1_000_000 satoshis`
 
-|redemptionTreasuryFeeDivisor
-|A divisor used to compute the treasury fee taken from each redemption request
-and transferred to the treasury upon successful request finalization.
-|Yes
-|`2_000 => 1/2_000 = 5 BPS`
-
-|redemptionTxMaxFee
-|The max amount of satoshis per redemption that the wallet is allowed to pay
-miners for processing the redemption transaction.
-|Yes
-|`10_000 satoshis`
-
-|redemptionTimeout
-|The amount of time a wallet has to fulfill a redemption request.
-|Yes
+|redemptionTimeout 
+|The amount of time a wallet has to fulfill a redemption request. 
+|Yes 
 |`172_800 seconds = 48 hours`
 
-|redemptionTimeoutSlashingAmount
-|The amount of stake in T tokens that each group member will lose if they do
-not fulfill a redemption request.
-|Yes
+|redemptionTimeoutNotifierRewardMultiplier 
+|The percentage of the slashed stake from a redemption timeout that the notifier receives as a reward. 
+|Yes 
+|`100%`
+
+|redemptionTimeoutSlashingAmount 
+|The amount of stake in T tokens that each group member will lose if they do not fulfill a redemption request. 
+|Yes 
 |`10_000 * 1e18 = 10_000 T tokens` 
 
-|redemptionTimeoutNotifierRewardMultiplier 
-|The percentage of the slashed stake from a redemption timeout that the
-notifier receives as a reward.
-|Yes
-|`100%`
+|redemptionTreasuryFeeDivisor 
+|A divisor used to compute the treasury fee taken from each redemption request and transferred to the treasury upon successful request finalization. 
+|Yes 
+|`2_000 => 1/2_000 = 5 BPS`
+
+|redemptionTxMaxFee 
+|The max amount of satoshis per redemption that the wallet is allowed to pay miners for processing the redemption transaction. 
+|Yes 
+|`10_000 satoshis`
 
 4+s|Fraud 
 
-|fraudChallengeDepositAmount
-|The amount of ether a challenger must deposit in order to make a wallet prove
-its honesty.
-|Yes
-|`2 ether`
-
-|fraudChallengeDefeatTimeout
-|The amount of time a wallet has to defend itself from a fraud challenge.
-|Yes
+|fraudChallengeDefeatTimeout 
+|The amount of time a wallet has to defend itself from a fraud challenge. 
+|Yes 
 |`7 days`
 
-|fraudSlashingAmount
-|The amount of T tokens that the operators of a wallet lose if the fraud
-challenge does not get defeated.
-|Yes
-|`10_000 * 1e18 = 10_000 T`
+|fraudChallengeDepositAmount 
+|The amount of ether a challenger must deposit in order to make a wallet prove its honesty. 
+|Yes 
+|`2 ether`
 
-|fraudNotifierRewardMultiplier
-|The percentage of the slashed stake from a fraud challenge that the challenger
-receives as a reward.
-|Yes
+|fraudNotifierRewardMultiplier 
+|The percentage of the slashed stake from a fraud challenge that the challenger receives as a reward. 
+|Yes 
 |`100%`
 
+|fraudSlashingAmount 
+|The amount of T tokens that the operators of a wallet lose if the fraud challenge does not get defeated. 
+|Yes 
+|`10_000 * 1e18 = 10_000 T`

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -385,7 +385,7 @@ the creation of a new active wallet.
 |The amount of satoshis an active wallet needs to have before we allow for the
 creation of a new active wallet regardless of age.
 |Yes
-|`100e8 satoshis`
+|`100e8 satoshis = 100 BTC`
 
 4+s|Wallet Closure
 
@@ -394,15 +394,10 @@ creation of a new active wallet regardless of age.
 |Yes
 |`1 week`
 
-|movedFundsSweepTimeoutNotifierRewardMultiplier
-|The the percentage of the slashed stake that the notifier receives as a reward.
-|Yes
-|`5%`
-
 |walletMaxBtcTransfer
 |The amount of satoshis at which we try to divide up a closing wallet into multiple target wallets.
 |Yes
-|`10e8`
+|`10e8 = 10 BTC`
 
 |walletClosingPeriod
 |The amount of time the wallet remains in the `Closing` state before it is closed.
@@ -412,7 +407,7 @@ creation of a new active wallet regardless of age.
 |walletClosureMinBtcBalance
 |The minimum amount of satoshis at which a wallet is eligible to begin closing.
 |Yes
-|`5 * 1e7`
+|`5e7 = 0.5 BTC`
 
 |walletMaxAge
 |The age at which a wallet is eligible to begin closing.
@@ -422,12 +417,12 @@ creation of a new active wallet regardless of age.
 |movingFundsTxMaxTotalFee
 |The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction.
 |Yes
-|`10000 satoshis`
+|`10_000 satoshis`
 
 |movingFundsDustThreshold
 |The minimum amount of satoshis that we move from wallet to wallet when closing a wallet.
 |Yes
-|`20000 satoshis`
+|`20_000 satoshis`
 
 |movingFundsTimeoutResetDelay
 |The amount of time operators must wait to request a timeout reset on moving funds when there is no active wallet.
@@ -442,17 +437,17 @@ creation of a new active wallet regardless of age.
 |movingFundsTimeoutSlashingAmount
 |The amount of stake in T tokens that operators lose if they do not move fulfill a moving funds request.
 |Yes
-|`10000 * 1e18`
+|`10_000 * 1e18 = 10_000 T`
 
 |movingFundsTimeoutNotifierRewardMultiplier
 |The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed fulfill a moving funds request.
 |Yes
-|`100`
+|`100%`
 
 |movedFundsSweepTxMaxTotalFee
 |The max amount of satoshis that the target wallet is allowed to pay miners to sweep a moving funds transaction.
 |Yes
-|`10000`
+|`10_000 satoshis`
 
 |movedFundsSweepTimeout
 |The amount of time that the target wallet has to sweep the moved funds once they arrive.
@@ -467,58 +462,58 @@ creation of a new active wallet regardless of age.
 |movedFundsSweepTimeoutNotifierRewardMultiplier
 |The percentage of slashed stake that the notifier receives when they notify the system about a wallet that has failed to sweep the moved funds.
 |Yes
-|`100`
+|`100%`
 
 4+s|Depositing
 
 |depositDustThreshold
 |The minimum amount of satoshis in a valid deposit.
 |Yes
-|`1000000 satoshis`
+|`1_000_000 satoshis`
 
 4+s|Sweeping
 
 |depositTreasuryFeeDivisor
 |The deposit fee divisor of one BTC to take as a treasury fee.
 |Yes
-|`2000 => 1/2000 = 5 BPS`
+|`2_000 => 1/2_000 = 5 BPS`
 
 |depositTxMaxFee
 |The max amount of satoshis per deposit that the wallet is allowed to pay to miners.
 |Yes
-|`10000 satoshis`
+|`10_000 satoshis`
 
 4+s|Redeeming
 
 |redemptionDustThreshold
 |The minimum amount of satoshis in a valid redemption.
 |Yes
-|`1000000 satoshis`
+|`1_000_000 satoshis`
 
 |redemptionTreasuryFeeDivisor
 |The redemption fee divisor of one BTC to take as a treasury fee.
 |Yes
-|`2000 => 1/2000 = 5 BPS`
+|`2_000 => 1/2_000 = 5 BPS`
 
 |redemptionTxMaxFee
 |The max amount of satoshis per redemption that the wallet is allowed to pay miners.
 |Yes
-|`10000 satoshis`
+|`10_000 satoshis`
 
 |redemptionTimeout
 |The amount of seconds a wallet has to fulfill a redemption request.
 |Yes
-|`172800 seconds = 48 hours`
+|`172_800 seconds = 48 hours`
 
 |redemptionTimeoutSlashingAmount
 |The amount of stake in T tokens that operators will lose if they do not fulfill a redemption request.
 |Yes
-|`10000 * 1e18` 
+|`10_000 * 1e18 = 10_000 T tokens` 
 
 |redemptionTimeoutNotifierRewardMultiplier 
 |The percentage of slashed stake from a redemption timeout that the notifier receives as a reward.
 |Yes
-|`100`
+|`100%`
 
 4+s|Fraud 
 
@@ -535,10 +530,10 @@ creation of a new active wallet regardless of age.
 |fraudSlashingAmount
 |The amount of T tokens that the operators of a wallet lose if they are defeated by a fraud challenge.
 |Yes
-|`10000 * 1e18`
+|`10_000 * 1e18 = 10_000 T`
 
 |fraudNotifierRewardMultiplier
 |The percentage of slashed stake from a fraud challenge that the challenger receives as a reward.
 |Yes
-|`100`
+|`100%`
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -500,11 +500,6 @@ creation of a new active wallet regardless of age.
 |Yes
 |`2000 => 1/2000 = 5 BPS`
 
-|redemptionTimeout
-|Length of time a wallet has to fulfill a redemption.
-|Yes
-|`48 hours`
-
 |redemptionTxMaxFee
 |The max amount of satoshis per redemption that the wallet is allowed to pay miners.
 |Yes

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -553,7 +553,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |walletCreationMinBtcBalance 
 |The minimum amount of satoshis an active wallet needs to hold before we allow for the creation of a new active wallet. 
 |Yes 
-|`1e8 satoshis`
+|`1e8 satoshis = 1 BTC`
 
 |walletCreationPeriod      
 |The length of time a wallet needs to exist for before a new one can be created 
@@ -580,12 +580,12 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |movedFundsSweepTxMaxTotalFee 
 |The max amount of satoshis that the target wallet is allowed to pay miners to process a moved funds sweep transaction. 
 |Yes 
-|`100_000 satoshis`
+|`100_000 satoshis = 0.001 BTC`
 
 |movingFundsDustThreshold 
 |The minimum amount of satoshis held by a closing wallet that needs to be moved to a different wallet before closing. 
 |Yes 
-|`200_000 satoshis`
+|`200_000 satoshis = 0.002 BTC`
 
 |movingFundsTimeout 
 |The amount of time group members have to move their wallet's funds to another live wallet(s). 
@@ -610,7 +610,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |movingFundsTxMaxTotalFee 
 |The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction. 
 |Yes 
-|`100_000 satoshis`
+|`100_000 satoshis = 0.001 BTC`
 
 |walletClosingPeriod 
 |The amount of time the wallet remains in the `Closing` state before it can be closed. 
@@ -620,7 +620,7 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |walletClosureMinBtcBalance 
 |The minimum amount of satoshis at which a non-active wallet is eligible to begin closing. 
 |Yes 
-|`5e7 = 0.5 BTC`
+|`5e7 satoshis = 0.5 BTC`
 
 |walletMaxAge 
 |The age at which a non-active wallet is eligible to begin closing. 
@@ -630,14 +630,14 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |walletMaxBtcTransfer 
 |The amount of satoshis held by the closing wallet at which it should try to split the moved funds to multiple target wallets. 
 |Yes 
-|`10e8 = 10 BTC`
+|`10e8 satoshis = 10 BTC`
 
 4+s|Depositing
 
 |depositDustThreshold
 |The minimum amount of satoshis in a valid deposit.
 |Yes
-|`1_000_000 satoshis`
+|`1_000_000 satoshis = 0.01 BTC`
 
 4+s|Sweeping
 
@@ -645,19 +645,19 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |A divisor used to compute the treasury fee taken from each deposit and transferred to the treasury upon sweep proof submission.
 |The deposit fee divisor of one BTC to take as a treasury fee. 
 |Yes 
-|`2_000 => 1/2_000 = 5 BPS`
+|`1/2_000 = 0.05%`
 
 |depositTxMaxFee 
 |The max amount of satoshis per deposit that the wallet is allowed to pay to miners for processing the sweep transaction. 
 |Yes 
-|`100_000 satoshis`
+|`100_000 satoshis = 0.001 BTC`
 
 4+s|Redeeming
 
 |redemptionDustThreshold 
 |The minimum amount of satoshis in a valid redemption. 
 |Yes 
-|`1_000_000 satoshis`
+|`1_000_000 satoshis = 0.01 BTC`
 
 |redemptionTimeout 
 |The amount of time a wallet has to fulfill a redemption request. 
@@ -677,12 +677,12 @@ This diagram maps out how the `CLOSING` state transitions to the `CLOSED` state.
 |redemptionTreasuryFeeDivisor 
 |A divisor used to compute the treasury fee taken from each redemption request and transferred to the treasury upon successful request finalization. 
 |Yes 
-|`2_000 => 1/2_000 = 5 BPS`
+|`1/2_000 = 0.05%`
 
 |redemptionTxMaxFee 
 |The max amount of satoshis per redemption that the wallet is allowed to pay miners for processing the redemption transaction. 
 |Yes 
-|`100_000 satoshis`
+|`100_000 satoshis = 0.001 BTC`
 
 4+s|Fraud 
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -431,7 +431,7 @@ entirely, they can save a transaction and gas by calling
 |`20_000 satoshis`
 
 |movingFundsTimeout 
-|The amount of time the operators have to move their wallet's funds to another live wallet(s). 
+|The amount of time group members have to move their wallet's funds to another live wallet(s). 
 |Yes 
 |`7 days`
 
@@ -485,6 +485,7 @@ entirely, they can save a transaction and gas by calling
 4+s|Sweeping
 
 |depositTreasuryFeeDivisor 
+|A divisor used to compute the treasury fee taken from each deposit and transferred to the treasury upon sweep proof submission.
 |The deposit fee divisor of one BTC to take as a treasury fee. 
 |Yes 
 |`2_000 => 1/2_000 = 5 BPS`
@@ -514,7 +515,7 @@ entirely, they can save a transaction and gas by calling
 |redemptionTimeoutSlashingAmount 
 |The amount of stake in T tokens that each group member will lose if they do not fulfill a redemption request. 
 |Yes 
-|`10_000 * 1e18 = 10_000 T tokens` 
+|`10_000 * 1e18 = 10_000 T` 
 
 |redemptionTreasuryFeeDivisor 
 |A divisor used to compute the treasury fee taken from each redemption request and transferred to the treasury upon successful request finalization. 
@@ -544,6 +545,6 @@ entirely, they can save a transaction and gas by calling
 |`100%`
 
 |fraudSlashingAmount 
-|The amount of T tokens that the operators of a wallet lose if the fraud challenge does not get defeated. 
+|The amount of T tokens that each group member of a wallet loses if the fraud challenge does not get defeated. 
 |Yes 
 |`10_000 * 1e18 = 10_000 T`

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -418,17 +418,17 @@ entirely, they can save a transaction and gas by calling
 |movedFundsSweepTimeoutSlashingAmount 
 |The amount of stake in T tokens that each group member of the target wallet loses if they do not sweep moved funds. 
 |Yes 
-|`7 days`
+|`100 * 1e18 = 100 T`
 
 |movedFundsSweepTxMaxTotalFee 
 |The max amount of satoshis that the target wallet is allowed to pay miners to process a moved funds sweep transaction. 
 |Yes 
-|`10_000 satoshis`
+|`100_000 satoshis`
 
 |movingFundsDustThreshold 
 |The minimum amount of satoshis held by a closing wallet that needs to be moved to a different wallet before closing. 
 |Yes 
-|`20_000 satoshis`
+|`200_000 satoshis`
 
 |movingFundsTimeout 
 |The amount of time group members have to move their wallet's funds to another live wallet(s). 
@@ -448,12 +448,12 @@ entirely, they can save a transaction and gas by calling
 |movingFundsTimeoutSlashingAmount 
 |The amount of stake in T tokens that each group member loses if they do not fulfill a moving funds request. 
 |Yes 
-|`10_000 * 1e18 = 10_000 T`
+|`100 * 1e18 = 100 T`
 
 |movingFundsTxMaxTotalFee 
 |The max amount of satoshis that the wallet is allowed to pay miners for a moving funds transaction. 
 |Yes 
-|`10_000 satoshis`
+|`100_000 satoshis`
 
 |walletClosingPeriod 
 |The amount of time the wallet remains in the `Closing` state before it can be closed. 
@@ -493,7 +493,7 @@ entirely, they can save a transaction and gas by calling
 |depositTxMaxFee 
 |The max amount of satoshis per deposit that the wallet is allowed to pay to miners for processing the sweep transaction. 
 |Yes 
-|`10_000 satoshis`
+|`100_000 satoshis`
 
 4+s|Redeeming
 
@@ -505,7 +505,7 @@ entirely, they can save a transaction and gas by calling
 |redemptionTimeout 
 |The amount of time a wallet has to fulfill a redemption request. 
 |Yes 
-|`172_800 seconds = 48 hours`
+|`5 days`
 
 |redemptionTimeoutNotifierRewardMultiplier 
 |The percentage of the slashed stake from a redemption timeout that the notifier receives as a reward. 
@@ -515,7 +515,7 @@ entirely, they can save a transaction and gas by calling
 |redemptionTimeoutSlashingAmount 
 |The amount of stake in T tokens that each group member will lose if they do not fulfill a redemption request. 
 |Yes 
-|`10_000 * 1e18 = 10_000 T` 
+|`100 * 1e18 = 100 T` 
 
 |redemptionTreasuryFeeDivisor 
 |A divisor used to compute the treasury fee taken from each redemption request and transferred to the treasury upon successful request finalization. 
@@ -525,7 +525,7 @@ entirely, they can save a transaction and gas by calling
 |redemptionTxMaxFee 
 |The max amount of satoshis per redemption that the wallet is allowed to pay miners for processing the redemption transaction. 
 |Yes 
-|`10_000 satoshis`
+|`100_000 satoshis`
 
 4+s|Fraud 
 
@@ -537,7 +537,7 @@ entirely, they can save a transaction and gas by calling
 |fraudChallengeDepositAmount 
 |The amount of ether a challenger must deposit in order to make a wallet prove its honesty. 
 |Yes 
-|`2 ether`
+|`5 ether`
 
 |fraudNotifierRewardMultiplier 
 |The percentage of the slashed stake from a fraud challenge that the challenger receives as a reward. 
@@ -547,4 +547,4 @@ entirely, they can save a transaction and gas by calling
 |fraudSlashingAmount 
 |The amount of T tokens that each group member of a wallet loses if the fraud challenge does not get defeated. 
 |Yes 
-|`10_000 * 1e18 = 10_000 T`
+|`100 * 1e18 = 100 T`

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -52,7 +52,7 @@ There are six states for a wallet:
   funds to another wallet before a timeout, or did not sweep funds moved to it
   from another wallet before a timeout. The wallet is blocked and can not
   perform any actions in the Bridge. Off-chain coordination with the wallet
-  operators is needed to recover funds.
+  group members is needed to recover funds.
 
 
 image::diagrams/wallet-lifecycle/wallet-state-transition.png[Wallet State Transition]
@@ -133,6 +133,24 @@ itself Bank Balance to hold on behalf of the user, in exchange for minting the
 user the equivalent amount of TBTC tokens. Later, anyone with TBTC tokens can
 send them back to the `TBTCVault` and the vault will grant them Bank balance.
 
+=== Operators vs Group Members
+
+tBTCv2 works by combining on-chain smart contracts with off-chain operators.
+Those operators must _stake_ T tokens into the contracts, which exposes
+themselves to punishment for misbehavior, and in exchange are delegated work by
+the smart contracts.
+
+A single operator can be selected multiple times to be in one signing group.
+For more details about how this works, see
+link:https://github.com/keep-network/keep-core/tree/main/solidity/ecdsa#the-mechanism[Wallet
+Creation]. Since this is the case, we differentiate between an _Operator_,
+which represents a staker on the network running client software, and a _Group
+Member_, which is an _Operator_ who has been selected to help custody a specific
+wallet. 
+
+To reiterate, One _Operator_ can be a _Group Member_ multiple times on the same
+wallet, and can be a _Group Member_ in multiple wallets at the same time.
+
 == The Mechanism
 
 [wallet-lifecycle]
@@ -163,7 +181,7 @@ wallet. Going forward, it will receive deposits.
 
 Wallets can close in a few ways:
 
-* The operators notify the chain that the wallet is failing a heartbeat:
+* The group members notify the chain that the wallet is failing a heartbeat:
 `Bridge. __ecdsaWalletHeartbeatFailedCallback` (called by `ecdsa`
 `WalletRegistry.notifyOperatorInactivity`)`
 * Someone notifies the chain that the wallet timed out while filling a
@@ -187,7 +205,7 @@ After `movingFundsTimeout` goes by, anyone can call
 `ecdsaWalletRegistry.closeWallet` after changing the state to
 `WalletState.Terminated`.
 
-Furthermore, the `ecdsaWalletRegistry.seize` call is punishing the operators by
+Furthermore, the `ecdsaWalletRegistry.seize` call is punishing the group members by
 `movedFundsSweepTimeoutSlashingAmount` and rewarding the notifier with a reward
 multiplier of `movedFundsSweepTimeoutNotifierRewardMultiplier` (the notifier
 gets a percentaged of the slashed stake).
@@ -316,13 +334,13 @@ can either be made in a separate transaction first via
 If the redemption was not performed by the wallet, after the redemption
 timeout, anyone may call `Bridge.notifyRedemptionTimeout`. This will decrease
 `wallet.pendingRedemptionsValue`, mark the redemption as "timed out", punish
-the operators for `Bridge.redemptionTimeoutSlashingAmount`, and reward the
+the group members for `Bridge.redemptionTimeoutSlashingAmount`, and reward the
 notifier for a percentage (`Bridge.redemptionTimeoutNotifierRewardMultiplier`)
 of the slashed stake. The redeemer is reimbursed the Bank balance of the
 redemption, and the wallet begins to move its funds via
 `Wallets.notifyWalletTimedOutRedemption`.
 
-To avoid this, the operators must fulfill the redemption by signing a
+To avoid this, the group members must fulfill the redemption by signing a
 transaction off-chain (potentially in a batch), submitting it to the Bitcoin
 chain, and then proving that they did so via `Bridge.submitRedemptionProof`. We
 perform an SPV proof to ensure the transaction occurred, it is well-formed, and
@@ -425,17 +443,17 @@ creation of a new active wallet regardless of age.
 |`20_000 satoshis`
 
 |movingFundsTimeoutResetDelay
-|The amount of time operators must wait to request a timeout reset on moving funds when there is no active wallet.
+|The amount of time one must wait to request a timeout reset on moving funds when there is no active wallet.
 |Yes
 |`6 days`
 
 |movingFundsTimeout
-|The amount of time operators have to move their wallet's funds to another live wallet(s).
+|The amount of time group members have to move their wallet's funds to another live wallet(s).
 |Yes
 |`7 days`
 
 |movingFundsTimeoutSlashingAmount
-|The amount of stake in T tokens that operators lose if they do not move fulfill a moving funds request.
+|The amount of stake in T tokens that each group member loses if they do not fulfill a moving funds request.
 |Yes
 |`10_000 * 1e18 = 10_000 T`
 
@@ -455,7 +473,7 @@ creation of a new active wallet regardless of age.
 |`7 days`
 
 |movedFundsSweepTimeoutSlashingAmount
-|The amount of stake in T tokens that operators of the target wallet lose if they do not sweep moved funds.
+|The amount of stake in T tokens that each group member of the target wallet loses if they do not sweep moved funds.
 |Yes
 |`7 days`
 
@@ -506,7 +524,7 @@ creation of a new active wallet regardless of age.
 |`172_800 seconds = 48 hours`
 
 |redemptionTimeoutSlashingAmount
-|The amount of stake in T tokens that operators will lose if they do not fulfill a redemption request.
+|The amount of stake in T tokens that each group member will lose if they do not fulfill a redemption request.
 |Yes
 |`10_000 * 1e18 = 10_000 T tokens` 
 
@@ -528,7 +546,7 @@ creation of a new active wallet regardless of age.
 |`7 days`
 
 |fraudSlashingAmount
-|The amount of T tokens that the operators of a wallet lose if they are defeated by a fraud challenge.
+|The amount of T tokens that the each group member of a wallet will lose if they are defeated by a fraud challenge.
 |Yes
 |`10_000 * 1e18 = 10_000 T`
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -407,11 +407,6 @@ for the creation of a new active wallet regardless of age.
 
 4+s|Wallet Closure
 
-|movingFundsTimeout
-|The amount of time a wallet has to move funds before facing penalty.
-|Yes
-|`1 week`
-
 |walletMaxBtcTransfer
 |The amount of satoshis held by the closing wallet at which it should try to
 split the moved funds to multiple target wallets.


### PR DESCRIPTION
This PR adds the rest of the params from https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/bridge/Bridge.sol#L263-L292 to the documentation.

I used the bridge as the source of truth here. Notably out of scope and still important to do is checking to make sure that the values are what we want them to be - that'll be a follow-up. This just makes sure that the bridge and docs agree, and that the descriptions are accurate.

Tagging @pdyraga or @michalinacienciala for review