### PR TITLE
Use upgrade --exact for NPM package publication

### DIFF
--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn upgrade @keep-network/tbtc
+          yarn upgrade --exact \
+            @keep-network/tbtc
 
       # Deploy contracts to a local network to generate deployment artifacts that
       # are required by dashboard compilation.

--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Resolve latest contracts
         run: |
           yarn upgrade --exact \
+            @keep-network/ecdsa \
+            @keep-network/random-beacon \
             @keep-network/tbtc
 
       # Deploy contracts to a local network to generate deployment artifacts that


### PR DESCRIPTION
We want to add `--exact` flag so the version of tagged package is
resolved to an exact value. Without this flag by default the version is
resolved by adding `^`, which can cause problems when resolving versions
with `-dev`, `-goerli`, `-mainnet` suffixes.