### PR TITLE
Validate deposit refund locktime during deposit reveal

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -287,6 +287,7 @@ contract Bridge is
 
         self.depositDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
         self.depositTxMaxFee = 100000; // 100000 satoshi = 0.001 BTC
+        self.depositRevealAheadPeriod = 15 days;
         self.depositTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
         self.redemptionDustThreshold = 1000000; // 1000000 satoshi = 0.01 BTC
         self.redemptionTreasuryFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -188,7 +188,8 @@ contract Bridge is
     event DepositParametersUpdated(
         uint64 depositDustThreshold,
         uint64 depositTreasuryFeeDivisor,
-        uint64 depositTxMaxFee
+        uint64 depositTxMaxFee,
+        uint32 depositRevealAheadPeriod
     );
 
     event RedemptionParametersUpdated(
@@ -1214,19 +1215,26 @@ contract Bridge is
     ///        be incurred by each swept deposit being part of the given sweep
     ///        transaction. If the maximum BTC transaction fee is exceeded,
     ///        such transaction is considered a fraud.
+    /// @param depositRevealAheadPeriod New value of the deposit reveal ahead
+    ///        period parameter in seconds. It defines the length of the period
+    ///        that must be preserved between the deposit reveal time and the
+    ///        deposit refund locktime.
     /// @dev Requirements:
     ///      - Deposit dust threshold must be greater than zero,
     ///      - Deposit treasury fee divisor must be greater than zero,
     ///      - Deposit transaction max fee must be greater than zero.
+    ///      - Deposit reveal ahead period must be grater than zero.
     function updateDepositParameters(
         uint64 depositDustThreshold,
         uint64 depositTreasuryFeeDivisor,
-        uint64 depositTxMaxFee
+        uint64 depositTxMaxFee,
+        uint32 depositRevealAheadPeriod
     ) external onlyGovernance {
         self.updateDepositParameters(
             depositDustThreshold,
             depositTreasuryFeeDivisor,
-            depositTxMaxFee
+            depositTxMaxFee,
+            depositRevealAheadPeriod
         );
     }
 
@@ -1615,18 +1623,25 @@ contract Bridge is
     ///         be incurred by each swept deposit being part of the given sweep
     ///         transaction. If the maximum BTC transaction fee is exceeded,
     ///         such transaction is considered a fraud.
+    /// @return depositRevealAheadPeriod Defines the length of the period that
+    ///         must be preserved between the deposit reveal time and the
+    ///         deposit refund locktime. For example, if the deposit become
+    ///         refundable on August 1st, and the ahead period is 7 days, the
+    ///         latest moment for deposit reveal is July 25th. Value in seconds.
     function depositParameters()
         external
         view
         returns (
             uint64 depositDustThreshold,
             uint64 depositTreasuryFeeDivisor,
-            uint64 depositTxMaxFee
+            uint64 depositTxMaxFee,
+            uint32 depositRevealAheadPeriod
         )
     {
         depositDustThreshold = self.depositDustThreshold;
         depositTreasuryFeeDivisor = self.depositTreasuryFeeDivisor;
         depositTxMaxFee = self.depositTxMaxFee;
+        depositRevealAheadPeriod = self.depositRevealAheadPeriod;
     }
 
     /// @notice Returns the current values of Bridge redemption parameters.

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -76,6 +76,12 @@ contract BridgeGovernance is Ownable {
     );
     event DepositTxMaxFeeUpdated(uint64 depositTxMaxFee);
 
+    event DepositRevealAheadPeriodUpdateStarted(
+        uint32 newDepositRevealAheadPeriod,
+        uint256 timestamp
+    );
+    event DepositRevealAheadPeriodUpdated(uint32 depositRevealAheadPeriod);
+
     event RedemptionDustThresholdUpdateStarted(
         uint64 newRedemptionDustThreshold,
         uint256 timestamp
@@ -392,12 +398,17 @@ contract BridgeGovernance is Ownable {
     /// @dev Can be called only by the contract owner, after the governance
     ///      delay elapses.
     function finalizeDepositDustThresholdUpdate() external onlyOwner {
-        (, uint64 depositTreasuryFeeDivisor, uint64 depositTxMaxFee) = bridge
-            .depositParameters();
+        (
+            ,
+            uint64 depositTreasuryFeeDivisor,
+            uint64 depositTxMaxFee,
+            uint32 depositRevealAheadPeriod
+        ) = bridge.depositParameters();
         bridge.updateDepositParameters(
             depositData.getNewDepositDustThreshold(),
             depositTreasuryFeeDivisor,
-            depositTxMaxFee
+            depositTxMaxFee,
+            depositRevealAheadPeriod
         );
         depositData.finalizeDepositDustThresholdUpdate(governanceDelay());
     }
@@ -417,13 +428,18 @@ contract BridgeGovernance is Ownable {
     /// @dev Can be called only by the contract owner, after the governance
     ///      delay elapses.
     function finalizeDepositTreasuryFeeDivisorUpdate() external onlyOwner {
-        (uint64 depositDustThreshold, , uint64 depositTxMaxFee) = bridge
-            .depositParameters();
+        (
+            uint64 depositDustThreshold,
+            ,
+            uint64 depositTxMaxFee,
+            uint32 depositRevealAheadPeriod
+        ) = bridge.depositParameters();
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateDepositParameters(
             depositDustThreshold,
             depositData.getNewDepositTreasuryFeeDivisor(),
-            depositTxMaxFee
+            depositTxMaxFee,
+            depositRevealAheadPeriod
         );
         depositData.finalizeDepositTreasuryFeeDivisorUpdate(governanceDelay());
     }
@@ -445,15 +461,48 @@ contract BridgeGovernance is Ownable {
         (
             uint64 depositDustThreshold,
             uint64 depositTreasuryFeeDivisor,
+            ,
+            uint32 depositRevealAheadPeriod
+        ) = bridge.depositParameters();
+        // slither-disable-next-line reentrancy-no-eth
+        bridge.updateDepositParameters(
+            depositDustThreshold,
+            depositTreasuryFeeDivisor,
+            depositData.getNewDepositTxMaxFee(),
+            depositRevealAheadPeriod
+        );
+        depositData.finalizeDepositTxMaxFeeUpdate(governanceDelay());
+    }
+
+    /// @notice Begins the deposit reveal ahead period update process.
+    /// @dev Can be called only by the contract owner.
+    /// @param _newDepositRevealAheadPeriod New deposit reveal ahead period.
+    function beginDepositRevealAheadPeriodUpdate(
+        uint32 _newDepositRevealAheadPeriod
+    ) external onlyOwner {
+        depositData.beginDepositRevealAheadPeriodUpdate(
+            _newDepositRevealAheadPeriod
+        );
+    }
+
+    /// @notice Finalizes the deposit reveal ahead period update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeDepositRevealAheadPeriodUpdate() external onlyOwner {
+        (
+            uint64 depositDustThreshold,
+            uint64 depositTreasuryFeeDivisor,
+            uint64 depositTxMaxFee,
 
         ) = bridge.depositParameters();
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateDepositParameters(
             depositDustThreshold,
             depositTreasuryFeeDivisor,
-            depositData.getNewDepositTxMaxFee()
+            depositTxMaxFee,
+            depositData.getNewDepositRevealAheadPeriod()
         );
-        depositData.finalizeDepositTxMaxFeeUpdate(governanceDelay());
+        depositData.finalizeDepositRevealAheadPeriodUpdate(governanceDelay());
     }
 
     // --- Redemption

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -69,7 +69,8 @@ library BridgeState {
         // the deposit reveal time and the deposit refund locktime. For example,
         // if the deposit become refundable on August 1st, and the ahead period
         // is 7 days, the latest moment for deposit reveal is July 25th.
-        // Value in seconds.
+        // Value in seconds. The value equal to zero disables the validation
+        // of this parameter.
         uint32 depositRevealAheadPeriod;
         // Move movingFundsTxMaxTotalFee to the next storage slot for a more
         // efficient variable layout in the storage.
@@ -417,11 +418,6 @@ library BridgeState {
         require(
             _depositTxMaxFee > 0,
             "Deposit transaction max fee must be greater than zero"
-        );
-
-        require(
-            _depositRevealAheadPeriod > 0,
-            "Deposit reveal ahead period must be greater than zero"
         );
 
         self.depositDustThreshold = _depositDustThreshold;

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -65,6 +65,12 @@ library BridgeState {
         //
         // This is a per-deposit input max fee for the sweep transaction.
         uint64 depositTxMaxFee;
+        // Defines the length of the period that must be preserved between
+        // the deposit reveal time and the deposit refund locktime. For example,
+        // if the deposit become refundable on August 1st, and the ahead period
+        // is 7 days, the latest moment for deposit reveal is July 25th.
+        // Value in seconds.
+        uint32 depositRevealAheadPeriod;
         // Move movingFundsTxMaxTotalFee to the next storage slot for a more
         // efficient variable layout in the storage.
         // slither-disable-next-line unused-state

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -318,7 +318,8 @@ library BridgeState {
     event DepositParametersUpdated(
         uint64 depositDustThreshold,
         uint64 depositTreasuryFeeDivisor,
-        uint64 depositTxMaxFee
+        uint64 depositTxMaxFee,
+        uint32 depositRevealAheadPeriod
     );
 
     event RedemptionParametersUpdated(
@@ -381,16 +382,22 @@ library BridgeState {
     ///        be incurred by each swept deposit being part of the given sweep
     ///        transaction. If the maximum BTC transaction fee is exceeded,
     ///        such transaction is considered a fraud.
+    /// @param _depositRevealAheadPeriod New value of the deposit reveal ahead
+    ///        period parameter in seconds. It defines the length of the period
+    ///        that must be preserved between the deposit reveal time and the
+    ///        deposit refund locktime.
     /// @dev Requirements:
     ///      - Deposit dust threshold must be greater than zero,
     ///      - Deposit dust threshold must be greater than deposit TX max fee,
     ///      - Deposit treasury fee divisor must be greater than zero,
     ///      - Deposit transaction max fee must be greater than zero.
+    ///      - Deposit reveal ahead period must be grater than zero.
     function updateDepositParameters(
         Storage storage self,
         uint64 _depositDustThreshold,
         uint64 _depositTreasuryFeeDivisor,
-        uint64 _depositTxMaxFee
+        uint64 _depositTxMaxFee,
+        uint32 _depositRevealAheadPeriod
     ) internal {
         require(
             _depositDustThreshold > 0,
@@ -412,14 +419,21 @@ library BridgeState {
             "Deposit transaction max fee must be greater than zero"
         );
 
+        require(
+            _depositRevealAheadPeriod > 0,
+            "Deposit reveal ahead period must be greater than zero"
+        );
+
         self.depositDustThreshold = _depositDustThreshold;
         self.depositTreasuryFeeDivisor = _depositTreasuryFeeDivisor;
         self.depositTxMaxFee = _depositTxMaxFee;
+        self.depositRevealAheadPeriod = _depositRevealAheadPeriod;
 
         emit DepositParametersUpdated(
             _depositDustThreshold,
             _depositTreasuryFeeDivisor,
-            _depositTxMaxFee
+            _depositTxMaxFee,
+            _depositRevealAheadPeriod
         );
     }
 

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -301,9 +301,9 @@ library Deposit {
         // sweep the deposit and avoid a potential competition with the
         // depositor making the deposit refund.
         require(
-        /* solhint-disable-next-line not-rely-on-time */
+            /* solhint-disable-next-line not-rely-on-time */
             block.timestamp + self.depositRevealAheadPeriod <=
-            depositRefundableTimestamp,
+                depositRefundableTimestamp,
             "Deposit refund locktime is too close"
         );
     }

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -162,7 +162,9 @@ library Deposit {
             "Vault is not trusted"
         );
 
-        validateDepositRefundLocktime(self, reveal.refundLocktime);
+        if (self.depositRevealAheadPeriod > 0) {
+            validateDepositRefundLocktime(self, reveal.refundLocktime);
+        }
 
         bytes memory expectedScript = abi.encodePacked(
             hex"14", // Byte length of depositor Ethereum address.

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -162,6 +162,8 @@ library Deposit {
             "Vault is not trusted"
         );
 
+        validateDepositRefundLocktime(self, reveal.refundLocktime);
+
         bytes memory expectedScript = abi.encodePacked(
             hex"14", // Byte length of depositor Ethereum address.
             reveal.depositor,
@@ -264,6 +266,45 @@ library Deposit {
             reveal.refundPubKeyHash,
             reveal.refundLocktime,
             reveal.vault
+        );
+    }
+
+    /// @notice Validates the deposit refund locktime. The validation passes
+    ///         successfully only if the deposit reveal is done respectively
+    ///         earlier than the moment when the deposit refund locktime is
+    ///         reached, i.e. the deposit become refundable. Reverts otherwise.
+    /// @param refundLocktime The deposit refund locktime as 4-byte LE.
+    /// @dev Requirements:
+    ///      - `refundLocktime` as integer must be >= 500M
+    ///      - `refundLocktime` must denote a timestamp that is at least
+    ///        `depositRevealAheadPeriod` seconds later than the moment
+    ///        of `block.timestamp`
+    function validateDepositRefundLocktime(
+        BridgeState.Storage storage self,
+        bytes4 refundLocktime
+    ) internal {
+        // Convert the refund locktime byte array to a LE integer. This is
+        // the moment in time when the deposit become refundable.
+        uint32 depositRefundableTimestamp = BTCUtils.reverseUint32(
+            uint32(refundLocktime)
+        );
+        // According to https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number
+        // the locktime is parsed as a block number if less than 500M. We always
+        // want to parse the locktime as an Unix timestamp so we allow only for
+        // values bigger than or equal to 500M.
+        require(
+            depositRefundableTimestamp >= 500 * 1e6,
+            "Refund locktime must be a value >= 500M"
+        );
+        // The deposit must be revealed before it becomes refundable.
+        // This is because the sweeping wallet needs to have some time to
+        // sweep the deposit and avoid a potential competition with the
+        // depositor making the deposit refund.
+        require(
+        /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp + self.depositRevealAheadPeriod <=
+            depositRefundableTimestamp,
+            "Deposit refund locktime is too close"
         );
     }
 }

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -159,10 +159,4 @@ contract BridgeStub is Bridge {
             .registeredWallets[walletPubKeyHash]
             .pendingMovedFundsSweepRequestsCount--;
     }
-
-    function setMovedFundsSweepTxMaxTotalFee(
-        uint64 _movedFundsSweepTxMaxTotalFee
-    ) external {
-        self.movedFundsSweepTxMaxTotalFee = _movedFundsSweepTxMaxTotalFee;
-    }
 }

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -159,4 +159,10 @@ contract BridgeStub is Bridge {
             .registeredWallets[walletPubKeyHash]
             .pendingMovedFundsSweepRequestsCount--;
     }
+
+    function setDepositRevealAheadPeriod(uint32 _depositRevealAheadPeriod)
+        external
+    {
+        self.depositRevealAheadPeriod = _depositRevealAheadPeriod;
+    }
 }

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -198,6 +198,7 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
+    except: ["BridgeStub$"],
   },
   mocha: {
     timeout: 60_000,

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../typechain"
 import type { DepositRevealInfoStruct } from "../../typechain/Bridge"
 import bridgeFixture from "../fixtures/bridge"
-import { walletState } from "../fixtures"
+import { constants, walletState } from "../fixtures"
 import {
   DepositSweepTestData,
   MultipleDepositsNoMainUtxo,
@@ -32,7 +32,7 @@ import {
 chai.use(smock.matchers)
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
-const { lastBlockTime } = helpers.time
+const { lastBlockTime, increaseTime } = helpers.time
 
 const ZERO_ADDRESS = ethers.constants.AddressZero
 
@@ -63,6 +63,9 @@ describe("Bridge - Deposit", () => {
     // Set the deposit dust threshold to 0.0001 BTC, i.e. 100x smaller than
     // the initial value in the Bridge in order to save test Bitcoins.
     await bridge.setDepositDustThreshold(10000)
+    // Disable the reveal ahead period since refund locktimes are fixed
+    // within transactions used in this test suite.
+    await bridge.setDepositRevealAheadPeriod(0)
   })
 
   describe("revealDeposit", () => {

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -3,7 +3,7 @@
 
 import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import { Contract, ContractTransaction } from "ethers"
+import { BigNumber, Contract, ContractTransaction } from "ethers"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import type {
@@ -141,17 +141,201 @@ describe("Bridge - Deposit", () => {
         await restoreSnapshot()
       })
 
-      context("when funding transaction is P2SH", () => {
-        context("when funding output script hash is correct", () => {
-          context("when deposit was not revealed yet", () => {
-            context("when amount is not below the dust threshold", () => {
+      context("when reveal ahead period validation is disabled", () => {
+        context("when funding transaction is P2SH", () => {
+          context("when funding output script hash is correct", () => {
+            context("when deposit was not revealed yet", () => {
+              context("when amount is not below the dust threshold", () => {
+                context("when deposit is routed to a trusted vault", () => {
+                  let tx: ContractTransaction
+
+                  before(async () => {
+                    await createSnapshot()
+
+                    tx = await bridge.revealDeposit(P2SHFundingTx, reveal)
+                  })
+
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
+
+                  it("should store proper deposit data", async () => {
+                    // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+                    const depositKey = ethers.utils.solidityKeccak256(
+                      ["bytes32", "uint32"],
+                      [
+                        "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                        reveal.fundingOutputIndex,
+                      ]
+                    )
+
+                    const deposit = await bridge.deposits(depositKey)
+
+                    // Depositor address, same as in `reveal.depositor`.
+                    expect(deposit.depositor).to.be.equal(
+                      "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637"
+                    )
+                    // Deposit amount in satoshi. In this case it's 10000 satoshi
+                    // because the P2SH deposit transaction set this value for the
+                    // funding output.
+                    expect(deposit.amount).to.be.equal(10000)
+                    // Revealed time should be set.
+                    expect(deposit.revealedAt).to.be.equal(
+                      await lastBlockTime()
+                    )
+                    // Deposit vault, same as in `reveal.vault`.
+                    expect(deposit.vault).to.be.equal(
+                      "0x594cfd89700040163727828AE20B52099C58F02C"
+                    )
+                    // Treasury fee should be computed according to the current
+                    // value of the `depositTreasuryFeeDivisor`.
+                    expect(deposit.treasuryFee).to.be.equal(5)
+                    // Swept time should be unset.
+                    expect(deposit.sweptAt).to.be.equal(0)
+                  })
+
+                  it("should emit DepositRevealed event", async () => {
+                    await expect(tx)
+                      .to.emit(bridge, "DepositRevealed")
+                      .withArgs(
+                        "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                        reveal.fundingOutputIndex,
+                        "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+                        10000,
+                        "0xf9f0c90d00039523",
+                        "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
+                        "0x28e081f285138ccbe389c1eb8985716230129f89",
+                        "0x60bcea61",
+                        reveal.vault
+                      )
+                  })
+                })
+
+                context("when deposit is not routed to a vault", () => {
+                  let tx: ContractTransaction
+                  let nonRoutedReveal: DepositRevealInfoStruct
+
+                  before(async () => {
+                    await createSnapshot()
+
+                    nonRoutedReveal = { ...reveal }
+                    nonRoutedReveal.vault = ZERO_ADDRESS
+                    tx = await bridge.revealDeposit(
+                      P2SHFundingTx,
+                      nonRoutedReveal
+                    )
+                  })
+
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
+
+                  it("should accept the deposit", async () => {
+                    await expect(tx)
+                      .to.emit(bridge, "DepositRevealed")
+                      .withArgs(
+                        "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                        reveal.fundingOutputIndex,
+                        "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+                        10000,
+                        "0xf9f0c90d00039523",
+                        "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
+                        "0x28e081f285138ccbe389c1eb8985716230129f89",
+                        "0x60bcea61",
+                        ZERO_ADDRESS
+                      )
+                  })
+                })
+
+                context("when deposit is routed to a non-trusted vault", () => {
+                  let nonTrustedVaultReveal
+
+                  before(async () => {
+                    await createSnapshot()
+
+                    nonTrustedVaultReveal = { ...reveal }
+                    nonTrustedVaultReveal.vault =
+                      "0x92499afEAD6c41f757Ec3558D0f84bf7ec5aD967"
+                  })
+
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
+
+                  it("should revert", async () => {
+                    await expect(
+                      bridge.revealDeposit(P2SHFundingTx, nonTrustedVaultReveal)
+                    ).to.be.revertedWith("Vault is not trusted")
+                  })
+                })
+              })
+
+              context("when amount is below the dust threshold", () => {
+                before(async () => {
+                  await createSnapshot()
+
+                  // The `P2SHFundingTx` used within this scenario has an output
+                  // whose value is 10000 satoshi. To make the scenario happen, it
+                  // is enough that the contract's deposit dust threshold is
+                  // bigger by 1 satoshi.
+                  await bridge.setDepositDustThreshold(10001)
+                })
+
+                after(async () => {
+                  await restoreSnapshot()
+                })
+
+                it("should revert", async () => {
+                  await expect(
+                    bridge.revealDeposit(P2SHFundingTx, reveal)
+                  ).to.be.revertedWith("Deposit amount too small")
+                })
+              })
+            })
+
+            context("when deposit was already revealed", () => {
+              before(async () => {
+                await createSnapshot()
+
+                await bridge.revealDeposit(P2SHFundingTx, reveal)
+              })
+
+              after(async () => {
+                await restoreSnapshot()
+              })
+
+              it("should revert", async () => {
+                await expect(
+                  bridge.revealDeposit(P2SHFundingTx, reveal)
+                ).to.be.revertedWith("Deposit already revealed")
+              })
+            })
+          })
+
+          context("when funding output script hash is wrong", () => {
+            it("should revert", async () => {
+              // Corrupt reveal data by setting a wrong depositor address.
+              const corruptedReveal = { ...reveal }
+              corruptedReveal.depositor =
+                "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+
+              await expect(
+                bridge.revealDeposit(P2SHFundingTx, corruptedReveal)
+              ).to.be.revertedWith("Wrong 20-byte script hash")
+            })
+          })
+        })
+
+        context("when funding transaction is P2WSH", () => {
+          context("when funding output script hash is correct", () => {
+            context("when deposit was not revealed yet", () => {
               context("when deposit is routed to a trusted vault", () => {
                 let tx: ContractTransaction
 
                 before(async () => {
                   await createSnapshot()
 
-                  tx = await bridge.revealDeposit(P2SHFundingTx, reveal)
+                  tx = await bridge.revealDeposit(P2WSHFundingTx, reveal)
                 })
 
                 after(async () => {
@@ -163,7 +347,7 @@ describe("Bridge - Deposit", () => {
                   const depositKey = ethers.utils.solidityKeccak256(
                     ["bytes32", "uint32"],
                     [
-                      "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                      "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
                       reveal.fundingOutputIndex,
                     ]
                   )
@@ -195,7 +379,7 @@ describe("Bridge - Deposit", () => {
                   await expect(tx)
                     .to.emit(bridge, "DepositRevealed")
                     .withArgs(
-                      "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                      "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
                       reveal.fundingOutputIndex,
                       "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
                       10000,
@@ -218,7 +402,7 @@ describe("Bridge - Deposit", () => {
                   nonRoutedReveal = { ...reveal }
                   nonRoutedReveal.vault = ZERO_ADDRESS
                   tx = await bridge.revealDeposit(
-                    P2SHFundingTx,
+                    P2WSHFundingTx,
                     nonRoutedReveal
                   )
                 })
@@ -231,7 +415,7 @@ describe("Bridge - Deposit", () => {
                   await expect(tx)
                     .to.emit(bridge, "DepositRevealed")
                     .withArgs(
-                      "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                      "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
                       reveal.fundingOutputIndex,
                       "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
                       10000,
@@ -261,21 +445,17 @@ describe("Bridge - Deposit", () => {
 
                 it("should revert", async () => {
                   await expect(
-                    bridge.revealDeposit(P2SHFundingTx, nonTrustedVaultReveal)
+                    bridge.revealDeposit(P2WSHFundingTx, nonTrustedVaultReveal)
                   ).to.be.revertedWith("Vault is not trusted")
                 })
               })
             })
 
-            context("when amount is below the dust threshold", () => {
+            context("when deposit was already revealed", () => {
               before(async () => {
                 await createSnapshot()
 
-                // The `P2SHFundingTx` used within this scenario has an output
-                // whose value is 10000 satoshi. To make the scenario happen, it
-                // is enough that the contract's deposit dust threshold is
-                // bigger by 1 satoshi.
-                await bridge.setDepositDustThreshold(10001)
+                await bridge.revealDeposit(P2WSHFundingTx, reveal)
               })
 
               after(async () => {
@@ -284,212 +464,131 @@ describe("Bridge - Deposit", () => {
 
               it("should revert", async () => {
                 await expect(
-                  bridge.revealDeposit(P2SHFundingTx, reveal)
-                ).to.be.revertedWith("Deposit amount too small")
+                  bridge.revealDeposit(P2WSHFundingTx, reveal)
+                ).to.be.revertedWith("Deposit already revealed")
               })
             })
           })
 
-          context("when deposit was already revealed", () => {
-            before(async () => {
-              await createSnapshot()
-
-              await bridge.revealDeposit(P2SHFundingTx, reveal)
-            })
-
-            after(async () => {
-              await restoreSnapshot()
-            })
-
+          context("when funding output script hash is wrong", () => {
             it("should revert", async () => {
+              // Corrupt reveal data by setting a wrong depositor address.
+              const corruptedReveal = { ...reveal }
+              corruptedReveal.depositor =
+                "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+
               await expect(
-                bridge.revealDeposit(P2SHFundingTx, reveal)
-              ).to.be.revertedWith("Deposit already revealed")
+                bridge.revealDeposit(P2WSHFundingTx, corruptedReveal)
+              ).to.be.revertedWith("Wrong 32-byte script hash")
             })
           })
         })
 
-        context("when funding output script hash is wrong", () => {
+        context("when funding transaction is neither P2SH nor P2WSH", () => {
           it("should revert", async () => {
-            // Corrupt reveal data by setting a wrong depositor address.
-            const corruptedReveal = { ...reveal }
-            corruptedReveal.depositor =
-              "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+            // Corrupt transaction output data by making a 21-byte script hash.
+            const corruptedP2SHFundingTx = { ...P2SHFundingTx }
+            corruptedP2SHFundingTx.outputVector =
+              "0x02102700000000000017a9156a6ade1c799a3e5a59678e776f21be14d66dc" +
+              "15ed8877ed73b00000000001600147ac2d9378a1c47e589dfb8095ca95ed2" +
+              "140d2726"
 
             await expect(
-              bridge.revealDeposit(P2SHFundingTx, corruptedReveal)
-            ).to.be.revertedWith("Wrong 20-byte script hash")
+              bridge.revealDeposit(corruptedP2SHFundingTx, reveal)
+            ).to.be.revertedWith("Wrong script hash length")
           })
         })
       })
 
-      context("when funding transaction is P2WSH", () => {
-        context("when funding output script hash is correct", () => {
-          context("when deposit was not revealed yet", () => {
-            context("when deposit is routed to a trusted vault", () => {
-              let tx: ContractTransaction
+      context("when reveal ahead period validation is enabled", () => {
+        const encodeRefundLocktime = (refundLocktimeTimestamp: number) => {
+          const refundLocktimeTimestampHex = BigNumber.from(
+            refundLocktimeTimestamp
+          )
+            .toHexString()
+            .substring(2)
+          const refundLocktimeBuffer = Buffer.from(
+            refundLocktimeTimestampHex,
+            "hex"
+          )
+          return `0x${refundLocktimeBuffer.reverse().toString("hex")}`
+        }
 
-              before(async () => {
-                await createSnapshot()
+        before(async () => {
+          await createSnapshot()
 
-                tx = await bridge.revealDeposit(P2WSHFundingTx, reveal)
-              })
+          // Reveal ahead period is disabled by default in this test suite
+          // (see root before clause). We need to enable it manually.
+          await bridge.setDepositRevealAheadPeriod(
+            constants.depositRevealAheadPeriod
+          )
+        })
 
-              after(async () => {
-                await restoreSnapshot()
-              })
+        after(async () => {
+          await restoreSnapshot()
+        })
 
-              it("should store proper deposit data", async () => {
-                // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
-                const depositKey = ethers.utils.solidityKeccak256(
-                  ["bytes32", "uint32"],
-                  [
-                    "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
-                    reveal.fundingOutputIndex,
-                  ]
-                )
+        context("when reveal ahead period is preserved", () => {
+          it("should pass the refund locktime validation", async () => {
+            const now = Math.floor(Date.now() / 1000)
+            const refundLocktimeDuration = 2592000 // 30 days
+            const refundLocktimeTimestamp = now + refundLocktimeDuration
+            const latestPossibleRevealTimestamp =
+              refundLocktimeTimestamp - constants.depositRevealAheadPeriod
 
-                const deposit = await bridge.deposits(depositKey)
+            const alteredReveal = {
+              ...reveal,
+              refundLocktime: encodeRefundLocktime(refundLocktimeTimestamp),
+            }
 
-                // Depositor address, same as in `reveal.depositor`.
-                expect(deposit.depositor).to.be.equal(
-                  "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637"
-                )
-                // Deposit amount in satoshi. In this case it's 10000 satoshi
-                // because the P2SH deposit transaction set this value for the
-                // funding output.
-                expect(deposit.amount).to.be.equal(10000)
-                // Revealed time should be set.
-                expect(deposit.revealedAt).to.be.equal(await lastBlockTime())
-                // Deposit vault, same as in `reveal.vault`.
-                expect(deposit.vault).to.be.equal(
-                  "0x594cfd89700040163727828AE20B52099C58F02C"
-                )
-                // Treasury fee should be computed according to the current
-                // value of the `depositTreasuryFeeDivisor`.
-                expect(deposit.treasuryFee).to.be.equal(5)
-                // Swept time should be unset.
-                expect(deposit.sweptAt).to.be.equal(0)
-              })
+            await ethers.provider.send("evm_setNextBlockTimestamp", [
+              BigNumber.from(latestPossibleRevealTimestamp).toHexString(),
+            ])
 
-              it("should emit DepositRevealed event", async () => {
-                await expect(tx)
-                  .to.emit(bridge, "DepositRevealed")
-                  .withArgs(
-                    "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
-                    reveal.fundingOutputIndex,
-                    "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-                    10000,
-                    "0xf9f0c90d00039523",
-                    "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
-                    "0x28e081f285138ccbe389c1eb8985716230129f89",
-                    "0x60bcea61",
-                    reveal.vault
-                  )
-              })
-            })
-
-            context("when deposit is not routed to a vault", () => {
-              let tx: ContractTransaction
-              let nonRoutedReveal: DepositRevealInfoStruct
-
-              before(async () => {
-                await createSnapshot()
-
-                nonRoutedReveal = { ...reveal }
-                nonRoutedReveal.vault = ZERO_ADDRESS
-                tx = await bridge.revealDeposit(P2WSHFundingTx, nonRoutedReveal)
-              })
-
-              after(async () => {
-                await restoreSnapshot()
-              })
-
-              it("should accept the deposit", async () => {
-                await expect(tx)
-                  .to.emit(bridge, "DepositRevealed")
-                  .withArgs(
-                    "0x6a81de17ce3da1eadc833c5fd9d85dac307d3b78235f57afbcd9f068fc01b99e",
-                    reveal.fundingOutputIndex,
-                    "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
-                    10000,
-                    "0xf9f0c90d00039523",
-                    "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
-                    "0x28e081f285138ccbe389c1eb8985716230129f89",
-                    "0x60bcea61",
-                    ZERO_ADDRESS
-                  )
-              })
-            })
-
-            context("when deposit is routed to a non-trusted vault", () => {
-              let nonTrustedVaultReveal
-
-              before(async () => {
-                await createSnapshot()
-
-                nonTrustedVaultReveal = { ...reveal }
-                nonTrustedVaultReveal.vault =
-                  "0x92499afEAD6c41f757Ec3558D0f84bf7ec5aD967"
-              })
-
-              after(async () => {
-                await restoreSnapshot()
-              })
-
-              it("should revert", async () => {
-                await expect(
-                  bridge.revealDeposit(P2WSHFundingTx, nonTrustedVaultReveal)
-                ).to.be.revertedWith("Vault is not trusted")
-              })
-            })
-          })
-
-          context("when deposit was already revealed", () => {
-            before(async () => {
-              await createSnapshot()
-
-              await bridge.revealDeposit(P2WSHFundingTx, reveal)
-            })
-
-            after(async () => {
-              await restoreSnapshot()
-            })
-
-            it("should revert", async () => {
-              await expect(
-                bridge.revealDeposit(P2WSHFundingTx, reveal)
-              ).to.be.revertedWith("Deposit already revealed")
-            })
+            // We cannot assert that the reveal transaction succeeded since
+            // we modified the revealed refund locktime which differs from
+            // the one embedded in the transaction P2SH. We just make sure
+            // the execution does not revert on the refund locktime validation.
+            await expect(
+              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+            ).to.be.not.revertedWith("Deposit refund locktime is too close")
           })
         })
 
-        context("when funding output script hash is wrong", () => {
+        context("when reveal ahead period is not preserved", () => {
           it("should revert", async () => {
-            // Corrupt reveal data by setting a wrong depositor address.
-            const corruptedReveal = { ...reveal }
-            corruptedReveal.depositor =
-              "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+            const now = Math.floor(Date.now() / 1000)
+            const refundLocktimeDuration = 2592000 // 30 days
+            const refundLocktimeTimestamp = now + refundLocktimeDuration
+            const latestPossibleRevealTimestamp =
+              refundLocktimeTimestamp - constants.depositRevealAheadPeriod
+
+            const alteredReveal = {
+              ...reveal,
+              refundLocktime: encodeRefundLocktime(refundLocktimeTimestamp),
+            }
+
+            await ethers.provider.send("evm_setNextBlockTimestamp", [
+              BigNumber.from(latestPossibleRevealTimestamp + 1).toHexString(),
+            ])
 
             await expect(
-              bridge.revealDeposit(P2WSHFundingTx, corruptedReveal)
-            ).to.be.revertedWith("Wrong 32-byte script hash")
+              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+            ).to.be.revertedWith("Deposit refund locktime is too close")
           })
         })
-      })
 
-      context("when funding transaction is neither P2SH nor P2WSH", () => {
-        it("should revert", async () => {
-          // Corrupt transaction output data by making a 21-byte script hash.
-          const corruptedP2SHFundingTx = { ...P2SHFundingTx }
-          corruptedP2SHFundingTx.outputVector =
-            "0x02102700000000000017a9156a6ade1c799a3e5a59678e776f21be14d66dc" +
-            "15ed8877ed73b00000000001600147ac2d9378a1c47e589dfb8095ca95ed2" +
-            "140d2726"
+        context("when refund locktime integer value is less than 500M", () => {
+          it("should revert", async () => {
+            const alteredReveal = {
+              ...reveal,
+              refundLocktime: encodeRefundLocktime(499999999),
+            }
 
-          await expect(
-            bridge.revealDeposit(corruptedP2SHFundingTx, reveal)
-          ).to.be.revertedWith("Wrong script hash length")
+            await expect(
+              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+            ).to.be.revertedWith("Refund locktime must be a value >= 500M")
+          })
         })
       })
     })

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -613,6 +613,132 @@ describe("Bridge - Governance", () => {
     )
   })
 
+  describe("beginDepositRevealAheadPeriodUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(thirdParty)
+            .beginDepositRevealAheadPeriodUpdate(1)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await bridgeGovernance
+          .connect(governance)
+          .beginDepositRevealAheadPeriodUpdate(1337)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not update the deposit tx max fee", async () => {
+        const { depositRevealAheadPeriod } = await bridge.depositParameters()
+        expect(depositRevealAheadPeriod).to.be.equal(
+          constants.depositRevealAheadPeriod
+        )
+      })
+
+      it("should emit DepositRevealAheadPeriodUpdateStarted event", async () => {
+        const blockTimestamp = await helpers.time.lastBlockTime()
+        await expect(tx)
+          .to.emit(bridgeGovernance, "DepositRevealAheadPeriodUpdateStarted")
+          .withArgs(1337, blockTimestamp)
+      })
+    })
+  })
+
+  describe("finalizeDepositRevealAheadPeriodUpdate", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(thirdParty)
+            .finalizeDepositRevealAheadPeriodUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initialized", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(governance)
+            .finalizeDepositRevealAheadPeriodUpdate()
+        ).to.be.revertedWith(
+          "Deposit reveal ahead period must be greater than zero"
+        )
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await bridgeGovernance
+          .connect(governance)
+          .beginDepositRevealAheadPeriodUpdate(7331)
+
+        await helpers.time.increaseTime(constants.governanceDelay - 60) // -1min
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(governance)
+            .finalizeDepositRevealAheadPeriodUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+      })
+    })
+
+    context(
+      "when the update process is initialized and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await bridgeGovernance
+            .connect(governance)
+            .beginDepositRevealAheadPeriodUpdate(7331)
+
+          await helpers.time.increaseTime(constants.governanceDelay)
+
+          tx = await bridgeGovernance
+            .connect(governance)
+            .finalizeDepositRevealAheadPeriodUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the deposit reveal ahead period", async () => {
+          const { depositRevealAheadPeriod } = await bridge.depositParameters()
+          expect(depositRevealAheadPeriod).to.be.equal(7331)
+        })
+
+        it("should emit DepositRevealAheadPeriodUpdated event", async () => {
+          await expect(tx)
+            .to.emit(bridgeGovernance, "DepositRevealAheadPeriodUpdated")
+            .withArgs(7331)
+        })
+      }
+    )
+  })
+
   describe("beginRedemptionDustThresholdUpdate", () => {
     context("when the caller is not the owner", () => {
       it("should revert", async () => {

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -639,7 +639,7 @@ describe("Bridge - Governance", () => {
         await restoreSnapshot()
       })
 
-      it("should not update the deposit tx max fee", async () => {
+      it("should not update the deposit reveal ahead period", async () => {
         const { depositRevealAheadPeriod } = await bridge.depositParameters()
         expect(depositRevealAheadPeriod).to.be.equal(
           constants.depositRevealAheadPeriod
@@ -672,9 +672,7 @@ describe("Bridge - Governance", () => {
           bridgeGovernance
             .connect(governance)
             .finalizeDepositRevealAheadPeriodUpdate()
-        ).to.be.revertedWith(
-          "Deposit reveal ahead period must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -3067,7 +3067,13 @@ describe("Bridge - Moving funds", () => {
 
                           // Set the max fee to one satoshi less than the fee
                           // used by the transaction.
-                          await bridge.setMovedFundsSweepTxMaxTotalFee(1999)
+                          await bridgeGovernance
+                            .connect(governance)
+                            .beginMovedFundsSweepTxMaxTotalFeeUpdate(1999)
+                          await increaseTime(constants.governanceDelay)
+                          await bridgeGovernance
+                            .connect(governance)
+                            .finalizeMovedFundsSweepTxMaxTotalFeeUpdate()
                         })
 
                         after(async () => {

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -230,24 +230,6 @@ describe("Bridge - Parameters", () => {
           )
         })
       })
-
-      context("when new deposit reveal ahead period is zero", () => {
-        it("should revert", async () => {
-          await bridgeGovernance
-            .connect(governance)
-            .beginDepositRevealAheadPeriodUpdate(0)
-
-          await helpers.time.increaseTime(constants.governanceDelay)
-
-          await expect(
-            bridgeGovernance
-              .connect(governance)
-              .finalizeDepositRevealAheadPeriodUpdate()
-          ).to.be.revertedWith(
-            "Deposit reveal ahead period must be greater than zero"
-          )
-        })
-      })
     })
 
     context("when caller is not the contract guvnor", () => {
@@ -281,7 +263,9 @@ describe("Bridge - Parameters", () => {
         await expect(
           bridgeGovernance
             .connect(thirdParty)
-            .beginDepositRevealAheadPeriodUpdate(constants.depositRevealAheadPeriod)
+            .beginDepositRevealAheadPeriodUpdate(
+              constants.depositRevealAheadPeriod
+            )
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })

--- a/solidity/test/bridge/VendingMachine.Upgrade.test.ts
+++ b/solidity/test/bridge/VendingMachine.Upgrade.test.ts
@@ -84,6 +84,9 @@ describe("VendingMachine - Upgrade", () => {
     // Set the deposit dust threshold to 0.0001 BTC, i.e. 100x smaller than
     // the initial value in the Bridge in order to save test Bitcoins.
     await bridge.setDepositDustThreshold(10000)
+    // Disable the reveal ahead period since refund locktimes are fixed
+    // within transactions used in this test suite.
+    await bridge.setDepositRevealAheadPeriod(0)
 
     await bridgeGovernance
       .connect(governance)

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -5,6 +5,7 @@ export const constants = {
   depositDustThreshold: 1000000, // 1000000 satoshi = 0.01 BTC
   depositTxMaxFee: 100000, // 100000 satoshi = 0.001 BTC
   depositTreasuryFeeDivisor: 2000, // 1/2000 == 5bps == 0.05% == 0.0005
+  depositRevealAheadPeriod: 1296000, // 15 days
   redemptionDustThreshold: 1000000, // 1000000 satoshi = 0.01 BTC
   redemptionTreasuryFeeDivisor: 2000, // 1/2000 == 5bps == 0.05% == 0.0005
   redemptionTxMaxFee: 100000, // 100000 satoshi = 0.001 BTC

--- a/solidity/test/maintainer/MaintainerProxy.test.ts
+++ b/solidity/test/maintainer/MaintainerProxy.test.ts
@@ -117,6 +117,9 @@ describe("MaintainerProxy", () => {
     // Scaling down deposit TX max fee as well.
     await bridge.setDepositDustThreshold(10000)
     await bridge.setDepositTxMaxFee(2000)
+    // Disable the reveal ahead period since refund locktimes are fixed
+    // within transactions used in this test suite.
+    await bridge.setDepositRevealAheadPeriod(0)
 
     await deployer.sendTransaction({
       to: walletRegistry.address,


### PR DESCRIPTION
Here we introduce the validation of the deposit refund locktime during the deposit reveal. That validation ensures that a given period of time is preserved between the moment of the deposit reveal and the moment when the deposit becomes refundable. The exact duration of this period is determined by the `depositRevealAheadPeriod` governable parameter. This validation is needed to give the wallet enough time to sweep a revealed deposit and avoid potential competition with the depositor doing a deposit refund. The validation is not performed if the value of the `depositRevealAheadPeriod` is `0`.