### PR TITLE
Update @keep-network/hardhat-helpers version

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.7",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.9",
     "@keep-network/hardhat-local-networks-config": "^0.1.0-pre.4",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1509,15 +1509,15 @@
   integrity sha512-KlpY9BbasyLvYXSS7dsJktgRChu/yjdFLOX8ldGA/pltLicCm/l0F4oqxL8wSws9XD12vq9x0B5qzPygVLB2TQ==
 
 "@keep-network/ecdsa@development":
-  version "2.0.0-dev.46"
-  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.0.0-dev.46.tgz#ac73146894d25e937c87716df0fb2c51110b3f0d"
-  integrity sha512-2pWH4WEVNMuv+e2Z4MfqdKYy0HItWJF2Oxg6e6BT/hXM+KeH5hQSFZmNABW614HT/ID0Ua31N0tz28Oc5h557g==
+  version "2.0.0-dev.49"
+  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.0.0-dev.49.tgz#2b06d133c3a59023e0f0dd070e3eace098bf23f2"
+  integrity sha512-vmaxCe4XCnOtrbuCI8Zr4xe4IhhM6XYxkM9xgRh5Lu/1V2i2En0tA7Q+WvtSw4aE5+/Bqmu/JeQ1V9+gtpx5rA==
   dependencies:
-    "@keep-network/random-beacon" "^2.0.0-dev.39"
+    "@keep-network/random-beacon" "^2.0.0-dev.48"
     "@keep-network/sortition-pools" "^2.0.0-pre.9"
     "@openzeppelin/contracts" "^4.6.0"
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
-    "@threshold-network/solidity-contracts" ">1.2.0-dev <1.2.0-ropsten"
+    "@threshold-network/solidity-contracts" "^1.2.0-dev.17"
 
 "@keep-network/hardhat-helpers@^0.6.0-pre.9":
   version "0.6.0-pre.9"
@@ -1540,10 +1540,10 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/keep-core@>1.8.1-dev <1.8.1-pre":
-  version "1.8.1-dev.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-dev.0.tgz#d95864b25800214de43d8840376a68336cb12055"
-  integrity sha512-gFXkgN4PYOYCZ14AskL7fZHEFW5mu3BDd+TJKBuKZc1q9CgRMOK+dxpJnSctxmSH1tV+Ln9v9yqlSkfPCoiBHw==
+"@keep-network/keep-core@goerli":
+  version "1.8.1-goerli.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-goerli.0.tgz#238485aab51902021d42357bf59695225002f0ab"
+  integrity sha512-h3La/RqbyEZjBBPg8V+pcRFo3UpWZUF4CxWfXHZnUR4PnkZKnIDrTNFQPhpV2uYFZwrbJxTR9mzOq/DOAiXPwA==
   dependencies:
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
@@ -1558,15 +1558,25 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
-"@keep-network/random-beacon@^2.0.0-dev.39", "@keep-network/random-beacon@development":
-  version "2.0.0-dev.43"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.43.tgz#3a586ee76c9b1aa449112eec1dc2f11829d9cb58"
-  integrity sha512-dtQMZtBysAMZ135+0QO0RTdAvfaWa9/6KULJ376OjjKg+cTlitIqAHRfx2/Z/j2gHJWhOt3R4FrxrIdjgSBjLA==
+"@keep-network/random-beacon@^2.0.0-dev.48":
+  version "2.0.0-goerli.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-goerli.0.tgz#933dab809309a87734835e818fe8ef22f96830ae"
+  integrity sha512-M1RSjgBP/V65clWL+Kn8UaTZBxhthWwoCbxGk0Nw9OU1Qc/59w05XpowHY2VJPe22MZVM0FgVGSDeYNnBthUEA==
   dependencies:
     "@keep-network/sortition-pools" "^2.0.0-pre.9"
     "@openzeppelin/contracts" "^4.6.0"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" development
+    "@threshold-network/solidity-contracts" goerli
+
+"@keep-network/random-beacon@development":
+  version "2.0.0-dev.48"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.0.0-dev.48.tgz#43cd8f7eb2181af47a52b6235f9d38b417bdd1c6"
+  integrity sha512-kv1LM9VLkHWrMWwIZSVteI3Yr7jKqc51QtbRIwW4ilQacLdbFeSp0Lxtm4ZY8PA5rVtPsHANroaiUGpiPiHshg==
+  dependencies:
+    "@keep-network/sortition-pools" "^2.0.0-pre.9"
+    "@openzeppelin/contracts" "^4.6.0"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+    "@threshold-network/solidity-contracts" "^1.2.0-dev.17"
 
 "@keep-network/sortition-pools@1.2.0-dev.1":
   version "1.2.0-dev.1"
@@ -2065,12 +2075,12 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@>1.2.0-dev <1.2.0-ropsten", "@threshold-network/solidity-contracts@development":
-  version "1.2.0-dev.15"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-dev.15.tgz#3415579a3be37aed452656a91124c8bd575df569"
-  integrity sha512-kETXCaWVho0uTh8Dtq3pAewlbw37tfqzFQRwh2cHjiQ78xtKpj1JZ+VbsAOnsPuLqqfCLHZmfWvK2dLfLaeFZQ==
+"@threshold-network/solidity-contracts@^1.2.0-dev.17", "@threshold-network/solidity-contracts@goerli":
+  version "1.2.0-goerli.0"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.2.0-goerli.0.tgz#888d4fc39ccbe8bc6ffafebfb7eff2e640d3752b"
+  integrity sha512-BLSz43ofUnkq/edn5lCfnpO00l5Z/XUQu0ls0iPmsyAQwhWgQEWmT8GgQsQsnaAfKJYZ7IhUQoZ/3T7QzT8HVw==
   dependencies:
-    "@keep-network/keep-core" ">1.8.1-dev <1.8.1-pre"
+    "@keep-network/keep-core" goerli
     "@openzeppelin/contracts" "~4.5.0"
     "@openzeppelin/contracts-upgradeable" "~4.5.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1519,10 +1519,10 @@
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" ">1.2.0-dev <1.2.0-ropsten"
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.7":
-  version "0.6.0-pre.7"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.7.tgz#0b8fbc7c8ee7248f0babbfe4f2f957f5ef3f8507"
-  integrity sha512-6inPdST2lAwxYLGl619udVLJDoW41maQzxc2MD1YmvUDlkrHsI4GmSmqkj+mJPtLVVEbxqCjwQNjyDkSmIICvQ==
+"@keep-network/hardhat-helpers@^0.6.0-pre.9":
+  version "0.6.0-pre.9"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.9.tgz#6277fcecfd7effbf6a6e7090b849593ffd23cc78"
+  integrity sha512-QXJ5sAa6sy2Y0DE4iMAelPW+guCh95SmWC/l52t6dz+AlLlke9jw/myWsQ/s5J4XQfIRwsfoRO36f6qSiIQjhg==
 
 "@keep-network/hardhat-local-networks-config@^0.1.0-pre.4":
   version "0.1.0-pre.4"


### PR DESCRIPTION
We update @keep-network/hardhat-helpers version to 0.6.0-pre.9 as it
contains improvements introduced in https://github.com/keep-network/hardhat-helpers/pull/27
that will modify the artifact exported for proxy contracts. The new
artifact matches the artifacts produced for contracts deployed non-proxy
way, which is important for Go code generator.