### PR TITLE
Expose test utils as Hardhat tasks

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -1,4 +1,5 @@
 import { HardhatUserConfig } from "hardhat/config"
+import "./tasks"
 
 import "@keep-network/hardhat-helpers"
 import "@keep-network/hardhat-local-networks-config"

--- a/solidity/tasks/index.ts
+++ b/solidity/tasks/index.ts
@@ -1,1 +1,9 @@
-import "./test-utils"
+import fs from "fs"
+
+// Load the `test-utils` module conditionally as it depends on the `typechain`
+// directory. The `./typechain` path is used as the `tasks` module is loaded
+// in the root directory context.
+if (fs.existsSync("./typechain")) {
+  // eslint-disable-next-line global-require
+  require("./test-utils")
+}

--- a/solidity/tasks/index.ts
+++ b/solidity/tasks/index.ts
@@ -1,0 +1,1 @@
+import "./test-utils"

--- a/solidity/tasks/test-utils.ts
+++ b/solidity/tasks/test-utils.ts
@@ -1,0 +1,173 @@
+/* eslint-disable no-console */
+/* eslint-disable no-await-in-loop */
+
+import { task, types } from "hardhat/config"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import { BigNumberish, BytesLike } from "ethers"
+import { authorizeApplication, stake } from "../test/integration/utils/staking"
+import {
+  performEcdsaDkg,
+  registerOperator,
+} from "../test/integration/utils/ecdsa-wallet-registry"
+import { Bridge, SortitionPool, WalletRegistry } from "../typechain"
+
+task(
+  "test-utils:register-operators",
+  "Registers operators in the sortition pool"
+)
+  .addOptionalParam(
+    "numberOfOperators",
+    "Number of operators to register",
+    110,
+    types.int
+  )
+  .addOptionalParam(
+    "unnamedSignersOffset",
+    "Offset indicating the unnamed signers",
+    0,
+    types.int
+  )
+  .addOptionalParam(
+    "stakeAmount",
+    "Amount of each operator's stake",
+    "40000000000000000000000",
+    types.string
+  )
+  .setAction(async (args, hre) => {
+    const { numberOfOperators, unnamedSignersOffset, stakeAmount } = args
+    await registerOperators(
+      hre,
+      numberOfOperators,
+      unnamedSignersOffset,
+      stakeAmount
+    )
+  })
+
+task(
+  "test-utils:create-wallet",
+  "Creates a wallet and registers it in the bridge"
+)
+  .addParam(
+    "walletPublicKey",
+    "Uncompressed wallet ECDSA public key",
+    undefined,
+    types.string
+  )
+  .setAction(async (args, hre) => {
+    const { walletPublicKey } = args
+    await createWallet(hre, walletPublicKey)
+  })
+
+async function registerOperators(
+  hre: HardhatRuntimeEnvironment,
+  numberOfOperators: number,
+  unnamedSignersOffset: number,
+  stakeAmount: BigNumberish
+): Promise<void> {
+  const { helpers } = hre
+
+  const walletRegistry = await helpers.contracts.getContract<WalletRegistry>(
+    "WalletRegistry"
+  )
+  const sortitionPool = await helpers.contracts.getContract<SortitionPool>(
+    "EcdsaSortitionPool"
+  )
+  const t = await helpers.contracts.getContract("T")
+  const staking = await helpers.contracts.getContract("TokenStaking")
+
+  const signers = (await helpers.signers.getUnnamedSigners()).slice(
+    unnamedSignersOffset
+  )
+
+  // We use unique accounts for each staking role for each operator.
+  if (signers.length < numberOfOperators * 5) {
+    throw new Error(
+      "not enough unnamed signers; update hardhat network's configuration account count"
+    )
+  }
+
+  console.log(`Starting registration of ${numberOfOperators} operators`)
+
+  for (let i = 0; i < numberOfOperators; i++) {
+    const owner = signers[i]
+    const stakingProvider = signers[1 * numberOfOperators + i]
+    const operator = signers[2 * numberOfOperators + i]
+    const beneficiary = signers[3 * numberOfOperators + i]
+    const authorizer = signers[4 * numberOfOperators + i]
+
+    console.log(`Registering operator ${i} with address ${operator.address}`)
+
+    await stake(
+      hre,
+      t,
+      staking,
+      stakeAmount,
+      owner,
+      stakingProvider.address,
+      beneficiary.address,
+      authorizer.address
+    )
+    await authorizeApplication(
+      staking,
+      walletRegistry.address,
+      authorizer,
+      stakingProvider.address,
+      stakeAmount
+    )
+    await registerOperator(
+      walletRegistry,
+      sortitionPool,
+      stakingProvider,
+      operator
+    )
+  }
+
+  console.log(`Registered ${numberOfOperators} sortition pool operators`)
+}
+
+async function createWallet(
+  hre: HardhatRuntimeEnvironment,
+  walletPublicKey: BytesLike
+) {
+  const { ethers, helpers } = hre
+  const { governance } = await helpers.signers.getNamedSigners()
+
+  const bridge = await helpers.contracts.getContract<Bridge>("Bridge")
+  const walletRegistry = await helpers.contracts.getContract<WalletRegistry>(
+    "WalletRegistry"
+  )
+  const walletRegistryGovernance = await helpers.contracts.getContract(
+    "WalletRegistryGovernance"
+  )
+
+  const requestNewWalletTx = await bridge.requestNewWallet({
+    txHash: ethers.constants.HashZero,
+    txOutputIndex: 0,
+    txOutputValue: 0,
+  })
+
+  // Using smock to make a fake RandomBeacon instance does not work in the
+  // task environment. In order to provide a relay entry to the registry, we
+  // set the governance as the random beacon and provide a relay entry as usual.
+  await walletRegistryGovernance
+    .connect(governance)
+    .upgradeRandomBeacon(governance.address)
+  // eslint-disable-next-line no-underscore-dangle
+  await walletRegistry
+    .connect(governance)
+    .__beaconCallback(ethers.utils.randomBytes(32), 0)
+
+  await performEcdsaDkg(
+    hre,
+    walletRegistry,
+    walletPublicKey,
+    requestNewWalletTx.blockNumber
+  )
+
+  console.log(`Created wallet with public key ${walletPublicKey}`)
+}
+
+export default {
+  registerOperators,
+  createWallet,
+}

