### PR TITLE
Mint, stake, increase authorization and adding an operator for the wallet registry.

### DIFF
--- a/solidity/tasks/increase-authorization.ts
+++ b/solidity/tasks/increase-authorization.ts
@@ -8,7 +8,7 @@ task("increase-authorization", "Increases authorization")
   .addParam("provider", "Staking Provider", undefined, types.string)
   .addParam(
     "application",
-    "Name of the Application Contract",
+    "Application Contract Name",
     undefined,
     types.string
   )

--- a/solidity/tasks/increase-authorization.ts
+++ b/solidity/tasks/increase-authorization.ts
@@ -1,0 +1,80 @@
+import { task, types } from "hardhat/config"
+
+import type { BigNumber } from "ethers"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("increase-authorization", "Increases authorization")
+  .addParam("owner", "Stake Owner address", undefined, types.string)
+  .addParam("provider", "Staking Provider", undefined, types.string)
+  .addParam(
+    "application",
+    "Name of the Application Contract",
+    undefined,
+    types.string
+  )
+  .addOptionalParam("authorizer", "Stake Authorizer", undefined, types.string)
+  .addOptionalParam(
+    "authorization",
+    "Authorization amount (default: minimumAuthorization)",
+    undefined,
+    types.int
+  )
+  .setAction(async (args, hre) => {
+    await setup(hre, args)
+  })
+
+async function setup(
+  hre: HardhatRuntimeEnvironment,
+  args: {
+    owner: string
+    provider: string
+    application: string
+    authorizer: string
+    authorization: BigNumber
+  }
+) {
+  const { ethers, helpers } = hre
+  const { owner, provider, application } = args
+  let { authorizer, authorization } = args
+
+  const { to1e18 } = helpers.number
+  const staking = await helpers.contracts.getContract("TokenStaking")
+  const applicationContract = await helpers.contracts.getContract(application)
+
+  // If not set, authorizer can be the owner. This simplification is used for
+  // development purposes.
+  if (!authorizer) {
+    authorizer = owner
+  }
+
+  if (authorization) {
+    authorization = to1e18(authorization)
+  } else {
+    authorization = await applicationContract.minimumAuthorization()
+  }
+
+  const authorizerSigner = await ethers.getSigner(authorizer)
+
+  console.log(
+    `Increasing authorization ${authorization.toString()} for the ${application.toString()} ...`
+  )
+
+  await (
+    await staking
+      .connect(authorizerSigner)
+      .increaseAuthorization(
+        provider,
+        applicationContract.address,
+        authorization
+      )
+  ).wait()
+
+  const authorizedStaked = await staking.authorizedStake(
+    provider,
+    applicationContract.address
+  )
+
+  console.log(
+    `Staked authorization ${authorizedStaked.toString()} was increased for the ${application.toString()}`
+  )
+}

--- a/solidity/tasks/increase-authorization.ts
+++ b/solidity/tasks/increase-authorization.ts
@@ -6,12 +6,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 task("increase-authorization", "Increases authorization")
   .addParam("owner", "Stake Owner address", undefined, types.string)
   .addParam("provider", "Staking Provider", undefined, types.string)
