### PR TITLE
Export contracts artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ artifacts/
 build/
 cache/
 deployments/
+export/
 export.json
 
 typechain/

--- a/solidity/.prettierignore
+++ b/solidity/.prettierignore
@@ -3,6 +3,7 @@ artifacts/
 build/
 cache/
 deployments/
+export/
 hardhat-dependency-compiler/
 typechain/
 export.json

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -8,6 +8,7 @@
     "contracts/",
     "!**/test/",
     "deploy/",
+    "export/",
     "export.json"
   ],
   "scripts": {
@@ -24,6 +25,7 @@
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
     "test": "TEST_USE_STUBS_TBTC=true hardhat test",
     "test:integration": "NODE_ENV=integration-test hardhat test ./test/integration/*.test.ts",
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
     "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network"
   },
   "dependencies": {

--- a/solidity/tsconfig.export.json
+++ b/solidity/tsconfig.export.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./test", "./typechain"],
+  "compilerOptions": {
+    "target": "es5",
+    "outDir": "export"
+  }
+}


### PR DESCRIPTION
We want to export contracts artifacts for usage in other projects or in
Go client.

This is consistent with what we have in e.g. ecdsa and random-beacon
projects.