### PR TITLE
Bridge governance cleanup

### DIFF
--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -325,7 +325,6 @@ library BridgeGovernanceParameters {
     // --- Deposit
 
     /// @notice Begins the deposit dust threshold amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newDepositDustThreshold New deposit dust threshold amount.
     function beginDepositDustThresholdUpdate(
         DepositData storage self,
@@ -342,8 +341,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the deposit dust threshold amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeDepositDustThresholdUpdate(
         DepositData storage self,
         uint256 governanceDelay
@@ -371,7 +369,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the deposit treasury fee divisor amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newDepositTreasuryFeeDivisor New deposit treasury fee divisor amount.
     function beginDepositTreasuryFeeDivisorUpdate(
         DepositData storage self,
@@ -388,8 +385,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the deposit treasury fee divisor amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeDepositTreasuryFeeDivisorUpdate(
         DepositData storage self,
         uint256 governanceDelay
@@ -419,7 +415,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the deposit tx max fee amount update process.
-    /// @dev Can be called only by the contract owner.
+
     /// @param _newDepositTxMaxFee New deposit tx max fee amount.
     function beginDepositTxMaxFeeUpdate(
         DepositData storage self,
@@ -433,8 +429,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the deposit tx max fee amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeDepositTxMaxFeeUpdate(
         DepositData storage self,
         uint256 governanceDelay
@@ -464,7 +459,6 @@ library BridgeGovernanceParameters {
     // --- Redemption
 
     /// @notice Begins the redemption dust threshold amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionDustThreshold New redemption dust threshold amount.
     function beginRedemptionDustThresholdUpdate(
         RedemptionData storage self,
@@ -481,8 +475,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption dust threshold amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionDustThresholdUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -510,7 +503,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the redemption treasury fee divisor amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTreasuryFeeDivisor New redemption treasury fee divisor
     ///         amount.
     function beginRedemptionTreasuryFeeDivisorUpdate(
@@ -528,8 +520,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption treasury fee divisor amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTreasuryFeeDivisorUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -559,7 +550,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the redemption tx max fee amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTxMaxFee New redemption tx max fee amount.
     function beginRedemptionTxMaxFeeUpdate(
         RedemptionData storage self,
@@ -576,8 +566,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption tx max fee amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTxMaxFeeUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -605,7 +594,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the redemption tx max total fee amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTxMaxTotalFee New redemption tx max total fee amount.
     function beginRedemptionTxMaxTotalFeeUpdate(
         RedemptionData storage self,
@@ -622,8 +610,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption tx max total fee amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTxMaxTotalFeeUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -651,7 +638,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the redemption timeout amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTimeout New redemption timeout amount.
     function beginRedemptionTimeoutUpdate(
         RedemptionData storage self,
@@ -669,8 +655,7 @@ library BridgeGovernanceParameters {
 
     /// @notice Finalizes the redemption timeout amount update
     ///         process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTimeoutUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -698,7 +683,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the redemption timeout slashing amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTimeoutSlashingAmount New redemption timeout slashing
     ///         amount.
     function beginRedemptionTimeoutSlashingAmountUpdate(
@@ -717,8 +701,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption timeout slashing amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTimeoutSlashingAmountUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -749,7 +732,6 @@ library BridgeGovernanceParameters {
 
     /// @notice Begins the redemption timeout notifier reward multiplier amount
     ///         update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newRedemptionTimeoutNotifierRewardMultiplier New redemption
     ///         timeout notifier reward multiplier amount.
     function beginRedemptionTimeoutNotifierRewardMultiplierUpdate(
@@ -769,8 +751,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the redemption timeout notifier reward multiplier amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeRedemptionTimeoutNotifierRewardMultiplierUpdate(
         RedemptionData storage self,
         uint256 governanceDelay
@@ -800,7 +781,6 @@ library BridgeGovernanceParameters {
     // --- Moving funds
 
     /// @notice Begins the moving funds tx max total fee amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsTxMaxTotalFee New moving funds tx max total fee amount.
     function beginMovingFundsTxMaxTotalFeeUpdate(
         MovingFundsData storage self,
@@ -817,8 +797,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moving funds tx max total fee amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsTxMaxTotalFeeUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -846,7 +825,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moving funds dust threshold amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsDustThreshold New moving funds dust threshold amount.
     function beginMovingFundsDustThresholdUpdate(
         MovingFundsData storage self,
@@ -863,8 +841,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moving funds dust threshold amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsDustThresholdUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -892,7 +869,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moving funds timeout reset delay amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsTimeoutResetDelay New moving funds timeout reset
     ///         delay amount.
     function beginMovingFundsTimeoutResetDelayUpdate(
@@ -910,8 +886,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moving funds timeout reset delay amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsTimeoutResetDelayUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -941,7 +916,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moving funds timeout amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsTimeout New moving funds timeout amount.
     function beginMovingFundsTimeoutUpdate(
         MovingFundsData storage self,
@@ -958,8 +932,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moving funds timeout amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsTimeoutUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -987,7 +960,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moving funds timeout slashing amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsTimeoutSlashingAmount New moving funds timeout slashing amount.
     function beginMovingFundsTimeoutSlashingAmountUpdate(
         MovingFundsData storage self,
@@ -1005,8 +977,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moving funds timeout slashing amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsTimeoutSlashingAmountUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1035,7 +1006,6 @@ library BridgeGovernanceParameters {
 
     /// @notice Begins the moving funds timeout notifier reward multiplier amount
     ///         update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovingFundsTimeoutNotifierRewardMultiplier New moving funds
     ///         timeout notifier reward multiplier amount.
     function beginMovingFundsTimeoutNotifierRewardMultiplierUpdate(
@@ -1056,8 +1026,7 @@ library BridgeGovernanceParameters {
 
     /// @notice Finalizes the moving funds timeout notifier reward multiplier
     ///         amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovingFundsTimeoutNotifierRewardMultiplierUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1085,7 +1054,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moved funds sweep tx max total fee amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovedFundsSweepTxMaxTotalFee New moved funds sweep tx max total
     ///         fee amount.
     function beginMovedFundsSweepTxMaxTotalFeeUpdate(
@@ -1104,8 +1072,7 @@ library BridgeGovernanceParameters {
 
     /// @notice Finalizes the moved funds sweep tx max total fee amount update
     ///         process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovedFundsSweepTxMaxTotalFeeUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1135,7 +1102,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the moved funds sweep timeout amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovedFundsSweepTimeout New moved funds sweep timeout amount.
     function beginMovedFundsSweepTimeoutUpdate(
         MovingFundsData storage self,
@@ -1152,8 +1118,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the moved funds sweep timeout amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovedFundsSweepTimeoutUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1182,7 +1147,6 @@ library BridgeGovernanceParameters {
 
     /// @notice Begins the moved funds sweep timeout slashing amount update
     ///         process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovedFundsSweepTimeoutSlashingAmount New moved funds sweep
     ///         timeout slashing amount.
     function beginMovedFundsSweepTimeoutSlashingAmountUpdate(
@@ -1203,8 +1167,7 @@ library BridgeGovernanceParameters {
 
     /// @notice Finalizes the moved funds sweep timeout slashing amount
     ///         update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovedFundsSweepTimeoutSlashingAmountUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1233,7 +1196,6 @@ library BridgeGovernanceParameters {
 
     /// @notice Begins the moved funds sweep timeout notifier reward multiplier
     ///         amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newMovedFundsSweepTimeoutNotifierRewardMultiplier New moved funds
     ///         sweep timeout notifier reward multiplier amount.
     function beginMovedFundsSweepTimeoutNotifierRewardMultiplierUpdate(
@@ -1255,8 +1217,7 @@ library BridgeGovernanceParameters {
 
     /// @notice Finalizes the moved funds sweep timeout notifier reward multiplier
     ///         amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeMovedFundsSweepTimeoutNotifierRewardMultiplierUpdate(
         MovingFundsData storage self,
         uint256 governanceDelay
@@ -1286,7 +1247,6 @@ library BridgeGovernanceParameters {
     // --- Wallet params
 
     /// @notice Begins the wallet creation period amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletCreationPeriod New wallet creation period amount.
     function beginWalletCreationPeriodUpdate(
         WalletData storage self,
@@ -1303,8 +1263,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet creation period amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletCreationPeriodUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1332,7 +1291,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet creation min btc balance amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletCreationMinBtcBalance New wallet creation min btc balance
     ///         amount.
     function beginWalletCreationMinBtcBalanceUpdate(
@@ -1350,8 +1308,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet creation min btc balance amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletCreationMinBtcBalanceUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1381,7 +1338,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet creation max btc balance amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletCreationMaxBtcBalance New wallet creation max btc balance
     ///         amount.
     function beginWalletCreationMaxBtcBalanceUpdate(
@@ -1399,8 +1355,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet creation max btc balance amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletCreationMaxBtcBalanceUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1430,7 +1385,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet closure min btc balance amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletClosureMinBtcBalance New wallet closure min btc balance amount.
     function beginWalletClosureMinBtcBalanceUpdate(
         WalletData storage self,
@@ -1447,8 +1401,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet closure min btc balance amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletClosureMinBtcBalanceUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1478,7 +1431,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet max age amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletMaxAge New wallet max age amount.
     function beginWalletMaxAgeUpdate(
         WalletData storage self,
@@ -1492,8 +1444,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet max age amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletMaxAgeUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1521,7 +1472,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet max btc transfer amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletMaxBtcTransfer New wallet max btc transfer amount.
     function beginWalletMaxBtcTransferUpdate(
         WalletData storage self,
@@ -1538,8 +1488,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet max btc transfer amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletMaxBtcTransferUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1567,7 +1516,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the wallet closing period amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newWalletClosingPeriod New wallet closing period amount.
     function beginWalletClosingPeriodUpdate(
         WalletData storage self,
@@ -1584,8 +1532,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the wallet closing period amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeWalletClosingPeriodUpdate(
         WalletData storage self,
         uint256 governanceDelay
@@ -1615,7 +1562,6 @@ library BridgeGovernanceParameters {
     // --- Fraud
 
     /// @notice Begins the fraud challenge deposit amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newFraudChallengeDepositAmount New fraud challenge deposit amount.
     function beginFraudChallengeDepositAmountUpdate(
         FraudData storage self,
@@ -1632,8 +1578,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the fraud challenge deposit amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeFraudChallengeDepositAmountUpdate(
         FraudData storage self,
         uint256 governanceDelay
@@ -1663,7 +1608,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the fraud challenge defeat timeout amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newFraudChallengeDefeatTimeout New fraud challenge defeat timeout
     ///         amount.
     function beginFraudChallengeDefeatTimeoutUpdate(
@@ -1681,8 +1625,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the fraud challenge defeat timeout amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeFraudChallengeDefeatTimeoutUpdate(
         FraudData storage self,
         uint256 governanceDelay
@@ -1712,7 +1655,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the fraud slashing amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newFraudSlashingAmount New fraud slashing amount.
     function beginFraudSlashingAmountUpdate(
         FraudData storage self,
@@ -1729,8 +1671,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the fraud slashing amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeFraudSlashingAmountUpdate(
         FraudData storage self,
         uint256 governanceDelay
@@ -1758,7 +1699,6 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Begins the fraud notifier reward multiplier amount update process.
-    /// @dev Can be called only by the contract owner.
     /// @param _newFraudNotifierRewardMultiplier New fraud notifier reward multiplier
     ///         amount.
     function beginFraudNotifierRewardMultiplierUpdate(
@@ -1777,8 +1717,7 @@ library BridgeGovernanceParameters {
     }
 
     /// @notice Finalizes the fraud notifier reward multiplier amount update process.
-    /// @dev Can be called only by the contract owner, after the governance
-    ///      delay elapses.
+    /// @dev Can be called after the governance delay elapses.
     function finalizeFraudNotifierRewardMultiplierUpdate(
         FraudData storage self,
         uint256 governanceDelay

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -1,7 +1,7 @@
-import { helpers, waffle, ethers } from "hardhat"
+import { helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
-import { ContractTransaction, BigNumber } from "ethers"
+import { ContractTransaction } from "ethers"
 import type { BridgeGovernance, Bridge } from "../../typechain"
 import { constants } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"
@@ -160,8 +160,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit BridgeGovernanceTransferStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "BridgeGovernanceTransferStarted")
           .withArgs(thirdParty.address, blockTimestamp)
@@ -280,8 +279,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit DepositDustThresholdUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "DepositDustThresholdUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -407,8 +405,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit DepositTreasuryFeeDivisorUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "DepositTreasuryFeeDivisorUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -530,8 +527,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit DepositTxMaxFeeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "DepositTxMaxFeeUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -651,8 +647,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionDustThresholdUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "RedemptionDustThresholdUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -786,8 +781,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionTreasuryFeeDivisorUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -917,8 +911,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionTxMaxTotalFeeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "RedemptionTxMaxTotalFeeUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -1051,8 +1044,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionTimeoutUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "RedemptionTimeoutUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -1171,8 +1163,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionTimeoutSlashingAmountUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -1301,8 +1292,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit RedemptionTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -1434,8 +1424,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsTxMaxTotalFeeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "MovingFundsTxMaxTotalFeeUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -1563,8 +1552,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsDustThresholdUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "MovingFundsDustThresholdUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -1692,8 +1680,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsTimeoutResetDelayUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -1819,8 +1806,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsTimeoutUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "MovingFundsTimeoutUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -1951,8 +1937,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsTimeoutSlashingAmountUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -2084,8 +2069,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovingFundsTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -2217,8 +2201,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovedFundsSweepTxMaxTotalFeeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -2348,8 +2331,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovedFundsSweepTimeoutUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "MovedFundsSweepTimeoutUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -2477,8 +2459,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovedFundsSweepTimeoutSlashingAmountUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -2610,8 +2591,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit MovedFundsSweepTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,
@@ -2740,8 +2720,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletCreationPeriodUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletCreationPeriodUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -2865,8 +2844,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletCreationMinBtcBalanceUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletCreationMinBtcBalanceUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -2991,8 +2969,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletCreationMaxBtcBalanceUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletCreationMaxBtcBalanceUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3125,8 +3102,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletClosureMinBtcBalanceUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletClosureMinBtcBalanceUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3248,8 +3224,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletMaxAgeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletMaxAgeUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3363,8 +3338,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletMaxBtcTransferUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletMaxBtcTransferUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3486,8 +3460,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit WalletClosingPeriodUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "WalletClosingPeriodUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3611,8 +3584,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit FraudChallengeDepositAmountUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "FraudChallengeDepositAmountUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3736,8 +3708,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit FraudChallengeDefeatTimeoutUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "FraudChallengeDefeatTimeoutUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3859,8 +3830,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit FraudSlashingAmountUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(bridgeGovernance, "FraudSlashingAmountUpdateStarted")
           .withArgs(1337, blockTimestamp)
@@ -3984,8 +3954,7 @@ describe("Bridge - Governance", () => {
       })
 
       it("should emit FraudNotifierRewardMultiplierUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
+        const blockTimestamp = await helpers.time.lastBlockTime()
         await expect(tx)
           .to.emit(
             bridgeGovernance,

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -49,17 +49,6 @@ describe("Bridge - Governance", () => {
           constants.governanceDelay
         )
       })
-
-      it("should start the governance delay timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = await bridgeGovernance.governanceDelays(2)
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
     })
   })
 
@@ -168,17 +157,6 @@ describe("Bridge - Governance", () => {
 
       it("should not update the bridge governance owner", async () => {
         expect(await bridgeGovernance.owner()).to.be.equal(governance.address)
-      })
-
-      it("should start the bridge governance transfer timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit BridgeGovernanceTransferStarted event", async () => {
@@ -299,17 +277,6 @@ describe("Bridge - Governance", () => {
       it("should not update the deposit dust threshold", async () => {
         const { depositDustThreshold } = await bridge.depositParameters()
         expect(depositDustThreshold).to.be.equal(constants.depositDustThreshold)
-      })
-
-      it("should start the deposit dust threshold timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit DepositDustThresholdUpdateStarted event", async () => {
@@ -439,17 +406,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the deposit treasury fee divisor timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit DepositTreasuryFeeDivisorUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -573,17 +529,6 @@ describe("Bridge - Governance", () => {
         expect(depositTxMaxFee).to.be.equal(constants.depositTxMaxFee)
       })
 
-      it("should start the deposit tx max fee timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit DepositTxMaxFeeUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -703,17 +648,6 @@ describe("Bridge - Governance", () => {
         expect(redemptionDustThreshold).to.be.equal(
           constants.redemptionDustThreshold
         )
-      })
-
-      it("should start the redemption dust threshold timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit RedemptionDustThresholdUpdateStarted event", async () => {
@@ -851,17 +785,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the redemption treasury fee divisor timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit RedemptionTreasuryFeeDivisorUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -991,17 +914,6 @@ describe("Bridge - Governance", () => {
         expect(redemptionTxMaxTotalFee).to.be.equal(
           constants.redemptionTxMaxTotalFee
         )
-      })
-
-      it("should start the redemption tx max total fee timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit RedemptionTxMaxTotalFeeUpdateStarted event", async () => {
@@ -1138,17 +1050,6 @@ describe("Bridge - Governance", () => {
         expect(redemptionTimeout).to.be.equal(constants.redemptionTimeout)
       })
 
-      it("should start the redemption timeout timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit RedemptionTimeoutUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -1267,17 +1168,6 @@ describe("Bridge - Governance", () => {
         expect(redemptionTimeoutSlashingAmount).to.be.equal(
           constants.redemptionTimeoutSlashingAmount
         )
-      })
-
-      it("should start the redemption timeout slashing amount timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit RedemptionTimeoutSlashingAmountUpdateStarted event", async () => {
@@ -1408,17 +1298,6 @@ describe("Bridge - Governance", () => {
         expect(redemptionTimeoutNotifierRewardMultiplier).to.be.equal(
           constants.redemptionTimeoutNotifierRewardMultiplier
         )
-      })
-
-      it("should start the redemption timeout notifier reward multiplier timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit RedemptionTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
@@ -1554,17 +1433,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moving funds tx max total fee timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovingFundsTxMaxTotalFeeUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -1692,17 +1560,6 @@ describe("Bridge - Governance", () => {
         expect(movingFundsDustThreshold).to.be.equal(
           constants.movingFundsDustThreshold
         )
-      })
-
-      it("should start the moving funds dust threshold timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit MovingFundsDustThresholdUpdateStarted event", async () => {
@@ -1834,17 +1691,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moving funds timeout reset delay timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovingFundsTimeoutResetDelayUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -1970,17 +1816,6 @@ describe("Bridge - Governance", () => {
       it("should not update the moving funds timeout", async () => {
         const { movingFundsTimeout } = await bridge.movingFundsParameters()
         expect(movingFundsTimeout).to.be.equal(constants.movingFundsTimeout)
-      })
-
-      it("should start the moving funds timeout timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit MovingFundsTimeoutUpdateStarted event", async () => {
@@ -2113,17 +1948,6 @@ describe("Bridge - Governance", () => {
         expect(movingFundsTimeoutSlashingAmount).to.be.equal(
           constants.movingFundsTimeoutSlashingAmount
         )
-      })
-
-      it("should start the moving funds timeout slashing amount timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit MovingFundsTimeoutSlashingAmountUpdateStarted event", async () => {
@@ -2259,17 +2083,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moving funds timeout notifier reward multiplier timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovingFundsTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -2403,17 +2216,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moved funds sweep tx max total fee timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovedFundsSweepTxMaxTotalFeeUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -2545,17 +2347,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moved funds sweep timeout timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovedFundsSweepTimeoutUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -2683,17 +2474,6 @@ describe("Bridge - Governance", () => {
         expect(movedFundsSweepTimeoutSlashingAmount).to.be.equal(
           constants.movedFundsSweepTimeoutSlashingAmount
         )
-      })
-
-      it("should start the moved funds sweep timeout slashing amount timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit MovedFundsSweepTimeoutSlashingAmountUpdateStarted event", async () => {
@@ -2829,17 +2609,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the moved funds sweep timeout notifier reward multiplier timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit MovedFundsSweepTimeoutNotifierRewardMultiplierUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -2970,17 +2739,6 @@ describe("Bridge - Governance", () => {
         expect(walletCreationPeriod).to.be.equal(constants.walletCreationPeriod)
       })
 
-      it("should start the wallet creation period timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit WalletCreationPeriodUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -3104,17 +2862,6 @@ describe("Bridge - Governance", () => {
         expect(walletCreationMinBtcBalance).to.be.equal(
           constants.walletCreationMinBtcBalance
         )
-      })
-
-      it("should start the wallet creation min btc balance timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit WalletCreationMinBtcBalanceUpdateStarted event", async () => {
@@ -3241,17 +2988,6 @@ describe("Bridge - Governance", () => {
         expect(walletCreationMaxBtcBalance).to.be.equal(
           constants.walletCreationMaxBtcBalance
         )
-      })
-
-      it("should start the wallet creation max btc balance timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit WalletCreationMaxBtcBalanceUpdateStarted event", async () => {
@@ -3388,17 +3124,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the wallet closure min btc balance timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit WalletClosureMinBtcBalanceUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -3522,17 +3247,6 @@ describe("Bridge - Governance", () => {
         expect(walletMaxAge).to.be.equal(constants.walletMaxAge)
       })
 
-      it("should start the wallet max age timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit WalletMaxAgeUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -3646,17 +3360,6 @@ describe("Bridge - Governance", () => {
       it("should not update the wallet max btc transfer", async () => {
         const { walletMaxBtcTransfer } = await bridge.walletParameters()
         expect(walletMaxBtcTransfer).to.be.equal(constants.walletMaxBtcTransfer)
-      })
-
-      it("should start the wallet max btc transfer timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit WalletMaxBtcTransferUpdateStarted event", async () => {
@@ -3780,17 +3483,6 @@ describe("Bridge - Governance", () => {
       it("should not update the wallet closing period", async () => {
         const { walletClosingPeriod } = await bridge.walletParameters()
         expect(walletClosingPeriod).to.be.equal(constants.walletClosingPeriod)
-      })
-
-      it("should start the wallet closing period timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit WalletClosingPeriodUpdateStarted event", async () => {
@@ -3918,17 +3610,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the fraud challenge deposit amount timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit FraudChallengeDepositAmountUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -4054,17 +3735,6 @@ describe("Bridge - Governance", () => {
         )
       })
 
-      it("should start the fraud challenge defeat timeout timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
-      })
-
       it("should emit FraudChallengeDefeatTimeoutUpdateStarted event", async () => {
         const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
           .timestamp
@@ -4186,17 +3856,6 @@ describe("Bridge - Governance", () => {
       it("should not update the fraud slashing amount", async () => {
         const { fraudSlashingAmount } = await bridge.fraudParameters()
         expect(fraudSlashingAmount).to.be.equal(constants.fraudSlashingAmount)
-      })
-
-      it("should start the fraud slashing amount timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit FraudSlashingAmountUpdateStarted event", async () => {
@@ -4322,17 +3981,6 @@ describe("Bridge - Governance", () => {
         expect(fraudNotifierRewardMultiplier).to.be.equal(
           constants.fraudNotifierRewardMultiplier
         )
-      })
-
-      it("should start the fraud notifier reward multiplier timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        const initTimestamp = (await tx.wait()).events[0].args.timestamp
-        const elapsedTime = BigNumber.from(blockTimestamp).sub(initTimestamp)
-
-        expect(
-          BigNumber.from(constants.governanceDelay).sub(elapsedTime)
-        ).to.be.equal(constants.governanceDelay)
       })
 
       it("should emit FraudNotifierRewardMultiplierUpdateStarted event", async () => {


### PR DESCRIPTION
This PR:
- cleans up the docs around `onlyOwner` modifier. This modifier is in the `BridgeGovernance`, not in the `BridgeGovernanceParameters` lib.
- cleans up the tests around the delay timer. When the elapsed time is 0 we do not need to test the change of a delay timer, because everything happens in the same tx and the delay timer stays the same
- simplifying retrieval of a last block's timestamp