### PR TITLE
Does not allow updating an existing allowance to a non-zero value

### DIFF
--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -109,17 +109,21 @@ contract Bank is Ownable {
     }
 
     /// @notice Sets `amount` as the allowance of `spender` over the caller's
-    ///         balance.
+    ///         balance. Does not allow updating an existing allowance to
+    ///         a value that is non-zero to avoid someone using both the old and
+    ///         the new allowance by unfortunate transaction ordering. To update
+    ///         an allowance to a non-zero value please set it to zero first or
+    ///         use `increaseBalanceAllowance` or `decreaseBalanceAllowance` for
+    ///         an atomic update.
     /// @dev If the `amount` is set to `type(uint256).max`,
     ///      `transferBalanceFrom` will not reduce an allowance.
-    ///      Beware that changing an allowance with this function brings the
-    ///      risk that someone may use both the old and the new allowance by
-    ///      unfortunate transaction ordering. Please use
-    ///      `increaseBalanceAllowance` and `decreaseBalanceAllowance` to
-    ///      eliminate the risk.
     /// @param spender The address that will be allowed to spend the balance.
     /// @param amount The amount the spender is allowed to spend.
     function approveBalance(address spender, uint256 amount) external {
+        require(
+            amount == 0 || allowance[msg.sender][spender] == 0,
+            "Non-atomic allowance change not allowed"
+        );
         _approveBalance(msg.sender, spender, amount);
     }
 

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -424,15 +424,33 @@ describe("Bank", () => {
       before(async () => {
         await createSnapshot()
         await bank.connect(owner).approveBalance(spender, to1e18(1337))
-        await bank.connect(owner).approveBalance(spender, amount)
       })
 
       after(async () => {
         await restoreSnapshot()
       })
 
-      it("should replace the previous allowance", async () => {
-        expect(await bank.allowance(owner.address, spender)).to.equal(amount)
+      context("when setting approval back to zero", () => {
+        before(async () => {
+          await createSnapshot()
+          await bank.connect(owner).approveBalance(spender, 0)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should replace the previous allowance with zero", async () => {
+          expect(await bank.allowance(owner.address, spender)).to.equal(0)
+        })
+      })
+
+      context("when trying to overwrite with a non-zero value", () => {
+        it("should revert", async () => {
+          await expect(
+            bank.connect(owner).approveBalance(spender, 1)
+          ).to.be.revertedWith("Non-atomic allowance change not allowed")
+        })
       })
     })
   })
@@ -644,6 +662,10 @@ describe("Bank", () => {
 
       before(async () => {
         await createSnapshot()
+        // the initial approval was done in the `before` setup for
+        // `transferBalanceFrom`'s describe; we need to set back to 0
+        // before approving again
+        await bank.connect(owner).approveBalance(spender.address, 0)
         await bank.connect(owner).approveBalance(spender.address, amount)
       })
 
@@ -778,6 +800,10 @@ describe("Bank", () => {
 
       before(async () => {
         await createSnapshot()
+        // the initial approval was done in the `before` setup for
+        // `transferBalanceFrom`'s describe; we need to set back to 0
+        // before approving again
+        await bank.connect(owner).approveBalance(spender.address, 0)
         await bank.connect(owner).approveBalance(spender.address, amount)
         await bank
           .connect(spender)
@@ -804,6 +830,10 @@ describe("Bank", () => {
 
       before(async () => {
         await createSnapshot()
+        // the initial approval was done in the `before` setup for
+        // `transferBalanceFrom`'s describe; we need to set back to 0
+        // before approving again
+        await bank.connect(owner).approveBalance(spender.address, 0)
         await bank.connect(owner).approveBalance(spender.address, allowance)
         await bank
           .connect(spender)

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -322,6 +322,9 @@ describe("TBTCVault", () => {
 
       before(async () => {
         await createSnapshot()
+        // the initial approval was done in the top-level `before` setup;
+        // we need to set back to 0 before approving again
+        await bank.connect(account1).approveBalance(vault.address, 0)
         await bank.connect(account1).approveBalance(vault.address, amount)
       })
 


### PR DESCRIPTION
Does not allow updating an existing allowance to a value that is non-zero to
avoid someone using both the old and the new allowance by unfortunate
transaction ordering. To update an allowance to a non-zero value one should
update to zero first or use `increaseBalanceAllowance` or
`decreaseBalanceAllowance` for an atomic update. We have been warning about this
case in `approveBalance` documentation, but we were not enforcing this behavior.
Now we have a `require` making sure the rule is obeyed.