### PR TITLE
Tweaks around Bitcoin transaction processing code

### DIFF
--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -11,6 +11,15 @@ import { StaticWriter, BufferWriter } from "bufio"
 import { BigNumber } from "ethers"
 
 /**
+ * Represents a transaction hash (or transaction ID) as an un-prefixed hex
+ * string. This hash is supposed to have the same byte order as used by the
+ * Bitcoin block explorers which is the opposite of the byte order used
+ * by the Bitcoin protocol internally. That means the hash must be reversed in
+ * the use cases that expect the Bitcoin internal byte order.
+ */
+export type TransactionHash = string
+
+/**
  * Represents a raw transaction.
  */
 export interface RawTransaction {
@@ -27,7 +36,7 @@ export interface Transaction {
   /**
    * The transaction hash (or transaction ID) as an un-prefixed hex string.
    */
-  transactionHash: string
+  transactionHash: TransactionHash
 
   /**
    * The vector of transaction inputs.
@@ -47,7 +56,7 @@ export interface TransactionOutpoint {
   /**
    * The hash of the transaction the outpoint belongs to.
    */
-  transactionHash: string
+  transactionHash: TransactionHash
 
   /**
    * The zero-based index of the output from the specified transaction.
@@ -185,14 +194,14 @@ export interface Client {
    * @param transactionHash - Hash of the transaction.
    * @returns Transaction object.
    */
-  getTransaction(transactionHash: string): Promise<Transaction>
+  getTransaction(transactionHash: TransactionHash): Promise<Transaction>
 
   /**
    * Gets the raw transaction data for given transaction hash.
    * @param transactionHash - Hash of the transaction.
    * @returns Raw transaction.
    */
-  getRawTransaction(transactionHash: string): Promise<RawTransaction>
+  getRawTransaction(transactionHash: TransactionHash): Promise<RawTransaction>
 
   /**
    * Gets the number of confirmations that a given transaction has accumulated
@@ -200,7 +209,7 @@ export interface Client {
    * @param transactionHash - Hash of the transaction.
    * @returns The number of confirmations.
    */
-  getTransactionConfirmations(transactionHash: string): Promise<number>
+  getTransactionConfirmations(transactionHash: TransactionHash): Promise<number>
 
   /**
    * Gets height of the latest mined block.
@@ -224,7 +233,7 @@ export interface Client {
    * @return Merkle branch.
    */
   getTransactionMerkle(
-    transactionHash: string,
+    transactionHash: TransactionHash,
     blockHeight: number
   ): Promise<TransactionMerkleBranch>
 

--- a/typescript/src/deposit-sweep.ts
+++ b/typescript/src/deposit-sweep.ts
@@ -8,6 +8,7 @@ import {
   decomposeRawTransaction,
   isCompressedPublicKey,
   createKeyRing,
+  TransactionHash,
 } from "./bitcoin"
 import { createDepositScript, Deposit } from "./deposit"
 import { Bridge } from "./chain"
@@ -368,7 +369,7 @@ async function prepareInputSignData(
  * @returns Empty promise.
  */
 export async function proveDepositSweep(
-  transactionHash: string,
+  transactionHash: TransactionHash,
   mainUtxo: UnspentTransactionOutput,
   bridge: Bridge,
   bitcoinClient: BitcoinClient

--- a/typescript/src/deposit-sweep.ts
+++ b/typescript/src/deposit-sweep.ts
@@ -32,7 +32,9 @@ import { createTransactionProof } from "./proof"
  *        The number of UTXOs and deposit elements must equal.
  * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
  *        from the previous wallet transaction (optional).
- * @returns The UTXO that will be created by the sweep transaction.
+ * @returns The outcome consisting of:
+ *          - the sweep transaction hash,
+ *          - the new wallet's main UTXO produced by this transaction.
  */
 export async function sweepDeposits(
   bitcoinClient: BitcoinClient,
@@ -42,16 +44,19 @@ export async function sweepDeposits(
   utxos: UnspentTransactionOutput[],
   deposits: Deposit[],
   mainUtxo?: UnspentTransactionOutput
-): Promise<UnspentTransactionOutput> {
+): Promise<{
+  transactionHash: TransactionHash
+  newMainUtxo: UnspentTransactionOutput
+}> {
   const utxosWithRaw: (UnspentTransactionOutput & RawTransaction)[] = []
   for (const utxo of utxos) {
-    const rawTransaction = await bitcoinClient.getRawTransaction(
+    const utxoRawTransaction = await bitcoinClient.getRawTransaction(
       utxo.transactionHash
     )
 
     utxosWithRaw.push({
       ...utxo,
-      transactionHex: rawTransaction.transactionHex,
+      transactionHex: utxoRawTransaction.transactionHex,
     })
   }
 
@@ -67,21 +72,22 @@ export async function sweepDeposits(
     }
   }
 
-  const { transactionHex, ...resultUtxo } = await createDepositSweepTransaction(
-    fee,
-    walletPrivateKey,
-    witness,
-    utxosWithRaw,
-    deposits,
-    mainUtxoWithRaw
-  )
+  const { transactionHash, newMainUtxo, rawTransaction } =
+    await createDepositSweepTransaction(
+      fee,
+      walletPrivateKey,
+      witness,
+      utxosWithRaw,
+      deposits,
+      mainUtxoWithRaw
+    )
 
   // Note that `broadcast` may fail silently (i.e. no error will be returned,
   // even if the transaction is rejected by other nodes and does not enter the
   // mempool, for example due to an UTXO being already spent).
-  await bitcoinClient.broadcast({ transactionHex })
+  await bitcoinClient.broadcast(rawTransaction)
 
-  return resultUtxo
+  return { transactionHash, newMainUtxo }
 }
 
 /**
@@ -99,7 +105,10 @@ export async function sweepDeposits(
  *        The number of UTXOs and deposit elements must equal.
  * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
  *        from the previous wallet transaction (optional).
- * @returns Resulting UTXO with Bitcoin sweep transaction data in raw format.
+ * @returns The outcome consisting of:
+ *          - the sweep transaction hash,
+ *          - the new wallet's main UTXO produced by this transaction.
+ *          - the sweep transaction in the raw format
  */
 export async function createDepositSweepTransaction(
   fee: BigNumber,
@@ -108,7 +117,11 @@ export async function createDepositSweepTransaction(
   utxos: (UnspentTransactionOutput & RawTransaction)[],
   deposits: Deposit[],
   mainUtxo?: UnspentTransactionOutput & RawTransaction
-): Promise<UnspentTransactionOutput & RawTransaction> {
+): Promise<{
+  transactionHash: TransactionHash
+  newMainUtxo: UnspentTransactionOutput
+  rawTransaction: RawTransaction
+}> {
   if (utxos.length < 1) {
     throw new Error("There must be at least one deposit UTXO to sweep")
   }
@@ -207,11 +220,18 @@ export async function createDepositSweepTransaction(
     }
   }
 
+  const transactionHash = transaction.txid()
+
   return {
-    transactionHash: transaction.txid(),
-    outputIndex: 0, // There is only one output.
-    value: BigNumber.from(transaction.outputs[0].value),
-    transactionHex: transaction.toRaw().toString("hex"),
+    transactionHash,
+    newMainUtxo: {
+      transactionHash,
+      outputIndex: 0, // There is only one output.
+      value: BigNumber.from(transaction.outputs[0].value),
+    },
+    rawTransaction: {
+      transactionHex: transaction.toRaw().toString("hex"),
+    },
   }
 }
 

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -3,7 +3,8 @@ import bcoin from "bcoin"
 import {
   Client as BitcoinClient,
   RawTransaction,
-  Transaction, TransactionHash,
+  Transaction,
+  TransactionHash,
   TransactionInput,
   TransactionMerkleBranch,
   TransactionOutput,
@@ -162,7 +163,9 @@ export class Client implements BitcoinClient {
   /**
    * @see {BitcoinClient#getTransactionConfirmations}
    */
-  getTransactionConfirmations(transactionHash: TransactionHash): Promise<number> {
+  getTransactionConfirmations(
+    transactionHash: TransactionHash
+  ): Promise<number> {
     return this.withElectrum<number>(async (electrum: Electrum) => {
       const transaction = await electrum.blockchain_transaction_get(
         transactionHash,

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -3,7 +3,7 @@ import bcoin from "bcoin"
 import {
   Client as BitcoinClient,
   RawTransaction,
-  Transaction,
+  Transaction, TransactionHash,
   TransactionInput,
   TransactionMerkleBranch,
   TransactionOutput,
@@ -109,7 +109,7 @@ export class Client implements BitcoinClient {
   /**
    * @see {BitcoinClient#getTransaction}
    */
-  getTransaction(transactionHash: string): Promise<Transaction> {
+  getTransaction(transactionHash: TransactionHash): Promise<Transaction> {
     return this.withElectrum<Transaction>(async (electrum: Electrum) => {
       const transaction = await electrum.blockchain_transaction_get(
         transactionHash,
@@ -145,7 +145,7 @@ export class Client implements BitcoinClient {
   /**
    * @see {BitcoinClient#getRawTransaction}
    */
-  getRawTransaction(transactionHash: string): Promise<RawTransaction> {
+  getRawTransaction(transactionHash: TransactionHash): Promise<RawTransaction> {
     return this.withElectrum<RawTransaction>(async (electrum: Electrum) => {
       const transaction = await electrum.blockchain_transaction_get(
         transactionHash,
@@ -162,7 +162,7 @@ export class Client implements BitcoinClient {
   /**
    * @see {BitcoinClient#getTransactionConfirmations}
    */
-  getTransactionConfirmations(transactionHash: string): Promise<number> {
+  getTransactionConfirmations(transactionHash: TransactionHash): Promise<number> {
     return this.withElectrum<number>(async (electrum: Electrum) => {
       const transaction = await electrum.blockchain_transaction_get(
         transactionHash,
@@ -205,7 +205,7 @@ export class Client implements BitcoinClient {
    * @see {BitcoinClient#getTransactionMerkle}
    */
   getTransactionMerkle(
-    transactionHash: string,
+    transactionHash: TransactionHash,
     blockHeight: number
   ): Promise<TransactionMerkleBranch> {
     return this.withElectrum<TransactionMerkleBranch>(

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -133,7 +133,11 @@ export class Bridge implements ChainBridge {
     }
 
     const mainUtxoParam = {
-      txHash: `0x${mainUtxo.transactionHash}`,
+      // The Ethereum Bridge expects this hash to be in the Bitcoin internal
+      // byte order.
+      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
+        .reverse()
+        .toString("hex")}`,
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }
@@ -173,7 +177,11 @@ export class Bridge implements ChainBridge {
     const walletPublicKeyHash = `0x${computeHash160(walletPublicKey)}`
 
     const mainUtxoParam = {
-      txHash: `0x${mainUtxo.transactionHash}`,
+      // The Ethereum Bridge expects this hash to be in the Bitcoin internal
+      // byte order.
+      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
+        .reverse()
+        .toString("hex")}`,
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }
@@ -218,7 +226,11 @@ export class Bridge implements ChainBridge {
     }
 
     const mainUtxoParam = {
-      txHash: `0x${mainUtxo.transactionHash}`,
+      // The Ethereum Bridge expects this hash to be in the Bitcoin internal
+      // byte order.
+      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
+        .reverse()
+        .toString("hex")}`,
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }

--- a/typescript/src/proof.ts
+++ b/typescript/src/proof.ts
@@ -2,7 +2,7 @@ import {
   Transaction,
   Proof,
   TransactionMerkleBranch,
-  Client as BitcoinClient,
+  Client as BitcoinClient, TransactionHash,
 } from "./bitcoin"
 
 /**
@@ -28,7 +28,7 @@ function createMerkleProof(txMerkleBranch: TransactionMerkleBranch): string {
  * @returns Bitcoin transaction along with the inclusion proof.
  */
 export async function createTransactionProof(
-  transactionHash: string,
+  transactionHash: TransactionHash,
   requiredConfirmations: number,
   bitcoinClient: BitcoinClient
 ): Promise<Transaction & Proof> {

--- a/typescript/src/proof.ts
+++ b/typescript/src/proof.ts
@@ -2,7 +2,8 @@ import {
   Transaction,
   Proof,
   TransactionMerkleBranch,
-  Client as BitcoinClient, TransactionHash,
+  Client as BitcoinClient,
+  TransactionHash,
 } from "./bitcoin"
 
 /**

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -8,7 +8,7 @@ import {
   decomposeRawTransaction,
   RawTransaction,
   UnspentTransactionOutput,
-  Client as BitcoinClient,
+  Client as BitcoinClient, TransactionHash,
 } from "./bitcoin"
 import { Bridge, Identifier } from "./chain"
 import { createTransactionProof } from "./proof"
@@ -306,7 +306,7 @@ export async function createRedemptionTransaction(
  * @returns Empty promise.
  */
 export async function proveRedemption(
-  transactionHash: string,
+  transactionHash: TransactionHash,
   mainUtxo: UnspentTransactionOutput,
   walletPublicKey: string,
   bridge: Bridge,

--- a/typescript/src/tbtc.ts
+++ b/typescript/src/tbtc.ts
@@ -23,7 +23,8 @@ import {
 import { Bridge } from "./chain"
 import {
   Client as BitcoinClient,
-  RawTransaction, TransactionHash,
+  RawTransaction,
+  TransactionHash,
   UnspentTransactionOutput,
 } from "./bitcoin"
 import { BigNumber } from "ethers"
@@ -40,14 +41,19 @@ export interface TBTC {
    * @param bitcoinClient - Bitcoin client used to interact with the network.
    * @param witness - If true, a witness (P2WSH) transaction will be created.
    *        Otherwise, a legacy P2SH transaction will be made.
-   * @returns The deposit UTXO that will be created by the deposit transaction
+   * @returns The outcome consisting of:
+   *          - the deposit transaction hash,
+   *          - the deposit UTXO produced by this transaction.
    */
   makeDeposit(
     deposit: Deposit,
     depositorPrivateKey: string,
     bitcoinClient: BitcoinClient,
     witness: boolean
-  ): Promise<UnspentTransactionOutput>
+  ): Promise<{
+    transactionHash: TransactionHash
+    depositUtxo: UnspentTransactionOutput
+  }>
 
   /**
    * Creates a Bitcoin P2(W)SH deposit transaction.
@@ -56,14 +62,21 @@ export interface TBTC {
    * @param depositorPrivateKey - Bitcoin private key of the depositor.
    * @param witness - If true, a witness (P2WSH) transaction will be created.
    *        Otherwise, a legacy P2SH transaction will be made.
-   * @returns Deposit UTXO with Bitcoin P2(W)SH deposit transaction data in raw format.
+   * @returns The outcome consisting of:
+   *          - the deposit transaction hash,
+   *          - the deposit UTXO produced by this transaction.
+   *          - the deposit transaction in the raw format
    */
   createDepositTransaction(
     deposit: Deposit,
     utxos: (UnspentTransactionOutput & RawTransaction)[],
     depositorPrivateKey: string,
     witness: boolean
-  ): Promise<UnspentTransactionOutput & RawTransaction>
+  ): Promise<{
+    transactionHash: TransactionHash
+    depositUtxo: UnspentTransactionOutput
+    rawTransaction: RawTransaction
+  }>
 
   /**
    * Creates a Bitcoin locking script for P2(W)SH deposit transaction.
@@ -142,7 +155,9 @@ export interface TBTC {
    *        The number of UTXOs and deposit elements must equal.
    * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
    *        from the previous wallet transaction (optional).
-   * @returns The UTXO that will be created by the sweep transaction.
+   * @returns The outcome consisting of:
+   *          - the sweep transaction hash,
+   *          - the new wallet's main UTXO produced by this transaction.
    */
   sweepDeposits(
     bitcoinClient: BitcoinClient,
@@ -152,7 +167,10 @@ export interface TBTC {
     utxos: UnspentTransactionOutput[],
     deposits: Deposit[],
     mainUtxo?: UnspentTransactionOutput
-  ): Promise<UnspentTransactionOutput>
+  ): Promise<{
+    transactionHash: TransactionHash
+    newMainUtxo: UnspentTransactionOutput
+  }>
 
   /**
    * Creates a Bitcoin P2WPKH deposit sweep transaction.
@@ -169,7 +187,10 @@ export interface TBTC {
    *        The number of UTXOs and deposit elements must equal.
    * @param mainUtxo - main UTXO of the wallet, which is a P2WKH UTXO resulting
    *        from the previous wallet transaction (optional).
-   * @returns Resulting UTXO with Bitcoin sweep transaction data in raw format.
+   * @returns The outcome consisting of:
+   *          - the sweep transaction hash,
+   *          - the new wallet's main UTXO produced by this transaction.
+   *          - the sweep transaction in the raw format
    */
   createDepositSweepTransaction(
     fee: BigNumber,
@@ -178,7 +199,11 @@ export interface TBTC {
     utxos: (UnspentTransactionOutput & RawTransaction)[],
     deposits: Deposit[],
     mainUtxo?: UnspentTransactionOutput & RawTransaction
-  ): Promise<UnspentTransactionOutput & RawTransaction>
+  ): Promise<{
+    transactionHash: TransactionHash
+    newMainUtxo: UnspentTransactionOutput
+    rawTransaction: RawTransaction
+  }>
 
   /**
    * Prepares the proof of a deposit sweep transaction and submits it to the
@@ -234,7 +259,9 @@ export interface TBTC {
    *        not prepended with length
    * @param witness - The parameter used to decide about the type of the change
    *        output. P2WPKH if `true`, P2PKH if `false`
-   * @returns Empty promise.
+   * @returns The outcome consisting of:
+   *          - the redemption transaction hash,
+   *          - the optional new wallet's main UTXO produced by this transaction.
    */
   makeRedemptions(
     bitcoinClient: BitcoinClient,
@@ -243,7 +270,10 @@ export interface TBTC {
     mainUtxo: UnspentTransactionOutput,
     redeemerOutputScripts: string[],
     witness: boolean
-  ): Promise<void>
+  ): Promise<{
+    transactionHash: TransactionHash
+    newMainUtxo?: UnspentTransactionOutput
+  }>
 
   /**
    * Creates a Bitcoin redemption transaction.
@@ -262,14 +292,21 @@ export interface TBTC {
    * @param redemptionRequests - The list of redemption requests
    * @param witness - The parameter used to decide the type of the change output.
    *        P2WPKH if `true`, P2PKH if `false`
-   * @returns Bitcoin redemption transaction in the raw format.
+   * @returns The outcome consisting of:
+   *          - the redemption transaction hash,
+   *          - the optional new wallet's main UTXO produced by this transaction.
+   *          - the redemption transaction in the raw format
    */
   createRedemptionTransaction(
     walletPrivateKey: string,
     mainUtxo: UnspentTransactionOutput & RawTransaction,
     redemptionRequests: RedemptionRequest[],
     witness: boolean
-  ): Promise<RawTransaction>
+  ): Promise<{
+    transactionHash: TransactionHash
+    newMainUtxo?: UnspentTransactionOutput
+    rawTransaction: RawTransaction
+  }>
 
   /**
    * Prepares the proof of a redemption transaction and submits it to the

--- a/typescript/src/tbtc.ts
+++ b/typescript/src/tbtc.ts
@@ -23,7 +23,7 @@ import {
 import { Bridge } from "./chain"
 import {
   Client as BitcoinClient,
-  RawTransaction,
+  RawTransaction, TransactionHash,
   UnspentTransactionOutput,
 } from "./bitcoin"
 import { BigNumber } from "ethers"
@@ -190,7 +190,7 @@ export interface TBTC {
    * @returns Empty promise.
    */
   proveDepositSweep(
-    transactionHash: string,
+    transactionHash: TransactionHash,
     mainUtxo: UnspentTransactionOutput,
     bridge: Bridge,
     bitcoinClient: BitcoinClient
@@ -283,7 +283,7 @@ export interface TBTC {
    * @returns Empty promise.
    */
   proveRedemption(
-    transactionHash: string,
+    transactionHash: TransactionHash,
     mainUtxo: UnspentTransactionOutput,
     walletPublicKey: string,
     bridge: Bridge,

--- a/typescript/test/data/deposit-sweep.ts
+++ b/typescript/test/data/deposit-sweep.ts
@@ -5,6 +5,7 @@ import {
   RawTransaction,
   UnspentTransactionOutput,
   TransactionMerkleBranch,
+  TransactionHash,
 } from "../../src/bitcoin"
 import { computeDepositRefundLocktime, Deposit } from "../../src/deposit"
 import { BigNumber } from "ethers"
@@ -27,7 +28,7 @@ export interface DepositSweepTestData {
   mainUtxo: UnspentTransactionOutput & RawTransaction
   witness: boolean
   expectedSweep: {
-    transactionHash: string
+    transactionHash: TransactionHash
     transaction: RawTransaction
   }
 }

--- a/typescript/test/data/redemption.ts
+++ b/typescript/test/data/redemption.ts
@@ -6,6 +6,7 @@ import {
   RawTransaction,
   UnspentTransactionOutput,
   TransactionMerkleBranch,
+  TransactionHash,
 } from "../../src/bitcoin"
 import { RedemptionRequest } from "../../src/redemption"
 
@@ -43,7 +44,7 @@ export interface RedemptionTestData {
   }[]
   witness: boolean
   expectedRedemption: {
-    transactionHash: string
+    transactionHash: TransactionHash
     transaction: RawTransaction
   }
 }

--- a/typescript/test/ethereum.test.ts
+++ b/typescript/test/ethereum.test.ts
@@ -164,7 +164,7 @@ describe("Ethereum", () => {
           },
           {
             txHash:
-              "0xf8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+              "0x6896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea15ea542f2eaf8",
             txOutputIndex: 8,
             txOutputValue: BigNumber.from(9999),
           },
@@ -207,7 +207,7 @@ describe("Ethereum", () => {
           "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
           {
             txHash:
-              "0xf8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+              "0x6896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea15ea542f2eaf8",
             txOutputIndex: 8,
             txOutputValue: BigNumber.from(9999),
           },
@@ -258,7 +258,7 @@ describe("Ethereum", () => {
           },
           {
             txHash:
-              "0xf8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+              "0x6896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea15ea542f2eaf8",
             txOutputIndex: 8,
             txOutputValue: BigNumber.from(9999),
           },

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -1,5 +1,10 @@
 import TBTC from "./../src"
-import { Transaction, RawTransaction } from "../src/bitcoin"
+import {
+  Transaction,
+  RawTransaction,
+  TransactionHash,
+  UnspentTransactionOutput,
+} from "../src/bitcoin"
 // @ts-ignore
 import bcoin from "bcoin"
 import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
@@ -83,13 +88,17 @@ describe("Redemption", () => {
                     const data: RedemptionTestData =
                       singleP2PKHRedemptionWithWitnessChange
 
+                    let transactionHash: TransactionHash
+                    let newMainUtxo: UnspentTransactionOutput | undefined
+
                     beforeEach(async () => {
-                      await runRedemptionScenario(
-                        walletPrivateKey,
-                        bitcoinClient,
-                        bridge,
-                        data
-                      )
+                      ;({ transactionHash, newMainUtxo } =
+                        await runRedemptionScenario(
+                          walletPrivateKey,
+                          bitcoinClient,
+                          bridge,
+                          data
+                        ))
                     })
 
                     it("should broadcast redemption transaction with proper structure", () => {
@@ -97,6 +106,23 @@ describe("Redemption", () => {
                       expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                         data.expectedRedemption.transaction
                       )
+                    })
+
+                    it("should return the proper transaction hash", async () => {
+                      expect(transactionHash).to.be.equal(
+                        data.expectedRedemption.transactionHash
+                      )
+                    })
+
+                    it("should return the proper new main UTXO", () => {
+                      const expectedNewMainUtxo = {
+                        transactionHash:
+                          data.expectedRedemption.transactionHash,
+                        outputIndex: 1,
+                        value: BigNumber.from(1472680),
+                      }
+
+                      expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
                     })
                   }
                 )
@@ -107,13 +133,17 @@ describe("Redemption", () => {
                     const data: RedemptionTestData =
                       singleP2WPKHRedemptionWithWitnessChange
 
+                    let transactionHash: TransactionHash
+                    let newMainUtxo: UnspentTransactionOutput | undefined
+
                     beforeEach(async () => {
-                      await runRedemptionScenario(
-                        walletPrivateKey,
-                        bitcoinClient,
-                        bridge,
-                        data
-                      )
+                      ;({ transactionHash, newMainUtxo } =
+                        await runRedemptionScenario(
+                          walletPrivateKey,
+                          bitcoinClient,
+                          bridge,
+                          data
+                        ))
                     })
 
                     it("should broadcast redemption transaction with proper structure", () => {
@@ -121,6 +151,23 @@ describe("Redemption", () => {
                       expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                         data.expectedRedemption.transaction
                       )
+                    })
+
+                    it("should return the proper transaction hash", async () => {
+                      expect(transactionHash).to.be.equal(
+                        data.expectedRedemption.transactionHash
+                      )
+                    })
+
+                    it("should return the proper new main UTXO", () => {
+                      const expectedNewMainUtxo = {
+                        transactionHash:
+                          data.expectedRedemption.transactionHash,
+                        outputIndex: 1,
+                        value: BigNumber.from(1458780),
+                      }
+
+                      expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
                     })
                   }
                 )
@@ -131,13 +178,17 @@ describe("Redemption", () => {
                     const data: RedemptionTestData =
                       singleP2SHRedemptionWithWitnessChange
 
+                    let transactionHash: TransactionHash
+                    let newMainUtxo: UnspentTransactionOutput | undefined
+
                     beforeEach(async () => {
-                      await runRedemptionScenario(
-                        walletPrivateKey,
-                        bitcoinClient,
-                        bridge,
-                        data
-                      )
+                      ;({ transactionHash, newMainUtxo } =
+                        await runRedemptionScenario(
+                          walletPrivateKey,
+                          bitcoinClient,
+                          bridge,
+                          data
+                        ))
                     })
 
                     it("should broadcast redemption transaction with proper structure", () => {
@@ -145,6 +196,23 @@ describe("Redemption", () => {
                       expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                         data.expectedRedemption.transaction
                       )
+                    })
+
+                    it("should return the proper transaction hash", async () => {
+                      expect(transactionHash).to.be.equal(
+                        data.expectedRedemption.transactionHash
+                      )
+                    })
+
+                    it("should return the proper new main UTXO", () => {
+                      const expectedNewMainUtxo = {
+                        transactionHash:
+                          data.expectedRedemption.transactionHash,
+                        outputIndex: 1,
+                        value: BigNumber.from(1446580),
+                      }
+
+                      expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
                     })
                   }
                 )
@@ -155,13 +223,17 @@ describe("Redemption", () => {
                     const data: RedemptionTestData =
                       singleP2WSHRedemptionWithWitnessChange
 
+                    let transactionHash: TransactionHash
+                    let newMainUtxo: UnspentTransactionOutput | undefined
+
                     beforeEach(async () => {
-                      await runRedemptionScenario(
-                        walletPrivateKey,
-                        bitcoinClient,
-                        bridge,
-                        data
-                      )
+                      ;({ transactionHash, newMainUtxo } =
+                        await runRedemptionScenario(
+                          walletPrivateKey,
+                          bitcoinClient,
+                          bridge,
+                          data
+                        ))
                     })
 
                     it("should broadcast redemption transaction with proper structure", () => {
@@ -169,6 +241,23 @@ describe("Redemption", () => {
                       expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                         data.expectedRedemption.transaction
                       )
+                    })
+
+                    it("should return the proper transaction hash", async () => {
+                      expect(transactionHash).to.be.equal(
+                        data.expectedRedemption.transactionHash
+                      )
+                    })
+
+                    it("should return the proper new main UTXO", () => {
+                      const expectedNewMainUtxo = {
+                        transactionHash:
+                          data.expectedRedemption.transactionHash,
+                        outputIndex: 1,
+                        value: BigNumber.from(1429580),
+                      }
+
+                      expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
                     })
                   }
                 )
@@ -178,13 +267,17 @@ describe("Redemption", () => {
                 const data: RedemptionTestData =
                   multipleRedemptionsWithWitnessChange
 
+                let transactionHash: TransactionHash
+                let newMainUtxo: UnspentTransactionOutput | undefined
+
                 beforeEach(async () => {
-                  await runRedemptionScenario(
-                    walletPrivateKey,
-                    bitcoinClient,
-                    bridge,
-                    data
-                  )
+                  ;({ transactionHash, newMainUtxo } =
+                    await runRedemptionScenario(
+                      walletPrivateKey,
+                      bitcoinClient,
+                      bridge,
+                      data
+                    ))
                 })
 
                 it("should broadcast redemption transaction with proper structure", () => {
@@ -192,6 +285,22 @@ describe("Redemption", () => {
                   expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                     data.expectedRedemption.transaction
                   )
+                })
+
+                it("should return the proper transaction hash", async () => {
+                  expect(transactionHash).to.be.equal(
+                    data.expectedRedemption.transactionHash
+                  )
+                })
+
+                it("should return the proper new main UTXO", () => {
+                  const expectedNewMainUtxo = {
+                    transactionHash: data.expectedRedemption.transactionHash,
+                    outputIndex: 4,
+                    value: BigNumber.from(1375180),
+                  }
+
+                  expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
                 })
               })
             })
@@ -203,13 +312,17 @@ describe("Redemption", () => {
               const data: RedemptionTestData =
                 singleP2SHRedemptionWithNonWitnessChange
 
+              let transactionHash: TransactionHash
+              let newMainUtxo: UnspentTransactionOutput | undefined
+
               beforeEach(async () => {
-                await runRedemptionScenario(
-                  walletPrivateKey,
-                  bitcoinClient,
-                  bridge,
-                  data
-                )
+                ;({ transactionHash, newMainUtxo } =
+                  await runRedemptionScenario(
+                    walletPrivateKey,
+                    bitcoinClient,
+                    bridge,
+                    data
+                  ))
               })
 
               it("should broadcast redemption transaction with proper structure", () => {
@@ -217,6 +330,22 @@ describe("Redemption", () => {
                 expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                   data.expectedRedemption.transaction
                 )
+              })
+
+              it("should return the proper transaction hash", async () => {
+                expect(transactionHash).to.be.equal(
+                  data.expectedRedemption.transactionHash
+                )
+              })
+
+              it("should return the proper new main UTXO", () => {
+                const expectedNewMainUtxo = {
+                  transactionHash: data.expectedRedemption.transactionHash,
+                  outputIndex: 1,
+                  value: BigNumber.from(1364180),
+                }
+
+                expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
               })
             })
           })
@@ -227,13 +356,16 @@ describe("Redemption", () => {
             // will not contain the change output.
             const data: RedemptionTestData = multipleRedemptionsWithoutChange
 
+            let transactionHash: TransactionHash
+            let newMainUtxo: UnspentTransactionOutput | undefined
+
             beforeEach(async () => {
-              await runRedemptionScenario(
+              ;({ transactionHash, newMainUtxo } = await runRedemptionScenario(
                 walletPrivateKey,
                 bitcoinClient,
                 bridge,
                 data
-              )
+              ))
             })
 
             it("should broadcast redemption transaction with proper structure", () => {
@@ -241,6 +373,16 @@ describe("Redemption", () => {
               expect(bitcoinClient.broadcastLog[0]).to.be.eql(
                 data.expectedRedemption.transaction
               )
+            })
+
+            it("should return the proper transaction hash", async () => {
+              expect(transactionHash).to.be.equal(
+                data.expectedRedemption.transactionHash
+              )
+            })
+
+            it("should not return the new main UTXO", () => {
+              expect(newMainUtxo).to.be.undefined
             })
           })
         }
@@ -329,6 +471,9 @@ describe("Redemption", () => {
               () => {
                 const data: RedemptionTestData =
                   singleP2PKHRedemptionWithWitnessChange
+
+                let transactionHash: TransactionHash
+                let newMainUtxo: UnspentTransactionOutput | undefined
                 let transaction: RawTransaction
 
                 beforeEach(async () => {
@@ -336,12 +481,16 @@ describe("Redemption", () => {
                     (redemption) => redemption.pendingRedemption
                   )
 
-                  transaction = await TBTC.createRedemptionTransaction(
+                  ;({
+                    transactionHash,
+                    newMainUtxo,
+                    rawTransaction: transaction,
+                  } = await TBTC.createRedemptionTransaction(
                     walletPrivateKey,
                     data.mainUtxo,
                     redemptionRequests,
                     data.witness
-                  )
+                  ))
                 })
 
                 it("should return transaction with proper structure", async () => {
@@ -411,6 +560,22 @@ describe("Redemption", () => {
                   // The change output address should be the P2WPKH address of the wallet
                   expect(changeOutput.address).to.be.equal(p2wpkhWalletAddress)
                 })
+
+                it("should return the proper transaction hash", async () => {
+                  expect(transactionHash).to.be.equal(
+                    data.expectedRedemption.transactionHash
+                  )
+                })
+
+                it("should return the proper new main UTXO", () => {
+                  const expectedNewMainUtxo = {
+                    transactionHash: data.expectedRedemption.transactionHash,
+                    outputIndex: 1,
+                    value: BigNumber.from(1472680),
+                  }
+
+                  expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+                })
               }
             )
 
@@ -419,6 +584,9 @@ describe("Redemption", () => {
               () => {
                 const data: RedemptionTestData =
                   singleP2WPKHRedemptionWithWitnessChange
+
+                let transactionHash: TransactionHash
+                let newMainUtxo: UnspentTransactionOutput | undefined
                 let transaction: RawTransaction
 
                 beforeEach(async () => {
@@ -426,12 +594,16 @@ describe("Redemption", () => {
                     (redemption) => redemption.pendingRedemption
                   )
 
-                  transaction = await TBTC.createRedemptionTransaction(
+                  ;({
+                    transactionHash,
+                    newMainUtxo,
+                    rawTransaction: transaction,
+                  } = await TBTC.createRedemptionTransaction(
                     walletPrivateKey,
                     data.mainUtxo,
                     redemptionRequests,
                     data.witness
-                  )
+                  ))
                 })
 
                 it("should return transaction with proper structure", async () => {
@@ -500,6 +672,22 @@ describe("Redemption", () => {
                   // The change output address should be the P2WPKH address of the wallet
                   expect(changeOutput.address).to.be.equal(p2wpkhWalletAddress)
                 })
+
+                it("should return the proper transaction hash", async () => {
+                  expect(transactionHash).to.be.equal(
+                    data.expectedRedemption.transactionHash
+                  )
+                })
+
+                it("should return the proper new main UTXO", () => {
+                  const expectedNewMainUtxo = {
+                    transactionHash: data.expectedRedemption.transactionHash,
+                    outputIndex: 1,
+                    value: BigNumber.from(1458780),
+                  }
+
+                  expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+                })
               }
             )
 
@@ -508,6 +696,9 @@ describe("Redemption", () => {
               () => {
                 const data: RedemptionTestData =
                   singleP2SHRedemptionWithWitnessChange
+
+                let transactionHash: TransactionHash
+                let newMainUtxo: UnspentTransactionOutput | undefined
                 let transaction: RawTransaction
 
                 beforeEach(async () => {
@@ -515,12 +706,16 @@ describe("Redemption", () => {
                     (redemption) => redemption.pendingRedemption
                   )
 
-                  transaction = await TBTC.createRedemptionTransaction(
+                  ;({
+                    transactionHash,
+                    newMainUtxo,
+                    rawTransaction: transaction,
+                  } = await TBTC.createRedemptionTransaction(
                     walletPrivateKey,
                     data.mainUtxo,
                     redemptionRequests,
                     data.witness
-                  )
+                  ))
                 })
 
                 it("should return transaction with proper structure", async () => {
@@ -589,6 +784,22 @@ describe("Redemption", () => {
                   // The change output address should be the P2WPKH address of the wallet
                   expect(changeOutput.address).to.be.equal(p2wpkhWalletAddress)
                 })
+
+                it("should return the proper transaction hash", async () => {
+                  expect(transactionHash).to.be.equal(
+                    data.expectedRedemption.transactionHash
+                  )
+                })
+
+                it("should return the proper new main UTXO", () => {
+                  const expectedNewMainUtxo = {
+                    transactionHash: data.expectedRedemption.transactionHash,
+                    outputIndex: 1,
+                    value: BigNumber.from(1446580),
+                  }
+
+                  expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+                })
               }
             )
 
@@ -597,6 +808,9 @@ describe("Redemption", () => {
               () => {
                 const data: RedemptionTestData =
                   singleP2WSHRedemptionWithWitnessChange
+
+                let transactionHash: TransactionHash
+                let newMainUtxo: UnspentTransactionOutput | undefined
                 let transaction: RawTransaction
 
                 beforeEach(async () => {
@@ -604,12 +818,16 @@ describe("Redemption", () => {
                     (redemption) => redemption.pendingRedemption
                   )
 
-                  transaction = await TBTC.createRedemptionTransaction(
+                  ;({
+                    transactionHash,
+                    newMainUtxo,
+                    rawTransaction: transaction,
+                  } = await TBTC.createRedemptionTransaction(
                     walletPrivateKey,
                     data.mainUtxo,
                     redemptionRequests,
                     data.witness
-                  )
+                  ))
                 })
 
                 it("should return transaction with proper structure", async () => {
@@ -678,6 +896,22 @@ describe("Redemption", () => {
                   // The change output address should be the P2WPKH address of the wallet
                   expect(changeOutput.address).to.be.equal(p2wpkhWalletAddress)
                 })
+
+                it("should return the proper transaction hash", async () => {
+                  expect(transactionHash).to.be.equal(
+                    data.expectedRedemption.transactionHash
+                  )
+                })
+
+                it("should return the proper new main UTXO", () => {
+                  const expectedNewMainUtxo = {
+                    transactionHash: data.expectedRedemption.transactionHash,
+                    outputIndex: 1,
+                    value: BigNumber.from(1429580),
+                  }
+
+                  expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+                })
               }
             )
           })
@@ -685,6 +919,9 @@ describe("Redemption", () => {
           context("when there are multiple redeemers", () => {
             const data: RedemptionTestData =
               multipleRedemptionsWithWitnessChange
+
+            let transactionHash: TransactionHash
+            let newMainUtxo: UnspentTransactionOutput | undefined
             let transaction: RawTransaction
 
             beforeEach(async () => {
@@ -692,12 +929,16 @@ describe("Redemption", () => {
                 (redemption) => redemption.pendingRedemption
               )
 
-              transaction = await TBTC.createRedemptionTransaction(
+              ;({
+                transactionHash,
+                newMainUtxo,
+                rawTransaction: transaction,
+              } = await TBTC.createRedemptionTransaction(
                 walletPrivateKey,
                 data.mainUtxo,
                 redemptionRequests,
                 data.witness
-              )
+              ))
             })
 
             it("should return transaction with proper structure", async () => {
@@ -808,6 +1049,22 @@ describe("Redemption", () => {
               // The change output address should be the P2WPKH address of the wallet
               expect(changeOutput.address).to.be.equal(p2wpkhWalletAddress)
             })
+
+            it("should return the proper transaction hash", async () => {
+              expect(transactionHash).to.be.equal(
+                data.expectedRedemption.transactionHash
+              )
+            })
+
+            it("should return the proper new main UTXO", () => {
+              const expectedNewMainUtxo = {
+                transactionHash: data.expectedRedemption.transactionHash,
+                outputIndex: 4,
+                value: BigNumber.from(1375180),
+              }
+
+              expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+            })
           })
         })
 
@@ -819,6 +1076,9 @@ describe("Redemption", () => {
           // covered for P2WPKH change output tests.
           const data: RedemptionTestData =
             singleP2SHRedemptionWithNonWitnessChange
+
+          let transactionHash: TransactionHash
+          let newMainUtxo: UnspentTransactionOutput | undefined
           let transaction: RawTransaction
 
           beforeEach(async () => {
@@ -826,12 +1086,16 @@ describe("Redemption", () => {
               (redemption) => redemption.pendingRedemption
             )
 
-            transaction = await TBTC.createRedemptionTransaction(
+            ;({
+              transactionHash,
+              newMainUtxo,
+              rawTransaction: transaction,
+            } = await TBTC.createRedemptionTransaction(
               walletPrivateKey,
               data.mainUtxo,
               redemptionRequests,
               data.witness
-            )
+            ))
           })
 
           it("should return transaction with proper structure", async () => {
@@ -897,11 +1161,30 @@ describe("Redemption", () => {
             // The change output address should be the P2PKH address of the wallet
             expect(changeOutput.address).to.be.equal(p2pkhWalletAddress)
           })
+
+          it("should return the proper transaction hash", async () => {
+            expect(transactionHash).to.be.equal(
+              data.expectedRedemption.transactionHash
+            )
+          })
+
+          it("should return the proper new main UTXO", () => {
+            const expectedNewMainUtxo = {
+              transactionHash: data.expectedRedemption.transactionHash,
+              outputIndex: 1,
+              value: BigNumber.from(1364180),
+            }
+
+            expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+          })
         })
       })
 
       context("when there is no change UTXO created", () => {
         const data: RedemptionTestData = multipleRedemptionsWithoutChange
+
+        let transactionHash: TransactionHash
+        let newMainUtxo: UnspentTransactionOutput | undefined
         let transaction: RawTransaction
 
         beforeEach(async () => {
@@ -909,12 +1192,16 @@ describe("Redemption", () => {
             (redemption) => redemption.pendingRedemption
           )
 
-          transaction = await TBTC.createRedemptionTransaction(
+          ;({
+            transactionHash,
+            newMainUtxo,
+            rawTransaction: transaction,
+          } = await TBTC.createRedemptionTransaction(
             walletPrivateKey,
             data.mainUtxo,
             redemptionRequests,
             data.witness
-          )
+          ))
         })
 
         it("should return transaction with proper structure", async () => {
@@ -977,6 +1264,16 @@ describe("Redemption", () => {
           expect(p2wpkhOutput.address).to.be.equal(
             "tb1qf0ulldawp79s7knz9v254j5zjyn0demfx2d0xx"
           )
+        })
+
+        it("should return the proper transaction hash", async () => {
+          expect(transactionHash).to.be.equal(
+            data.expectedRedemption.transactionHash
+          )
+        })
+
+        it("should not return the new main UTXO", () => {
+          expect(newMainUtxo).to.be.undefined
         })
       })
     })
@@ -1080,7 +1377,10 @@ async function runRedemptionScenario(
   bitcoinClient: MockBitcoinClient,
   bridge: MockBridge,
   data: RedemptionTestData
-) {
+): Promise<{
+  transactionHash: TransactionHash
+  newMainUtxo?: UnspentTransactionOutput
+}> {
   const rawTransactions = new Map<string, RawTransaction>()
   rawTransactions.set(data.mainUtxo.transactionHash, {
     transactionHex: data.mainUtxo.transactionHex,
@@ -1098,7 +1398,7 @@ async function runRedemptionScenario(
     (redemption) => redemption.pendingRedemption.redeemerOutputScript
   )
 
-  await TBTC.makeRedemptions(
+  return TBTC.makeRedemptions(
     bitcoinClient,
     bridge,
     walletPrivKey,

--- a/typescript/test/utils/mock-bitcoin-client.ts
+++ b/typescript/test/utils/mock-bitcoin-client.ts
@@ -4,6 +4,7 @@ import {
   TransactionMerkleBranch,
   RawTransaction,
   Transaction,
+  TransactionHash,
 } from "../../src/bitcoin"
 
 /**
@@ -72,19 +73,21 @@ export class MockBitcoinClient implements Client {
     })
   }
 
-  getTransaction(transactionHash: string): Promise<Transaction> {
+  getTransaction(transactionHash: TransactionHash): Promise<Transaction> {
     return new Promise<Transaction>((resolve, _) => {
       resolve(this._transactions.get(transactionHash) as Transaction)
     })
   }
 
-  getRawTransaction(transactionHash: string): Promise<RawTransaction> {
+  getRawTransaction(transactionHash: TransactionHash): Promise<RawTransaction> {
     return new Promise<RawTransaction>((resolve, _) => {
       resolve(this._rawTransactions.get(transactionHash) as RawTransaction)
     })
   }
 
-  getTransactionConfirmations(transactionHash: string): Promise<number> {
+  getTransactionConfirmations(
+    transactionHash: TransactionHash
+  ): Promise<number> {
     return new Promise<number>((resolve, _) => {
       resolve(this._confirmations.get(transactionHash) as number)
     })
@@ -103,7 +106,7 @@ export class MockBitcoinClient implements Client {
   }
 
   getTransactionMerkle(
-    transactionHash: string,
+    transactionHash: TransactionHash,
     blockHeight: number
   ): Promise<TransactionMerkleBranch> {
     return new Promise<TransactionMerkleBranch>((resolve, _) => {


### PR DESCRIPTION
Refs: #143 

This pull request introduces some tweaks to functions that work with Bitcoin transactions.

First, we extract a separate type that represents the Bitcoin transaction hash (`TransactionHash`). We also make it explicit that this type represents a transaction hash in the byte order used by the block explorers and wallet software. This way we capture those details in one place which was not possible if we would still use the ordinary `string` type.

Second, all `make*` functions return now the transaction hash and the UTXO relevant for further processing (deposit UTXO or new main UTXO). The same was done for the `create*Transaction` functions. This change should allow all clients to follow up on the transaction after using one of the library functions.