### PR TITLE
🚧 😇 🔑  Update construction of a redemption key

### DIFF
--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -57,8 +57,11 @@ export class Bridge implements ChainBridge {
     // Build the redemption key by using the 0x-prefixed wallet PKH and
     // prefixed output script.
     const redemptionKey = utils.solidityKeccak256(
-      ["bytes20", "bytes"],
-      [`0x${walletPubKeyHash}`, prefixedRawRedeemerOutputScript]
+      ["bytes32", "bytes20"],
+      [
+        utils.solidityKeccak256(["bytes"], [prefixedRawRedeemerOutputScript]),
+        `0x${walletPubKeyHash}`,
+      ]
     )
 
     const request = await this._bridge.pendingRedemptions(redemptionKey)

--- a/typescript/test/data/redemption.ts
+++ b/typescript/test/data/redemption.ts
@@ -71,7 +71,7 @@ export const singleP2PKHRedemptionWithWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xe7a0e8b724c3ee7708701137cb57f0a742e284b4ad0b21cc16a3b3fbe733521a",
+        "0xcb493004c645792101cfa4cc5da4c16aa3148065034371a6f1478b7df4b92d39",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -126,7 +126,7 @@ export const singleP2WPKHRedemptionWithWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xbd6593f81039fe17735ef62f15a6532f5df31cd641400c45218cfbefcb9625e7",
+        "0x52a5e94b7f933cbc9565c61d43a83921a6b7bbf950156a2dfda7743a7cefffbf",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -180,7 +180,7 @@ export const singleP2SHRedemptionWithWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xa662ed384844519cdf051288008af701eeb24bd4d3bf157b0fc885656135c820",
+        "0x4f5c364239f365622168b8fcb3f4556a8bbad22f5b5ae598757c4fe83b3a78d7",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -234,7 +234,7 @@ export const singleP2WSHRedemptionWithWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xbc985c5ef4dec86ae1eba229623636f405e873ad5b154d294ec18f8cabc16185",
+        "0x2636de6d29da2c7e229a31f3a39b151e2dcd149b1cc2c4e28008f9ab1b02c112",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -289,7 +289,7 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xe7a0e8b724c3ee7708701137cb57f0a742e284b4ad0b21cc16a3b3fbe733521a",
+        "0xcb493004c645792101cfa4cc5da4c16aa3148065034371a6f1478b7df4b92d39",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -305,7 +305,7 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
     },
     {
       redemptionKey:
-        "0xbd6593f81039fe17735ef62f15a6532f5df31cd641400c45218cfbefcb9625e7",
+        "0x52a5e94b7f933cbc9565c61d43a83921a6b7bbf950156a2dfda7743a7cefffbf",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -320,7 +320,7 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
     },
     {
       redemptionKey:
-        "0xa662ed384844519cdf051288008af701eeb24bd4d3bf157b0fc885656135c820",
+        "0x4f5c364239f365622168b8fcb3f4556a8bbad22f5b5ae598757c4fe83b3a78d7",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -335,7 +335,7 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
     },
     {
       redemptionKey:
-        "0xbc985c5ef4dec86ae1eba229623636f405e873ad5b154d294ec18f8cabc16185",
+        "0x2636de6d29da2c7e229a31f3a39b151e2dcd149b1cc2c4e28008f9ab1b02c112",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -393,7 +393,7 @@ export const multipleRedemptionsWithoutChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xe7a0e8b724c3ee7708701137cb57f0a742e284b4ad0b21cc16a3b3fbe733521a",
+        "0xcb493004c645792101cfa4cc5da4c16aa3148065034371a6f1478b7df4b92d39",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -409,7 +409,7 @@ export const multipleRedemptionsWithoutChange: RedemptionTestData = {
     },
     {
       redemptionKey:
-        "0xddd0fd5d4e471ff4573eb0906088a53e8b8dbb3f1ce2f1b33b285a1c104b59a1",
+        "0xa690d9da3e64c337eb11344b94cf948ec2da333f0a985e09f1c120a326f6de87",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
@@ -466,7 +466,7 @@ export const singleP2SHRedemptionWithNonWitnessChange: RedemptionTestData = {
   pendingRedemptions: [
     {
       redemptionKey:
-        "0xa662ed384844519cdf051288008af701eeb24bd4d3bf157b0fc885656135c820",
+        "0x4f5c364239f365622168b8fcb3f4556a8bbad22f5b5ae598757c4fe83b3a78d7",
       pendingRedemption: {
         redeemer: {
           identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",

--- a/typescript/test/ethereum.test.ts
+++ b/typescript/test/ethereum.test.ts
@@ -38,10 +38,10 @@ describe("Ethereum", () => {
         // the test call.
         await bridgeContract.mock.pendingRedemptions
           .withArgs(
-            "0xa662ed384844519cdf051288008af701eeb24bd4d3bf157b0fc885656135c820"
+            "0x4f5c364239f365622168b8fcb3f4556a8bbad22f5b5ae598757c4fe83b3a78d7"
           )
           .returns({
-            redeemer: "0x82883a4C7A8dD73ef165deB402d432613615ced4",
+            redeemer: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
             requestedAmount: BigNumber.from(10000),
             treasuryFee: BigNumber.from(100),
             txMaxFee: BigNumber.from(50),
@@ -57,7 +57,7 @@ describe("Ethereum", () => {
           )
         ).to.be.eql({
           redeemer: {
-            identifierHex: "82883a4c7a8dd73ef165deb402d432613615ced4",
+            identifierHex: "f39fd6e51aad88f6f4ce6ab8827279cfffb92266",
           },
           redeemerOutputScript:
             "a9143ec459d0f3c29286ae5df5fcc421e2786024277e87",

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -143,8 +143,11 @@ export class MockBridge implements Bridge {
       ]).toString("hex")}`
 
       const redemptionKey = utils.solidityKeccak256(
-        ["bytes20", "bytes"],
-        [prefixedWalletPubKeyHash, prefixedOutputScript]
+        ["bytes32", "bytes20"],
+        [
+          utils.solidityKeccak256(["bytes"], [prefixedOutputScript]),
+          prefixedWalletPubKeyHash,
+        ]
       )
 
       // Return the redemption if it is found in the map.


### PR DESCRIPTION
Closes: #347 

There was a change that modified how the redemption key is build. Instead of
building it as `keccak256(walletPubKeyHash | redeemerOutputScript)` we now build
it as `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`. The
documentation in ts-lib was updated, but we did not update the values and
bulding redemptions key itself in tests.

I also tested the function using `walletPubKeyHash` and `redeemerOutputScript` 
used in 
https://github.com/keep-network/tbtc-v2/blob/de265cf8dd52411f853f01d18c520af473448efd/solidity/test/bridge/Bridge.Redemption.test.ts#L252-L255
and the generated key was correct.