### PR TITLE
Optimistic minting

### DIFF
--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -254,7 +254,9 @@ library DepositSweep {
         }
 
         // Pass the treasury fee to the treasury address.
-        self.bank.increaseBalance(self.treasury, totalTreasuryFee);
+        if (totalTreasuryFee > 0) {
+            self.bank.increaseBalance(self.treasury, totalTreasuryFee);
+        }
     }
 
     /// @notice Resolves sweeping wallet based on the provided wallet public key

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -626,7 +626,13 @@ library Redemption {
         emit RedemptionsCompleted(walletPubKeyHash, redemptionTxHash);
 
         self.bank.decreaseBalance(outputsInfo.totalBurnableValue);
-        self.bank.transferBalance(self.treasury, outputsInfo.totalTreasuryFee);
+
+        if (outputsInfo.totalTreasuryFee > 0) {
+            self.bank.transferBalance(
+                self.treasury,
+                outputsInfo.totalTreasuryFee
+            );
+        }
     }
 
     /// @notice Resolves redeeming wallet based on the provided wallet public

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -20,7 +20,7 @@ import "../bridge/Deposit.sol";
 
 abstract contract TBTCOptimisticMinting is Ownable {
     // TODO: make it governable?
-    uint256 public constant optimisticMintingDelay = 3 hours;
+    uint256 public constant OPTIMISTIC_MINTING_DELAY = 3 hours;
 
     Bridge public bridge;
 
@@ -112,10 +112,13 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
 
         uint256 requestedAt = pendingOptimisticMints[depositKey];
-        require(requestedAt != 0, "Optimistic minting not requested");
+        require(
+            requestedAt != 0,
+            "Optimistic minting not requested or already finalized"
+        );
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp - requestedAt > optimisticMintingDelay,
+            block.timestamp - requestedAt > OPTIMISTIC_MINTING_DELAY,
             "Optimistic minting delay has not passed yet"
         );
 
@@ -146,6 +149,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
         uint256 depositKey = calculateDepositKey(
             fundingTxHash,
             fundingOutputIndex
+        );
+
+        require(
+            pendingOptimisticMints[depositKey] > 0,
+            "Optimistic minting not requested of already finalized"
         );
 
         delete pendingOptimisticMints[depositKey];

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "../bridge/Bridge.sol";
+import "../bridge/Deposit.sol";
+
+abstract contract TBTCOptimisticMinting {
+
+    // TODO: make it governable?
+    uint256 public constant optimisticMintingDelay = 3 hours;
+
+    Bridge public bridge;
+
+    mapping(address => bool) public isMinter;
+    mapping(address => bool) public isWatchman;
+
+    mapping(uint256 => uint256) public pendingOptimisticMints;
+
+    mapping(address => uint256) public optimisticMintingDebt;
+
+    modifier onlyMinter() {
+        require(isMinter[msg.sender], "Caller is not a minter");
+        _;
+    }
+
+    modifier onlyWatchman() {
+        require(isWatchman[msg.sender], "Caller is not a watchman");
+        _;
+    }
+
+    constructor(Bridge _bridge) {
+        require(
+            address(_bridge) != address(0),
+            "Bridge can not be the zero address"
+        );
+
+        bridge = _bridge;
+    }
+
+    function _mint(address minter, uint256 amount) virtual internal;
+
+    function optimisticMint(uint256 depositKey) external onlyMinter {
+        Deposit.DepositRequest memory deposit = bridge.deposits(depositKey);
+
+        require(deposit.revealedAt != 0, "The deposit has not been revealed");
+        require(deposit.sweptAt == 0, "The deposit is already swept");
+        require(deposit.vault == address(this), "Unexpected vault address");
+
+        pendingOptimisticMints[depositKey] = block.timestamp;
+
+        // TODO: emit an event
+    }
+
+    function finalizeOptimisticMint(uint256 depositKey) external onlyMinter {
+        uint256 requestedAt = pendingOptimisticMints[depositKey];
+        require(requestedAt != 0, "Optimistic minting not requested");
+        require(
+            block.timestamp - requestedAt > optimisticMintingDelay,
+            "Optimistic minting delay has not passed yet"
+        );
+
+        Deposit.DepositRequest memory deposit = bridge.deposits(depositKey);
+        require(deposit.sweptAt == 0, "The deposit is already swept");
+
+        // TODO: deal with the minting fee
+        _mint(deposit.depositor, deposit.amount);
+        optimisticMintingDebt[deposit.depositor] += deposit.amount;
+
+        delete pendingOptimisticMints[depositKey];
+
+        // TODO: emit an event
+    }
+
+    // TODO: Is this function convenient enough to block minting at 3AM ?
+    //       Do we want to give watchment a chance to temporarily disable
+    //       finalizeOptimisticMint ?
+    function cancelOptimisticMint(uint256 depositKey) external onlyWatchman {
+        delete pendingOptimisticMints[depositKey];
+
+        // TODO: emit an event
+    }
+
+    function repayOptimisticMintDebt(address depositor, uint256 amount) internal returns (uint256) {
+        uint256 debt = optimisticMintingDebt[depositor];
+
+        if (amount > debt) {
+            optimisticMintingDebt[depositor] = 0;
+            return amount - debt;
+        } else {
+            optimisticMintingDebt[depositor] -= amount;
+            return 0;
+        }
+
+        // TODO: emit an event
+    }
+
+    // TODO: functions to manipulate the optimistic minter/watchmen set.
+}

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -37,6 +37,18 @@ abstract contract TBTCOptimisticMinting is Ownable {
         uint32 fundingOutputIndex,
         uint256 depositKey
     );
+    event OptimisticMintingFinalized(
+        address indexed minter,
+        bytes32 fundingTxHash,
+        uint32 fundingOutputIndex,
+        uint256 depositKey
+    );
+    event OptimisticMintingCancelled(
+        address indexed guard,
+        bytes32 fundingTxHash,
+        uint32 fundingOutputIndex,
+        uint256 depositKey
+    );
     event MinterAdded(address indexed minter);
     event MinterRemoved(address indexed minter);
     event GuardAdded(address indexed guard);
@@ -116,7 +128,12 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         delete pendingOptimisticMints[depositKey];
 
-        // TODO: emit an event
+        emit OptimisticMintingFinalized(
+            msg.sender,
+            fundingTxHash,
+            fundingOutputIndex,
+            depositKey
+        );
     }
 
     // TODO: Is this function convenient enough to block minting at 3AM ?
@@ -130,9 +147,15 @@ abstract contract TBTCOptimisticMinting is Ownable {
             fundingTxHash,
             fundingOutputIndex
         );
+
         delete pendingOptimisticMints[depositKey];
 
-        // TODO: emit an event
+        emit OptimisticMintingCancelled(
+            msg.sender,
+            fundingTxHash,
+            fundingOutputIndex,
+            depositKey
+        );
     }
 
     function addMinter(address minter) external onlyOwner {

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -98,6 +98,14 @@ abstract contract TBTCOptimisticMinting is Ownable {
         _;
     }
 
+    modifier onlyOwnerOrGuardian() {
+        require(
+            owner() == msg.sender || isGuardian[msg.sender],
+            "Caller is not the owner or guardian"
+        );
+        _;
+    }
+
     constructor(Bridge _bridge) {
         require(
             address(_bridge) != address(0),
@@ -265,9 +273,6 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
     }
 
-    // TODO: Find a convenient way for a Guardian to block minting at 3AM and
-    //       deal with an errant Minter.
-
     /// @notice Adds the address to the Minter set.
     function addMinter(address minter) external onlyOwner {
         require(!isMinter[minter], "This address is already a minter");
@@ -276,7 +281,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     }
 
     /// @notice Removes the address from the Minter set.
-    function removeMinter(address minter) external onlyOwner {
+    function removeMinter(address minter) external onlyOwnerOrGuardian {
         require(isMinter[minter], "This address is not a minter");
         delete isMinter[minter];
         emit MinterRemoved(minter);

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -58,12 +58,13 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         optimistically minted deposit and transferred to the treasury
     ///         upon finalization of the optimistic mint. This fee is computed
     ///         as follows: `fee = amount / optimisticMintingFeeDivisor`.
-    ///         For example, if the fee needs to be 2% of each deposit,
-    ///         the `optimisticMintingFeeDivisor` should be set to `50` because
+    ///         For example, if the fee needs to be 2%, the
+    ///         `optimisticMintingFeeDivisor` should be set to `50` because
     ///         `1/50 = 0.02 = 2%`.
-    ///         Note that the optimistic minting fee does not replace the
-    ///         deposit treasury fee cut by the Bridge. Both fees are deducted
-    ///         from the minted token amount.
+    ///         The optimistic minting fee does not replace the deposit treasury
+    ///         fee cut by the Bridge. The optimistic fee is a percentage AFTER
+    ///         the treasury fee is cut:
+    ///         `optimisticMintingFee = (depositAmount - treasuryFee) / optimisticMintingFeeDivisor`
     uint32 public optimisticMintingFeeDivisor;
 
     /// @notice The time that needs to pass between the moment the optimistic
@@ -99,7 +100,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         not.
     mapping(address => uint256) public optimisticMintingDebt;
 
-    /// @notice New optimistic minting fee deivisor value. Set only when the
+    /// @notice New optimistic minting fee divisor value. Set only when the
     ///         parameter update process is pending. Once the update gets
     //          finalized, this will be the value of the divisor.
     uint32 public newOptimisticMintingFeeDivisor;

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -370,8 +370,6 @@ abstract contract TBTCOptimisticMinting is Ownable {
             return 0;
         }
 
-        // TODO: emit an event
-
-        // TODO: cover with unit tests
+        // TODO: emit an event ?
     }
 }

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -79,25 +79,25 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
     event OptimisticMintingRequested(
         address indexed minter,
-        address depositor,
+        uint256 indexed depositKey,
+        address indexed depositor,
         uint256 amount,
         bytes32 fundingTxHash,
-        uint32 fundingOutputIndex,
-        uint256 depositKey
+        uint32 fundingOutputIndex
     );
     event OptimisticMintingFinalized(
         address indexed minter,
-        address depositor,
+        uint256 indexed depositKey,
+        address indexed depositor,
         uint256 amount,
         bytes32 fundingTxHash,
-        uint32 fundingOutputIndex,
-        uint256 depositKey
+        uint32 fundingOutputIndex
     );
     event OptimisticMintingCancelled(
         address indexed guardian,
+        uint256 indexed depositKey,
         bytes32 fundingTxHash,
-        uint32 fundingOutputIndex,
-        uint256 depositKey
+        uint32 fundingOutputIndex
     );
     event MinterAdded(address indexed minter);
     event MinterRemoved(address indexed minter);
@@ -199,11 +199,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         emit OptimisticMintingRequested(
             msg.sender,
+            depositKey,
             deposit.depositor,
             deposit.amount,
             fundingTxHash,
-            fundingOutputIndex,
-            depositKey
+            fundingOutputIndex
         );
     }
 
@@ -272,11 +272,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         emit OptimisticMintingFinalized(
             msg.sender,
+            depositKey,
             deposit.depositor,
             amountToMint,
             fundingTxHash,
-            fundingOutputIndex,
-            depositKey
+            fundingOutputIndex
         );
     }
 
@@ -322,9 +322,9 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         emit OptimisticMintingCancelled(
             msg.sender,
+            depositKey,
             fundingTxHash,
-            fundingOutputIndex,
-            depositKey
+            fundingOutputIndex
         );
     }
 

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -245,7 +245,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp - request.requestedAt > OPTIMISTIC_MINTING_DELAY,
+            block.timestamp > request.requestedAt + OPTIMISTIC_MINTING_DELAY,
             "Optimistic minting delay has not passed yet"
         );
 
@@ -317,7 +317,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
 
         // Delete it. It allows to request optimistic minting for the given
