### PR TITLE
Add missing `chai` import

### DIFF
--- a/system-tests/test/deposit-redemption.test.ts
+++ b/system-tests/test/deposit-redemption.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@keep-network/tbtc-v2.ts"
 import { computeHash160 } from "@keep-network/tbtc-v2.ts/dist/bitcoin"
 import { BigNumber, constants, Contract } from "ethers"
-import { expect } from "chai"
+import chai, { expect } from "chai"
 import { submitDepositTransaction } from "@keep-network/tbtc-v2.ts/dist/deposit"
 import { submitDepositSweepTransaction } from "@keep-network/tbtc-v2.ts/dist/deposit-sweep"
 import { submitRedemptionTransaction } from "@keep-network/tbtc-v2.ts/dist/redemption"


### PR DESCRIPTION
Adds a missing `chai` import in deposit and redemption system test scenario.