### PR TITLE
Split development external contracts deployment

### DIFF
--- a/solidity/deploy/17_transfer_proxy_admin_ownership.ts
+++ b/solidity/deploy/17_transfer_proxy_admin_ownership.ts
@@ -20,7 +20,9 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // set to the desired address.
   if (!helpers.address.equal(currentOwner, newProxyAdminOwner)) {
     log(`transferring ownership of ProxyAdmin to ${newProxyAdminOwner}`)
-    await proxyAdmin.connect(deployer).transferOwnership(newProxyAdminOwner)
+    await (
+      await proxyAdmin.connect(deployer).transferOwnership(newProxyAdminOwner)
+    ).wait()
   }
 }
 

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -123,33 +123,35 @@ const config: HardhatUserConfig = {
   // localNetworksConfig: "./.hardhat/networks.ts",
 
   external: {
-    contracts: process.env.USE_EXTERNAL_DEPLOY === "true"
-    ? [
-        {
-          artifacts: "node_modules/@keep-network/tbtc/artifacts",
-        },
-        {
-          artifacts:
-            "node_modules/@threshold-network/solidity-contracts/export/artifacts",
-          deploy:
-            "node_modules/@threshold-network/solidity-contracts/export/deploy",
-        },
-        {
-          artifacts: "node_modules/@keep-network/random-beacon/export/artifacts",
-          deploy: "node_modules/@keep-network/random-beacon/export/deploy",
-        },
-        {
-          artifacts: "node_modules/@keep-network/ecdsa/export/artifacts",
-          deploy: "node_modules/@keep-network/ecdsa/export/deploy",
-        },
-      ] 
-    : undefined,
+    contracts:
+      process.env.USE_EXTERNAL_DEPLOY === "true"
+        ? [
+            {
+              artifacts: "node_modules/@keep-network/tbtc/artifacts",
+            },
+            {
+              artifacts:
+                "node_modules/@threshold-network/solidity-contracts/export/artifacts",
+              deploy:
+                "node_modules/@threshold-network/solidity-contracts/export/deploy",
+            },
+            {
+              artifacts:
+                "node_modules/@keep-network/random-beacon/export/artifacts",
+              deploy: "node_modules/@keep-network/random-beacon/export/deploy",
+            },
+            {
+              artifacts: "node_modules/@keep-network/ecdsa/export/artifacts",
+              deploy: "node_modules/@keep-network/ecdsa/export/deploy",
+            },
+          ]
+        : undefined,
     deployments: {
       // For development environment we expect the local dependencies to be
       // linked with `yarn link` command.
       development: [
         "node_modules/@keep-network/random-beacon/deployments/development",
-        "node_modules/@keep-network/ecdsa/deployments/development"
+        "node_modules/@keep-network/ecdsa/deployments/development",
       ],
       ropsten: ["node_modules/@keep-network/tbtc/artifacts"],
       mainnet: ["./external/mainnet"],

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -123,28 +123,34 @@ const config: HardhatUserConfig = {
   // localNetworksConfig: "./.hardhat/networks.ts",
 
   external: {
-    contracts: [
-      {
-        artifacts: "node_modules/@keep-network/tbtc/artifacts",
-      },
-      {
-        artifacts:
-          "node_modules/@threshold-network/solidity-contracts/export/artifacts",
-        deploy:
-          "node_modules/@threshold-network/solidity-contracts/export/deploy",
-      },
-      {
-        artifacts: "node_modules/@keep-network/random-beacon/export/artifacts",
-        deploy: "node_modules/@keep-network/random-beacon/export/deploy",
-      },
-      {
-        artifacts: "node_modules/@keep-network/ecdsa/export/artifacts",
-        deploy: "node_modules/@keep-network/ecdsa/export/deploy",
-      },
-    ],
+    contracts: process.env.USE_EXTERNAL_DEPLOY === "true"
+    ? [
+        {
+          artifacts: "node_modules/@keep-network/tbtc/artifacts",
+        },
+        {
+          artifacts:
+            "node_modules/@threshold-network/solidity-contracts/export/artifacts",
+          deploy:
+            "node_modules/@threshold-network/solidity-contracts/export/deploy",
+        },
+        {
+          artifacts: "node_modules/@keep-network/random-beacon/export/artifacts",
+          deploy: "node_modules/@keep-network/random-beacon/export/deploy",
+        },
+        {
+          artifacts: "node_modules/@keep-network/ecdsa/export/artifacts",
+          deploy: "node_modules/@keep-network/ecdsa/export/deploy",
+        },
+      ] 
+    : undefined,
     deployments: {
       // For development environment we expect the local dependencies to be
       // linked with `yarn link` command.
+      development: [
+        "node_modules/@keep-network/random-beacon/deployments/development",
+        "node_modules/@keep-network/ecdsa/deployments/development"
+      ],
       ropsten: ["node_modules/@keep-network/tbtc/artifacts"],
       mainnet: ["./external/mainnet"],
     },
@@ -154,13 +160,14 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 1,
     },
-    treasury: {
-      default: 2,
-    },
     // TODO: Governance should be the Threshold Council.
     //       Inspect usages and rename.
     governance: {
+      default: 2,
+    },
+    esdm: {
       default: 3,
+      // mainnet: ""
     },
     keepTechnicalWalletTeam: {
       default: 4,
@@ -170,9 +177,8 @@ const config: HardhatUserConfig = {
       default: 5,
       mainnet: "0x19FcB32347ff4656E4E6746b4584192D185d640d",
     },
-    esdm: {
+    treasury: {
       default: 6,
-      // mainnet: ""
     },
     spvMaintainer: {
       default: 7,

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -25,7 +25,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
     "test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat test",
-    "test:integration": "NODE_ENV=integration-test TEST_USE_STUBS_TBTC=true hardhat test ./test/integration/*.test.ts",
+    "test:integration": "NODE_ENV=integration-test USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat test ./test/integration/*.test.ts",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
     "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -15,7 +15,7 @@
     "clean": "hardhat clean",
     "build": "hardhat compile",
     "deploy": "hardhat deploy --export export.json",
-    "deploy:test": "TEST_USE_STUBS_TBTC=true npm run deploy",
+    "deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true npm run deploy",
     "format": "npm run lint && prettier --check .",
     "format:fix": "npm run lint:fix && prettier --write .",
     "lint": "npm run lint:eslint && npm run lint:sol",
@@ -24,7 +24,7 @@
     "lint:fix:eslint": "eslint . --fix",
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lint:fix:sol": "solhint 'contracts/**/*.sol' --fix",
-    "test": "TEST_USE_STUBS_TBTC=true hardhat test",
+    "test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat test",
     "test:integration": "NODE_ENV=integration-test TEST_USE_STUBS_TBTC=true hardhat test ./test/integration/*.test.ts",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
     "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network"


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3040

In this PR we separate contracts deployment. Hardhat will deploy dependency contracts when running tests with a "USE_EXTERNAL_DEPLOY=true" flag. This is a "all-in-once" approach. 
When deploying contracts on the development env. ex. Geth, each project `beacon, ecdsa, and tbtc` handles its own contracts deployment. We need to provide a path in the "deployments" field where those contract artifacts are saved.