### PR TITLE
Zero deposit and redemption fees

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1240,7 +1240,7 @@ contract Bridge is
     ///        deposit refund locktime.
     /// @dev Requirements:
     ///      - Deposit dust threshold must be greater than zero,
-    ///      - Deposit treasury fee divisor must be greater than zero,
+    ///      - Deposit dust threshold must be greater than deposit TX max fee,
     ///      - Deposit transaction max fee must be greater than zero.
     function updateDepositParameters(
         uint64 depositDustThreshold,

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1302,7 +1302,8 @@ contract Bridge is
     /// @dev Requirements:
     ///      - Redemption dust threshold must be greater than moving funds dust
     ///        threshold,
-    ///      - Redemption treasury fee divisor must be greater than zero,
+    ///      - Redemption dust threshold must be greater than the redemption TX
+    ///        max fee,
     ///      - Redemption transaction max fee must be greater than zero,
     ///      - Redemption timeout must be greater than zero,
     ///      - Redemption timeout notifier reward multiplier must be in the

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1305,6 +1305,8 @@ contract Bridge is
     ///      - Redemption dust threshold must be greater than the redemption TX
     ///        max fee,
     ///      - Redemption transaction max fee must be greater than zero,
+    ///      - Redemption transaction max total fee must be greater than or
+    ///        equal to the redemption transaction per-request max fee,
     ///      - Redemption timeout must be greater than zero,
     ///      - Redemption timeout notifier reward multiplier must be in the
     ///        range [0, 100].

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -484,6 +484,8 @@ library BridgeState {
     ///      - Redemption dust threshold must be greater than the redemption TX
     ///        max fee,
     ///      - Redemption transaction max fee must be greater than zero,
+    ///      - Redemption transaction max total fee must be greater than or
+    ///        equal to the redemption transaction per-request max fee,
     ///      - Redemption timeout must be greater than zero,
     ///      - Redemption timeout notifier reward multiplier must be in the
     ///        range [0, 100].

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -399,7 +399,6 @@ library BridgeState {
     /// @dev Requirements:
     ///      - Deposit dust threshold must be greater than zero,
     ///      - Deposit dust threshold must be greater than deposit TX max fee,
-    ///      - Deposit treasury fee divisor must be greater than zero,
     ///      - Deposit transaction max fee must be greater than zero.
     function updateDepositParameters(
         Storage storage self,
@@ -416,11 +415,6 @@ library BridgeState {
         require(
             _depositDustThreshold > _depositTxMaxFee,
             "Deposit dust threshold must be greater than deposit TX max fee"
-        );
-
-        require(
-            _depositTreasuryFeeDivisor > 0,
-            "Deposit treasury fee divisor must be greater than zero"
         );
 
         require(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -483,7 +483,6 @@ library BridgeState {
     ///        threshold,
     ///      - Redemption dust threshold must be greater than the redemption TX
     ///        max fee,
-    ///      - Redemption treasury fee divisor must be greater than zero,
     ///      - Redemption transaction max fee must be greater than zero,
     ///      - Redemption timeout must be greater than zero,
     ///      - Redemption timeout notifier reward multiplier must be in the
@@ -506,11 +505,6 @@ library BridgeState {
         require(
             _redemptionDustThreshold > _redemptionTxMaxFee,
             "Redemption dust threshold must be greater than redemption TX max fee"
-        );
-
-        require(
-            _redemptionTreasuryFeeDivisor > 0,
-            "Redemption treasury fee divisor must be greater than zero"
         );
 
         require(

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -931,9 +931,7 @@ describe("Bridge - Governance", () => {
           bridgeGovernance
             .connect(governance)
             .finalizeRedemptionTreasuryFeeDivisorUpdate()
-        ).to.be.revertedWith(
-          "Redemption treasury fee divisor must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -430,9 +430,7 @@ describe("Bridge - Governance", () => {
           bridgeGovernance
             .connect(governance)
             .finalizeDepositTreasuryFeeDivisorUpdate()
-        ).to.be.revertedWith(
-          "Deposit treasury fee divisor must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -197,24 +197,6 @@ describe("Bridge - Parameters", () => {
         }
       )
 
-      context("when new deposit treasury fee divisor is zero", () => {
-        it("should revert", async () => {
-          await bridgeGovernance
-            .connect(governance)
-            .beginDepositTreasuryFeeDivisorUpdate(0)
-
-          await helpers.time.increaseTime(constants.governanceDelay)
-
-          await expect(
-            bridgeGovernance
-              .connect(governance)
-              .finalizeDepositTreasuryFeeDivisorUpdate()
-          ).to.be.revertedWith(
-            "Deposit treasury fee divisor must be greater than zero"
-          )
-        })
-      })
-
       context("when new deposit transaction max fee is zero", () => {
         it("should revert", async () => {
           await bridgeGovernance

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -579,24 +579,6 @@ describe("Bridge - Parameters", () => {
         }
       )
 
-      context("when new redemption treasury fee divisor is zero", () => {
-        it("should revert", async () => {
-          await bridgeGovernance
-            .connect(governance)
-            .beginRedemptionTreasuryFeeDivisorUpdate(0)
-
-          await helpers.time.increaseTime(constants.governanceDelay)
-
-          await expect(
-            bridgeGovernance
-              .connect(governance)
-              .finalizeRedemptionTreasuryFeeDivisorUpdate()
-          ).to.be.revertedWith(
-            "Redemption treasury fee divisor must be greater than zero"
-          )
-        })
-      })
-
       context("when new redemption transaction max fee is zero", () => {
         it("should revert", async () => {
           await bridgeGovernance

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -38,7 +38,7 @@ import {
   MultiplePendingRequestedRedemptionsWithProvablyUnspendable,
   MultiplePendingRequestedRedemptionsWithMultipleInputs,
 } from "../data/redemption"
-import { walletState } from "../fixtures"
+import { constants, walletState } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"
 
 chai.use(smock.matchers)
@@ -91,7 +91,9 @@ describe("Bridge - Redemption", () => {
 
     // Set the deposit dust threshold to 0.0001 BTC, i.e. 100x smaller than
     // the initial value in the Bridge in order to save test Bitcoins.
+    // Scaling down deposit TX max fee as well.
     await bridge.setDepositDustThreshold(10000)
+    await bridge.setDepositTxMaxFee(2000)
     // Set the redemption dust threshold to 0.001 BTC, i.e. 10x smaller than
     // the initial value in the Bridge in order to save test Bitcoins.
     await bridge.setRedemptionDustThreshold(100000)
@@ -347,7 +349,7 @@ describe("Bridge - Redemption", () => {
                                   await restoreSnapshot()
                                 })
 
-                                // Do not repeat all check made in the
+                                // Do not repeat all checks made in the
                                 // "when redeemer output script is P2WPKH"
                                 // scenario but just assert the call succeeds
                                 // for an P2WSH output script.
@@ -377,7 +379,7 @@ describe("Bridge - Redemption", () => {
                                   await restoreSnapshot()
                                 })
 
-                                // Do not repeat all check made in the
+                                // Do not repeat all checks made in the
                                 // "when redeemer output script is P2WPKH"
                                 // scenario but just assert the call succeeds
                                 // for an P2PKH output script.
@@ -407,7 +409,7 @@ describe("Bridge - Redemption", () => {
                                   await restoreSnapshot()
                                 })
 
-                                // Do not repeat all check made in the
+                                // Do not repeat all checks made in the
                                 // "when redeemer output script is P2WPKH"
                                 // scenario but just assert the call succeeds
                                 // for an P2SH output script.
@@ -422,6 +424,64 @@ describe("Bridge - Redemption", () => {
                                         requestedAmount
                                       )
                                   ).to.not.be.reverted
+                                })
+                              }
+                            )
+
+                            context(
+                              "when redemption treasury fee is zero",
+                              () => {
+                                const redeemerOutputScript =
+                                  redeemerOutputScriptP2WPKH
+
+                                before(async () => {
+                                  await createSnapshot()
+
+                                  await bridgeGovernance
+                                    .connect(governance)
+                                    .beginRedemptionTreasuryFeeDivisorUpdate(0)
+                                  await helpers.time.increaseTime(
+                                    constants.governanceDelay
+                                  )
+                                  await bridgeGovernance
+                                    .connect(governance)
+                                    .finalizeRedemptionTreasuryFeeDivisorUpdate()
+
+                                  await bridge
+                                    .connect(redeemer)
+                                    .requestRedemption(
+                                      walletPubKeyHash,
+                                      mainUtxo,
+                                      redeemerOutputScript,
+                                      requestedAmount
+                                    )
+                                })
+
+                                after(async () => {
+                                  await restoreSnapshot()
+                                })
+
+                                // Do not repeat all checks made in the
+                                // "when redeemer output script is P2WPKH"
+                                // scenario but just assert the requested
+                                // amount and treasury fee
+                                it("should store the redemption request with zero fee", async () => {
+                                  const redemptionKey = buildRedemptionKey(
+                                    walletPubKeyHash,
+                                    redeemerOutputScript
+                                  )
+
+                                  const redemptionRequest =
+                                    await bridge.pendingRedemptions(
+                                      redemptionKey
+                                    )
+
+                                  expect(
+                                    redemptionRequest.requestedAmount
+                                  ).to.be.equal(requestedAmount)
+                                  expect(
+                                    redemptionRequest.treasuryFee
+                                  ).to.be.equal(0)
                                 })
                               }
                             )


### PR DESCRIPTION
During the work on the optimistic minting fee in #424, I realized the validation of the deposit and redemption treasury fee parameter in the Bridge does not allow setting the fee to zero, while the Bridge supports the zero-case for deposit and redemption.

We have a condition in `Deposit.sol` in the `revealDeposit` function allowing to properly handle the case when the Bridge's deposit treasury fee is zero:

```
deposit.treasuryFee = self.depositTreasuryFeeDivisor > 0
    ? fundingOutputAmount / self.depositTreasuryFeeDivisor
    : 0;
```

Similarly, we have a condition in `Redemption.sol` in the `requestRedemption` function allowing to properly handle the case when the Bridge's redemption treasury fee is zero:

```
uint64 treasuryFee = self.redemptionTreasuryFeeDivisor > 0
    ? amount / self.redemptionTreasuryFeeDivisor
    : 0;
```

This has been fixed and zero `depositTreasuryFeeDivisor` and `redemptionTreasuryFeeDivisor ` are allowed now. I have
also added unit tests ensuring:

- revealing a deposit with a zero treasury fee works fine,
- sweeping a deposit with a zero treasury fee works fine,
- requesting a redemption with a zero treasury fee works fine. 
 
The case of providing a redemption proof when the fee is zero is already covered, see all the `bridge.setRedemptionTreasuryFeeDivisor(0)` calls across `Bridge.Redemption.test.ts`.