### PR TITLE
EIP-2612 complicance fix: n/nonce/nonces

### DIFF
--- a/solidity/contracts/bank/Bank.sol
+++ b/solidity/contracts/bank/Bank.sol
@@ -43,7 +43,7 @@ contract Bank is Ownable {
     ///         provided balance owner to protect against replay attacks. Used
     ///         to construct an EIP2612 signature provided to the `permit`
     ///         function.
-    mapping(address => uint256) public nonce;
+    mapping(address => uint256) public nonces;
 
     uint256 public immutable cachedChainId;
     bytes32 public immutable cachedDomainSeparator;
@@ -277,7 +277,7 @@ contract Bank is Ownable {
                         owner,
                         spender,
                         amount,
-                        nonce[owner]++,
+                        nonces[owner]++,
                         deadline
                     )
                 )

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -892,7 +892,7 @@ describe("Bank", () => {
 
       const domainSeparator = await bank.DOMAIN_SEPARATOR()
       const permitTypehash = await bank.PERMIT_TYPEHASH()
-      const nonce = await bank.nonce(owner.address)
+      const nonce = await bank.nonces(owner.address)
 
       const approvalDigest = ethers.utils.keccak256(
         ethers.utils.solidityPack(
@@ -1107,8 +1107,8 @@ describe("Bank", () => {
       })
 
       it("should increment the nonce for the permitting owner", async () => {
-        expect(await bank.nonce(owner.address)).to.equal(1)
-        expect(await bank.nonce(spender)).to.equal(0)
+        expect(await bank.nonces(owner.address)).to.equal(1)
+        expect(await bank.nonces(spender)).to.equal(0)
       })
     })
 
@@ -1163,8 +1163,8 @@ describe("Bank", () => {
       })
 
       it("should increment the nonce for the permitting owner", async () => {
-        expect(await bank.nonce(owner.address)).to.equal(2)
-        expect(await bank.nonce(spender)).to.equal(0)
+        expect(await bank.nonces(owner.address)).to.equal(2)
+        expect(await bank.nonces(spender)).to.equal(0)
       })
     })
 


### PR DESCRIPTION
~~Depends on #404~~

The Bank smart contract implements EIP-2612 but used mapping `nonce` (singular)
instead of `nonces`. This might create an issue when third-party libraries
(that support EIP-2612) try to interact with the Bank and assume that nonces are
tracked with `nonces` instead of `nonce`. Fixed it by renaming `nonce` mapping
to `nonces`.