### PR TITLE
Configure tbtc-v2 for local deploy

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -129,7 +129,13 @@ const config: HardhatUserConfig = {
     deployments: {
       // For development environment we expect the local dependencies to be
       // linked with `yarn link` command.
-      development: ["node_modules/@keep-network/tbtc/artifacts"],
+      development: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
+        "node_modules/@keep-network/keep-core/artifacts",
+        "node_modules/@keep-network/tbtc/artifacts",
+        "node_modules/@keep-network/ecdsa/artifacts",
+        "node_modules/@keep-network/random-beacon/artifacts",
+      ],
       ropsten: ["node_modules/@keep-network/tbtc/artifacts"],
       mainnet: ["./external/mainnet"],
     },


### PR DESCRIPTION
Configure `hardhag.config` in `solitidy` so it can be deployed locally with 
linked packages.