### PR TITLE
Fix command used in `deploy:test` script

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -16,7 +16,7 @@
     "clean": "hardhat clean && rm -rf cache/ export/ external/npm export.json",
     "build": "hardhat compile",
     "deploy": "hardhat deploy --export export.json",
-    "deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true npm run deploy",
+    "deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat deploy",
     "format": "npm run lint && prettier --check .",
     "format:fix": "npm run lint:fix && prettier --write .",
     "lint": "npm run lint:eslint && npm run lint:sol",


### PR DESCRIPTION
With `npm run deploy` used in the `deploy:test` script we were getting `Error
HH308: Unrecognized positional argument hardhat` error when running the script.

Similar change was done a while ago in `keep-core`: https://github.com/keep-network/keep-core/pull/3147.