### PR TITLE
Use public key hashes in assembleDepositScript()

### DIFF
--- a/typescript/test/deposit.test.ts
+++ b/typescript/test/deposit.test.ts
@@ -314,12 +314,14 @@ describe("Deposit", () => {
       let transaction: RawTransaction
 
       beforeEach(async () => {
+        const depositScriptParameters = getDepositScriptParameters(deposit)
         ;({
           transactionHash,
           depositUtxo,
           rawTransaction: transaction,
         } = await assembleDepositTransaction(
-          deposit,
+          depositScriptParameters,
+          deposit.amount,
           [testnetUTXO],
           testnetPrivateKey,
           true
@@ -407,12 +409,14 @@ describe("Deposit", () => {
       let transaction: RawTransaction
 
       beforeEach(async () => {
+        const depositScriptParameters = getDepositScriptParameters(deposit)
         ;({
           transactionHash,
           depositUtxo,
           rawTransaction: transaction,
         } = await assembleDepositTransaction(
-          deposit,
+          depositScriptParameters,
+          deposit.amount,
           [testnetUTXO],
           testnetPrivateKey,
           false
@@ -686,9 +690,11 @@ describe("Deposit", () => {
     let bridge: MockBridge
 
     beforeEach(async () => {
+      const depositScriptParameters = getDepositScriptParameters(deposit)
       // Create a deposit transaction.
       const result = await assembleDepositTransaction(
-        deposit,
+        depositScriptParameters,
+        deposit.amount,
         [testnetUTXO],
         testnetPrivateKey,
         true
@@ -729,8 +735,10 @@ describe("Deposit", () => {
 
     beforeEach(async () => {
       // Create a deposit transaction.
+      const depositScriptParameters = getDepositScriptParameters(deposit)
       ;({ depositUtxo } = await assembleDepositTransaction(
-        deposit,
+        depositScriptParameters,
+        deposit.amount,
         [testnetUTXO],
         testnetPrivateKey,
         true


### PR DESCRIPTION
For the dashboard we want to be able to mock the deposit transaction with custom mocked bitcoin client. This is needed to be able ot test the dashboard without the need to connect to the real bitcoin client.

For that we wanted to use `assembleDepositScript` function but the problem was that it used `Deposit` object as a parameter, which had `walletPublicKey` and `refundPublicKey`. We then hash it into `walletPublicKeyHash` and `refundPublicKeyHash` inside that function, so we didn't use `refundPublicKey` and `walletPublicKey` there at all besides that. From the dashboard perspective we only have the `refundPublicKeyHash` and we can`t really convert it to a `refundPublicKey` since the convertion goes as below:

`private key -> public key -> compressed public key -> public key hash (PKH) <-> base58 encoded PKH (address)`

This commit changes that in a way that we pass `DepositScriptParameters` instead of `Deposit` object + `amount` as a separate property (before it was placed inside `Deposit` parameters and `DepositScriptParameters` doesn't have that).