### PR TITLE
Fix badges after change in shields.io syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,10 +2,10 @@
 
 = TBTC v2
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/Solidity/main?event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
-https://github.com/keep-network/tbtc-v2/actions/workflows/typescript.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/TypeScript%20bindings/main?event=push&label=TypeScript%20bindings%20build[TypeScript bindings build status]]
-https://github.com/keep-network/tbtc-v2/actions/workflows/yearn.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/Yearn/main?event=push&label=Yearn%20build[Yearn build status]]
-https://github.com/keep-network/tbtc-v2/actions/workflows/system-tests.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/System%20tests?event=schedule&label=System%20tests[System tests status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/contracts.yml?branch=main&event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/typescript.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/typescript.yml?branch=main&event=push&label=TypeScript%20bindings%20build[TypeScript bindings build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/yearn.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/yearn.yml?branch=main&vent=push&label=Yearn%20build[Yearn build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/system-tests.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/system-tests.yml?branch=main&event=schedule&label=System%20tests[System tests status]]
 https://docs.threshold.network/fundamentals/tbtc-v2[image:https://img.shields.io/badge/docs-website-green.svg[Docs]]
 https://discord.gg/threshold[image:https://img.shields.io/badge/chat-Discord-5865f2.svg[Chat with us on Discord]]
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,6 +1,6 @@
 = TBTC v2
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/Solidity/main?event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/contracts.yml?branch=main&event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
 
 == Abstract
 

--- a/solidity/README.adoc
+++ b/solidity/README.adoc
@@ -2,7 +2,7 @@
 
 = tBTC v2 contracts
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/Solidity/main?event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/contracts.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/contracts.yml?branch=main&event=push&label=TBTC%20contracts%20build[TBTC contracts build status]]
 
 This package contains tBTC v2 contracts.
 

--- a/system-tests/README.adoc
+++ b/system-tests/README.adoc
@@ -2,7 +2,7 @@
 
 = tBTC v2 System tests
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/system-tests.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/System%20tests?event=schedule&label=System%20tests[System tests status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/system-tests.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/system-tests.yml?branch=main&event=schedule&label=System%20tests[System tests status]]
 
 This module contains the system test scenarios stressing the tBTC v2 system.
 

--- a/typescript/README.adoc
+++ b/typescript/README.adoc
@@ -2,7 +2,7 @@
 
 = tBTC v2 TypeScript bindings
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/typescript.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/TypeScript%20bindings/main?event=push&label=TypeScript%20bindings%20build[TypeScript bindings build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/typescript.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/typescript.yml?branch=main&event=push&label=TypeScript%20bindings%20build[TypeScript bindings build status]]
 
 This package provides TypeScript bindings to the tBTC v2 system.
 

--- a/yearn/README.adoc
+++ b/yearn/README.adoc
@@ -2,7 +2,7 @@
 
 = Yearn components for tBTC v2
 
-https://github.com/keep-network/tbtc-v2/actions/workflows/yearn.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc-v2/Yearn/main?event=push&label=Yearn%20build[Yearn build status]]
+https://github.com/keep-network/tbtc-v2/actions/workflows/yearn.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/tbtc-v2/yearn.yml?branch=main&event=push&label=Yearn%20build[Yearn build status]]
 
 This package contains Yearn components (like strategies) intended to be used
 with Yearn vaults working on top of tBTC v2.


### PR DESCRIPTION
The `shields.io` have changed the syntax of the endpoints generating status badges, resulting in showing false failure status when old syntax was used. Updating the READMEs to use the new syntax.
Read more: badges/shields#8671.

Refs:
https://github.com/keep-network/keep-common/pull/112
https://github.com/keep-network/sortition-pools/pull/198
https://github.com/keep-network/keep-core/pull/3449
https://github.com/keep-network/coverage-pools/pull/221