### PR TITLE
Use msg.sender directly to save on gas

### DIFF
--- a/solidity/contracts/vault/DonationVault.sol
+++ b/solidity/contracts/vault/DonationVault.sol
@@ -56,16 +56,14 @@ contract DonationVault is IVault {
     ///      - Donation Vault must have an allowance for caller's balance in
     ///        the Bank for at least `amount`.
     function donate(uint256 amount) external {
-        address donor = msg.sender;
-
         require(
-            bank.balanceOf(donor) >= amount,
+            bank.balanceOf(msg.sender) >= amount,
             "Amount exceeds balance in the bank"
         );
 
-        emit DonationReceived(donor, amount);
+        emit DonationReceived(msg.sender, amount);
 
-        bank.transferBalanceFrom(donor, address(this), amount);
+        bank.transferBalanceFrom(msg.sender, address(this), amount);
         bank.decreaseBalance(amount);
     }
 

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -91,13 +91,12 @@ contract TBTCVault is IVault, Ownable {
     ///      for at least `amount`.
     /// @param amount Amount of TBTC to mint.
     function mint(uint256 amount) external {
-        address minter = msg.sender;
         require(
-            bank.balanceOf(minter) >= amount,
+            bank.balanceOf(msg.sender) >= amount,
             "Amount exceeds balance in the bank"
         );
-        _mint(minter, amount);
-        bank.transferBalanceFrom(minter, address(this), amount);
+        _mint(msg.sender, amount);
+        bank.transferBalanceFrom(msg.sender, address(this), amount);
     }
 
     /// @notice Transfers the given `amount` of the Bank balance from the caller


### PR DESCRIPTION
Depends on #407

The memory variables were not needed. The caller reference is more cost-effective than load.

This change brings some small savings to the gas used.

Before/After (Min/Max/Avg):
```
|  DonationVault  ·  donate   ·     -  ·      -  ·  55068  │
|  DonationVault  ·  donate   ·     -  ·      -  ·  55034  │
|  TBTCVault      ·  mint     · 64283  · 120443  ·  93832  │
|  TBTCVault      ·  mint     · 64246  · 120406  ·  93795  │
```