### PR TITLE
Warn about 32-bits timestamp representation limitation

### DIFF
--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -85,7 +85,7 @@ library Deposit {
         // Deposit amount in satoshi.
         uint64 amount;
         // UNIX timestamp the deposit was revealed at.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 revealedAt;
         // Address of the Bank vault the deposit is routed to.
         // Optional, can be 0x0.
@@ -95,7 +95,7 @@ library Deposit {
         // UNIX timestamp the deposit was swept at. Note this is not the
         // time when the deposit was swept on the Bitcoin chain but actually
         // the time when the sweep proof was delivered to the Ethereum chain.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 sweptAt;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -85,6 +85,7 @@ library Deposit {
         // Deposit amount in satoshi.
         uint64 amount;
         // UNIX timestamp the deposit was revealed at.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 revealedAt;
         // Address of the Bank vault the deposit is routed to.
         // Optional, can be 0x0.
@@ -94,6 +95,7 @@ library Deposit {
         // UNIX timestamp the deposit was swept at. Note this is not the
         // time when the deposit was swept on the Bitcoin chain but actually
         // the time when the sweep proof was delivered to the Ethereum chain.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 sweptAt;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -65,6 +65,7 @@ library Fraud {
         // The amount of ETH the challenger deposited.
         uint256 depositAmount;
         // The timestamp the challenge was submitted at.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 reportedAt;
         // The flag indicating whether the challenge has been resolved.
         bool resolved;

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -65,7 +65,7 @@ library Fraud {
         // The amount of ETH the challenger deposited.
         uint256 depositAmount;
         // The timestamp the challenge was submitted at.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 reportedAt;
         // The flag indicating whether the challenge has been resolved.
         bool resolved;

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -84,7 +84,7 @@ library MovingFunds {
         // Value of the received funds.
         uint64 value;
         // UNIX timestamp the request was created at.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 createdAt;
         // The current state of the request.
         MovedFundsSweepRequestState state;

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -84,6 +84,7 @@ library MovingFunds {
         // Value of the received funds.
         uint64 value;
         // UNIX timestamp the request was created at.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 createdAt;
         // The current state of the request.
         MovedFundsSweepRequestState state;

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -145,7 +145,7 @@ library Redemption {
         // creation.
         uint64 txMaxFee;
         // UNIX timestamp the request was created at.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 requestedAt;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -145,6 +145,7 @@ library Redemption {
         // creation.
         uint64 txMaxFee;
         // UNIX timestamp the request was created at.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 requestedAt;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -73,12 +73,15 @@ library Wallets {
         // that wallet.
         uint64 pendingRedemptionsValue;
         // UNIX timestamp the wallet was created at.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 createdAt;
         // UNIX timestamp indicating the moment the wallet was requested to
         // move their funds.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 movingFundsRequestedAt;
         // UNIX timestamp indicating the moment the wallet's closing period
         // started.
+        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
         uint32 closingStartedAt;
         // Total count of pending moved funds sweep requests targeting this wallet.
         uint32 pendingMovedFundsSweepRequestsCount;

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -73,15 +73,15 @@ library Wallets {
         // that wallet.
         uint64 pendingRedemptionsValue;
         // UNIX timestamp the wallet was created at.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 createdAt;
         // UNIX timestamp indicating the moment the wallet was requested to
         // move their funds.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 movingFundsRequestedAt;
         // UNIX timestamp indicating the moment the wallet's closing period
         // started.
-        // XXX: unsigned 32-bit integer unix seconds, will break around 2106
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 closingStartedAt;
         // Total count of pending moved funds sweep requests targeting this wallet.
         uint32 pendingMovedFundsSweepRequestsCount;


### PR DESCRIPTION
~~Depends on #405~~

The timestamp/locktime is represented using 32 bits for gas efficiency and to be consistent with Bitcoin.

This way, `OperatorRewards` structure in `Rewards` contract takes a single EVM word and the reward withdrawal consumes less gas. `DepositRequest` structure in `Deposit` library of the `Bridge` contract takes two EVM words and the operation revealing a deposit and the operation sweeping a deposit consume less gas. `Wallet` structure takes 4 EVM words and wallet lifecycle operations consume less gas.

`FraudChallenge`, `MovingFundsSweepRequest` ,`Redemtion` libraries of `Bridge` contract represent the timestamp as `uint32` for consistency with the rest of the code.

Note that Bitcoin represents the locktime using 32 bits as well: https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number

Added a comment to the code to make it clear the `uint32` representation is sufficient only until 2106. 