### PR TITLE
Improve blinding factor explanation

### DIFF
--- a/docs/rfc/rfc-1.adoc
+++ b/docs/rfc/rfc-1.adoc
@@ -158,9 +158,9 @@ ELSE
 ENDIF
 ```
 
-Since each depositor has their own ethereum address and their own secret
-blinding factor (which is an additional security layer), each depositor's
-script will be unique, and the hash of each depositor's script will be unique.
+Since each depositor has their own ethereum address and their own blinding
+factor, each depositor's script will be unique, and the hash of each depositor's
+script will be unique.
 
 In order to unlock the funds, one must provide the unhashed script, (which
 means that they know the eth address and blinding factor), as well as an

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -42,7 +42,7 @@ import "./Wallets.sol";
 ///      ```
 ///
 ///      Since each depositor has their own Ethereum address and their own
-///      secret blinding factor, each depositor’s script is unique, and the hash
+///      blinding factor, each depositor’s script is unique, and the hash
 ///      of each depositor’s script is unique.
 library Deposit {
     using BTCUtils for bytes;
@@ -56,7 +56,8 @@ library Deposit {
         // Ethereum depositor address.
         address depositor;
         // The blinding factor as 8 bytes. Byte endianness doesn't matter
-        // as this factor is not interpreted as uint.
+        // as this factor is not interpreted as uint. The blinding factor allows
+        // to distinguish deposits from the same depositor.
         bytes8 blindingFactor;
         // The compressed Bitcoin public key (33 bytes and 02 or 03 prefix)
         // of the deposit's wallet hashed in the HASH160 Bitcoin opcode style.


### PR DESCRIPTION
During the course of the audit, auditors stated that if an attacker can operate a dedicated hardware device at 100 mh/s, he can explore a 64-bit space in ~200,000 days and guess someone's blinding factor.

It is worth noting the `blindingFactor` (64 bits) is not the only parameter that changes for every deposit: `refundLocktime` (32 bits) changes as a timestamp for every deposit, and walletPubKeyHash (160 bits) rotates according to the rules of an active wallet rotation.

All the mentioned values are a part of DepositRevealInfo so the space to explore is not 64-bit but 64+32=96 bits assuming the active wallet is known. The active wallet is rotating so there is a limited time to explore a 96-bit space and there is absolutely no financial incentive for anyone to do that as they gain nothing and make no harm to the depositor. They will pay gas for something the depositor intended to do anyway. The analogy is front-running someone to call a smart contract’s function that has the same effect no matter the caller. The blinding factor is used to distinguish deposits from the same depositor.

We improved the documentation to make it clear the blinding factor is not a security-critical parameter.