### PR TITLE
Replacing hardhat network check with the network.tags.local

### DIFF
--- a/solidity/deploy/00_resolve_relay.ts
+++ b/solidity/deploy/00_resolve_relay.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (Relay && helpers.address.isValid(Relay.address)) {
     log(`using external Relay at ${Relay.address}`)
-  } else if (hre.network.name !== "hardhat") {
+  } else if (!hre.network.tags.local) {
     throw new Error("deployed Relay contract not found")
   } else {
     log("deploying Relay stub")

--- a/solidity/deploy/00_resolve_tbtc_v1_token.ts
+++ b/solidity/deploy/00_resolve_tbtc_v1_token.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (TBTCToken && helpers.address.isValid(TBTCToken.address)) {
     log(`using external TBTCToken at ${TBTCToken.address}`)
-  } else if (hre.network.name !== "hardhat") {
+  } else if (!hre.network.tags.local) {
     throw new Error("deployed TBTCToken contract not found")
   } else {
     log("deploying TBTCToken stub")

--- a/solidity/deploy/05_deploy_bridge.ts
+++ b/solidity/deploy/05_deploy_bridge.ts
@@ -15,8 +15,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const WalletRegistry = await deployments.get("WalletRegistry")
 
   // For local tests use `1`.
-  const txProofDifficultyFactor =
-    deployments.getNetworkName() === "hardhat" ? 1 : 6
+  const txProofDifficultyFactor = hre.network.tags.local ? 1 : 6
 
   const Deposit = await deploy("Deposit", { from: deployer, log: true })
   const DepositSweep = await deploy("DepositSweep", {


### PR DESCRIPTION
Trying to deploy contracts on local Geth when `tbtc-v2` is one of the
dependencies is not possible without this change. Local deployments use some of the contract stubs. When a project like `keep-core` is trying to deploy contracts on local Geth it can't find them. 
This change makes it possible for the stubs to be deployed on either network: Hardhat or Geth.