--- a/solidity/tasks/test-utils.ts
+++ b/solidity/tasks/test-utils.ts
@@ -9,7 +9,7 @@ import {
   performEcdsaDkg,
   registerOperator,
 } from "../test/integration/utils/ecdsa-wallet-registry"
-import { Bridge, SortitionPool, WalletRegistry } from "../typechain"
+import type { Bridge, SortitionPool, WalletRegistry } from "../typechain"
 
 task(
   "test-utils:register-operators",

--- a/solidity/test/integration/FullFlow.test.ts
+++ b/solidity/test/integration/FullFlow.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable @typescript-eslint/no-extra-semi */
-import { ethers, helpers, waffle } from "hardhat"
+import hre, { ethers, helpers, waffle } from "hardhat"
 import type { FakeContract } from "@defi-wonderland/smock"
 import type { BigNumberish } from "ethers"
 import { utils } from "ethers"
@@ -66,6 +66,7 @@ describeFn("Integration Test - Full flow", async () => {
     } = await waffle.loadFixture(fixture))
     // Update only the parameters that are crucial for this test.
     await updateWalletRegistryDkgResultChallengePeriodLength(
+      hre,
       walletRegistry,
       governance,
       dkgResultChallengePeriodLength
@@ -95,6 +96,7 @@ describeFn("Integration Test - Full flow", async () => {
 
         await produceRelayEntry(walletRegistry, randomBeacon)
         await performEcdsaDkg(
+          hre,
           walletRegistry,
           walletPublicKey,
           requestNewWalletTx.blockNumber

--- a/solidity/test/integration/Slashing.test.ts
+++ b/solidity/test/integration/Slashing.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable @typescript-eslint/no-extra-semi */
-import { ethers, helpers, waffle } from "hardhat"
+import hre, { ethers, helpers, waffle } from "hardhat"
 import { expect } from "chai"
 
 import type { FakeContract } from "@defi-wonderland/smock"
@@ -79,6 +79,7 @@ describeFn("Integration Test - Slashing", async () => {
 
     // Update only the parameters that are crucial for this test.
     await updateWalletRegistryDkgResultChallengePeriodLength(
+      hre,
       walletRegistry,
       governance,
       dkgResultChallengePeriodLength
@@ -112,6 +113,7 @@ describeFn("Integration Test - Slashing", async () => {
 
         await produceRelayEntry(walletRegistry, randomBeacon)
         ;({ walletMembers } = await performEcdsaDkg(
+          hre,
           walletRegistry,
           walletPublicKey,
           requestNewWalletTx.blockNumber
@@ -217,6 +219,7 @@ describeFn("Integration Test - Slashing", async () => {
 
         await produceRelayEntry(walletRegistry, randomBeacon)
         ;({ walletMembers } = await performEcdsaDkg(
+          hre,
           walletRegistry,
           walletPublicKey,
           requestNewWalletTx.blockNumber
@@ -373,6 +376,7 @@ describeFn("Integration Test - Slashing", async () => {
 
         await produceRelayEntry(walletRegistry, randomBeacon)
         ;({ walletMembers } = await performEcdsaDkg(
+          hre,
           walletRegistry,
           walletPublicKey,
           requestNewWalletTx.blockNumber
@@ -411,6 +415,7 @@ describeFn("Integration Test - Slashing", async () => {
 
         const inactiveMembersIndices = [26, 40, 63, 78, 89]
         const claim = await produceOperatorInactivityClaim(
+          hre,
           ecdsaWalletID,
           walletMembers,
           nonce,

--- a/solidity/test/integration/WalletCreation.test.ts
+++ b/solidity/test/integration/WalletCreation.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-extra-semi */
-import { ethers, waffle } from "hardhat"
+import hre, { ethers, waffle } from "hardhat"
 import { expect } from "chai"
 
 import type { FakeContract } from "@defi-wonderland/smock"
@@ -46,6 +46,7 @@ describeFn("Integration Test - Wallet Creation", async () => {
 
     // Update only the parameters that are crucial for this test.
     await updateWalletRegistryDkgResultChallengePeriodLength(
+      hre,
       walletRegistry,
       governance,
       dkgResultChallengePeriodLength
@@ -66,6 +67,7 @@ describeFn("Integration Test - Wallet Creation", async () => {
 
       await produceRelayEntry(walletRegistry, randomBeacon)
       ;({ approveDkgResultTx: walletRegistrationTx } = await performEcdsaDkg(
+        hre,
         walletRegistry,
         walletPublicKey,
         startBlock

--- a/solidity/test/integration/utils/fixture.ts
+++ b/solidity/test/integration/utils/fixture.ts
@@ -3,7 +3,7 @@
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { Contract } from "ethers"
-import { deployments, ethers, helpers } from "hardhat"
+import hre, { deployments, ethers, helpers } from "hardhat"
 import {
   TBTC,
   Bridge,
@@ -102,6 +102,7 @@ export const fixture = deployments.createFixture(
       const authorizer: SignerWithAddress = signers[4 * numberOfOperators + i]
 
       await stake(
+        hre,
         t,
         staking,
         stakeAmount,

--- a/solidity/test/integration/utils/staking.ts
+++ b/solidity/test/integration/utils/staking.ts
@@ -1,8 +1,8 @@
-import { helpers } from "hardhat"
-
 import type { BigNumberish, Contract, Signer } from "ethers"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
 
 export async function stake(
+  hre: HardhatRuntimeEnvironment,
   t: Contract,
   staking: Contract,
   stakeAmount: BigNumberish,
@@ -11,6 +11,7 @@ export async function stake(
   beneficiary: string,
   authorizer: string
 ): Promise<void> {
+  const { helpers } = hre
   const { deployer } = await helpers.signers.getNamedSigners()
 
   await t.connect(deployer).mint(await owner.getAddress(), stakeAmount)

--- a/solidity/tsconfig.json
+++ b/solidity/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
+    "module": "commonJS",
     "downlevelIteration": true,
     "esModuleInterop": true
   },

--- a/solidity/tsconfig.json
+++ b/solidity/tsconfig.json
@@ -6,5 +6,5 @@
     "esModuleInterop": true
   },
   "files": ["./hardhat.config.ts"],
-  "include": ["./deploy", "./test", "./typechain"]
+  "include": ["./deploy", "./tasks", "./test", "./typechain"]
 }


### PR DESCRIPTION
Refs: #143 

This pull request exposes some useful test utils (defined in `test/integration/utils`) as Hardhat tasks that can be used from the outside. Those utils will be essential for system test scenarios (developed as part of #339) that must use the local Hardhat network until the Ropsten deployment goes live. 

For now, two new commands are available:
- `npx hardhat test-utils:register-operators` that registers an arbitrary number of pre-defined signers as sortition pool operators. This is required to perform wallet creation.
- `npx hardhat test-utils:create-wallet` that creates a wallet with a given public key and registers it in the bridge. This is required to perform deposits and redemptions.

I recommend exploring the commit history to get the full picture of each change.
