### PR TITLE
Change SemVer range for `@tenderly/hardhat-tenderly` dependency

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -37,7 +37,7 @@
     "@keep-network/tbtc": "development",
     "@openzeppelin/contracts": "^4.6.0",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
-    "@tenderly/hardhat-tenderly": "^1.0.12",
+    "@tenderly/hardhat-tenderly": ">=1.0.12 <1.2.0",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "devDependencies": {

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -690,7 +690,7 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.7.0":
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.6.2", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
   integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
@@ -2259,13 +2259,17 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tenderly/hardhat-tenderly@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.0.12.tgz#fa64da2bf2f6d35a1c131ac9ccaf2f7e8b189a50"
-  integrity sha512-zx2zVpbBxGWVp+aLgf59sZR5lxdqfq/PjqUhga6+iazukQNu/Y6pLfVnCcF1ggvLsf7gnMjwLe3YEx/GxCAykQ==
+"@tenderly/hardhat-tenderly@>=1.0.12 <1.2.0":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.1.6.tgz#b706c7c337ebae7ecd314df3e8ee3d244ed1de08"
+  integrity sha512-B6vVdDAxQwjahrvsxjNirJW2ynDENLBD8LLFy8sYVJ+RCb4B8HXT1IGSceqpySNPr2iLYcD5cKC/YCHX+/O48Q==
   dependencies:
+    "@ethersproject/bignumber" "^5.6.2"
+    "@nomiclabs/hardhat-ethers" "^2.0.6"
     axios "^0.21.1"
+    ethers "^5.6.8"
     fs-extra "^9.0.1"
+    hardhat-deploy "^0.11.10"
     js-yaml "^3.14.0"
 
 "@thesis-co/eslint-config@github:thesis/eslint-config":
@@ -6355,7 +6359,7 @@ ethers@^5.0.1, ethers@^5.0.2:
     "@ethersproject/web" "5.3.0"
     "@ethersproject/wordlists" "5.3.0"
 
-ethers@^5.2.0:
+ethers@^5.2.0, ethers@^5.6.8:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -7373,6 +7377,25 @@ hardhat-dependency-compiler@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/hardhat-dependency-compiler/-/hardhat-dependency-compiler-1.1.2.tgz#02867b7c6dd3de4924d9d3d6593feab8408f1eeb"
   integrity sha512-LVnsPSZnGvzWVvlpewlkPKlPtFP/S9V41RC1fd/ygZc4jkG8ubNlfE82nwiGw5oPueHSmFi6TACgmyrEOokK8w==
+
+hardhat-deploy@^0.11.10:
+  version "0.11.22"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.22.tgz#9799c0266a0fc40c84690de54760f1b4dae5e487"
+  integrity sha512-ZhHVNB7Jo2l8Is+KIAk9F8Q3d7pptyiX+nsNbIFXztCz81kaP+6kxNODRBqRCy7SOD3It4+iKCL6tWsPAA/jVQ==
+  dependencies:
+    "@types/qs" "^6.9.7"
+    axios "^0.21.1"
+    chalk "^4.1.2"
+    chokidar "^3.5.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
+    ethers "^5.5.3"
+    form-data "^4.0.0"
+    fs-extra "^10.0.0"
+    match-all "^1.2.6"
+    murmur-128 "^0.2.1"
+    qs "^6.9.4"
+    zksync-web3 "^0.8.1"
 
 hardhat-deploy@^0.11.11:
   version "0.11.15"


### PR DESCRIPTION
We can't use `@tenderly/hardhat-tenderly` in versions `1.4.x` and higher on Node.js `v14`, as those `1.4.x` versions introduce dependency to `tslog` package, which is incompatible with `v14` of Node.js (works on `v16` or higher). There are also some problems with deployment scripts (possibly fixable) on `@tenderly/hardhat-tenderly` in versions `1.2.x`, so we're limiting the allowed versions to `<1.2.0`.

Using `"@tenderly/hardhat-tenderly": "^1.0.12"` in `tbtc-v2` was causing problems with building/testing of the `@threshold-network/solidity-contracts`, where we upgrade the `tbtc-v2` dependency.