-  .addParam(
-    "application",
-    "Application Contract Name",
-    undefined,
-    types.string
-  )
+  .addParam("application", "Application Contract Name", undefined, types.string)
   .addOptionalParam("authorizer", "Stake Authorizer", undefined, types.string)
   .addOptionalParam(
     "authorization",

--- a/solidity/tasks/index.ts
+++ b/solidity/tasks/index.ts
@@ -7,5 +7,11 @@ if (fs.existsSync("./typechain")) {
   // eslint-disable-next-line global-require
   require("./test-utils")
   // eslint-disable-next-line global-require
+  require("./mint")
+  // eslint-disable-next-line global-require
   require("./stake")
+  // eslint-disable-next-line global-require
+  require("./increase-authorization")
+  // eslint-disable-next-line global-require
+  require("./register-operator")
 }

--- a/solidity/tasks/index.ts
+++ b/solidity/tasks/index.ts
@@ -6,4 +6,6 @@ import fs from "fs"
 if (fs.existsSync("./typechain")) {
   // eslint-disable-next-line global-require
   require("./test-utils")
+  // eslint-disable-next-line global-require
+  require("./stake")
 }

--- a/solidity/tasks/mint.ts
+++ b/solidity/tasks/mint.ts
@@ -5,7 +5,7 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 
 task("mint", "Mints and approves T tokens for staking")
   .addParam("owner", "Stake Owner address", undefined, types.string)
-  .addOptionalParam("amount", "Stake amount", 1_000_000, types.int)
+  .addOptionalParam("amount", "Amount to mint", 1_000_000, types.int)
   .setAction(async (args, hre) => {
     await setup(hre, args)
   })

--- a/solidity/tasks/mint.ts
+++ b/solidity/tasks/mint.ts
@@ -1,0 +1,39 @@
+import { task, types } from "hardhat/config"
+
+import type { BigNumber } from "ethers"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("mint", "Mints and approves T tokens for staking")
+  .addParam("owner", "Stake Owner address", undefined, types.string)
+  .addOptionalParam("amount", "Stake amount", 1_000_000, types.int)
+  .setAction(async (args, hre) => {
+    await setup(hre, args)
+  })
+
+async function setup(
+  hre: HardhatRuntimeEnvironment,
+  args: {
+    owner: string
+    amount: BigNumber
+  }
+) {
+  const { ethers, helpers } = hre
+  const { owner, amount } = args
+
+  const { deployer } = await helpers.signers.getNamedSigners()
+  const { to1e18 } = helpers.number
+  const t = await helpers.contracts.getContract("T")
+  const staking = await helpers.contracts.getContract("TokenStaking")
+
+  const toMintAndApprove = to1e18(amount)
+
+  console.log(
+    `Minting ${toMintAndApprove.toString()}T for the ${owner} and approving for staking ...`
+  )
+
+  await (await t.connect(deployer).mint(owner, toMintAndApprove)).wait()
+  const stakeOwnerSigner = await ethers.getSigner(owner)
+  await (
+    await t.connect(stakeOwnerSigner).approve(staking.address, toMintAndApprove)
+  ).wait()
+}

--- a/solidity/tasks/register-operator.ts
+++ b/solidity/tasks/register-operator.ts
@@ -1,0 +1,43 @@
+import { task, types } from "hardhat/config"
+
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("register-operator", "Registers the operator")
+  .addParam("owner", "Stake Owner address", undefined, types.string)
+  .addParam("provider", "Staking Provider", undefined, types.string)
+  .addParam("operator", "Staking Operator", undefined, types.string)
+  .addParam(
+    "application",
+    "Name of the Application Contract",
+    undefined,
+    types.string
+  )
+  .setAction(async (args, hre) => {
+    await setup(hre, args)
+  })
+
+async function setup(
+  hre: HardhatRuntimeEnvironment,
+  args: {
+    owner: string
+    provider: string
+    operator: string
+    application: string
+  }
+) {
+  const { ethers, helpers } = hre
+  const { provider, operator, application } = args
+
+  const applicationContract = await helpers.contracts.getContract(application)
+
+  console.log(
+    `Registering operator ${operator.toString()} for a staking provider ${provider.toString()} ...`
+  )
+
+  const stakingProviderSigner = await ethers.getSigner(provider)
+  await (
+    await applicationContract
+      .connect(stakingProviderSigner)
+      .registerOperator(operator)
+  ).wait()
+}

--- a/solidity/tasks/register-operator.ts
+++ b/solidity/tasks/register-operator.ts
@@ -8,7 +8,7 @@ task("register-operator", "Registers the operator")
   .addParam("operator", "Staking Operator", undefined, types.string)
   .addParam(
     "application",
-    "Name of the Application Contract",
+    "Application Contract Name",
     undefined,
     types.string
   )

--- a/solidity/tasks/register-operator.ts
+++ b/solidity/tasks/register-operator.ts
@@ -6,12 +6,7 @@ task("register-operator", "Registers the operator")
   .addParam("owner", "Stake Owner address", undefined, types.string)
   .addParam("provider", "Staking Provider", undefined, types.string)
   .addParam("operator", "Staking Operator", undefined, types.string)
-  .addParam(
-    "application",
-    "Application Contract Name",
-    undefined,
-    types.string
-  )
+  .addParam("application", "Application Contract Name", undefined, types.string)
   .setAction(async (args, hre) => {
     await setup(hre, args)
   })

--- a/solidity/tasks/stake.ts
+++ b/solidity/tasks/stake.ts
@@ -3,19 +3,12 @@ import { task, types } from "hardhat/config"
 import type { BigNumber } from "ethers"
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 
-task("stake", "Increases authorization and registers the operator ")
+task("stake", "Stake amount for the owner")
   .addParam("owner", "Stake Owner address", undefined, types.string)
   .addParam("provider", "Staking Provider", undefined, types.string)
-  .addParam("operator", "Staking Operator", undefined, types.string)
   .addOptionalParam("beneficiary", "Stake Beneficiary", undefined, types.string)
   .addOptionalParam("authorizer", "Stake Authorizer", undefined, types.string)
   .addOptionalParam("amount", "Stake amount", 1_000_000, types.int)
-  .addOptionalParam(
-    "authorization",
-    "Authorization amount (default: minimumAuthorization)",
-    undefined,
-    types.int
-  )
   .setAction(async (args, hre) => {
     await setup(hre, args)
   })
@@ -25,22 +18,19 @@ async function setup(
   args: {
     owner: string
     provider: string
-    operator: string
     beneficiary: string
     authorizer: string
     amount: BigNumber
-    authorization: BigNumber
   }
 ) {
   const { ethers, helpers } = hre
-  const { owner, provider, operator, amount } = args
-  let { beneficiary, authorizer, authorization } = args
+  const { owner, provider, amount } = args
+  let { beneficiary, authorizer } = args
 
   const { deployer } = await helpers.signers.getNamedSigners()
   const { to1e18 } = helpers.number
   const t = await helpers.contracts.getContract("T")
   const staking = await helpers.contracts.getContract("TokenStaking")
-  const walletRegistry = await helpers.contracts.getContract("WalletRegistry")
 
   const stakedAmount = to1e18(amount)
 
@@ -77,42 +67,4 @@ async function setup(
       await t.balanceOf(staking.address)
     ).toString()}`
   )
-
-  if (authorization) {
-    authorization = to1e18(authorization)
-  } else {
-    authorization = await walletRegistry.minimumAuthorization()
-  }
-
-  const authorizerSigner = await ethers.getSigner(authorizer)
-
-  console.log(
-    `Increasing authorization ${authorization.toString()} for the Wallet Registry ...`
-  )
-
-  await (
-    await staking
-      .connect(authorizerSigner)
-      .increaseAuthorization(provider, walletRegistry.address, authorization)
-  ).wait()
-
-  const authorizedStaked = await staking.authorizedStake(
-    provider,
-    walletRegistry.address
-  )
-
-  console.log(
-    `Staked authorization ${authorizedStaked.toString()} was increased for the Wallet Registry`
-  )
-
-  console.log(
-    `Registering operator ${operator.toString()} for a staking provider ${provider.toString()} ...`
-  )
-
-  const stakingProviderSigner = await ethers.getSigner(provider)
-  await (
-    await walletRegistry
-      .connect(stakingProviderSigner)
-      .registerOperator(operator)
-  ).wait()
 }

--- a/solidity/tasks/stake.ts
+++ b/solidity/tasks/stake.ts
@@ -1,0 +1,118 @@
+import { task, types } from "hardhat/config"
+
+import type { BigNumber } from "ethers"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+
+task("stake", "Increases authorization and registers the operator ")
+  .addParam("owner", "Stake Owner address", undefined, types.string)
+  .addParam("provider", "Staking Provider", undefined, types.string)
+  .addParam("operator", "Staking Operator", undefined, types.string)
+  .addOptionalParam("beneficiary", "Stake Beneficiary", undefined, types.string)
+  .addOptionalParam("authorizer", "Stake Authorizer", undefined, types.string)
+  .addOptionalParam("amount", "Stake amount", 1_000_000, types.int)
+  .addOptionalParam(
+    "authorization",
+    "Authorization amount (default: minimumAuthorization)",
+    undefined,
+    types.int
+  )
+  .setAction(async (args, hre) => {
+    await setup(hre, args)
+  })
+
+async function setup(
+  hre: HardhatRuntimeEnvironment,
+  args: {
+    owner: string
+    provider: string
+    operator: string
+    beneficiary: string
+    authorizer: string
+    amount: BigNumber
+    authorization: BigNumber
+  }
+) {
+  const { ethers, helpers } = hre
+  const { owner, provider, operator, amount } = args
+  let { beneficiary, authorizer, authorization } = args
+
+  const { deployer } = await helpers.signers.getNamedSigners()
+  const { to1e18 } = helpers.number
+  const t = await helpers.contracts.getContract("T")
+  const staking = await helpers.contracts.getContract("TokenStaking")
+  const walletRegistry = await helpers.contracts.getContract("WalletRegistry")
+
+  const stakedAmount = to1e18(amount)
+
+  await (await t.connect(deployer).mint(owner, stakedAmount)).wait()
+  const stakeOwnerSigner = await ethers.getSigner(owner)
+  await (
+    await t.connect(stakeOwnerSigner).approve(staking.address, stakedAmount)
+  ).wait()
+
+  // If not set, beneficiary can be the owner. This simplification is used for
+  // development purposes.
+  if (!beneficiary) {
+    beneficiary = owner
+  }
+
+  // If not set, authorizer can be the owner. This simplification is used for
+  // development purposes.
+  if (!authorizer) {
+    authorizer = owner
+  }
+
+  console.log(
+    `Staking ${stakedAmount.toString()} to the staking provider ${provider} ...`
+  )
+
+  await (
+    await staking
+      .connect(stakeOwnerSigner)
+      .stake(provider, beneficiary, authorizer, stakedAmount)
+  ).wait()
+
+  console.log(
+    `T balance of the staking contract: ${(
+      await t.balanceOf(staking.address)
+    ).toString()}`
+  )
+
+  if (authorization) {
+    authorization = to1e18(authorization)
+  } else {
+    authorization = await walletRegistry.minimumAuthorization()
+  }
+
+  const authorizerSigner = await ethers.getSigner(authorizer)
+
+  console.log(
+    `Increasing authorization ${authorization.toString()} for the Wallet Registry ...`
+  )
+
+  await (
+    await staking
+      .connect(authorizerSigner)
+      .increaseAuthorization(provider, walletRegistry.address, authorization)
+  ).wait()
+
+  const authorizedStaked = await staking.authorizedStake(
+    provider,
+    walletRegistry.address
+  )
+
+  console.log(
+    `Staked authorization ${authorizedStaked.toString()} was increased for the Wallet Registry`
+  )
+
+  console.log(
+    `Registering operator ${operator.toString()} for a staking provider ${provider.toString()} ...`
+  )
+
+  const stakingProviderSigner = await ethers.getSigner(provider)
+  await (
+    await walletRegistry
+      .connect(stakingProviderSigner)
+      .registerOperator(operator)
+  ).wait()
+}


### PR DESCRIPTION
This PR adds 4 different tasks that: mint, stake, increases authorization, and register an operator on a given application. 

How to run:

**Mint**

```
npx hardhat mint --network <network> --owner <address>
```
Mandatory params:
- owner - Stake Owner address

Optional params:
- amount - Amount to mint for the <owner address> (default: 1M)

**Stake**
```
npx hardhat stake --network <network> --owner <address> --provider <address>
```
Mandatory params:
- owner - Stake Owner address
- provider - Staking Provider address

Optional params:
- beneficiary - Stake Beneficiary
- authorizer - Stake Authorizer
- amount - Stake amount (default: 1M)

**Increase Authorization**
```
npx hardhat increase-authorization --network <network> --owner <address> --provider <address> --application <application_contract_name>
```

Mandatory params:
- owner - Stake Owner address
- provider - Staking Provider address

Optional params:
- application - Application contract name

**Register Operator**
```
npx hardhat register-operator --network <network> --owner <address> --provider <address> --operator <address> --application <application_contract_name>
```

Mandatory params:
- owner - Stake Owner address
- provider - Staking Provider address
- operator - Staking Operator address

Optional params:
- application - Application contract name
