### PR TITLE
Delete entry from `timedOutRedemptions` when it has been processed

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1517,12 +1517,14 @@ contract Bridge is
     ///         (computed using Bitcoin HASH160 over the compressed ECDSA
     ///         public key) and `redeemerOutputScript` is the Bitcoin script
     ///         (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the timed
-    ///         out request. Timed out requests are stored in this mapping to
-    ///         avoid slashing the wallets multiple times for the same timeout.
+    ///         out request.
     ///         Only one method can add to this mapping:
     ///         - `notifyRedemptionTimeout` which puts the redemption key
-    ///           to this mapping basing on a timed out request stored
+    ///           to this mapping based on a timed out request stored
     ///           previously in `pendingRedemptions` mapping.
+    ///         Only one method removes entries from this mapping:
+    ///         - `submitRedemptionProof` in case the timed out redemption
+    ///           request was a part of the proven transaction.
     function timedOutRedemptions(uint256 redemptionKey)
         external
         view

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1522,7 +1522,7 @@ contract Bridge is
     ///         - `notifyRedemptionTimeout` which puts the redemption key
     ///           to this mapping based on a timed out request stored
     ///           previously in `pendingRedemptions` mapping.
-    ///         Only one method removes entries from this mapping:
+    ///         Only one method can remove entries from this mapping:
     ///         - `submitRedemptionProof` in case the timed out redemption
     ///           request was a part of the proven transaction.
     function timedOutRedemptions(uint256 redemptionKey)

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -290,7 +290,7 @@ library BridgeState {
         // - `notifyRedemptionTimeout` which puts the redemption key to this
         //    mapping based on a timed out request stored previously in
         //    `pendingRedemptions` mapping.
-        // Only one method removes entries from this mapping:
+        // Only one method can remove entries from this mapping:
         // - `submitRedemptionProof` in case the timed out redemption request
         //    was a part of the proven transaction.
         mapping(uint256 => Redemption.RedemptionRequest) timedOutRedemptions;

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -285,12 +285,14 @@ library BridgeState {
         // (computed using Bitcoin HASH160 over the compressed ECDSA
         // public key) and `redeemerOutputScript` is the Bitcoin script
         // (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the timed
-        // out request. Timed out requests are stored in this mapping to
-        // avoid slashing the wallets multiple times for the same timeout.
+        // out request.
         // Only one method can add to this mapping:
         // - `notifyRedemptionTimeout` which puts the redemption key to this
-        //    mapping basing on a timed out request stored previously in
+        //    mapping based on a timed out request stored previously in
         //    `pendingRedemptions` mapping.
+        // Only one method removes entries from this mapping:
+        // - `submitRedemptionProof` in case the timed out redemption request
+        //    was a part of the proven transaction.
         mapping(uint256 => Redemption.RedemptionRequest) timedOutRedemptions;
         // Collection of all submitted fraud challenges indexed by challenge
         // key built as `keccak256(walletPublicKey|sighash)`.

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -940,6 +940,8 @@ library Redemption {
                     outputValue <= redeemableAmount,
                 "Output value is not within the acceptable range of the timed out request"
             );
+
+            delete self.timedOutRedemptions[redemptionKey];
         }
     }
 

