### PR TITLE
Making solidity-contracts dependency for development env

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -150,6 +150,7 @@ const config: HardhatUserConfig = {
       // For development environment we expect the local dependencies to be
       // linked with `yarn link` command.
       development: [
+        "node_modules/@threshold-network/solidity-contracts/deployments/development",
         "node_modules/@keep-network/random-beacon/deployments/development",
         "node_modules/@keep-network/ecdsa/deployments/development",
       ],


### PR DESCRIPTION
For the development env. we are not going to use "all-in-one" approach for deploying contracts that is available for Hardhat. Each project is responsible for its own contracts. 
`solidity-contracts` is a dependency in tbtc, and we need to add this dependency to the "development" field to point to the linked and deployed artifacts.