### PR TITLE
Use `development` tag for `tbtc` dependency

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -33,7 +33,7 @@
     "@keep-network/bitcoin-spv-sol": "3.4.0-solc-0.8",
     "@keep-network/ecdsa": "development",
     "@keep-network/random-beacon": "development",
-    "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
+    "@keep-network/tbtc": "development",
     "@openzeppelin/contracts": "^4.6.0",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@tenderly/hardhat-tenderly": "^1.0.12",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1593,10 +1593,10 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc@>1.1.2-dev <1.1.2-pre":
-  version "1.1.2-dev.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-dev.0.tgz#52f61f6455406c2d3650d9f14cc3d734fe2addab"
-  integrity sha512-G/JbDht/IgdX8Ety0i0iUl+kB2J2ofiAmNw+HmN/YUN9BYFhhzQqltPtYjS/krBkWzBYmNJmZBFeX/h+q4EJvA==
+"@keep-network/tbtc@development":
+  version "1.1.2-dev.1"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-dev.1.tgz#dd1e734c0fed50474c74d7170c8749127231d1f9"
+  integrity sha512-IRa0j1D7JBG8UpduaFxkaq2Ii6F61HhNMUBmxr7kAIZwj/yx8sYXWi921mn0L2Z+hAYNcwEUVhCM91VKQH29pQ==
   dependencies:
     "@celo/contractkit" "^1.0.2"
     "@keep-network/keep-ecdsa" ">1.9.0-dev <1.9.0-ropsten"


### PR DESCRIPTION
The range that we had in `package.json` for `@keep-network/tbtc`
dependency was no longer containing the packages that we wanted. Since
we introduced `-goerli` suffixed packages, those packages were also
withing the range (and we want only `-dev` suffixed packages to be
within the range). Instead of using suffixes in the ranges we can also
use tags, which should be easier to maintain. So now we use
`development` tag, which should always point to the latest `tbtc`
package meant for development purposes.