--- a/solidity/contracts/maintainer/MaintainerProxy.sol
+++ b/solidity/contracts/maintainer/MaintainerProxy.sol
@@ -166,7 +166,7 @@ contract MaintainerProxy is Ownable, Reimbursable {
         bridge = _bridge;
         reimbursementPool = _reimbursementPool;
         submitDepositSweepProofGasOffset = 27000;
-        submitRedemptionProofGasOffset = 9750;
+        submitRedemptionProofGasOffset = 0;
         submitMovingFundsCommitmentGasOffset = 8000;
         resetMovingFundsTimeoutGasOffset = 1000;
         submitMovingFundsProofGasOffset = 15000;

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -46,6 +46,8 @@ const { createSnapshot, restoreSnapshot } = helpers.snapshot
 const { lastBlockTime, increaseTime } = helpers.time
 const { impersonateAccount } = helpers.account
 
+const ZERO_ADDRESS = ethers.constants.AddressZero
+
 describe("Bridge - Redemption", () => {
   let governance: SignerWithAddress
   let thirdParty: SignerWithAddress
@@ -1301,7 +1303,7 @@ describe("Bridge - Redemption", () => {
                               await restoreSnapshot()
                             })
 
-                            it("should hold the timed out request in the contract state", async () => {
+                            it("should remove the timed out request from the contract state", async () => {
                               const redemptionRequest =
                                 await bridge.timedOutRedemptions(
                                   buildRedemptionKey(
@@ -1311,12 +1313,15 @@ describe("Bridge - Redemption", () => {
                                   )
                                 )
 
-                              expect(
-                                redemptionRequest.requestedAt
-                              ).to.be.greaterThan(
-                                0,
-                                "Timed out request was removed from the contract state"
+                              expect(redemptionRequest.redeemer).to.equal(
+                                ZERO_ADDRESS
                               )
+                              expect(
+                                redemptionRequest.requestedAmount
+                              ).to.equal(0)
+                              expect(redemptionRequest.treasuryFee).to.equal(0)
+                              expect(redemptionRequest.txMaxFee).to.equal(0)
+                              expect(redemptionRequest.requestedAt).to.equal(0)
                             })
 
                             it("should delete the wallet's main UTXO", async () => {
@@ -2035,7 +2040,7 @@ describe("Bridge - Redemption", () => {
                               await restoreSnapshot()
                             })
 
-                            it("should hold the timed out requests in the contract state", async () => {
+                            it("should remove the timed out requests from the contract state", async () => {
                               for (
                                 let i = 0;
                                 i < data.redemptionRequests.length;
@@ -2051,11 +2056,18 @@ describe("Bridge - Redemption", () => {
                                     )
                                   )
 
+                                expect(redemptionRequest.redeemer).to.equal(
+                                  ZERO_ADDRESS
+                                )
                                 expect(
-                                  redemptionRequest.requestedAt
-                                ).to.be.greaterThan(
-                                  0,
-                                  `Timed out request with index ${i} was removed from the contract state`
+                                  redemptionRequest.requestedAmount
+                                ).to.equal(0)
+                                expect(redemptionRequest.treasuryFee).to.equal(
+                                  0
+                                )
+                                expect(redemptionRequest.txMaxFee).to.equal(0)
+                                expect(redemptionRequest.requestedAt).to.equal(
+                                  0
                                 )
                               }
                             })
@@ -2203,7 +2215,7 @@ describe("Bridge - Redemption", () => {
                               await restoreSnapshot()
                             })
 
-                            it("should hold the timed out requests in the contract state", async () => {
+                            it("should remove the timed out requests from the contract state", async () => {
                               for (
                                 let i = 0;
                                 i < data.redemptionRequests.length;
@@ -2219,11 +2231,18 @@ describe("Bridge - Redemption", () => {
                                     )
                                   )
 
+                                expect(redemptionRequest.redeemer).to.equal(
+                                  ZERO_ADDRESS
+                                )
                                 expect(
-                                  redemptionRequest.requestedAt
-                                ).to.be.greaterThan(
-                                  0,
-                                  `Timed out request with index ${i} was removed from the contract state`
+                                  redemptionRequest.requestedAmount
+                                ).to.equal(0)
+                                expect(redemptionRequest.treasuryFee).to.equal(
+                                  0
+                                )
+                                expect(redemptionRequest.txMaxFee).to.equal(0)
+                                expect(redemptionRequest.requestedAt).to.equal(
+                                  0
                                 )
                               }
                             })
@@ -2380,7 +2399,7 @@ describe("Bridge - Redemption", () => {
                               await restoreSnapshot()
                             })
 
-                            it("should hold the timed out requests in the contract state", async () => {
+                            it("should remove the timed out requests from the contract state", async () => {
                               // Check the two first requests reported as timed out
                               // are actually held in the contract state after
                               // proof submission.
@@ -2395,11 +2414,18 @@ describe("Bridge - Redemption", () => {
                                     )
                                   )
 
+                                expect(redemptionRequest.redeemer).to.equal(
+                                  ZERO_ADDRESS
+                                )
                                 expect(
-                                  redemptionRequest.requestedAt
-                                ).to.be.greaterThan(
-                                  0,
-                                  `Timed out request with index ${i} was removed from the contract state`
+                                  redemptionRequest.requestedAmount
+                                ).to.equal(0)
+                                expect(redemptionRequest.treasuryFee).to.equal(
+                                  0
+                                )
+                                expect(redemptionRequest.txMaxFee).to.equal(0)
+                                expect(redemptionRequest.requestedAt).to.equal(
+                                  0
                                 )
                               }
                             })
@@ -2583,7 +2609,7 @@ describe("Bridge - Redemption", () => {
                               await restoreSnapshot()
                             })
 
-                            it("should hold the timed out requests in the contract state", async () => {
+                            it("should remove the timed out requests from the contract state", async () => {
                               // Check the two first requests reported as timed out
                               // are actually held in the contract state after
                               // proof submission.
@@ -2598,11 +2624,18 @@ describe("Bridge - Redemption", () => {
                                     )
                                   )
 
+                                expect(redemptionRequest.redeemer).to.equal(
+                                  ZERO_ADDRESS
+                                )
                                 expect(
-                                  redemptionRequest.requestedAt
-                                ).to.be.greaterThan(
-                                  0,
-                                  `Timed out request with index ${i} was removed from the contract state`
+                                  redemptionRequest.requestedAmount
+                                ).to.equal(0)
+                                expect(redemptionRequest.treasuryFee).to.equal(
+                                  0
+                                )
+                                expect(redemptionRequest.txMaxFee).to.equal(0)
+                                expect(redemptionRequest.requestedAt).to.equal(
+                                  0
                                 )
                               }
                             })

--- a/solidity/test/maintainer/MaintainerProxy.test.ts
+++ b/solidity/test/maintainer/MaintainerProxy.test.ts
@@ -1115,9 +1115,13 @@ describe("MaintainerProxy", () => {
                 initialSpvMaintainerBalance
               )
 
-              expect(diff).to.be.gt(ethers.utils.parseUnits("-1000000", "gwei")) // // -0,001 ETH
+              expect(diff).to.be.gt(0)
+              // The submitter deletes from `timedOutRedemptions` mapping
+              // multiple times in this scenario. They will end up being more
+              // net-positive than in all other scenarios.
+              // Such a situation is quite unlikely to happen in practice.
               expect(diff).to.be.lt(
-                ethers.utils.parseUnits("1000000", "gwei") // 0,001 ETH
+                ethers.utils.parseUnits("10000000", "gwei") // 0,01 ETH
               )
             })
           }
@@ -1173,9 +1177,13 @@ describe("MaintainerProxy", () => {
                 initialSpvMaintainerBalance
               )
 
-              expect(diff).to.be.gt(ethers.utils.parseUnits("-2000000", "gwei")) // -0,002 ETH
+              expect(diff).to.be.gt(0)
+              // The submitter deletes from `timedOutRedemptions` mapping
+              // multiple times in this scenario. They will end up being more
+              // net-positive than in all other scenarios.
+              // Such a situation is quite unlikely to happen in practice.
               expect(diff).to.be.lt(
-                ethers.utils.parseUnits("2000000", "gwei") // 0,002 ETH
+                ethers.utils.parseUnits("10000000", "gwei") // 0,01 ETH
               )
             })
           }
@@ -1241,7 +1249,7 @@ describe("MaintainerProxy", () => {
 
               expect(diff).to.be.gt(0)
               expect(diff).to.be.lt(
-                ethers.utils.parseUnits("6000000", "gwei") // 0,006 ETH
+                ethers.utils.parseUnits("7000000", "gwei") // 0,007 ETH
               )
             })
           }
@@ -1301,7 +1309,7 @@ describe("MaintainerProxy", () => {
 
               expect(diff).to.be.gt(0)
               expect(diff).to.be.lt(
-                ethers.utils.parseUnits("5500000", "gwei") // 0,0055 ETH
+                ethers.utils.parseUnits("7000000", "gwei") // 0,007 ETH
               )
             })
           }


### PR DESCRIPTION
In `BridgeState` we used to say that:

> Timed out requests are stored in this mapping to avoid slashing the wallets multiple times for the same timeout.

This was not true, because when it comes to requesting redemption we say that:
> There is no need to check for existence in timedOutRedemptions since the  wallet's state is changed to other than Live after first time out is reported so making new requests is not possible.

And when the redemption timeout is reported we say that:
> It is worth noting that there is no need to check if timedOutRedemption mapping already contains the given redemption key. There is no possibility to re-use a key of a reported timed-out redemption because the wallet responsible for causing the timeout is moved to a state that prevents it to receive new redemption requests.

Given that the wallet lifecycle prevents the wallet from being slashed twice for the redemption timeout, we can delete an entry from `timedOutRedemptions` mapping when the timed-out redemption has been processed.

Redemption request is deleted from `pendingRedemptions` when it is processed. Pending redemption can be processed in two ways: it can be used in SPV proof and it can be marked as timed-out. Deleting `timedOutRedemptions` when it is processed is consistent with how `pendingRedemptions` are deleted and leaves no dangling state in the Bridge. A timed-out redemption in `timedOutRedemptions` can be processed in just one way: used in SPV proof.