### PR TITLE
Revisited initial Bridge parameters

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -294,7 +294,7 @@ contract Bridge is
         self.walletCreationMaxBtcBalance = 100e8; // 100 BTC
         self.walletClosureMinBtcBalance = 5 * 1e7; // 0.5 BTC
         self.walletMaxAge = 26 weeks; // ~6 months
-        self.walletMaxBtcTransfer = 50e8; // 50 BTC
+        self.walletMaxBtcTransfer = 10e8; // 10 BTC
         self.walletClosingPeriod = 40 days;
 
         _transferGovernance(msg.sender);

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -258,37 +258,43 @@ contract Bridge is
 
         self.txProofDifficultyFactor = _txProofDifficultyFactor;
 
-        // TODO: Revisit initial values.
-        //       https://github.com/keep-network/tbtc-v2/issues/258
+        //
+        // All parameters set in the constructor are initial ones, used at the
+        // moment contracts were deployed for the first time. Parameters are
+        // governable and values assigned in the constructor do not need to
+        // reflect the current ones. Keep in mind the initial parameters are
+        // pretty forgiving and valid only for the early stage of the network.
+        //
+
         self.depositDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
-        self.depositTxMaxFee = 10000; // 10000 satoshi
+        self.depositTxMaxFee = 100000; // 100000 satoshi = 0.001 BTC
         self.depositTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
         self.redemptionDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
         self.redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
-        self.redemptionTxMaxFee = 10000; // 10000 satoshi
-        self.redemptionTimeout = 172800; // 48 hours
-        self.redemptionTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
+        self.redemptionTxMaxFee = 100000; // 100000 satoshi = 0.001 BTC
+        self.redemptionTimeout = 5 days;
+        self.redemptionTimeoutSlashingAmount = 100 * 1e18; // 100 T
         self.redemptionTimeoutNotifierRewardMultiplier = 100; // 100%
-        self.movingFundsTxMaxTotalFee = 10000; // 10000 satoshi
-        self.movingFundsDustThreshold = 20000; // 20000 satoshi
+        self.movingFundsTxMaxTotalFee = 100000; // 100000 satoshi = 0.001 BTC
+        self.movingFundsDustThreshold = 200000; // 200000 satoshi = 0.002 BTC
         self.movingFundsTimeoutResetDelay = 6 days;
         self.movingFundsTimeout = 7 days;
-        self.movingFundsTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
+        self.movingFundsTimeoutSlashingAmount = 100 * 1e18; // 100 T
         self.movingFundsTimeoutNotifierRewardMultiplier = 100; //100%
-        self.movedFundsSweepTxMaxTotalFee = 10000; // 10000 satoshi
+        self.movedFundsSweepTxMaxTotalFee = 100000; // 100000 satoshi = 0.001 BTC
         self.movedFundsSweepTimeout = 7 days;
-        self.movedFundsSweepTimeoutSlashingAmount = 10000 * 1e18; // 10000 T
+        self.movedFundsSweepTimeoutSlashingAmount = 100 * 1e18; // 100 T
         self.movedFundsSweepTimeoutNotifierRewardMultiplier = 100; //100%
-        self.fraudChallengeDepositAmount = 2 ether;
+        self.fraudChallengeDepositAmount = 5 ether;
         self.fraudChallengeDefeatTimeout = 7 days;
-        self.fraudSlashingAmount = 10000 * 1e18; // 10000 T
+        self.fraudSlashingAmount = 100 * 1e18; // 100 T
         self.fraudNotifierRewardMultiplier = 100; // 100%
         self.walletCreationPeriod = 1 weeks;
         self.walletCreationMinBtcBalance = 1e8; // 1 BTC
         self.walletCreationMaxBtcBalance = 100e8; // 100 BTC
         self.walletClosureMinBtcBalance = 5 * 1e7; // 0.5 BTC
         self.walletMaxAge = 26 weeks; // ~6 months
