### PR TITLE
Removing development env from `deployments` option

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -145,7 +145,6 @@ const config: HardhatUserConfig = {
     deployments: {
       // For development environment we expect the local dependencies to be
       // linked with `yarn link` command.
-      development: ["node_modules/@keep-network/tbtc/artifacts"],
       ropsten: ["node_modules/@keep-network/tbtc/artifacts"],
       mainnet: ["./external/mainnet"],
     },


### PR DESCRIPTION
`development` env is used for local development on networks other than
Hardhat. Currently, it is Geth. Having development env in the `deployments`
field prevents from the proper deployment of `tbtc` contracts on Geth. The
transaction won't be completed and the contract won't be deployed on
Geth. Removing it, so we can properly deploy `tbtc` contracts.