### PR TITLE
Deploy LightRelay on goerli

### DIFF
--- a/solidity/deploy/00_resolve_relay.ts
+++ b/solidity/deploy/00_resolve_relay.ts
@@ -16,10 +16,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (LightRelay && helpers.address.isValid(LightRelay.address)) {
     log(`using external LightRelay at ${LightRelay.address}`)
   } else {
-    // Temporarily for goerli we deploy `TestRelay` contract, until the relay
-    // maintainer is ready.
     await deployments.deploy("LightRelay", {
-      contract: hre.network.name === "goerli" ? "TestRelay" : "LightRelay",
+      contract: "LightRelay",
       from: deployer,
       log: true,
       waitConfirmations: 1,


### PR DESCRIPTION
We need to deploy a real `LightRelay` contract (no a stub) on goerli to generate the client bindings for goerli.

Once we merge the PR and deploy the contract on goerli, we'll need to commit it under `deployments/goerli/LightRelay.json`.