-        self.walletMaxBtcTransfer = 10e8; // 10 BTC
+        self.walletMaxBtcTransfer = 50e8; // 50 BTC
         self.walletClosingPeriod = 40 days;
 
         _transferGovernance(msg.sender);

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -356,6 +356,7 @@ library BridgeState {
     ///        such transaction is considered a fraud.
     /// @dev Requirements:
     ///      - Deposit dust threshold must be greater than zero,
+    ///      - Deposit dust threshold must be greater than deposit TX max fee,
     ///      - Deposit treasury fee divisor must be greater than zero,
     ///      - Deposit transaction max fee must be greater than zero.
     function updateDepositParameters(
@@ -367,6 +368,11 @@ library BridgeState {
         require(
             _depositDustThreshold > 0,
             "Deposit dust threshold must be greater than zero"
+        );
+
+        require(
+            _depositDustThreshold > _depositTxMaxFee,
+            "Deposit dust threshold must be greater than deposit TX max fee"
         );
 
         require(
@@ -431,6 +437,8 @@ library BridgeState {
     /// @dev Requirements:
     ///      - Redemption dust threshold must be greater than moving funds dust
     ///        threshold,
+    ///      - Redemption dust threshold must be greater than the redemption TX
+    ///        max fee,
     ///      - Redemption treasury fee divisor must be greater than zero,
     ///      - Redemption transaction max fee must be greater than zero,
     ///      - Redemption timeout must be greater than zero,
@@ -448,6 +456,11 @@ library BridgeState {
         require(
             _redemptionDustThreshold > self.movingFundsDustThreshold,
             "Redemption dust threshold must be greater than moving funds dust threshold"
+        );
+
+        require(
+            _redemptionDustThreshold > _redemptionTxMaxFee,
+            "Redemption dust threshold must be greater than redemption TX max fee"
         );
 
         require(

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -86,6 +86,10 @@ contract BridgeStub is Bridge {
         self.redemptionDustThreshold = _redemptionDustThreshold;
     }
 
+    function setRedemptionTxMaxFee(uint64 _redemptionTxMaxFee) external {
+        self.redemptionTxMaxFee = _redemptionTxMaxFee;
+    }
+
     function setRedemptionTreasuryFeeDivisor(
         uint64 _redemptionTreasuryFeeDivisor
     ) external {

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -157,12 +157,12 @@ describe("Bridge - Moving funds", () => {
 
                   context("when passed wallet main UTXO is valid", () => {
                     context("when wallet balance is greater than zero", () => {
-                      // Just an arbitrary main UTXO with value of 130 BTC.
+                      // Just an arbitrary main UTXO with value of 26 BTC.
                       const mainUtxo = {
                         txHash:
                           "0xc9e58780c6c289c25ae1fe293f85a4db4d0af4f305172f2a1868ddd917458bdf",
                         txOutputIndex: 0,
-                        txOutputValue: to1ePrecision(130, 8),
+                        txOutputValue: to1ePrecision(26, 8),
                       }
 
                       before(async () => {
@@ -213,13 +213,13 @@ describe("Bridge - Moving funds", () => {
                           context(
                             "when the submitted target wallets count is same as the expected",
                             () => {
-                              // The source wallet has a main UTXO with value of 130 BTC,
-                              // the max BTC transfer is 50 BTC by default (see
+                              // The source wallet has a main UTXO with value of 26 BTC,
+                              // the max BTC transfer is 10 BTC by default (see
                               // `constants.walletMaxBtcTransfer`) and the count of
                               // live wallets is `5`. We compute the expected target
                               // wallets count as:
                               // `N = min(liveWalletsCount, ceil(walletBtcBalance / walletMaxBtcTransfer))`
-                              // so we have `N = min(5, 130 / 50) = min(5, 3) = 3`
+                              // so we have `N = min(5, 26 / 10) = min(5, 3) = 3`
                               const expectedTargetWalletsCount = 3
 
                               context(
@@ -441,7 +441,7 @@ describe("Bridge - Moving funds", () => {
                       txHash:
                         "0xc9e58780c6c289c25ae1fe293f85a4db4d0af4f305172f2a1868ddd917458bdf",
                       txOutputIndex: 0,
-                      txOutputValue: to1ePrecision(130, 8), // 130 BTC
+                      txOutputValue: to1ePrecision(26, 8), // 26 BTC
                     }
 
                     before(async () => {

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -157,12 +157,12 @@ describe("Bridge - Moving funds", () => {
 
                   context("when passed wallet main UTXO is valid", () => {
                     context("when wallet balance is greater than zero", () => {
-                      // Just an arbitrary main UTXO with value of 26 BTC.
+                      // Just an arbitrary main UTXO with value of 130 BTC.
                       const mainUtxo = {
                         txHash:
                           "0xc9e58780c6c289c25ae1fe293f85a4db4d0af4f305172f2a1868ddd917458bdf",
                         txOutputIndex: 0,
-                        txOutputValue: to1ePrecision(26, 8),
+                        txOutputValue: to1ePrecision(130, 8),
                       }
 
                       before(async () => {
@@ -213,13 +213,13 @@ describe("Bridge - Moving funds", () => {
                           context(
                             "when the submitted target wallets count is same as the expected",
                             () => {
-                              // The source wallet has a main UTXO with value of 26 BTC,
-                              // the max BTC transfer is 10 BTC by default (see
+                              // The source wallet has a main UTXO with value of 130 BTC,
+                              // the max BTC transfer is 50 BTC by default (see
                               // `constants.walletMaxBtcTransfer`) and the count of
                               // live wallets is `5`. We compute the expected target
                               // wallets count as:
                               // `N = min(liveWalletsCount, ceil(walletBtcBalance / walletMaxBtcTransfer))`
-                              // so we have `N = min(5, 26 / 10) = min(5, 3) = 3`
+                              // so we have `N = min(5, 130 / 50) = min(5, 3) = 3`
                               const expectedTargetWalletsCount = 3
 
                               context(
@@ -441,7 +441,7 @@ describe("Bridge - Moving funds", () => {
                       txHash:
                         "0xc9e58780c6c289c25ae1fe293f85a4db4d0af4f305172f2a1868ddd917458bdf",
                       txOutputIndex: 0,
-                      txOutputValue: to1ePrecision(26, 8), // 26 BTC
+                      txOutputValue: to1ePrecision(130, 8), // 130 BTC
                     }
 
                     before(async () => {

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -85,6 +85,44 @@ describe("Bridge - Parameters", () => {
         })
       })
 
+      context(
+        "when new deposit dust threshold is same as deposit TX max fee",
+        () => {
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(governance)
+                .updateDepositParameters(
+                  constants.depositTxMaxFee,
+                  constants.depositTreasuryFeeDivisor,
+                  constants.depositTxMaxFee
+                )
+            ).to.be.revertedWith(
+              "Deposit dust threshold must be greater than deposit TX max fee"
+            )
+          })
+        }
+      )
+
+      context(
+        "when new deposit dust threshold is lower than deposit TX max fee",
+        () => {
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(governance)
+                .updateDepositParameters(
+                  constants.depositTxMaxFee - 1,
+                  constants.depositTreasuryFeeDivisor,
+                  constants.depositTxMaxFee
+                )
+            ).to.be.revertedWith(
+              "Deposit dust threshold must be greater than deposit TX max fee"
+            )
+          })
+        }
+      )
+
       context("when new deposit treasury fee divisor is zero", () => {
         it("should revert", async () => {
           await expect(
@@ -220,6 +258,50 @@ describe("Bridge - Parameters", () => {
                 )
             ).to.be.revertedWith(
               "Redemption dust threshold must be greater than moving funds dust threshold"
+            )
+          })
+        }
+      )
+
+      context(
+        "when new redemption dust threshold is same as redemption tx max fee",
+        () => {
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(governance)
+                .updateRedemptionParameters(
+                  constants.redemptionDustThreshold,
+                  constants.redemptionTreasuryFeeDivisor,
+                  constants.redemptionDustThreshold,
+                  constants.redemptionTimeout,
+                  constants.redemptionTimeoutSlashingAmount,
+                  constants.redemptionTimeoutNotifierRewardMultiplier
+                )
+            ).to.be.revertedWith(
+              "Redemption dust threshold must be greater than redemption TX max fee"
+            )
+          })
+        }
+      )
+
+      context(
+        "when new redemption dust threshold is lower than redemption tx max fee",
+        () => {
+          it("should revert", async () => {
+            await expect(
+              bridge
+                .connect(governance)
+                .updateRedemptionParameters(
+                  constants.redemptionDustThreshold - 1,
+                  constants.redemptionTreasuryFeeDivisor,
+                  constants.redemptionDustThreshold,
+                  constants.redemptionTimeout,
+                  constants.redemptionTimeoutSlashingAmount,
+                  constants.redemptionTimeoutNotifierRewardMultiplier
+                )
+            ).to.be.revertedWith(
+              "Redemption dust threshold must be greater than redemption TX max fee"
             )
           })
         }

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -85,6 +85,8 @@ describe("Bridge - Redemption", () => {
     // Set the redemption dust threshold to 0.001 BTC, i.e. 10x smaller than
     // the initial value in the Bridge in order to save test Bitcoins.
     await bridge.setRedemptionDustThreshold(100000)
+    // Adjust redemption TX max fee by the same - 10x smaller - scale.
+    await bridge.setRedemptionTxMaxFee(10000)
 
     redemptionTimeout = (await bridge.redemptionParameters()).redemptionTimeout
   })

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -3,35 +3,35 @@ import { to1ePrecision } from "../helpers/contract-test-helpers"
 export const constants = {
   unmintFee: to1ePrecision(1, 15), // 0.001
   depositDustThreshold: 1000000, // 1000000 satoshi = 0.01 BTC
+  depositTxMaxFee: 100000, // 100000 satoshi = 0.001 BTC
   depositTreasuryFeeDivisor: 2000, // 1/2000 == 5bps == 0.05% == 0.0005
-  depositTxMaxFee: 10000, // 10000 satoshi
   redemptionDustThreshold: 1000000, // 1000000 satoshi = 0.01 BTC
   redemptionTreasuryFeeDivisor: 2000, // 1/2000 == 5bps == 0.05% == 0.0005
-  redemptionTxMaxFee: 10000, // 10000 satoshi
-  redemptionTimeout: 172800, // 48 hours
-  redemptionTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
+  redemptionTxMaxFee: 100000, // 100000 satoshi = 0.001 BTC
+  redemptionTimeout: 432000, // 5 days
+  redemptionTimeoutSlashingAmount: to1ePrecision(100, 18), // 100 T
   redemptionTimeoutNotifierRewardMultiplier: 100, // 100%
-  movingFundsTxMaxTotalFee: 10000, // 10000 satoshi
-  movingFundsDustThreshold: 20000, // 20000 satoshi
+  movingFundsTxMaxTotalFee: 100000, // 100000 satoshi = 0.001 BTC
+  movingFundsDustThreshold: 200000, // 200000 satoshi = 0.002 BTC
   movingFundsTimeoutResetDelay: 518400, // 6 days
   movingFundsTimeout: 604800, // 1 week
-  movingFundsTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
+  movingFundsTimeoutSlashingAmount: to1ePrecision(100, 18), // 100 T
   movingFundsTimeoutNotifierRewardMultiplier: 100, // 100%
-  movedFundsSweepTxMaxTotalFee: 10000, // 10000 satoshi
+  movedFundsSweepTxMaxTotalFee: 100000, // 100000 satoshi = 0.001 BTC
   movedFundsSweepTimeout: 604800, // 1 week
-  movedFundsSweepTimeoutSlashingAmount: to1ePrecision(10000, 18), // 10000 T
+  movedFundsSweepTimeoutSlashingAmount: to1ePrecision(100, 18), // 100 T
   movedFundsSweepTimeoutNotifierRewardMultiplier: 100, // 100%
+  fraudChallengeDepositAmount: to1ePrecision(5, 18), // 5 ether
+  fraudChallengeDefeatTimeout: 604800, // 1 week
+  fraudSlashingAmount: to1ePrecision(100, 18), // 100 T
+  fraudNotifierRewardMultiplier: 100, // 100%
   walletCreationPeriod: 604800, // 1 week
   walletCreationMinBtcBalance: to1ePrecision(1, 8), // 1 BTC
   walletCreationMaxBtcBalance: to1ePrecision(100, 8), // 100 BTC
   walletClosureMinBtcBalance: to1ePrecision(5, 7), // 0.5 BTC
-  walletMaxAge: 8 * 604800, // 8 weeks,
-  walletMaxBtcTransfer: to1ePrecision(10, 8), // 10 BTC
+  walletMaxAge: 26 * 7 * 604800, // 26 weeks ~ 6 months
+  walletMaxBtcTransfer: to1ePrecision(50, 8), // 50 BTC
   walletClosingPeriod: 3456000, // 40 days
-  fraudChallengeDepositAmount: to1ePrecision(2, 18), // 2 ethers
-  fraudChallengeDefeatTimeout: 604800, // 1 week
-  fraudSlashingAmount: to1ePrecision(10000, 18), // 10000 T
-  fraudNotifierRewardMultiplier: 100, // 100%
 }
 
 export const walletState = {

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -30,7 +30,7 @@ export const constants = {
   walletCreationMaxBtcBalance: to1ePrecision(100, 8), // 100 BTC
   walletClosureMinBtcBalance: to1ePrecision(5, 7), // 0.5 BTC
   walletMaxAge: 26 * 7 * 604800, // 26 weeks ~ 6 months
-  walletMaxBtcTransfer: to1ePrecision(50, 8), // 50 BTC
+  walletMaxBtcTransfer: to1ePrecision(10, 8), // 10 BTC
   walletClosingPeriod: 3456000, // 40 days
 }
 

--- a/solidity/test/integration/Slashing.test.ts
+++ b/solidity/test/integration/Slashing.test.ts
@@ -224,8 +224,10 @@ describeFn("Integration Test - Slashing", async () => {
 
         // We use a deposit funding bitcoin transaction with a very low amount,
         // so we need to update the dust and redemption thresholds to be below it.
-        await updateDepositDustThreshold(10_000) // 0.0001 BTC
-        await updateRedemptionDustThreshold(2_000) // 0.00002 BTC
+        // TX max fees need to be adjusted as well given that they need to
+        // be lower than dust thresholds.
+        await updateDepositDustThresholdAndTxMaxFee(10_000, 2_000) // 0.0001 BTC, 0.00002 BTC
+        await updateRedemptionDustThresholdAndTxMaxFee(2_000, 200) // 0.00002 BTC, 0.000002 BTC
 
         // Reveal and sweep the deposit to set up a positive Bank balance for
         // the redeemer, to be able to request a redemption.
@@ -375,7 +377,9 @@ describeFn("Integration Test - Slashing", async () => {
 
         // We use a deposit funding bitcoin transaction with a very low amount,
         // so we need to update the dust threshold to be below it.
-        await updateDepositDustThreshold(10000) // 0.0001 BTC)
+        // TX max fee needs to be updated as well given it has to be lower
+        // than the dust threshold.
+        await updateDepositDustThresholdAndTxMaxFee(10_000, 2_000) // 0.0001 BTC, 0.00002 BTC
 
         // Reveal and sweep the deposit to set up a main UTXO for the wallet,
         // so when operator inactivity is reported the wallet is transferred to
@@ -479,8 +483,9 @@ describeFn("Integration Test - Slashing", async () => {
     })
   })
 
-  async function updateDepositDustThreshold(
-    newDepositDustThreshold: BigNumberish
+  async function updateDepositDustThresholdAndTxMaxFee(
+    newDepositDustThreshold: BigNumberish,
+    newDepositTxMaxFee: BigNumberish
   ) {
     const currentDepositParameters = await bridge.depositParameters()
     await bridge
@@ -488,12 +493,13 @@ describeFn("Integration Test - Slashing", async () => {
       .updateDepositParameters(
         newDepositDustThreshold,
         currentDepositParameters.depositTreasuryFeeDivisor,
-        currentDepositParameters.depositTxMaxFee
+        newDepositTxMaxFee
       )
   }
 
-  async function updateRedemptionDustThreshold(
-    newRedemptionDustThreshold: number
+  async function updateRedemptionDustThresholdAndTxMaxFee(
+    newRedemptionDustThreshold: number,
+    newRedemptionTxMaxFee: number
   ) {
     // Redemption dust threshold has to be greater than moving funds dust threshold,
     // so first we need to align the moving funds dust threshold.
@@ -520,7 +526,7 @@ describeFn("Integration Test - Slashing", async () => {
       .updateRedemptionParameters(
         newRedemptionDustThreshold,
         currentRedemptionParameters.redemptionTreasuryFeeDivisor,
-        currentRedemptionParameters.redemptionTxMaxFee,
+        newRedemptionTxMaxFee,
         currentRedemptionParameters.redemptionTimeout,
         currentRedemptionParameters.redemptionTimeoutSlashingAmount,
         currentRedemptionParameters.redemptionTimeoutNotifierRewardMultiplier


### PR DESCRIPTION
Closes #258 

Parameters are set to be more forgiving for the early days of the network. Timeouts are pretty long and slashing amounts are minimal.

During this work, I realized we should improve validation for deposit and redemption parameters. The deposit dust threshold must be greater than the per-deposit max allowed Bitcoin network fee. The redemption dust threshold must be greater than the per-redemption max allowed Bitcoin network fee. Added the validation in f9f75faeed956fbce381be8d11017a23097877c1.