-        // deposit again. Useful in case of an errant Guarian.
+        // deposit again. Useful in case of an errant Guardian.
         delete optimisticMintingRequests[depositKey];
 
         emit OptimisticMintingCancelled(

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -356,7 +356,12 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         sweeps a deposit, the debt is fully or partially paid off, no
     ///         matter if that particular deposit was used for the optimistic
     ///         minting or not.
-    function repayOptimisticMintDebt(address depositor, uint256 amount)
+    /// @dev See TBTCVault.receiveBalanceIncrease
+    /// @param depositor The depositor whose balance increase is received.
+    /// @param amount The balance increase amount for the depositor received.
+    /// @return The TBTC amount that should be minted after paying off the
+    ///         optimistic minting debt.
+    function repayOptimisticMintingDebt(address depositor, uint256 amount)
         internal
         returns (uint256)
     {

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -31,6 +31,10 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
     mapping(address => uint256) public optimisticMintingDebt;
 
+    event OptimisticMintingRequested(
+        address indexed minter,
+        uint256 depositKey
+    );
     event MinterAdded(address indexed minter);
     event MinterRemoved(address indexed minter);
     event GuardAdded(address indexed guard);
@@ -60,6 +64,8 @@ abstract contract TBTCOptimisticMinting is Ownable {
     function optimisticMint(uint256 depositKey) external onlyMinter {
         Deposit.DepositRequest memory deposit = bridge.deposits(depositKey);
 
+        // TODO: validate when it was revealed?
+
         require(deposit.revealedAt != 0, "The deposit has not been revealed");
         require(deposit.sweptAt == 0, "The deposit is already swept");
         require(deposit.vault == address(this), "Unexpected vault address");
@@ -67,7 +73,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
         /* solhint-disable-next-line not-rely-on-time */
         pendingOptimisticMints[depositKey] = block.timestamp;
 
-        // TODO: emit an event
+        emit OptimisticMintingRequested(msg.sender, depositKey);
     }
 
     function finalizeOptimisticMint(uint256 depositKey) external onlyMinter {

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -24,10 +24,10 @@ import "../GovernanceUtils.sol";
 ///         `TBTCVault` receives the Bank balance. There are two permissioned
 ///         sets in the system: Minters and Guardians, both set up in 1-of-n
 ///         mode. Minters observe the revealed deposits and request minting TBTC.
-///         Any single Minter can perform this action. There is a 3 hours delay
-///         between the time of the request from a Minter to the time TBTC is
-///         minted. During the time of the delay, any Guardian can cancel the
-///         minting.
+///         Any single Minter can perform this action. There is an
+///         `optimisticMintingDelay` between the time of the request from
+///         a Minter to the time TBTC is minted. During the time of the delay,
+///         any Guardian can cancel the minting.
 /// @dev This functionality is a part of `TBTCVault`. It is implemented in
 ///      a separate abstract contract to achieve better separation of concerns
 ///      and easier-to-follow code.
@@ -280,8 +280,8 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///           been canceled by a Guardian.
     ///         - The optimistic minting is not paused.
     ///         This function mints TBTC and increases `optimisticMintingDebt`
-    ///         for the given depositor. The finalized optimistic minting
-    ///         request is removed from the contract.
+    ///         for the given depositor. The optimistic minting request is
+    ///         marked as finalized.
     function finalizeOptimisticMint(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -64,12 +64,12 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         Note that the optimistic minting fee does not replace the
     ///         deposit treasury fee cut by the Bridge. Both fees are deducted
     ///         from the minted token amount.
-    uint256 public optimisticMintingFeeDivisor;
+    uint32 public optimisticMintingFeeDivisor;
 
     /// @notice The time that needs to pass between the moment the optimistic
     ///         minting is requested and the moment optimistic minting is
     ///         finalized with minting TBTC.
-    uint256 public optimisticMintingDelay = 3 hours;
+    uint32 public optimisticMintingDelay = 3 hours;
 
     /// @notice Indicates if the given address is a Minter. Only Minters can
     ///         request optimistic minting.
@@ -97,7 +97,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     /// @notice New optimistic minting fee deivisor value. Set only when the
     ///         parameter update process is pending. Once the update gets
     //          finalized, this will be the value of the divisor.
-    uint256 public newOptimisticMintingFeeDivisor;
+    uint32 public newOptimisticMintingFeeDivisor;
     /// @notice The timestamp at which the update of the optimistic minting fee
     ///         divisor started. Zero if update is not in progress.
     uint256 public optimisticMintingFeeUpdateInitiatedTimestamp;
@@ -105,7 +105,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     /// @notice New optimistic minting delay value. Set only when the parameter
     ///         update process is pending. Once the update gets finalized, this
     //          will be the value of the delay.
-    uint256 public newOptimisticMintingDelay;
+    uint32 public newOptimisticMintingDelay;
     /// @notice The timestamp at which the update of the optimistic minting
     ///         delay started. Zero if update is not in progress.
     uint256 public optimisticMintingDelayUpdateInitiatedTimestamp;
@@ -120,17 +120,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
     );
     event OptimisticMintingFinalized(
         address indexed minter,
-        uint256 indexed depositKey,
-        address indexed depositor,
-        uint256 amount,
-        bytes32 fundingTxHash,
-        uint32 fundingOutputIndex
+        uint256 indexed depositKey
     );
     event OptimisticMintingCancelled(
         address indexed guardian,
-        uint256 indexed depositKey,
-        bytes32 fundingTxHash,
-        uint32 fundingOutputIndex
+        uint256 indexed depositKey
     );
     event MinterAdded(address indexed minter);
     event MinterRemoved(address indexed minter);
@@ -140,14 +134,12 @@ abstract contract TBTCOptimisticMinting is Ownable {
     event OptimisticMintingUnpaused();
 
     event OptimisticMintingFeeUpdateStarted(
-        uint256 newOptimisticMintingFeeDivisor
+        uint32 newOptimisticMintingFeeDivisor
     );
-    event OptimisticMintingFeeUpdated(uint256 newOptimisticMintingFeeDivisor);
+    event OptimisticMintingFeeUpdated(uint32 newOptimisticMintingFeeDivisor);
 
-    event OptimisticMintingDelayUpdateStarted(
-        uint256 newOptimisticMintingDelay
-    );
-    event OptimisticMintingDelayUpdated(uint256 newOptimisticMintingDelay);
+    event OptimisticMintingDelayUpdateStarted(uint32 newOptimisticMintingDelay);
+    event OptimisticMintingDelayUpdated(uint32 newOptimisticMintingDelay);
 
     modifier onlyMinter() {
         require(isMinter[msg.sender], "Caller is not a minter");
@@ -337,14 +329,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
         /* solhint-disable-next-line not-rely-on-time */
         request.finalizedAt = uint64(block.timestamp);
 
-        emit OptimisticMintingFinalized(
-            msg.sender,
-            depositKey,
-            deposit.depositor,
-            amountToMint,
-            fundingTxHash,
-            fundingOutputIndex
-        );
+        emit OptimisticMintingFinalized(msg.sender, depositKey);
     }
 
     /// @notice Allows a Guardian to cancel optimistic minting request. The
@@ -387,12 +372,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
         // deposit again. Useful in case of an errant Guardian.
         delete optimisticMintingRequests[depositKey];
 
-        emit OptimisticMintingCancelled(
-            msg.sender,
-            depositKey,
-            fundingTxHash,
-            fundingOutputIndex
-        );
+        emit OptimisticMintingCancelled(msg.sender, depositKey);
     }
 
     /// @notice Adds the address to the Minter set.
@@ -450,7 +430,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         `1/50 = 0.02 = 2%`.
     /// @dev See the documentation for optimisticMintingFeeDivisor.
     function beginOptimisticMintingFeeUpdate(
-        uint256 _newOptimisticMintingFeeDivisor
+        uint32 _newOptimisticMintingFeeDivisor
     ) external onlyOwner {
         /* solhint-disable-next-line not-rely-on-time */
         optimisticMintingFeeUpdateInitiatedTimestamp = block.timestamp;
@@ -473,7 +453,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
     /// @notice Begins the process of updating optimistic minting delay.
     function beginOptimisticMintingDelayUpdate(
-        uint256 _newOptimisticMintingDelay
+        uint32 _newOptimisticMintingDelay
     ) external onlyOwner {
         /* solhint-disable-next-line not-rely-on-time */
         optimisticMintingDelayUpdateInitiatedTimestamp = block.timestamp;

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -18,17 +18,47 @@ pragma solidity 0.8.17;
 import "../bridge/Bridge.sol";
 import "../bridge/Deposit.sol";
 
+/// @title TBTC Optimistic Minting
+/// @notice The Optimistic Minting mechanism allows to mint TBTC before
+///         TBTCVault receives the Bank balance. There are two permissioned sets
+///         in the system: Minters and Guards, both set up in 1-of-n mode.
+///         Minters observe the revealed deposits and request minting TBTC.
+///         Any single Minter can perform this action. There is a 3 hours delay
+///         between the time of the request from a Minter to the time TBTC is
+///         minted. During the time of the delay, any Guard can cancel the
+///         minting.
+/// @dev This functionality is a part of TBTCVault. It is implemented in
+///      a separate abstract contract to achieve better separation of concerns
+///      and easier-to-follow code.
 abstract contract TBTCOptimisticMinting is Ownable {
-    // TODO: make it governable?
+    /// @notice The time that needs to pass between the moment the optimistic
+    ///         minting is requested and the moment optimistic minting is
+    ///         finalized with minting TBTC.
     uint256 public constant OPTIMISTIC_MINTING_DELAY = 3 hours;
 
     Bridge public bridge;
 
+    /// @notice Indicates if the given address is a minter. Only minters can
+    ///         request optimistic minting.
     mapping(address => bool) public isMinter;
+
+    /// @notice Indicates if the given address is a guard. Only guards can
+    ///         cancel requested optimistic minting.
     mapping(address => bool) public isGuard;
 
+    /// @notice Collection of all revealed deposits for which the optimistic
+    ///         minting was requested. Indexed by a deposit key computed as
+    ///         keccak256(fundingTxHash | fundingOutputIndex). The value is
+    ///         a UNIX timestamp at which the optimistic minting was requested.
     mapping(uint256 => uint256) public pendingOptimisticMints;
 
+    /// @notice Optimistic minting debt value per depositor's address. The debt
+    ///         represents the total value of all depositor's deposits revealed
+    ///         to the Bridge that has not been yet swept and led to the
+    ///         optimistic minting of TBTC. When TBTCVault sweeps a deposit,
+    ///         the debt is fully or partially paid off, no matter if that
+    ///         particular swept deposit was used for the optimistic minting or
+    ///         not.
     mapping(address => uint256) public optimisticMintingDebt;
 
     event OptimisticMintingRequested(
@@ -77,8 +107,19 @@ abstract contract TBTCOptimisticMinting is Ownable {
         bridge = _bridge;
     }
 
+    /// @dev Mints the given amount of TBTC to the given depositor's address.
+    ///      Implemented by TBTCVault.
     function _mint(address minter, uint256 amount) internal virtual;
 
+    /// @notice Allows a minter to request for an optimistic minting of TBTC.
+    ///         The following conditions must be met:
+    ///         - The deposit with the given Bitcoin funding transaction hash
+    ///           and output index has been revealed to the Bridge.
+    ///         - The deposit has not been swept yet.
+    ///         - The deposit is targeted into the TBTCVault.
+    ///         After calling this function, the minter has to wait for
+    ///         OPTIMISTIC_MINTING_DELAY before finalizing the mint with a call
+    ///         to finalizeOptimisticMint.
     function optimisticMint(bytes32 fundingTxHash, uint32 fundingOutputIndex)
         external
         onlyMinter
@@ -89,7 +130,13 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
         Deposit.DepositRequest memory deposit = bridge.deposits(depositKey);
 
-        // TODO: validate when it was revealed?
+        // TODO: Validate when it was revealed. The deposit must be revealed
+        //       early enough to the Bridge to pass the Bridge's validation.
+        //       It may happen that none of the Minters request for an
+        //       optimistic mint of a deposit early and one of them do it just
+        //       before the Bitcoin refund unlocks. It should not be possible
+        //       to request an optimistic mint for such a deposit because
+        //       there is no guarantee the wallet will be able to sweep it.
 
         require(deposit.revealedAt != 0, "The deposit has not been revealed");
         require(deposit.sweptAt == 0, "The deposit is already swept");
@@ -108,6 +155,20 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
     }
 
+    /// @notice Allows a minter to finalize previously requested optimistic
+    ///         minting. The following conditions must be met:
+    ///         - The optimistic minting has been requested for the given
+    ///           deposit.
+    ///         - The deposit has not been swept yet.
+    ///         - At least OPTIMISTIC_MINTING_DELAY passed since the optimistic
+    ///           minting was requested for the given deposit.
+    ///         - The optimistic minting has not been finalized earlier for the
+    ///           given deposit.
+    ///         - The optimistic minting request for the given deposit has not
+    ///           been canceled by a guard.
+    ///         This function mints TBTC and increases pendingOptimisticMints
+    ///         for the given depositor. The finalized optimistic minting
+    ///         request is removed from the contract.
     function finalizeOptimisticMint(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex
@@ -131,7 +192,14 @@ abstract contract TBTCOptimisticMinting is Ownable {
         Deposit.DepositRequest memory deposit = bridge.deposits(depositKey);
         require(deposit.sweptAt == 0, "The deposit is already swept");
 
-        // TODO: deal with the minting fee
+        // TODO: Deal with the minting fee. Right now we mint amount of TBTC
+        //       equal to the output value of the Bitcoin deposit transaction.
+        //       Bridge, when sweeping, will cut a sweeping fee and Bitcoin TX
+        //       fee. If we do not take it into account here, we will create
+        //       an imbalance in the system. Worth noting that even if we do not
+        //       decide to cut fees here, it is possible to fix this imbalance
+        //       later by a donation to the Bridge (see DonationVault).
+
         _mint(deposit.depositor, deposit.amount);
         optimisticMintingDebt[deposit.depositor] += deposit.amount;
 
@@ -147,9 +215,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
     }
 
-    // TODO: Is this function convenient enough to block minting at 3AM ?
-    //       Do we want to give watchment a chance to temporarily disable
-    //       finalizeOptimisticMint ?
+    /// @notice Allows a guard to cancel optimistic minting request. The
+    ///         following conditions must be met:
+    ///         - The optimistic minting request for the given deposit exists.
+    ///         - The optimistic minting request for the given deposit has not
+    ///           been finalized yet.
     function cancelOptimisticMint(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex
@@ -174,30 +244,40 @@ abstract contract TBTCOptimisticMinting is Ownable {
         );
     }
 
+    // TODO: Find a convenient way for a guard to block minting at 3AM and deal
+    //       with an errant minter.
+
+    /// @notice Adds the address to the minter set.
     function addMinter(address minter) external onlyOwner {
         require(!isMinter[minter], "This address is already a minter");
         isMinter[minter] = true;
         emit MinterAdded(minter);
     }
 
+    /// @notice Removes the address from the minter set.
     function removeMinter(address minter) external onlyOwner {
         require(isMinter[minter], "This address is not a minter");
         delete isMinter[minter];
         emit MinterRemoved(minter);
     }
 
+    /// @notice Adds the address to the guard set.
     function addGuard(address guard) external onlyOwner {
         require(!isGuard[guard], "This address is already a guard");
         isGuard[guard] = true;
         emit GuardAdded(guard);
     }
 
+    /// @notice Removes the address from the guard set.
     function removeGuard(address guard) external onlyOwner {
         require(isGuard[guard], "This address is not a guard");
         delete isGuard[guard];
         emit GuardRemoved(guard);
     }
 
+    /// @notice Calculates deposit key the same way as the Bridge contract.
+    ///         The deposit key is computed as
+    ///         keccak256(fundingTxHash | fundingOutputIndex).
     function calculateDepositKey(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex
@@ -208,6 +288,13 @@ abstract contract TBTCOptimisticMinting is Ownable {
             );
     }
 
+    /// @notice Used by TBTCVault.receiveBalanceIncrease to repay the optimistic
+    ///         minting debt before TBTC is minted. When optimistic minting is
+    ///         finalized, debt equal to the value of the deposit being
+    ///         a subject of the optimistic minting is incurred. When TBTCVault
+    ///         sweeps a deposit, the debt is fully or partially paid off, no
+    ///         matter if that particular deposit was used for the optimistic
+    ///         minting or not.
     function repayOptimisticMintDebt(address depositor, uint256 amount)
         internal
         returns (uint256)
@@ -223,5 +310,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
         }
 
         // TODO: emit an event
+
+        // TODO: cover with unit tests
     }
 }

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -500,7 +500,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     function calculateDepositKey(
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex
-    ) public view returns (uint256) {
+    ) public pure returns (uint256) {
         return
             uint256(
                 keccak256(abi.encodePacked(fundingTxHash, fundingOutputIndex))

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -171,11 +171,10 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///      Bitcoin, that the script hash has the expected format, and that the
     ///      wallet is an active one so they can also validate the time left for
     ///      the refund.
-    function optimisticMint(bytes32 fundingTxHash, uint32 fundingOutputIndex)
-        external
-        onlyMinter
-        whenOptimisticMintingNotPaused
-    {
+    function requestOptimisticMint(
+        bytes32 fundingTxHash,
+        uint32 fundingOutputIndex
+    ) external onlyMinter whenOptimisticMintingNotPaused {
         uint256 depositKey = calculateDepositKey(
             fundingTxHash,
             fundingOutputIndex
@@ -220,7 +219,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
     ///         - The optimistic minting request for the given deposit has not
     ///           been canceled by a Guardian.
     ///         - The optimistic minting is not paused.
-    ///         This function mints TBTC and increases pendingOptimisticMints
+    ///         This function mints TBTC and increases optimisticMintingDebt
     ///         for the given depositor. The finalized optimistic minting
     ///         request is removed from the contract.
     function finalizeOptimisticMint(

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -33,12 +33,16 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
     event OptimisticMintingRequested(
         address indexed minter,
+        address depositor,
+        uint256 amount,
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex,
         uint256 depositKey
     );
     event OptimisticMintingFinalized(
         address indexed minter,
+        address depositor,
+        uint256 amount,
         bytes32 fundingTxHash,
         uint32 fundingOutputIndex,
         uint256 depositKey
@@ -96,6 +100,8 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         emit OptimisticMintingRequested(
             msg.sender,
+            deposit.depositor,
+            deposit.amount,
             fundingTxHash,
             fundingOutputIndex,
             depositKey
@@ -133,6 +139,8 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         emit OptimisticMintingFinalized(
             msg.sender,
+            deposit.depositor,
+            deposit.amount,
             fundingTxHash,
             fundingOutputIndex,
             depositKey

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -276,7 +276,7 @@ abstract contract TBTCOptimisticMinting is Ownable {
 
         require(
             pendingOptimisticMints[depositKey] > 0,
-            "Optimistic minting not requested of already finalized"
+            "Optimistic minting not requested or already finalized"
         );
 
         delete pendingOptimisticMints[depositKey];

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -136,7 +136,7 @@ contract TBTCVault is IVault, Ownable, TBTCOptimisticMinting {
         for (uint256 i = 0; i < depositors.length; i++) {
             address depositor = depositors[i];
             uint256 amount = depositedAmounts[i];
-            _mint(depositor, repayOptimisticMintDebt(depositor, amount));
+            _mint(depositor, repayOptimisticMintingDebt(depositor, amount));
         }
     }
 

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -306,6 +306,6 @@ contract TBTCVault is IVault, Ownable, TBTCOptimisticMinting {
     ) internal {
         emit Unminted(redeemer, amount);
         tbtcToken.burnFrom(redeemer, amount);
-        bank.approveBalanceAndCall(bank.bridge(), amount, redemptionData);
+        bank.approveBalanceAndCall(address(bridge), amount, redemptionData);
     }
 }

--- a/solidity/contracts/vault/TBTCVault.sol
+++ b/solidity/contracts/vault/TBTCVault.sol
@@ -71,7 +71,11 @@ contract TBTCVault is IVault, Ownable, TBTCOptimisticMinting {
         _;
     }
 
-    constructor(Bank _bank, TBTC _tbtcToken, Bridge _bridge) TBTCOptimisticMinting(_bridge) {
+    constructor(
+        Bank _bank,
+        TBTC _tbtcToken,
+        Bridge _bridge
+    ) TBTCOptimisticMinting(_bridge) {
         require(
             address(_bank) != address(0),
             "Bank can not be the zero address"
@@ -284,7 +288,7 @@ contract TBTCVault is IVault, Ownable, TBTCOptimisticMinting {
     }
 
     // slither-disable-next-line calls-loop
-    function _mint(address minter, uint256 amount) override internal {
+    function _mint(address minter, uint256 amount) internal override {
         emit Minted(minter, amount);
         tbtcToken.mint(minter, amount);
     }

--- a/solidity/deploy/06_deploy_tbtc_vault.ts
+++ b/solidity/deploy/06_deploy_tbtc_vault.ts
@@ -8,11 +8,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const Bank = await deployments.get("Bank")
   const TBTC = await deployments.get("TBTC")
+  const Bridge = await deployments.get("Bridge")
 
   const TBTCVault = await deploy("TBTCVault", {
     contract: "TBTCVault",
     from: deployer,
-    args: [Bank.address, TBTC.address],
+    args: [Bank.address, TBTC.address, Bridge.address],
     log: true,
     waitConfirmations: 1,
   })

--- a/solidity/test/bank/Bank.test.ts
+++ b/solidity/test/bank/Bank.test.ts
@@ -1411,7 +1411,7 @@ describe("Bank", () => {
       await tbtc.deployed()
 
       const Vault = await ethers.getContractFactory("TBTCVault")
-      vault = await Vault.deploy(bank.address, tbtc.address)
+      vault = await Vault.deploy(bank.address, tbtc.address, bridge.address)
       await vault.deployed()
 
       await tbtc.connect(deployer).transferOwnership(vault.address)

--- a/solidity/test/data/deposit-sweep.ts
+++ b/solidity/test/data/deposit-sweep.ts
@@ -118,7 +118,7 @@ export const SingleP2SHDeposit: DepositSweepTestData = {
       },
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x934b98637ca318a4d6e7ca6ffd1690b8e77df637",
+        depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         blindingFactor: "0xf9f0c90d00039523",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -1,0 +1,235 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import { expect } from "chai"
+import { ContractTransaction } from "ethers"
+
+import bridgeFixture from "../fixtures/bridge"
+
+import type { Bridge, BridgeStub, TBTCVault } from "../../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("TBTCVault - OptimisticMinting", () => {
+  let bridge: Bridge & BridgeStub
+  let tbtcVault: TBTCVault
+
+  let governance: SignerWithAddress
+
+  let account1: SignerWithAddress
+  let account2: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ governance, bridge, tbtcVault } = await waffle.loadFixture(
+      bridgeFixture
+    ))
+
+    const accounts = await getUnnamedAccounts()
+    account1 = await ethers.getSigner(accounts[0])
+    account2 = await ethers.getSigner(accounts[1])
+  })
+
+  describe("addMinter", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).addMinter(account1.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is not a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await tbtcVault.connect(governance).addMinter(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add address as a minter", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isMinter(account1.address)).to.be.true
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "MinterAdded")
+            .withArgs(account1.address)
+        })
+      })
+
+      context("when address is a minter", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addMinter(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).addMinter(account1.address)
+          ).to.be.revertedWith("This address is already a minter")
+        })
+      })
+    })
+  })
+
+  describe("removeMinter", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).removeMinter(account1.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addMinter(account1.address)
+          tx = await tbtcVault
+            .connect(governance)
+            .removeMinter(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take minter role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isMinter(account1.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "MinterRemoved")
+            .withArgs(account1.address)
+        })
+      })
+
+      context("when address is not a minter", () => {
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).removeMinter(account1.address)
+          ).to.be.revertedWith("This address is not a minter")
+        })
+      })
+    })
+  })
+
+  describe("addGuard", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).addGuard(account1.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is not a guard", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await tbtcVault.connect(governance).addGuard(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add address as a guard", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isGuard(account1.address)).to.be.true
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "GuardAdded")
+            .withArgs(account1.address)
+        })
+      })
+
+      context("when address is a guard", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addGuard(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).addGuard(account1.address)
+          ).to.be.revertedWith("This address is already a guard")
+        })
+      })
+    })
+  })
+
+  describe("removeGuard", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).removeGuard(account1.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is a guard", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addGuard(account1.address)
+          tx = await tbtcVault.connect(governance).removeGuard(account1.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take guard role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isGuard(account1.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "GuardRemoved")
+            .withArgs(account1.address)
+        })
+      })
+
+      context("when address is not a guard", () => {
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).removeGuard(account1.address)
+          ).to.be.revertedWith("This address is not a guard")
+        })
+      })
+    })
+  })
+})

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -33,7 +33,7 @@ describe("TBTCVault - OptimisticMinting", () => {
   let spvMaintainer: SignerWithAddress
 
   let minter: SignerWithAddress
-  let guard: SignerWithAddress
+  let guardian: SignerWithAddress
   let thirdParty: SignerWithAddress
 
   // used by bridge.revealDeposit(fundingTx, depositRevealInfo)
@@ -55,7 +55,7 @@ describe("TBTCVault - OptimisticMinting", () => {
   before(async () => {
     const accounts = await getUnnamedAccounts()
     minter = await ethers.getSigner(accounts[0])
-    guard = await ethers.getSigner(accounts[1])
+    guardian = await ethers.getSigner(accounts[1])
     thirdParty = await ethers.getSigner(accounts[2])
 
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -245,46 +245,46 @@ describe("TBTCVault - OptimisticMinting", () => {
     })
   })
 
-  describe("addGuard", () => {
+  describe("addGuardian", () => {
     context("when called not by the governance", () => {
       it("should revert", async () => {
         await expect(
-          tbtcVault.connect(guard).addGuard(guard.address)
+          tbtcVault.connect(guardian).addGuardian(guardian.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
 
     context("when called by the governance", () => {
-      context("when address is not a guard", () => {
+      context("when address is not a guardian", () => {
         let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
 
-          tx = await tbtcVault.connect(governance).addGuard(guard.address)
+          tx = await tbtcVault.connect(governance).addGuardian(guardian.address)
         })
 
         after(async () => {
           await restoreSnapshot()
         })
 
-        it("should add address as a guard", async () => {
+        it("should add address as a guardian", async () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isGuard(guard.address)).to.be.true
+          expect(await tbtcVault.isGuardian(guardian.address)).to.be.true
         })
 
         it("should emit an event", async () => {
           await expect(tx)
-            .to.emit(tbtcVault, "GuardAdded")
-            .withArgs(guard.address)
+            .to.emit(tbtcVault, "GuardianAdded")
+            .withArgs(guardian.address)
         })
       })
 
-      context("when address is a guard", () => {
+      context("when address is a guardian", () => {
         before(async () => {
           await createSnapshot()
 
-          await tbtcVault.connect(governance).addGuard(guard.address)
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
         })
 
         after(async () => {
@@ -293,54 +293,54 @@ describe("TBTCVault - OptimisticMinting", () => {
 
         it("should revert", async () => {
           await expect(
-            tbtcVault.connect(governance).addGuard(guard.address)
-          ).to.be.revertedWith("This address is already a guard")
+            tbtcVault.connect(governance).addGuardian(guardian.address)
+          ).to.be.revertedWith("This address is already a guardian")
         })
       })
     })
   })
 
-  describe("removeGuard", () => {
+  describe("removeGuardian", () => {
     context("when called not by the governance", () => {
       it("should revert", async () => {
         await expect(
-          tbtcVault.connect(thirdParty).removeGuard(guard.address)
+          tbtcVault.connect(thirdParty).removeGuardian(guardian.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
 
     context("when called by the governance", () => {
-      context("when address is a guard", () => {
+      context("when address is a guardian", () => {
         let tx: ContractTransaction
 
         before(async () => {
           await createSnapshot()
 
-          await tbtcVault.connect(governance).addGuard(guard.address)
-          tx = await tbtcVault.connect(governance).removeGuard(guard.address)
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
+          tx = await tbtcVault.connect(governance).removeGuardian(guardian.address)
         })
 
         after(async () => {
           await restoreSnapshot()
         })
 
-        it("should take guard role from the address", async () => {
+        it("should take guardian role from the address", async () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isGuard(guard.address)).to.be.false
+          expect(await tbtcVault.isGuardian(guardian.address)).to.be.false
         })
 
         it("should emit an event", async () => {
           await expect(tx)
-            .to.emit(tbtcVault, "GuardRemoved")
-            .withArgs(guard.address)
+            .to.emit(tbtcVault, "GuardianRemoved")
+            .withArgs(guardian.address)
         })
       })
 
-      context("when address is not a guard", () => {
+      context("when address is not a guardian", () => {
         it("should revert", async () => {
           await expect(
-            tbtcVault.connect(governance).removeGuard(guard.address)
-          ).to.be.revertedWith("This address is not a guard")
+            tbtcVault.connect(governance).removeGuardian(guardian.address)
+          ).to.be.revertedWith("This address is not a guardian")
         })
       })
     })
@@ -651,21 +651,21 @@ describe("TBTCVault - OptimisticMinting", () => {
   })
 
   describe("cancelOptimisticMint", () => {
-    context("when called not by a guard", () => {
+    context("when called not by a guardian", () => {
       it("should revert", async () => {
         await expect(
           tbtcVault
             .connect(thirdParty)
             .cancelOptimisticMint(fundingTxHash, fundingOutputIndex)
-        ).to.be.revertedWith("Caller is not a guard")
+        ).to.be.revertedWith("Caller is not a guardian")
       })
     })
 
-    context("when called by a guard", () => {
+    context("when called by a guardian", () => {
       before(async () => {
         await createSnapshot()
         await tbtcVault.connect(governance).addMinter(minter.address)
-        await tbtcVault.connect(governance).addGuard(guard.address)
+        await tbtcVault.connect(governance).addGuardian(guardian.address)
 
         await bridge.revealDeposit(fundingTx, depositRevealInfo)
       })
@@ -677,7 +677,7 @@ describe("TBTCVault - OptimisticMinting", () => {
       context("when minting has not been requested", () => {
         it("should revert", async () => {
           await expect(
-            tbtcVault.connect(guard).cancelOptimisticMint(fundingTxHash, 99)
+            tbtcVault.connect(guardian).cancelOptimisticMint(fundingTxHash, 99)
           ).to.be.revertedWith(
             "Optimistic minting not requested of already finalized"
           )
@@ -704,7 +704,7 @@ describe("TBTCVault - OptimisticMinting", () => {
         it("should revert", async () => {
           await expect(
             tbtcVault
-              .connect(guard)
+              .connect(guardian)
               .cancelOptimisticMint(fundingTxHash, fundingOutputIndex)
           ).to.be.revertedWith(
             "Optimistic minting not requested of already finalized"
@@ -723,7 +723,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             .optimisticMint(fundingTxHash, fundingOutputIndex)
 
           tx = await tbtcVault
-            .connect(guard)
+            .connect(guardian)
             .cancelOptimisticMint(fundingTxHash, fundingOutputIndex)
         })
 
@@ -750,7 +750,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await expect(tx)
             .to.emit(tbtcVault, "OptimisticMintingCancelled")
             .withArgs(
-              guard.address,
+              guardian.address,
               fundingTxHash,
               fundingOutputIndex,
               depositKey

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -340,8 +340,6 @@ describe("TBTCVault - OptimisticMinting", () => {
       before(async () => {
         await createSnapshot()
         await tbtcVault.connect(governance).addMinter(minter.address)
-
-        await bridge.revealDeposit(fundingTx, depositRevealInfo)
       })
 
       after(async () => {
@@ -383,6 +381,8 @@ describe("TBTCVault - OptimisticMinting", () => {
         before(async () => {
           await createSnapshot()
 
+          await bridge.revealDeposit(fundingTx, depositRevealInfo)
+
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -407,6 +407,8 @@ describe("TBTCVault - OptimisticMinting", () => {
       context("when requested minting has been already finalized", () => {
         before(async () => {
           await createSnapshot()
+
+          await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
           await tbtcVault
             .connect(minter)
@@ -435,6 +437,8 @@ describe("TBTCVault - OptimisticMinting", () => {
       context("when the deposit has been already swept", () => {
         before(async () => {
           await createSnapshot()
+
+          await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
           await tbtcVault
             .connect(minter)
@@ -476,6 +480,8 @@ describe("TBTCVault - OptimisticMinting", () => {
             await createSnapshot()
 
             await tbtcVault.connect(governance).updateOptimisticMintingFee(50) // 2%
+
+            await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
             await tbtcVault
               .connect(minter)
@@ -550,6 +556,8 @@ describe("TBTCVault - OptimisticMinting", () => {
 
             await tbtcVault.connect(governance).updateOptimisticMintingFee(0)
 
+            await bridge.revealDeposit(fundingTx, depositRevealInfo)
+
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -623,6 +631,8 @@ describe("TBTCVault - OptimisticMinting", () => {
             await bridgeGovernance
               .connect(governance)
               .finalizeDepositTreasuryFeeDivisorUpdate()
+
+            await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
             await tbtcVault
               .connect(minter)
@@ -703,6 +713,8 @@ describe("TBTCVault - OptimisticMinting", () => {
               .connect(governance)
               .finalizeDepositTreasuryFeeDivisorUpdate()
 
+            await bridge.revealDeposit(fundingTx, depositRevealInfo)
+
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -716,20 +728,20 @@ describe("TBTCVault - OptimisticMinting", () => {
             await restoreSnapshot()
           })
 
-          // Output value is 200000.
+          // Output value is 20000.
           // Bridge deposit treasury fee is 0.
           // Optimistic minting fee is 0.
 
           it("should mint TBTC to depositor", async () => {
             expect(
               await tbtc.balanceOf(depositRevealInfo.depositor)
-            ).to.be.equal(200000)
+            ).to.be.equal(20000)
           })
 
           it("should incur optimistic mint debt", async () => {
             expect(
               await tbtcVault.optimisticMintingDebt(depositRevealInfo.depositor)
-            ).to.be.equal(200000)
+            ).to.be.equal(20000)
           })
 
           it("should mark the request as finalized", async () => {
@@ -747,7 +759,7 @@ describe("TBTCVault - OptimisticMinting", () => {
                 minter.address,
                 depositKey,
                 depositRevealInfo.depositor,
-                200000,
+                20000,
                 fundingTxHash,
                 fundingOutputIndex
               )

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -523,7 +523,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await expect(
             tbtcVault.connect(guardian).cancelOptimisticMint(fundingTxHash, 99)
           ).to.be.revertedWith(
-            "Optimistic minting not requested of already finalized"
+            "Optimistic minting not requested or already finalized"
           )
         })
       })
@@ -551,7 +551,7 @@ describe("TBTCVault - OptimisticMinting", () => {
               .connect(guardian)
               .cancelOptimisticMint(fundingTxHash, fundingOutputIndex)
           ).to.be.revertedWith(
-            "Optimistic minting not requested of already finalized"
+            "Optimistic minting not requested or already finalized"
           )
         })
       })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -386,9 +386,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-          await increaseTime(
-            (await tbtcVault.OPTIMISTIC_MINTING_DELAY()).sub(1)
-          )
+          await increaseTime((await tbtcVault.optimisticMintingDelay()).sub(1))
         })
 
         after(async () => {
@@ -413,7 +411,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
           await tbtcVault
             .connect(minter)
             .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -443,7 +441,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
 
           relay.getPrevEpochDifficulty.returns(chainDifficulty)
           relay.getCurrentEpochDifficulty.returns(chainDifficulty)
@@ -479,14 +477,20 @@ describe("TBTCVault - OptimisticMinting", () => {
           before(async () => {
             await createSnapshot()
 
-            await tbtcVault.connect(governance).updateOptimisticMintingFee(50) // 2%
+            await tbtcVault
+              .connect(governance)
+              .beginOptimisticMintingFeeUpdate(50) // 2%
+            await increaseTime(86400) // 24h
+            await tbtcVault
+              .connect(governance)
+              .finalizeOptimisticMintingFeeUpdate()
 
             await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-            await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+            await increaseTime(await tbtcVault.optimisticMintingDelay())
             tx = await tbtcVault
               .connect(minter)
               .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -554,14 +558,20 @@ describe("TBTCVault - OptimisticMinting", () => {
           before(async () => {
             await createSnapshot()
 
-            await tbtcVault.connect(governance).updateOptimisticMintingFee(0)
+            await tbtcVault
+              .connect(governance)
+              .beginOptimisticMintingFeeUpdate(0)
+            await increaseTime(86400) // 24h
+            await tbtcVault
+              .connect(governance)
+              .finalizeOptimisticMintingFeeUpdate()
 
             await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-            await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+            await increaseTime(await tbtcVault.optimisticMintingDelay())
             tx = await tbtcVault
               .connect(minter)
               .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -622,12 +632,16 @@ describe("TBTCVault - OptimisticMinting", () => {
           before(async () => {
             await createSnapshot()
 
-            await tbtcVault.connect(governance).updateOptimisticMintingFee(50) // 2%
-
             await bridgeGovernance
               .connect(governance)
               .beginDepositTreasuryFeeDivisorUpdate(0)
-            await helpers.time.increaseTime(constants.governanceDelay)
+            await tbtcVault
+              .connect(governance)
+              .beginOptimisticMintingFeeUpdate(50) // 2%
+            await increaseTime(constants.governanceDelay)
+            await tbtcVault
+              .connect(governance)
+              .finalizeOptimisticMintingFeeUpdate()
             await bridgeGovernance
               .connect(governance)
               .finalizeDepositTreasuryFeeDivisorUpdate()
@@ -637,7 +651,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-            await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+            await increaseTime(await tbtcVault.optimisticMintingDelay())
 
             tx = await tbtcVault
               .connect(minter)
@@ -703,12 +717,16 @@ describe("TBTCVault - OptimisticMinting", () => {
           before(async () => {
             await createSnapshot()
 
-            await tbtcVault.connect(governance).updateOptimisticMintingFee(0)
-
             await bridgeGovernance
               .connect(governance)
               .beginDepositTreasuryFeeDivisorUpdate(0)
-            await helpers.time.increaseTime(constants.governanceDelay)
+            await tbtcVault
+              .connect(governance)
+              .beginOptimisticMintingFeeUpdate(0)
+            await increaseTime(constants.governanceDelay)
+            await tbtcVault
+              .connect(governance)
+              .finalizeOptimisticMintingFeeUpdate()
             await bridgeGovernance
               .connect(governance)
               .finalizeDepositTreasuryFeeDivisorUpdate()
@@ -718,7 +736,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             await tbtcVault
               .connect(minter)
               .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-            await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+            await increaseTime(await tbtcVault.optimisticMintingDelay())
             tx = await tbtcVault
               .connect(minter)
               .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -810,7 +828,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
           await tbtcVault
             .connect(minter)
             .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
@@ -855,7 +873,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           expect(request.requestedAt).to.be.equal(0)
           expect(request.finalizedAt).to.be.equal(0)
 
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
           await expect(
             tbtcVault
               .connect(minter)
@@ -1224,11 +1242,11 @@ describe("TBTCVault - OptimisticMinting", () => {
     })
   })
 
-  describe("updateOptimisticMintingFee", () => {
+  describe("beginOptimisticMintingFeeUpdate", () => {
     context("when called not by the governance", () => {
       it("should revert", async () => {
         await expect(
-          tbtcVault.connect(thirdParty).updateOptimisticMintingFee(1)
+          tbtcVault.connect(thirdParty).beginOptimisticMintingFeeUpdate(10)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -1238,23 +1256,230 @@ describe("TBTCVault - OptimisticMinting", () => {
 
       before(async () => {
         await createSnapshot()
-        tx = await tbtcVault.connect(governance).updateOptimisticMintingFee(991)
+
+        tx = await tbtcVault
+          .connect(governance)
+          .beginOptimisticMintingFeeUpdate(10)
       })
 
       after(async () => {
         await restoreSnapshot()
       })
 
-      it("should update the fee divisor", async () => {
-        expect(await tbtcVault.optimisticMintingFeeDivisor()).to.equal(991)
+      it("should not update the optimistic minting fee", async () => {
+        expect(await tbtcVault.optimisticMintingFeeDivisor()).to.equal(0)
+      })
+
+      it("should start the governance delay timer", async () => {
+        expect(
+          await tbtcVault.optimisticMintingFeeUpdateInitiatedTimestamp()
+        ).to.equal(await lastBlockTime())
       })
 
       it("should emit an event", async () => {
         await expect(tx)
-          .to.emit(tbtcVault, "OptimisticMintingFeeUpdated")
-          .withArgs(991)
+          .to.emit(tbtcVault, "OptimisticMintingFeeUpdateStarted")
+          .withArgs(10)
       })
     })
+  })
+
+  describe("finalizeOptimisticMintingFeeUpdate", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(thirdParty).finalizeOptimisticMintingFeeUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initiated", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(governance).finalizeOptimisticMintingFeeUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await tbtcVault.connect(governance).beginOptimisticMintingFeeUpdate(10)
+
+        await increaseTime(86400 - 60) // 24h - 1m
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(governance).finalizeOptimisticMintingFeeUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+      })
+    })
+
+    context(
+      "when the update process is initiated and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault
+            .connect(governance)
+            .beginOptimisticMintingFeeUpdate(15)
+          await increaseTime(86400) // 24h
+          tx = await tbtcVault
+            .connect(governance)
+            .finalizeOptimisticMintingFeeUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the optimistic minting fee", async () => {
+          expect(await tbtcVault.optimisticMintingFeeDivisor()).to.equal(15)
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "OptimisticMintingFeeUpdated")
+            .withArgs(15)
+        })
+
+        it("should reset the governance delay timer", async () => {
+          expect(
+            await tbtcVault.optimisticMintingFeeUpdateInitiatedTimestamp()
+          ).to.equal(0)
+        })
+      }
+    )
+  })
+
+  describe("beginOptimisticMintingDelayUpdate", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(thirdParty).beginOptimisticMintingDelayUpdate(60)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await tbtcVault
+          .connect(governance)
+          .beginOptimisticMintingDelayUpdate(60)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not update the optimistic minting delay", async () => {
+        expect(await tbtcVault.optimisticMintingDelay()).to.equal(10800) // 3h
+      })
+
+      it("should start the governance delay timer", async () => {
+        expect(
+          await tbtcVault.optimisticMintingDelayUpdateInitiatedTimestamp()
+        ).to.equal(await lastBlockTime())
+      })
+
+      it("should emit an event", async () => {
+        await expect(tx)
+          .to.emit(tbtcVault, "OptimisticMintingDelayUpdateStarted")
+          .withArgs(60)
+      })
+    })
+  })
+
+  describe("finalizeOptimisticMintingDelayUpdate", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(thirdParty).finalizeOptimisticMintingDelayUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initiated", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(governance).finalizeOptimisticMintingDelayUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await tbtcVault
+          .connect(governance)
+          .beginOptimisticMintingDelayUpdate(60)
+
+        await increaseTime(86400 - 60) // 24h - 1m
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(governance).finalizeOptimisticMintingDelayUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+      })
+    })
+
+    context(
+      "when the update process is initiated and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault
+            .connect(governance)
+            .beginOptimisticMintingDelayUpdate(60)
+          await increaseTime(86400) // 24h
+          tx = await tbtcVault
+            .connect(governance)
+            .finalizeOptimisticMintingDelayUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the optimistic minting delay", async () => {
+          expect(await tbtcVault.optimisticMintingDelay()).to.equal(60)
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "OptimisticMintingDelayUpdated")
+            .withArgs(60)
+        })
+
+        it("should reset the governance delay timer", async () => {
+          expect(
+            await tbtcVault.optimisticMintingDelayUpdateInitiatedTimestamp()
+          ).to.equal(0)
+        })
+      }
+    )
   })
 
   describe("calculateDepositKey", () => {
@@ -1293,7 +1518,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
 
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
 
           await tbtcVault
             .connect(minter)
@@ -1420,7 +1645,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await f.tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, 2)
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
           await f.tbtcVault
             .connect(minter)
             .finalizeOptimisticMint(fundingTxHash, 1)
@@ -1478,7 +1703,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await f.tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, 1)
-          await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
+          await increaseTime(await tbtcVault.optimisticMintingDelay())
           await f.tbtcVault
             .connect(minter)
             .finalizeOptimisticMint(fundingTxHash, 1)

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -463,6 +463,8 @@ describe("TBTCVault - OptimisticMinting", () => {
               .to.emit(tbtcVault, "OptimisticMintingRequested")
               .withArgs(
                 minter.address,
+                depositRevealInfo.depositor,
+                20000,
                 fundingTxHash,
                 fundingOutputIndex,
                 depositKey
@@ -637,6 +639,8 @@ describe("TBTCVault - OptimisticMinting", () => {
             .to.emit(tbtcVault, "OptimisticMintingFinalized")
             .withArgs(
               minter.address,
+              depositRevealInfo.depositor,
+              20000,
               fundingTxHash,
               fundingOutputIndex,
               depositKey

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -386,7 +386,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await tbtcVault
             .connect(minter)
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
-          await increaseTime((await tbtcVault.optimisticMintingDelay()).sub(1))
+          await increaseTime((await tbtcVault.optimisticMintingDelay()) - 1)
         })
 
         after(async () => {
@@ -541,14 +541,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           it("should emit an event", async () => {
             await expect(tx)
               .to.emit(tbtcVault, "OptimisticMintingFinalized")
-              .withArgs(
-                minter.address,
-                depositKey,
-                depositRevealInfo.depositor,
-                19591,
-                fundingTxHash,
-                fundingOutputIndex
-              )
+              .withArgs(minter.address, depositKey)
           })
         })
 
@@ -615,14 +608,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           it("should emit an event", async () => {
             await expect(tx)
               .to.emit(tbtcVault, "OptimisticMintingFinalized")
-              .withArgs(
-                minter.address,
-                depositKey,
-                depositRevealInfo.depositor,
-                19990,
-                fundingTxHash,
-                fundingOutputIndex
-              )
+              .withArgs(minter.address, depositKey)
           })
         })
 
@@ -700,14 +686,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           it("should emit an event", async () => {
             await expect(tx)
               .to.emit(tbtcVault, "OptimisticMintingFinalized")
-              .withArgs(
-                minter.address,
-                depositKey,
-                depositRevealInfo.depositor,
-                19600,
-                fundingTxHash,
-                fundingOutputIndex
-              )
+              .withArgs(minter.address, depositKey)
           })
         })
 
@@ -773,14 +752,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           it("should emit an event", async () => {
             await expect(tx)
               .to.emit(tbtcVault, "OptimisticMintingFinalized")
-              .withArgs(
-                minter.address,
-                depositKey,
-                depositRevealInfo.depositor,
-                20000,
-                fundingTxHash,
-                fundingOutputIndex
-              )
+              .withArgs(minter.address, depositKey)
           })
         })
       })
@@ -886,12 +858,7 @@ describe("TBTCVault - OptimisticMinting", () => {
         it("should emit an event", async () => {
           await expect(tx)
             .to.emit(tbtcVault, "OptimisticMintingCancelled")
-            .withArgs(
-              guardian.address,
-              depositKey,
-              fundingTxHash,
-              fundingOutputIndex
-            )
+            .withArgs(guardian.address, depositKey)
         })
       })
     })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -48,7 +48,7 @@ describe("TBTCVault - OptimisticMinting", () => {
   let mainUtxo
   let chainDifficulty: number
 
-  // used by tbtcVault.optimisticMint(fundingTxHash, fundingOutputIndex)
+  // used by tbtcVault.requestOptimisticMint(fundingTxHash, fundingOutputIndex)
   let fundingTxHash: string
   let fundingOutputIndex: number
 
@@ -117,7 +117,7 @@ describe("TBTCVault - OptimisticMinting", () => {
     mainUtxo = bitcoinTestData.mainUtxo
 
     // Set up test data needed to request optimistic minting via
-    // tbtcVault.optimisticMint(fundingTxHash, fundingOutputIndex)
+    // tbtcVault.requestOptimisticMint(fundingTxHash, fundingOutputIndex)
     fundingTxHash = fundingTx.hash
     fundingOutputIndex = depositRevealInfo.fundingOutputIndex
 
@@ -145,13 +145,13 @@ describe("TBTCVault - OptimisticMinting", () => {
     await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
   })
 
-  describe("optimisticMint", () => {
+  describe("requestOptimisticMint", () => {
     context("when called not by a minter", () => {
       it("should revert", async () => {
         await expect(
           tbtcVault
             .connect(thirdParty)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
         ).to.be.revertedWith("Caller is not a minter")
       })
     })
@@ -180,7 +180,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await expect(
             tbtcVault
               .connect(minter)
-              .optimisticMint(fundingTxHash, fundingOutputIndex)
+              .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           ).to.be.revertedWith("Optimistic minting paused")
         })
       })
@@ -192,7 +192,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await bridge.revealDeposit(fundingTx, depositRevealInfo)
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
         })
 
         after(async () => {
@@ -203,7 +203,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await expect(
             tbtcVault
               .connect(minter)
-              .optimisticMint(fundingTxHash, fundingOutputIndex)
+              .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           ).to.be.revertedWith(
             "Optimistic minting already requested for the deposit"
           )
@@ -213,7 +213,7 @@ describe("TBTCVault - OptimisticMinting", () => {
       context("when the deposit has not been revealed", () => {
         it("should revert", async () => {
           await expect(
-            tbtcVault.connect(minter).optimisticMint(fundingTxHash, 10)
+            tbtcVault.connect(minter).requestOptimisticMint(fundingTxHash, 10)
           ).to.be.revertedWith("The deposit has not been revealed")
         })
       })
@@ -247,7 +247,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             await expect(
               tbtcVault
                 .connect(minter)
-                .optimisticMint(fundingTxHash, fundingOutputIndex)
+                .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
             ).to.be.revertedWith("The deposit is already swept")
           })
         })
@@ -278,7 +278,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             await expect(
               tbtcVault
                 .connect(minter)
-                .optimisticMint(fundingTxHash, fundingOutputIndex)
+                .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
             ).to.be.revertedWith("Unexpected vault address")
           })
         })
@@ -292,7 +292,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             await bridge.revealDeposit(fundingTx, depositRevealInfo)
             tx = await tbtcVault
               .connect(minter)
-              .optimisticMint(fundingTxHash, fundingOutputIndex)
+              .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           })
 
           after(async () => {
@@ -384,7 +384,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(
             (await tbtcVault.OPTIMISTIC_MINTING_DELAY()).sub(1)
           )
@@ -409,7 +409,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
           await tbtcVault
             .connect(minter)
@@ -437,7 +437,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
 
           relay.getPrevEpochDifficulty.returns(chainDifficulty)
@@ -475,7 +475,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
 
           tx = await tbtcVault
@@ -563,7 +563,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
           await tbtcVault
             .connect(minter)
@@ -593,7 +593,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
 
           tx = await tbtcVault
             .connect(guardian)
@@ -1012,7 +1012,7 @@ describe("TBTCVault - OptimisticMinting", () => {
           await bridge.revealDeposit(fundingTx, depositRevealInfo)
           await tbtcVault
             .connect(minter)
-            .optimisticMint(fundingTxHash, fundingOutputIndex)
+            .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
 
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
 
@@ -1135,8 +1135,12 @@ describe("TBTCVault - OptimisticMinting", () => {
             sweptAt: 0,
           })
 
-          await f.tbtcVault.connect(minter).optimisticMint(fundingTxHash, 1)
-          await f.tbtcVault.connect(minter).optimisticMint(fundingTxHash, 2)
+          await f.tbtcVault
+            .connect(minter)
+            .requestOptimisticMint(fundingTxHash, 1)
+          await f.tbtcVault
+            .connect(minter)
+            .requestOptimisticMint(fundingTxHash, 2)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
           await f.tbtcVault
             .connect(minter)
@@ -1192,7 +1196,9 @@ describe("TBTCVault - OptimisticMinting", () => {
             sweptAt: 0,
           })
 
-          await f.tbtcVault.connect(minter).optimisticMint(fundingTxHash, 1)
+          await f.tbtcVault
+            .connect(minter)
+            .requestOptimisticMint(fundingTxHash, 1)
           await increaseTime(await tbtcVault.OPTIMISTIC_MINTING_DELAY())
           await f.tbtcVault
             .connect(minter)

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -1599,7 +1599,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
   describe("receiveBalanceIncrease", () => {
     context(
-      "when the deposit for which optimistic minting was requested gets swept",
+      "when the deposit for which optimistic minting was requested gets swept after finalization",
       () => {
         let tx: ContractTransaction
 
@@ -1658,7 +1658,7 @@ describe("TBTCVault - OptimisticMinting", () => {
       }
     )
 
-    context("when multiple deposits gets swept", () => {
+    context("when multiple deposits gets swept after finalization", () => {
       interface Fixture {
         mockBank: FakeContract<Bank>
         mockBridge: FakeContract<Bridge>

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -939,4 +939,27 @@ describe("TBTCVault - OptimisticMinting", () => {
       })
     })
   })
+
+  describe("calculateDepositKey", () => {
+    before(async () => {
+      await createSnapshot()
+      await bridge.revealDeposit(fundingTx, depositRevealInfo)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should calculate the key as expected", async () => {
+      expect(
+        await tbtcVault.calculateDepositKey(fundingTxHash, fundingOutputIndex)
+      ).to.equal(depositKey)
+    })
+
+    it("should calculate the same key as the Bridge", async () => {
+      expect((await bridge.deposits(depositKey)).revealedAt).to.equal(
+        await lastBlockTime()
+      )
+    })
+  })
 })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -3,14 +3,52 @@ import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
 import { expect } from "chai"
 import { ContractTransaction } from "ethers"
 
+import { walletState } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"
 
-import type { Bridge, BridgeStub, TBTCVault } from "../../typechain"
+import type {
+  Bridge,
+  BridgeStub,
+  BridgeGovernance,
+  TBTCVault,
+} from "../../typechain"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime } = helpers.time
 
 describe("TBTCVault - OptimisticMinting", () => {
+  const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+
+  const mainUtxo = {
+    txHash:
+      "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
+    txOutputIndex: 0,
+    txOutputValue: 10000000,
+  }
+
+  // Data of a proper P2SH deposit funding transaction. Little-endian hash is:
+  // 0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2 and
+  // this is the same as `expectedP2SHDeposit.transaction` mentioned in
+  // tbtc-ts/test/deposit.test.ts file.
+  const P2SHFundingTx = {
+    version: "0x01000000",
+    inputVector:
+      "0x018348cdeb551134fe1f19d378a8adec9b146671cb67b945b71bf56b20d" +
+      "c2b952f0100000000ffffffff",
+    outputVector:
+      "0x02102700000000000017a9142c1444d23936c57bdd8b3e67e5938a5440c" +
+      "da455877ed73b00000000001600147ac2d9378a1c47e589dfb8095ca95ed2" +
+      "140d2726",
+    locktime: "0x00000000",
+  }
+
+  // Data matching the redeem script locking the funding output of
+  // P2SHFundingTx.
+  let depositReveal
+  let depositKey
+
   let bridge: Bridge & BridgeStub
+  let bridgeGovernance: BridgeGovernance
   let tbtcVault: TBTCVault
 
   let governance: SignerWithAddress
@@ -20,13 +58,58 @@ describe("TBTCVault - OptimisticMinting", () => {
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;({ governance, bridge, tbtcVault } = await waffle.loadFixture(
-      bridgeFixture
-    ))
+    ;({ governance, bridge, bridgeGovernance, tbtcVault } =
+      await waffle.loadFixture(bridgeFixture))
+
+    await bridgeGovernance
+      .connect(governance)
+      .setVaultStatus(tbtcVault.address, true)
 
     const accounts = await getUnnamedAccounts()
     account1 = await ethers.getSigner(accounts[0])
     account2 = await ethers.getSigner(accounts[1])
+
+    await bridge.setWallet(walletPubKeyHash, {
+      ecdsaWalletID: ethers.constants.HashZero,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+    await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+
+    // Set the deposit dust threshold to 0.0001 BTC, i.e. 100x smaller than
+    // the initial value in the Bridge; we had to save test Bitcoins when
+    // generating test data.
+    await bridge.setDepositDustThreshold(10000)
+    // Disable the reveal ahead period since refund locktimes are fixed
+    // within transactions used in this test suite.
+    await bridge.setDepositRevealAheadPeriod(0)
+
+    depositReveal = {
+      fundingOutputIndex: 0,
+      depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+      blindingFactor: "0xf9f0c90d00039523",
+      // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
+      walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
+      // HASH160 of 0300d6f28a2f6bf9836f57fcda5d284c9a8f849316119779f0d6090830d97763a9.
+      refundPubKeyHash: "0x28e081f285138ccbe389c1eb8985716230129f89",
+      refundLocktime: "0x60bcea61",
+      vault: tbtcVault.address,
+    }
+
+    // Deposit key is keccak256(fundingTxHash | fundingOutputIndex).
+    depositKey = ethers.utils.solidityKeccak256(
+      ["bytes32", "uint32"],
+      [
+        "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+        depositReveal.fundingOutputIndex,
+      ]
+    )
   })
 
   describe("addMinter", () => {
@@ -228,6 +311,97 @@ describe("TBTCVault - OptimisticMinting", () => {
           await expect(
             tbtcVault.connect(governance).removeGuard(account1.address)
           ).to.be.revertedWith("This address is not a guard")
+        })
+      })
+    })
+  })
+
+  describe("optimisticMint", () => {
+    context("when called not by a minter", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(account1).optimisticMint(1)
+        ).to.be.revertedWith("Caller is not a minter")
+      })
+    })
+
+    context("when called by a minter", () => {
+      let minter: SignerWithAddress
+
+      before(async () => {
+        await createSnapshot()
+
+        minter = account1
+        await tbtcVault.connect(governance).addMinter(minter.address)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      context("when the deposit has not been revealed", () => {
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(minter).optimisticMint(1)
+          ).to.be.revertedWith("The deposit has not been revealed")
+        })
+      })
+
+      context("when the deposit has been revealed", () => {
+        context("when the deposit is targeted to another vault", () => {
+          before(async () => {
+            await createSnapshot()
+
+            const anotherVault = "0x42B2bCa0377cEF0027BF308f2a84343D44338Bd9"
+
+            await bridgeGovernance
+              .connect(governance)
+              .setVaultStatus(anotherVault, true)
+
+            const revealToAnotherVault = JSON.parse(
+              JSON.stringify(depositReveal)
+            )
+            revealToAnotherVault.vault = anotherVault
+
+            await bridge.revealDeposit(P2SHFundingTx, revealToAnotherVault)
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            await expect(
+              tbtcVault.connect(minter).optimisticMint(depositKey)
+            ).to.be.revertedWith("Unexpected vault address")
+          })
+        })
+
+        context("when all conditions are met", () => {
+          let tx: ContractTransaction
+
+          before(async () => {
+            await createSnapshot()
+
+            await bridge.revealDeposit(P2SHFundingTx, depositReveal)
+            tx = await tbtcVault.connect(minter).optimisticMint(depositKey)
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should register pending optimistic mint", async () => {
+            expect(
+              await tbtcVault.pendingOptimisticMints(depositKey)
+            ).to.be.equal(await lastBlockTime())
+          })
+
+          it("should emit an event", async () => {
+            await expect(tx)
+              .to.emit(tbtcVault, "OptimisticMintingRequested")
+              .withArgs(minter.address, depositKey)
+          })
         })
       })
     })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -312,11 +312,11 @@ describe("TBTCVault - OptimisticMinting", () => {
               .to.emit(tbtcVault, "OptimisticMintingRequested")
               .withArgs(
                 minter.address,
+                depositKey,
                 depositRevealInfo.depositor,
                 20000,
                 fundingTxHash,
-                fundingOutputIndex,
-                depositKey
+                fundingOutputIndex
               )
           })
         })
@@ -512,11 +512,11 @@ describe("TBTCVault - OptimisticMinting", () => {
             .to.emit(tbtcVault, "OptimisticMintingFinalized")
             .withArgs(
               minter.address,
+              depositKey,
               depositRevealInfo.depositor,
               19990,
               fundingTxHash,
-              fundingOutputIndex,
-              depositKey
+              fundingOutputIndex
             )
         })
       })
@@ -624,9 +624,9 @@ describe("TBTCVault - OptimisticMinting", () => {
             .to.emit(tbtcVault, "OptimisticMintingCancelled")
             .withArgs(
               guardian.address,
+              depositKey,
               fundingTxHash,
-              fundingOutputIndex,
-              depositKey
+              fundingOutputIndex
             )
         })
       })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -317,7 +317,9 @@ describe("TBTCVault - OptimisticMinting", () => {
           await createSnapshot()
 
           await tbtcVault.connect(governance).addGuardian(guardian.address)
-          tx = await tbtcVault.connect(governance).removeGuardian(guardian.address)
+          tx = await tbtcVault
+            .connect(governance)
+            .removeGuardian(guardian.address)
         })
 
         after(async () => {
@@ -616,18 +618,17 @@ describe("TBTCVault - OptimisticMinting", () => {
         })
 
         it("should mint TBTC", async () => {
-          // TODO: The output value is 0.0002 BTC. We should take into account
-          // fees in the contract
-          // See https://live.blockcypher.com/btc-testnet/tx/c580e0e352570d90e303d912a506055ceeb0ee06f97dce6988c69941374f5479/
+          // Deposit treasury fee is 0.05%. The output value is 0.0002 BTC.
+          // Treasury fee is deducted so we should mint 19990 sat.
           expect(await tbtc.balanceOf(depositRevealInfo.depositor)).to.be.equal(
-            20000
+            19990
           )
         })
 
         it("should incur optimistic mint debt", async () => {
           expect(
             await tbtcVault.optimisticMintingDebt(depositRevealInfo.depositor)
-          ).to.be.equal(20000)
+          ).to.be.equal(19990)
         })
 
         it("should remove the request", async () => {
@@ -640,7 +641,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             .withArgs(
               minter.address,
               depositRevealInfo.depositor,
-              20000,
+              19990,
               fundingTxHash,
               fundingOutputIndex,
               depositKey

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -144,257 +144,6 @@ describe("TBTCVault - OptimisticMinting", () => {
     await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
   })
 
-  describe("addMinter", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          tbtcVault.connect(minter).addMinter(minter.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is not a minter", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          tx = await tbtcVault.connect(governance).addMinter(minter.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should add address as a minter", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isMinter(minter.address)).to.be.true
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(tbtcVault, "MinterAdded")
-            .withArgs(minter.address)
-        })
-      })
-
-      context("when address is a minter", () => {
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addMinter(minter.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          await expect(
-            tbtcVault.connect(governance).addMinter(minter.address)
-          ).to.be.revertedWith("This address is already a minter")
-        })
-      })
-    })
-  })
-
-  describe("removeMinter", () => {
-    context("when called not by the governance or a guardian", () => {
-      it("should revert", async () => {
-        await expect(
-          tbtcVault.connect(thirdParty).removeMinter(minter.address)
-        ).to.be.revertedWith("Caller is not the owner or guardian")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is a minter", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addMinter(minter.address)
-          tx = await tbtcVault.connect(governance).removeMinter(minter.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should take minter role from the address", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isMinter(minter.address)).to.be.false
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(tbtcVault, "MinterRemoved")
-            .withArgs(minter.address)
-        })
-      })
-
-      context("when address is not a minter", () => {
-        it("should revert", async () => {
-          await expect(
-            tbtcVault.connect(governance).removeMinter(thirdParty.address)
-          ).to.be.revertedWith("This address is not a minter")
-        })
-      })
-    })
-
-    context("when called by a guardian", () => {
-      context("when address is a minter", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addMinter(minter.address)
-          await tbtcVault.connect(governance).addGuardian(guardian.address)
-          tx = await tbtcVault.connect(guardian).removeMinter(minter.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should take minter role from the address", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isMinter(minter.address)).to.be.false
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(tbtcVault, "MinterRemoved")
-            .withArgs(minter.address)
-        })
-      })
-
-      context("when address is not a minter", () => {
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addGuardian(guardian.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          await expect(
-            tbtcVault.connect(guardian).removeMinter(thirdParty.address)
-          ).to.be.revertedWith("This address is not a minter")
-        })
-      })
-    })
-  })
-
-  describe("addGuardian", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          tbtcVault.connect(guardian).addGuardian(guardian.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is not a guardian", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          tx = await tbtcVault.connect(governance).addGuardian(guardian.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should add address as a guardian", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isGuardian(guardian.address)).to.be.true
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(tbtcVault, "GuardianAdded")
-            .withArgs(guardian.address)
-        })
-      })
-
-      context("when address is a guardian", () => {
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addGuardian(guardian.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          await expect(
-            tbtcVault.connect(governance).addGuardian(guardian.address)
-          ).to.be.revertedWith("This address is already a guardian")
-        })
-      })
-    })
-  })
-
-  describe("removeGuardian", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          tbtcVault.connect(thirdParty).removeGuardian(guardian.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is a guardian", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          await tbtcVault.connect(governance).addGuardian(guardian.address)
-          tx = await tbtcVault
-            .connect(governance)
-            .removeGuardian(guardian.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should take guardian role from the address", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await tbtcVault.isGuardian(guardian.address)).to.be.false
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(tbtcVault, "GuardianRemoved")
-            .withArgs(guardian.address)
-        })
-      })
-
-      context("when address is not a guardian", () => {
-        it("should revert", async () => {
-          await expect(
-            tbtcVault.connect(governance).removeGuardian(guardian.address)
-          ).to.be.revertedWith("This address is not a guardian")
-        })
-      })
-    })
-  })
-
   describe("optimisticMint", () => {
     context("when called not by a minter", () => {
       it("should revert", async () => {
@@ -841,6 +590,257 @@ describe("TBTCVault - OptimisticMinting", () => {
               fundingOutputIndex,
               depositKey
             )
+        })
+      })
+    })
+  })
+
+  describe("addMinter", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(minter).addMinter(minter.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is not a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await tbtcVault.connect(governance).addMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add address as a minter", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isMinter(minter.address)).to.be.true
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "MinterAdded")
+            .withArgs(minter.address)
+        })
+      })
+
+      context("when address is a minter", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).addMinter(minter.address)
+          ).to.be.revertedWith("This address is already a minter")
+        })
+      })
+    })
+  })
+
+  describe("removeMinter", () => {
+    context("when called not by the governance or a guardian", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(thirdParty).removeMinter(minter.address)
+        ).to.be.revertedWith("Caller is not the owner or guardian")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addMinter(minter.address)
+          tx = await tbtcVault.connect(governance).removeMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take minter role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isMinter(minter.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "MinterRemoved")
+            .withArgs(minter.address)
+        })
+      })
+
+      context("when address is not a minter", () => {
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).removeMinter(thirdParty.address)
+          ).to.be.revertedWith("This address is not a minter")
+        })
+      })
+    })
+
+    context("when called by a guardian", () => {
+      context("when address is a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addMinter(minter.address)
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
+          tx = await tbtcVault.connect(guardian).removeMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take minter role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isMinter(minter.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "MinterRemoved")
+            .withArgs(minter.address)
+        })
+      })
+
+      context("when address is not a minter", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(guardian).removeMinter(thirdParty.address)
+          ).to.be.revertedWith("This address is not a minter")
+        })
+      })
+    })
+  })
+
+  describe("addGuardian", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(guardian).addGuardian(guardian.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is not a guardian", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await tbtcVault.connect(governance).addGuardian(guardian.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add address as a guardian", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isGuardian(guardian.address)).to.be.true
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "GuardianAdded")
+            .withArgs(guardian.address)
+        })
+      })
+
+      context("when address is a guardian", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).addGuardian(guardian.address)
+          ).to.be.revertedWith("This address is already a guardian")
+        })
+      })
+    })
+  })
+
+  describe("removeGuardian", () => {
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          tbtcVault.connect(thirdParty).removeGuardian(guardian.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when address is a guardian", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await tbtcVault.connect(governance).addGuardian(guardian.address)
+          tx = await tbtcVault
+            .connect(governance)
+            .removeGuardian(guardian.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take guardian role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await tbtcVault.isGuardian(guardian.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(tbtcVault, "GuardianRemoved")
+            .withArgs(guardian.address)
+        })
+      })
+
+      context("when address is not a guardian", () => {
+        it("should revert", async () => {
+          await expect(
+            tbtcVault.connect(governance).removeGuardian(guardian.address)
+          ).to.be.revertedWith("This address is not a guardian")
         })
       })
     })

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -226,6 +226,7 @@ describe("TBTCVault - OptimisticMinting", () => {
 
             await bridge.revealDeposit(fundingTx, depositRevealInfo)
 
+            // Setting mocks to make the sweeping SPV proof validation pass.
             relay.getPrevEpochDifficulty.returns(chainDifficulty)
             relay.getCurrentEpochDifficulty.returns(chainDifficulty)
             await bridge
@@ -443,6 +444,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             .requestOptimisticMint(fundingTxHash, fundingOutputIndex)
           await increaseTime(await tbtcVault.optimisticMintingDelay())
 
+          // Setting mocks to make the sweeping SPV proof validation pass.
           relay.getPrevEpochDifficulty.returns(chainDifficulty)
           relay.getCurrentEpochDifficulty.returns(chainDifficulty)
           await bridge
@@ -1616,6 +1618,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             .connect(minter)
             .finalizeOptimisticMint(fundingTxHash, fundingOutputIndex)
 
+          // Setting mocks to make the sweeping SPV proof validation pass.
           relay.getPrevEpochDifficulty.returns(chainDifficulty)
           relay.getCurrentEpochDifficulty.returns(chainDifficulty)
           tx = await bridge

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -1,9 +1,9 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
 import { expect } from "chai"
-
 import { ContractTransaction } from "ethers"
 import { FakeContract, smock } from "@defi-wonderland/smock"
+
 import type {
   Bank,
   Bridge,
@@ -60,7 +60,7 @@ const fixture = async () => {
   }
 }
 
-describe.only("TBTCVault", () => {
+describe("TBTCVault", () => {
   let bridge: FakeContract<Bridge>
   let governance: SignerWithAddress
   let bank: Bank
@@ -1117,212 +1117,6 @@ describe.only("TBTCVault", () => {
           it("should reset the new vault address", async () => {
             expect(await vault.newVault()).to.equal(ZERO_ADDRESS)
           })
-        })
-      })
-    })
-  })
-
-  //
-  // Functionalities from TBTCOptimisticMinting.sol
-  //
-
-  describe("addMinter", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          vault.connect(account1).addMinter(account1.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is not a minter", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          tx = await vault.connect(governance).addMinter(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should add address as a minter", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await vault.isMinter(account1.address)).to.be.true
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(vault, "MinterAdded")
-            .withArgs(account1.address)
-        })
-      })
-
-      context("when address is a minter", () => {
-        before(async () => {
-          await createSnapshot()
-
-          await vault.connect(governance).addMinter(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          await expect(
-            vault.connect(governance).addMinter(account1.address)
-          ).to.be.revertedWith("This address is already a minter")
-        })
-      })
-    })
-  })
-
-  describe("removeMinter", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          vault.connect(account1).removeMinter(account1.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is a minter", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          await vault.connect(governance).addMinter(account1.address)
-          tx = await vault.connect(governance).removeMinter(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should take minter role from the address", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await vault.isMinter(account1.address)).to.be.false
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(vault, "MinterRemoved")
-            .withArgs(account1.address)
-        })
-      })
-
-      context("when address is not a minter", () => {
-        it("should revert", async () => {
-          await expect(
-            vault.connect(governance).removeMinter(account1.address)
-          ).to.be.revertedWith("This address is not a minter")
-        })
-      })
-    })
-  })
-
-  describe("addGuard", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          vault.connect(account1).addGuard(account1.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is not a guard", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          tx = await vault.connect(governance).addGuard(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should add address as a guard", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await vault.isGuard(account1.address)).to.be.true
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(vault, "GuardAdded")
-            .withArgs(account1.address)
-        })
-      })
-
-      context("when address is a guard", () => {
-        before(async () => {
-          await createSnapshot()
-
-          await vault.connect(governance).addGuard(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should revert", async () => {
-          await expect(
-            vault.connect(governance).addGuard(account1.address)
-          ).to.be.revertedWith("This address is already a guard")
-        })
-      })
-    })
-  })
-
-  describe("removeGuard", () => {
-    context("when called not by the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          vault.connect(account1).removeGuard(account1.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the governance", () => {
-      context("when address is a guard", () => {
-        let tx: ContractTransaction
-
-        before(async () => {
-          await createSnapshot()
-
-          await vault.connect(governance).addGuard(account1.address)
-          tx = await vault.connect(governance).removeGuard(account1.address)
-        })
-
-        after(async () => {
-          await restoreSnapshot()
-        })
-
-        it("should take guard role from the address", async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(await vault.isGuard(account1.address)).to.be.false
-        })
-
-        it("should emit an event", async () => {
-          await expect(tx)
-            .to.emit(vault, "GuardRemoved")
-            .withArgs(account1.address)
-        })
-      })
-
-      context("when address is not a guard", () => {
-        it("should revert", async () => {
-          await expect(
-            vault.connect(governance).removeGuard(account1.address)
-          ).to.be.revertedWith("This address is not a guard")
         })
       })
     })

--- a/solidity/test/vault/TBTCVault.test.ts
+++ b/solidity/test/vault/TBTCVault.test.ts
@@ -5,11 +5,13 @@ import { expect } from "chai"
 import { ContractTransaction } from "ethers"
 import type {
   Bank,
+  Bridge,
   TBTC,
   TBTCVault,
   TestERC20,
   TestERC721,
 } from "../../typechain"
+import { FakeContract, smock } from "@defi-wonderland/smock"
 
 const { to1e18 } = helpers.number
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
@@ -18,7 +20,15 @@ const { increaseTime, lastBlockTime } = helpers.time
 const ZERO_ADDRESS = ethers.constants.AddressZero
 
 const fixture = async () => {
-  const [deployer, bridge, governance] = await ethers.getSigners()
+  const [deployer, governance] = await ethers.getSigners()
+
+  const bridge = await smock.fake<Bridge>("Bridge")
+  // Fund the `bridge` account so it's possible to mock sending requests
+  // from it.
+  await deployer.sendTransaction({
+    to: bridge.address,
+    value: ethers.utils.parseEther("100"),
+  })
 
   const Bank = await ethers.getContractFactory("Bank")
   const bank = await Bank.deploy()
@@ -31,7 +41,7 @@ const fixture = async () => {
   await tbtc.deployed()
 
   const TBTCVault = await ethers.getContractFactory("TBTCVault")
-  const vault = await TBTCVault.deploy(bank.address, tbtc.address)
+  const vault = await TBTCVault.deploy(bank.address, tbtc.address, bridge.address)
   await vault.deployed()
 
   await tbtc.connect(deployer).transferOwnership(vault.address)
@@ -47,7 +57,7 @@ const fixture = async () => {
 }
 
 describe("TBTCVault", () => {
-  let bridge: SignerWithAddress
+  let bridge: FakeContract<Bridge>
   let governance: SignerWithAddress
   let bank: Bank
   let vault: TBTCVault
@@ -68,8 +78,8 @@ describe("TBTCVault", () => {
     account1 = await ethers.getSigner(accounts[0])
     account2 = await ethers.getSigner(accounts[1])
 
-    await bank.connect(bridge).increaseBalance(account1.address, initialBalance)
-    await bank.connect(bridge).increaseBalance(account2.address, initialBalance)
+    await bank.connect(bridge.wallet).increaseBalance(account1.address, initialBalance)
+    await bank.connect(bridge.wallet).increaseBalance(account2.address, initialBalance)
 
     await bank.connect(account1).approveBalance(vault.address, initialBalance)
     await bank.connect(account2).approveBalance(vault.address, initialBalance)
@@ -80,7 +90,7 @@ describe("TBTCVault", () => {
       it("should revert", async () => {
         const TBTCVault = await ethers.getContractFactory("TBTCVault")
         await expect(
-          TBTCVault.deploy(ZERO_ADDRESS, tbtc.address)
+          TBTCVault.deploy(ZERO_ADDRESS, tbtc.address, bridge.address)
         ).to.be.revertedWith("Bank can not be the zero address")
       })
     })
@@ -89,7 +99,7 @@ describe("TBTCVault", () => {
       it("should revert", async () => {
         const TBTCVault = await ethers.getContractFactory("TBTCVault")
         await expect(
-          TBTCVault.deploy(bank.address, ZERO_ADDRESS)
+          TBTCVault.deploy(bank.address, ZERO_ADDRESS, bridge.address)
         ).to.be.revertedWith("TBTC token can not be the zero address")
       })
     })
@@ -676,7 +686,7 @@ describe("TBTCVault", () => {
       it("should revert", async () => {
         await expect(
           vault
-            .connect(bridge)
+            .connect(bridge.wallet)
             .receiveBalanceApproval(account1.address, amount, [])
         ).to.be.revertedWith("Caller is not the Bank")
         await expect(
@@ -854,7 +864,7 @@ describe("TBTCVault", () => {
       it("should revert", async () => {
         await expect(
           vault
-            .connect(bridge)
+            .connect(bridge.wallet)
             .receiveBalanceIncrease([depositor1], [depositedAmount1])
         ).to.be.revertedWith("Caller is not the Bank")
       })
@@ -863,7 +873,7 @@ describe("TBTCVault", () => {
     context("when called with no depositors", () => {
       it("should revert", async () => {
         await expect(
-          bank.connect(bridge).increaseBalanceAndCall(vault.address, [], [])
+          bank.connect(bridge.wallet).increaseBalanceAndCall(vault.address, [], [])
         ).to.be.revertedWith("No depositors specified")
       })
     })
@@ -875,7 +885,7 @@ describe("TBTCVault", () => {
         await createSnapshot()
 
         tx = await bank
-          .connect(bridge)
+          .connect(bridge.wallet)
           .increaseBalanceAndCall(
             vault.address,
             [depositor1],
@@ -906,7 +916,7 @@ describe("TBTCVault", () => {
         await createSnapshot()
 
         tx = await bank
-          .connect(bridge)
+          .connect(bridge.wallet)
           .increaseBalanceAndCall(
             vault.address,
             [depositor1, depositor2, depositor3],


### PR DESCRIPTION
# Optimistic minting

There are two permissioned sets in the system: Minters and Guardians, both set up in 1-of-n mode. Minters observe the revealed deposits and request minting TBTC. Any single Minter can perform this action. There is a 3 hours delay between the time of the request from a Minter to the time TBTC is minted. During the time of the delay, any Guardian can cancel the minting.

# The mechanism

For any revealed, unswept deposit, any Minter can request minting using `requestOptimisticMint(bytes32 fundingTxHash, uint32 fundingOutputIndex) external onlyMinter` on `TBTCVault`.

Any Guardian can cancel the minting by calling `function cancelOptimisticMint(bytes32 fundingTxHash, uint32 fundingOutputIndex) external onlyGuard`.

If none of the Guardians canceled minting, any Minter can finalize the request by calling `function finalizeOptimisticMint(bytes32 fundingTxHash, uint32 fundingOutputIndex) external onlyMinter` to mint TBTC.

When TBTC is minted, depositor's optimistic minting debt balance is updated in `optimisticMintingDebt`. When a deposit is swept for the depositor, the vault updates `optimisticMintingDebt` and if this amount is non-zero, pay back the debt and mint only the amount of TBTC that is left after paying the debt.

# Future potential

The optimistic minting mechanism has the potential to be integrated as a quick-minting solution. The current implementation - as is - should fulfill all requirements of a quick-minting solution, including a fee for faster processing of deposits. If the depositor does not want to wait for the Bridge to pick up their deposit during a scheduled sweep, they can pay an additional fee and have the Minters / Guardians make the decision. The wallet will sweep that deposit later. I think the only problem we will need to solve is coordination between Minters, Wallets, and Guardians. A wallet should not pick deposits to sweep for which the optimistic minting was requested. If there was a synchronization issue and that already happened, the existing smart contract will handle it gracefully. If the wallet was first, `finalizeOptimisticMint` will revert for a swept deposit. If the Minter was first to finalize, `submitDepositSweepProof -> receiveBalanceIncrease` will process the swept deposit as an optimistic minting debt payment. 

# Fees

There are two fees in the system:
- Deposit fee - cut by the Bridge when sweeping a deposit.
- Optimistic Minting fee - cut by `TBTCVault` when finalizing optimistic mint, computed after the Deposit fee is cut.

The Optimistic Minting fee has an important role. The Bitcoin miner sweep transaction fee is covered by all depositors. The fee is split between all deposits in the sweep transaction, evenly. When tokens are optimistically minted, it is not possible to say what the Bitcoin miner sweeping fee will be. The fee is ignored and the intention is that the imbalance between the wallet balance and the amount of TBTC minted will be covered by a DAO donation (see `DonationVault`) from the fees cut by the system, especially the Optimistic Minting fee. This is exactly the same situation as with the move funds transaction between wallets.

One of the fees can be 0, both fees can be 0, and both fees can be non-zero. The amount of TBTC minted to the depositor's address has both the Deposit fee and the Optimistic Minting fee cut.

The fees are computed as follows:
```
depositFee = depositedAmount / depositFeeDivisor
optimisticMintingFee = (depositedAmount - depositFee) / optimiticMintingFeeDivisor
```

Say that the deposited amount is 100. If the deposit fee is 2%, and the optimistic minting fee is 1%, the amounts will be:
```
depositFee = 100 * 0.02 = 2
optimisticMintingFee = (100 - 2)* 0.01 = 98 * 0.01 = 0.98
```

This scheme allows the Optimistic Minting mechanism to cut a fee based on the amount the vault will actually receive. This wouldn't be guaranteed if we were calculating both fees based on the original deposited amount.

CoinList charges a flat 0.25% trading fee to wrap or unwrap WBTC (https://coinlist.co/help/what-are-the-fees-to-wrap-and-unwrap-wbtc). If we want to maintain the same fee, for the January release, we have two options:
- If the treasury should receive the fee at the moment of sweeping, set the Deposit fee to 0.25% and the Optimistic Minting fee to 0%.
- If the treasury should receive the fee at the moment of finalizing the Optimistic Mint, set the Optimistic Mint fee to 0.25% and the Deposit Fee to 0%.

# Governable parameters

The owner of the `TBTCVault` can add and remove Minters and Guardians. Additionally, there is an option that Minter can be removed by any Guardian. This is to allow dealing with an errant Minter. 

The owner of the contract can additionally update the delay between Optimistic Minting request and finalization. It can also update the Optimistic Minting fee.

# Note on the separation of concerns

So far we kept vaults completely separate from the `Bridge`. The `Bridge` was managing `Bank` balances. Vaults - including `TBTCVault` - were just applications working on top of the `Bank`. Neither `Bank` nor the vaults were interested in how the `Bridge` worked. They knew nothing about revealed deposits and sweeping.

Given that Minter should be only able to request minting for a revealed, unswept deposit, this separation may no longer be kept. At the same time, the goal is to minimize the impact and keep this "abstraction breaking change" local to the optimistic minting component the `TBTCVault` extends. This will let us easily unplug this mechanism in the future if needed.

Also, the approach where `TBTCVault` asks the `Bridge` for revealed deposits allows us to avoid passing deposit ID from the `Bridge`, through `Bank`, to `TBTCVault` which would break the abstractions and require a lot of changes in a quite complicated, gas-optimized `Bridge` contract. Last but not least, we can track - looking only at Ethereum - the amount of BTC that is in the queue for sweeping and has already been optimistically minted into TBTC ERC20.