### PR TITLE
Add `_disableInitializers` to `Bridge` contract constructor

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -225,6 +225,11 @@ contract Bridge is
         uint32 fraudNotifierRewardMultiplier
     );
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @dev Initializes upgradable contract on deployment.
     /// @param _bank Address of the Bank the Bridge belongs to.
     /// @param _relay Address of the Bitcoin relay providing the current Bitcoin

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -3,7 +3,7 @@
 
 import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import { ContractTransaction } from "ethers"
+import { Contract, ContractTransaction } from "ethers"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import type {
@@ -11,7 +11,6 @@ import type {
   BankStub,
   Bridge,
   BridgeStub,
-  BridgeStub__factory,
   IRelay,
   IVault,
   BridgeGovernance,
@@ -43,9 +42,9 @@ describe("Bridge - Deposit", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
-  let BridgeFactory: BridgeStub__factory
   let bridge: Bridge & BridgeStub
   let bridgeGovernance: BridgeGovernance
+  let deployBridge: (txProofDifficultyFactor: number) => Promise<Contract>
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -54,9 +53,9 @@ describe("Bridge - Deposit", () => {
       treasury,
       bank,
       relay,
-      BridgeFactory,
       bridge,
       bridgeGovernance,
+      deployBridge,
     } = await waffle.loadFixture(bridgeFixture))
 
     // Set the deposit dust threshold to 0.0001 BTC, i.e. 100x smaller than
@@ -2587,15 +2586,7 @@ describe("Bridge - Deposit", () => {
               // to deem transaction proof validity. This scenario uses test
               // data which has only 6 confirmations. That should force the
               // failure we expect within this scenario.
-              otherBridge = await BridgeFactory.deploy()
-              await otherBridge.initialize(
-                bank.address,
-                relay.address,
-                treasury.address,
-                ethers.utils.hexZeroPad("0x01", 20),
-                12
-              )
-              await otherBridge.deployed()
+              otherBridge = (await deployBridge(12)) as BridgeStub
             })
 
             after(async () => {

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -4,13 +4,10 @@ import chai, { assert, expect } from "chai"
 import { smock } from "@defi-wonderland/smock"
 import type { FakeContract } from "@defi-wonderland/smock"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import { BigNumber, ContractTransaction } from "ethers"
+import { BigNumber, Contract, ContractTransaction } from "ethers"
 import type {
-  Bank,
-  BankStub,
   Bridge,
   BridgeStub,
-  BridgeStub__factory,
   IRelay,
   IWalletRegistry,
 } from "../../typechain"
@@ -47,13 +44,11 @@ const { lastBlockTime, increaseTime } = helpers.time
 
 describe("Bridge - Moving funds", () => {
   let thirdParty: SignerWithAddress
-  let treasury: SignerWithAddress
 
-  let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
   let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
-  let BridgeFactory: BridgeStub__factory
+  let deployBridge: (txProofDifficultyFactor: number) => Promise<Contract>
 
   let movingFundsTimeoutResetDelay: number
   let movingFundsTimeout: number
@@ -65,15 +60,8 @@ describe("Bridge - Moving funds", () => {
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;({
-      thirdParty,
-      treasury,
-      bank,
-      relay,
-      walletRegistry,
-      bridge,
-      BridgeFactory,
-    } = await waffle.loadFixture(bridgeFixture))
+    ;({ thirdParty, relay, walletRegistry, bridge, deployBridge } =
+      await waffle.loadFixture(bridgeFixture))
     ;({
       movingFundsTimeoutResetDelay,
       movingFundsTimeout,
@@ -1926,14 +1914,7 @@ describe("Bridge - Moving funds", () => {
             // to deem transaction proof validity. This scenario uses test
             // data which has only 6 confirmations. That should force the
             // failure we expect within this scenario.
-            otherBridge = await BridgeFactory.deploy()
-            await otherBridge.initialize(
-              bank.address,
-              relay.address,
-              treasury.address,
-              walletRegistry.address,
-              12
-            )
+            otherBridge = (await deployBridge(12)) as BridgeStub
           })
 
           after(async () => {
@@ -3425,15 +3406,7 @@ describe("Bridge - Moving funds", () => {
             // to deem transaction proof validity. This scenario uses test
             // data which has only 6 confirmations. That should force the
             // failure we expect within this scenario.
-            otherBridge = await BridgeFactory.deploy()
-            await otherBridge.initialize(
-              bank.address,
-              relay.address,
-              treasury.address,
-              walletRegistry.address,
-              12
-            )
-            await otherBridge.deployed()
+            otherBridge = (await deployBridge(12)) as BridgeStub
           })
 
           after(async () => {

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -4,7 +4,7 @@
 import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import chai, { expect } from "chai"
-import { BigNumber, BigNumberish, ContractTransaction } from "ethers"
+import { BigNumber, BigNumberish, Contract, ContractTransaction } from "ethers"
 import { BytesLike } from "@ethersproject/bytes"
 import { smock } from "@defi-wonderland/smock"
 import type { FakeContract } from "@defi-wonderland/smock"
@@ -13,7 +13,6 @@ import type {
   BankStub,
   Bridge,
   BridgeStub,
-  BridgeStub__factory,
   IWalletRegistry,
   IRelay,
 } from "../../typechain"
@@ -53,9 +52,10 @@ describe("Bridge - Redemption", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
-  let BridgeFactory: BridgeStub__factory
   let bridge: Bridge & BridgeStub
   let walletRegistry: FakeContract<IWalletRegistry>
+
+  let deployBridge: (txProofDifficultyFactor: number) => Promise<Contract>
 
   let redemptionTimeout: number
   let redemptionTimeoutSlashingAmount: BigNumber
@@ -71,7 +71,7 @@ describe("Bridge - Redemption", () => {
       relay,
       walletRegistry,
       bridge,
-      BridgeFactory,
+      deployBridge,
     } = await waffle.loadFixture(bridgeFixture))
     ;({
       redemptionTimeout,
@@ -3366,14 +3366,7 @@ describe("Bridge - Redemption", () => {
             // to deem transaction proof validity. This scenario uses test
             // data which has only 6 confirmations. That should force the
             // failure we expect within this scenario.
-            otherBridge = await BridgeFactory.deploy()
-            await otherBridge.initialize(
-              bank.address,
-              relay.address,
-              treasury.address,
-              walletRegistry.address,
-              12
-            )
+            otherBridge = (await deployBridge(12)) as BridgeStub
           })
 
           after(async () => {

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -1,4 +1,5 @@
 import { deployments, ethers, helpers } from "hardhat"
+import { randomBytes } from "crypto"
 import { smock } from "@defi-wonderland/smock"
 import type {
   Bank,
@@ -65,18 +66,43 @@ export default async function bridgeFixture() {
 
   await bank.connect(governance).updateBridge(bridge.address)
 
-  const BridgeFactory = await ethers.getContractFactory("BridgeStub", {
-    libraries: {
-      Deposit: (await helpers.contracts.getContract("Deposit")).address,
-      DepositSweep: (
-        await helpers.contracts.getContract("DepositSweep")
-      ).address,
-      Redemption: (await helpers.contracts.getContract("Redemption")).address,
-      Wallets: (await helpers.contracts.getContract("Wallets")).address,
-      Fraud: (await helpers.contracts.getContract("Fraud")).address,
-      MovingFunds: (await helpers.contracts.getContract("MovingFunds")).address,
-    },
-  })
+  // Deploys a new instance of Bridge contract behind a proxy. Allows to
+  // specify txProofDifficultyFactor. The new instance is deployed with
+  // a random name to do not conflict with the main deployed instance.
+  // Same parameters as in `05_deploy_bridge.ts` deployment script are used.
+  const deployBridge = async (txProofDifficultyFactor: number) =>
+    helpers.upgrades.deployProxy(`Bridge_${randomBytes(8).toString("hex")}`, {
+      contractName: "BridgeStub",
+      initializerArgs: [
+        bank.address,
+        relay.address,
+        treasury.address,
+        walletRegistry.address,
+        txProofDifficultyFactor,
+      ],
+      factoryOpts: {
+        signer: deployer,
+        libraries: {
+          Deposit: (await helpers.contracts.getContract("Deposit")).address,
+          DepositSweep: (await helpers.contracts.getContract("DepositSweep"))
+            .address,
+          Redemption: (await helpers.contracts.getContract("Redemption"))
+            .address,
+          Wallets: (await helpers.contracts.getContract("Wallets")).address,
+          Fraud: (await helpers.contracts.getContract("Fraud")).address,
+          MovingFunds: (await helpers.contracts.getContract("MovingFunds"))
+            .address,
+        },
+      },
+      proxyOpts: {
+        kind: "transparent",
+        // Allow external libraries linking. We need to ensure manually that the
+        // external  libraries we link are upgrade safe, as the OpenZeppelin plugin
+        // doesn't perform such a validation yet.
+        // See: https://docs.openzeppelin.com/upgrades-plugins/1.x/faq#why-cant-i-use-external-libraries
+        unsafeAllow: ["external-library-linking"],
+      },
+    })
 
   return {
     deployer,
@@ -90,9 +116,9 @@ export default async function bridgeFixture() {
     relay,
     walletRegistry,
     bridge,
-    BridgeFactory,
     reimbursementPool,
     maintainerProxy,
     bridgeGovernance,
+    deployBridge,
   }
 }


### PR DESCRIPTION
The initialization function on the Bridge implementation contract was left
uninitialized. Anyone could call that method and set any parameters they wanted.
Because the Bridge contract is designed to be upgradeable, there was a risk that
future upgrades might introduce vulnerabilities (e.g. by adding
delegatecall/sefdestruct capabilities) that could be exploited by an
unauthorized account calling the initialize method on the implementation
contract. Adding `_disableInitializers` to `Bridge` contract constructor fixes
the problem.