### PR TITLE
Strict contract resolution during `typescript` package publication

### DIFF
--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -33,7 +33,7 @@ jobs:
         run: git config --global url."https://".insteadOf git://
 
       - name: Resolve latest contracts
-        run: yarn upgrade @keep-network/tbtc-v2
+        run: yarn upgrade @keep-network/tbtc-v2 --exact
 
       - name: Compile
         run: yarn build


### PR DESCRIPTION
We want that the `@keep-network/tbtc-v2` dependency is updated to the latest version before we publish the new version of the `@keep-network/tbtc-v2.ts` package.

This is achieved in the `Resolve latest contracts` step by using the `yarn upgrade @keep-network/tbtc-v2` command that bumps up this dependency according to the range specified in the `package.json` file and saves back that change there. However, the updated version is non-strict. That causes some unexpected problems during `tbtc-v2` version resolution in packages that depend on `tbtc-v2.ts`.

In order to fix the aforementioned problem, we just upgrade `@keep-network/tbtc-v2` with the `--exact` flag that guarantees that the upgraded version saved in `package.json` is unambiguous.