### PR TITLE
Allow only the depositor to reveal a deposit

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -347,12 +347,12 @@ contract Bridge is
     /// @param fundingTx Bitcoin funding transaction data, see `BitcoinTx.Info`.
     /// @param reveal Deposit reveal data, see `RevealInfo struct.
     /// @dev Requirements:
+    ///      - This function must be called by the same Ethereum address as the
+    ///        one used in the P2(W)SH BTC deposit transaction as a depositor,
     ///      - `reveal.walletPubKeyHash` must identify a `Live` wallet,
     ///      - `reveal.vault` must be 0x0 or point to a trusted vault,
     ///      - `reveal.fundingOutputIndex` must point to the actual P2(W)SH
     ///        output of the BTC deposit transaction,
-    ///      - `reveal.depositor` must be the Ethereum address used in the
-    ///        P2(W)SH BTC deposit transaction,
     ///      - `reveal.blindingFactor` must be the blinding factor used in the
     ///        P2(W)SH BTC deposit transaction,
     ///      - `reveal.walletPubKeyHash` must be the wallet pub key hash used in

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -53,8 +53,6 @@ library Deposit {
     struct DepositRevealInfo {
         // Index of the funding output belonging to the funding transaction.
         uint32 fundingOutputIndex;
-        // Ethereum depositor address.
-        address depositor;
         // The blinding factor as 8 bytes. Byte endianness doesn't matter
         // as this factor is not interpreted as uint. The blinding factor allows
         // to distinguish deposits from the same depositor.
@@ -129,12 +127,12 @@ library Deposit {
     /// @param fundingTx Bitcoin funding transaction data, see `BitcoinTx.Info`.
     /// @param reveal Deposit reveal data, see `RevealInfo struct.
     /// @dev Requirements:
+    ///      - This function must be called by the same Ethereum address as the
+    ///        one used in the P2(W)SH BTC deposit transaction as a depositor,
     ///      - `reveal.walletPubKeyHash` must identify a `Live` wallet,
     ///      - `reveal.vault` must be 0x0 or point to a trusted vault,
     ///      - `reveal.fundingOutputIndex` must point to the actual P2(W)SH
     ///        output of the BTC deposit transaction,
-    ///      - `reveal.depositor` must be the Ethereum address used in the
-    ///        P2(W)SH BTC deposit transaction,
     ///      - `reveal.blindingFactor` must be the blinding factor used in the
     ///        P2(W)SH BTC deposit transaction,
     ///      - `reveal.walletPubKeyHash` must be the wallet pub key hash used in
@@ -171,7 +169,7 @@ library Deposit {
 
         bytes memory expectedScript = abi.encodePacked(
             hex"14", // Byte length of depositor Ethereum address.
-            reveal.depositor,
+            msg.sender,
             hex"75", // OP_DROP
             hex"08", // Byte length of blinding factor value.
             reveal.blindingFactor,
@@ -253,7 +251,7 @@ library Deposit {
         );
 
         deposit.amount = fundingOutputAmount;
-        deposit.depositor = reveal.depositor;
+        deposit.depositor = msg.sender;
         /* solhint-disable-next-line not-rely-on-time */
         deposit.revealedAt = uint32(block.timestamp);
         deposit.vault = reveal.vault;
@@ -264,7 +262,7 @@ library Deposit {
         emit DepositRevealed(
             fundingTxHash,
             reveal.fundingOutputIndex,
-            reveal.depositor,
+            msg.sender,
             fundingOutputAmount,
             reveal.blindingFactor,
             reveal.walletPubKeyHash,
@@ -287,7 +285,7 @@ library Deposit {
     function validateDepositRefundLocktime(
         BridgeState.Storage storage self,
         bytes4 refundLocktime
-    ) internal {
+    ) internal view {
         // Convert the refund locktime byte array to a LE integer. This is
         // the moment in time when the deposit become refundable.
         uint32 depositRefundableTimestamp = BTCUtils.reverseUint32(

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { ethers, helpers, waffle } from "hardhat"
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { BigNumber, Contract, ContractTransaction } from "ethers"
 import chai, { expect } from "chai"
@@ -33,7 +33,8 @@ import {
 chai.use(smock.matchers)
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
-const { lastBlockTime, increaseTime } = helpers.time
+const { lastBlockTime } = helpers.time
+const { impersonateAccount } = helpers.account
 
 const ZERO_ADDRESS = ethers.constants.AddressZero
 
@@ -108,9 +109,9 @@ describe("Bridge - Deposit", () => {
 
     // Data matching the redeem script locking the funding output of
     // P2SHFundingTx and P2WSHFundingTx.
+    const depositorAddress = "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637"
     const reveal = {
       fundingOutputIndex: 0,
-      depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
       blindingFactor: "0xf9f0c90d00039523",
       // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
       walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -119,6 +120,15 @@ describe("Bridge - Deposit", () => {
       refundLocktime: "0x60bcea61",
       vault: "0x594cfd89700040163727828AE20B52099C58F02C",
     }
+
+    let depositor: SignerWithAddress
+
+    before(async () => {
+      depositor = await impersonateAccount(depositorAddress, {
+        from: governance,
+        value: 10,
+      })
+    })
 
     context("when wallet is in Live state", () => {
       before(async () => {
@@ -156,8 +166,9 @@ describe("Bridge - Deposit", () => {
 
                   before(async () => {
                     await createSnapshot()
-
-                    tx = await bridge.revealDeposit(P2SHFundingTx, reveal)
+                    tx = await bridge
+                      .connect(depositor)
+                      .revealDeposit(P2SHFundingTx, reveal)
                   })
 
                   after(async () => {
@@ -225,10 +236,9 @@ describe("Bridge - Deposit", () => {
 
                     nonRoutedReveal = { ...reveal }
                     nonRoutedReveal.vault = ZERO_ADDRESS
-                    tx = await bridge.revealDeposit(
-                      P2SHFundingTx,
-                      nonRoutedReveal
-                    )
+                    tx = await bridge
+                      .connect(depositor)
+                      .revealDeposit(P2SHFundingTx, nonRoutedReveal)
                   })
 
                   after(async () => {
@@ -266,7 +276,9 @@ describe("Bridge - Deposit", () => {
                       .connect(governance)
                       .finalizeDepositTreasuryFeeDivisorUpdate()
 
-                    tx = await bridge.revealDeposit(P2SHFundingTx, reveal)
+                    tx = await bridge
+                      .connect(depositor)
+                      .revealDeposit(P2SHFundingTx, reveal)
                   })
 
                   after(async () => {
@@ -330,7 +342,9 @@ describe("Bridge - Deposit", () => {
 
                   it("should revert", async () => {
                     await expect(
-                      bridge.revealDeposit(P2SHFundingTx, nonTrustedVaultReveal)
+                      bridge
+                        .connect(depositor)
+                        .revealDeposit(P2SHFundingTx, nonTrustedVaultReveal)
                     ).to.be.revertedWith("Vault is not trusted")
                   })
                 })
@@ -353,7 +367,9 @@ describe("Bridge - Deposit", () => {
 
                 it("should revert", async () => {
                   await expect(
-                    bridge.revealDeposit(P2SHFundingTx, reveal)
+                    bridge
+                      .connect(depositor)
+                      .revealDeposit(P2SHFundingTx, reveal)
                   ).to.be.revertedWith("Deposit amount too small")
                 })
               })
@@ -363,7 +379,9 @@ describe("Bridge - Deposit", () => {
               before(async () => {
                 await createSnapshot()
 
-                await bridge.revealDeposit(P2SHFundingTx, reveal)
+                await bridge
+                  .connect(depositor)
+                  .revealDeposit(P2SHFundingTx, reveal)
               })
 
               after(async () => {
@@ -372,7 +390,7 @@ describe("Bridge - Deposit", () => {
 
               it("should revert", async () => {
                 await expect(
-                  bridge.revealDeposit(P2SHFundingTx, reveal)
+                  bridge.connect(depositor).revealDeposit(P2SHFundingTx, reveal)
                 ).to.be.revertedWith("Deposit already revealed")
               })
             })
@@ -380,16 +398,33 @@ describe("Bridge - Deposit", () => {
 
           context("when funding output script hash is wrong", () => {
             it("should revert", async () => {
-              // Corrupt reveal data by setting a wrong depositor address.
+              // Corrupt reveal data by setting a wrong blinding factor
               const corruptedReveal = { ...reveal }
-              corruptedReveal.depositor =
-                "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+              corruptedReveal.blindingFactor = "0xf9f0c90d00039524"
 
               await expect(
-                bridge.revealDeposit(P2SHFundingTx, corruptedReveal)
+                bridge
+                  .connect(depositor)
+                  .revealDeposit(P2SHFundingTx, corruptedReveal)
               ).to.be.revertedWith("Wrong 20-byte script hash")
             })
           })
+
+          context(
+            "when the caller address does not match the funding output script",
+            () => {
+              it("should revert", async () => {
+                const accounts = await getUnnamedAccounts()
+                const thirdParty = await ethers.getSigner(accounts[0])
+
+                await expect(
+                  bridge
+                    .connect(thirdParty)
+                    .revealDeposit(P2SHFundingTx, reveal)
+                ).to.be.revertedWith("Wrong 20-byte script hash")
+              })
+            }
+          )
         })
 
         context("when funding transaction is P2WSH", () => {
@@ -401,7 +436,9 @@ describe("Bridge - Deposit", () => {
                 before(async () => {
                   await createSnapshot()
 
-                  tx = await bridge.revealDeposit(P2WSHFundingTx, reveal)
+                  tx = await bridge
+                    .connect(depositor)
+                    .revealDeposit(P2WSHFundingTx, reveal)
                 })
 
                 after(async () => {
@@ -467,10 +504,9 @@ describe("Bridge - Deposit", () => {
 
                   nonRoutedReveal = { ...reveal }
                   nonRoutedReveal.vault = ZERO_ADDRESS
-                  tx = await bridge.revealDeposit(
-                    P2WSHFundingTx,
-                    nonRoutedReveal
-                  )
+                  tx = await bridge
+                    .connect(depositor)
+                    .revealDeposit(P2WSHFundingTx, nonRoutedReveal)
                 })
 
                 after(async () => {
@@ -511,7 +547,9 @@ describe("Bridge - Deposit", () => {
 
                 it("should revert", async () => {
                   await expect(
-                    bridge.revealDeposit(P2WSHFundingTx, nonTrustedVaultReveal)
+                    bridge
+                      .connect(depositor)
+                      .revealDeposit(P2WSHFundingTx, nonTrustedVaultReveal)
                   ).to.be.revertedWith("Vault is not trusted")
                 })
               })
@@ -521,7 +559,9 @@ describe("Bridge - Deposit", () => {
               before(async () => {
                 await createSnapshot()
 
-                await bridge.revealDeposit(P2WSHFundingTx, reveal)
+                await bridge
+                  .connect(depositor)
+                  .revealDeposit(P2WSHFundingTx, reveal)
               })
 
               after(async () => {
@@ -530,7 +570,9 @@ describe("Bridge - Deposit", () => {
 
               it("should revert", async () => {
                 await expect(
-                  bridge.revealDeposit(P2WSHFundingTx, reveal)
+                  bridge
+                    .connect(depositor)
+                    .revealDeposit(P2WSHFundingTx, reveal)
                 ).to.be.revertedWith("Deposit already revealed")
               })
             })
@@ -538,16 +580,33 @@ describe("Bridge - Deposit", () => {
 
           context("when funding output script hash is wrong", () => {
             it("should revert", async () => {
-              // Corrupt reveal data by setting a wrong depositor address.
+              // Corrupt reveal data by setting a wrong blinding factor
               const corruptedReveal = { ...reveal }
-              corruptedReveal.depositor =
-                "0x24CbaB95C69e5bcbE328252F957A39d906eE75f3"
+              corruptedReveal.blindingFactor = "0xf9f0c90d00039524"
 
               await expect(
-                bridge.revealDeposit(P2WSHFundingTx, corruptedReveal)
+                bridge
+                  .connect(depositor)
+                  .revealDeposit(P2WSHFundingTx, corruptedReveal)
               ).to.be.revertedWith("Wrong 32-byte script hash")
             })
           })
+
+          context(
+            "when the caller address does not match the funding output script",
+            () => {
+              it("should revert", async () => {
+                const accounts = await getUnnamedAccounts()
+                const thirdParty = await ethers.getSigner(accounts[0])
+
+                await expect(
+                  bridge
+                    .connect(thirdParty)
+                    .revealDeposit(P2WSHFundingTx, reveal)
+                ).to.be.revertedWith("Wrong 32-byte script hash")
+              })
+            }
+          )
         })
 
         context("when funding transaction is neither P2SH nor P2WSH", () => {
@@ -560,7 +619,9 @@ describe("Bridge - Deposit", () => {
               "140d2726"
 
             await expect(
-              bridge.revealDeposit(corruptedP2SHFundingTx, reveal)
+              bridge
+                .connect(depositor)
+                .revealDeposit(corruptedP2SHFundingTx, reveal)
             ).to.be.revertedWith("Wrong script hash length")
           })
         })
@@ -616,7 +677,9 @@ describe("Bridge - Deposit", () => {
             // the one embedded in the transaction P2SH. We just make sure
             // the execution does not revert on the refund locktime validation.
             await expect(
-              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+              bridge
+                .connect(depositor)
+                .revealDeposit(P2WSHFundingTx, alteredReveal)
             ).to.be.not.revertedWith("Deposit refund locktime is too close")
           })
         })
@@ -639,7 +702,9 @@ describe("Bridge - Deposit", () => {
             ])
 
             await expect(
-              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+              bridge
+                .connect(depositor)
+                .revealDeposit(P2WSHFundingTx, alteredReveal)
             ).to.be.revertedWith("Deposit refund locktime is too close")
           })
         })
@@ -652,7 +717,9 @@ describe("Bridge - Deposit", () => {
             }
 
             await expect(
-              bridge.revealDeposit(P2WSHFundingTx, alteredReveal)
+              bridge
+                .connect(depositor)
+                .revealDeposit(P2WSHFundingTx, alteredReveal)
             ).to.be.revertedWith("Refund locktime must be a value >= 500M")
           })
         })
@@ -706,7 +773,7 @@ describe("Bridge - Deposit", () => {
 
           it("should revert", async () => {
             await expect(
-              bridge.revealDeposit(P2SHFundingTx, reveal)
+              bridge.connect(depositor).revealDeposit(P2SHFundingTx, reveal)
             ).to.be.revertedWith("Wallet must be in Live state")
           })
         })
@@ -807,9 +874,7 @@ describe("Bridge - Deposit", () => {
                             // initial value is 0.05% of the deposited amount so the
                             // final depositor balance should be cut by 10 satoshi.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(18490)
                           })
 
@@ -897,9 +962,7 @@ describe("Bridge - Deposit", () => {
                             // of the deposited amount so the final depositor balance
                             // should be cut by 40 satoshi.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(77960)
                           })
 
@@ -999,9 +1062,7 @@ describe("Bridge - Deposit", () => {
                           it("should not update the depositor's balance", async () => {
                             // The depositor balance should not be increased.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(0)
                           })
 
@@ -1025,7 +1086,7 @@ describe("Bridge - Deposit", () => {
                             expect(
                               vault.receiveBalanceIncrease
                             ).to.have.been.calledOnceWith(
-                              [data.deposits[0].reveal.depositor],
+                              [data.deposits[0].depositor],
                               [77960]
                             )
                           })
@@ -1090,9 +1151,7 @@ describe("Bridge - Deposit", () => {
                             // There is no deposit treasury fee so the final depositor
                             // balance is not additionally cut.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(18500)
                           })
 
@@ -1200,9 +1259,7 @@ describe("Bridge - Deposit", () => {
                             // of the deposited amount so the final depositor balance
                             // should be cut by 40 satoshi.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(77960)
                           })
 
@@ -1507,41 +1564,31 @@ describe("Bridge - Deposit", () => {
                             // (according to inputs order) and it should incur the
                             // remainder of the transaction fee.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(219287)
 
                             // Deposit with index 1 used as input with index 3
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[1].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[1].depositor)
                             ).to.be.equal(759021)
 
                             // Deposit with index 2 used as input with index 1
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[2].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[2].depositor)
                             ).to.be.equal(938931)
 
                             // Deposit with index 3 used as input with index 2
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[3].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[3].depositor)
                             ).to.be.equal(878961)
 
                             // Deposit with index 4 used as input with index 4
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[4].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[4].depositor)
                             ).to.be.equal(289256)
                           })
 
@@ -1673,33 +1720,23 @@ describe("Bridge - Deposit", () => {
 
                           it("should not update the depositors balances", async () => {
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(0)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[1].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[1].depositor)
                             ).to.be.equal(0)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[2].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[2].depositor)
                             ).to.be.equal(0)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[3].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[3].depositor)
                             ).to.be.equal(0)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[4].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[4].depositor)
                             ).to.be.equal(0)
                           })
 
@@ -1729,11 +1766,11 @@ describe("Bridge - Deposit", () => {
                               vault.receiveBalanceIncrease
                             ).to.have.been.calledOnceWith(
                               [
-                                data.deposits[2].reveal.depositor,
-                                data.deposits[3].reveal.depositor,
-                                data.deposits[1].reveal.depositor,
-                                data.deposits[4].reveal.depositor,
-                                data.deposits[0].reveal.depositor,
+                                data.deposits[2].depositor,
+                                data.deposits[3].depositor,
+                                data.deposits[1].depositor,
+                                data.deposits[4].depositor,
+                                data.deposits[0].depositor,
                               ],
                               [938931, 878961, 759021, 289256, 219287]
                             )
@@ -1891,41 +1928,31 @@ describe("Bridge - Deposit", () => {
                             // (according to inputs order) and it should incur the
                             // remainder of the transaction fee.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(219287)
 
                             // Deposit with index 1 used as input with index 3
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[1].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[1].depositor)
                             ).to.be.equal(759021)
 
                             // Deposit with index 2 used as input with index 1
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[2].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[2].depositor)
                             ).to.be.equal(938931)
 
                             // Deposit with index 3 used as input with index 2
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[3].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[3].depositor)
                             ).to.be.equal(878961)
 
                             // Deposit with index 4 used as input with index 4
                             // in the sweep transaction.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[4].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[4].depositor)
                             ).to.be.equal(289256)
                           })
 
@@ -2102,33 +2129,23 @@ describe("Bridge - Deposit", () => {
                             // should also incur the treasury fee whose initial
                             // value is 0.05% of the deposited amount.
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[0].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[0].depositor)
                             ).to.be.equal(29585)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[1].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[1].depositor)
                             ).to.be.equal(9595)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[2].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[2].depositor)
                             ).to.be.equal(209495)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[3].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[3].depositor)
                             ).to.be.equal(369415)
 
                             expect(
-                              await bank.balanceOf(
-                                data.deposits[4].reveal.depositor
-                              )
+                              await bank.balanceOf(data.deposits[4].depositor)
                             ).to.be.equal(439380)
                           })
 
@@ -2919,7 +2936,7 @@ describe("Bridge - Deposit", () => {
       // testing of `MovingFunds` state is limited to just one simple test case
       // (sweeping single P2SH deposit).
       const data: DepositSweepTestData = SingleP2SHDeposit
-      const { fundingTx, reveal } = data.deposits[0]
+      const { fundingTx, depositor, reveal } = data.deposits[0]
 
       before(async () => {
         await createSnapshot()
@@ -2933,7 +2950,11 @@ describe("Bridge - Deposit", () => {
         relay.getCurrentEpochDifficulty.returns(data.chainDifficulty)
         relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
 
-        await bridge.revealDeposit(fundingTx, reveal)
+        const depositorSigner = await impersonateAccount(depositor, {
+          from: governance,
+          value: 10,
+        })
+        await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
 
         // Simulate the wallet's state has changed to MovingFunds
         const wallet = await bridge.wallets(reveal.walletPubKeyHash)
@@ -2963,7 +2984,7 @@ describe("Bridge - Deposit", () => {
 
     context("when the wallet state is neither Live or MovingFunds", () => {
       const data: DepositSweepTestData = SingleP2SHDeposit
-      const { fundingTx, reveal } = data.deposits[0]
+      const { fundingTx, depositor, reveal } = data.deposits[0]
 
       const testData = [
         {
@@ -2998,7 +3019,13 @@ describe("Bridge - Deposit", () => {
             relay.getCurrentEpochDifficulty.returns(data.chainDifficulty)
             relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
 
-            await bridge.revealDeposit(fundingTx, reveal)
+            const depositorSigner = await impersonateAccount(depositor, {
+              from: governance,
+              value: 10,
+            })
+            await bridge
+              .connect(depositorSigner)
+              .revealDeposit(fundingTx, reveal)
 
             // Simulate the wallet's state has changed
             const wallet = await bridge.wallets(reveal.walletPubKeyHash)
@@ -3037,9 +3064,16 @@ describe("Bridge - Deposit", () => {
     relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
 
     for (let i = 0; i < data.deposits.length; i++) {
-      const { fundingTx, reveal } = data.deposits[i]
+      const { fundingTx, depositor, reveal } = data.deposits[i]
+
       // eslint-disable-next-line no-await-in-loop
-      await bridge.revealDeposit(fundingTx, reveal)
+      const depositorSigner = await impersonateAccount(depositor, {
+        from: governance,
+        value: 10,
+      })
+
+      // eslint-disable-next-line no-await-in-loop
+      await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
     }
 
     if (beforeProofActions) {

--- a/solidity/test/bridge/VendingMachine.Upgrade.test.ts
+++ b/solidity/test/bridge/VendingMachine.Upgrade.test.ts
@@ -20,6 +20,8 @@ import type {
   BridgeGovernance,
 } from "../../typechain"
 
+const { impersonateAccount } = helpers.account
+
 const { to1e18 } = helpers.number
 const { increaseTime, lastBlockTime } = helpers.time
 
@@ -149,7 +151,7 @@ describe("VendingMachine - Upgrade", () => {
         const data: DepositSweepTestData = JSON.parse(
           JSON.stringify(SingleP2SHDeposit)
         )
-        const { fundingTx, reveal } = data.deposits[0] // it's a single deposit
+        const { fundingTx, depositor, reveal } = data.deposits[0] // it's a single deposit
         reveal.vault = tbtcVault.address
 
         // Simulate the wallet is a Live one and is known in the system.
@@ -165,7 +167,11 @@ describe("VendingMachine - Upgrade", () => {
           movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
         })
 
-        await bridge.revealDeposit(fundingTx, reveal)
+        const depositorSigner = await impersonateAccount(depositor, {
+          from: governance,
+          value: 10,
+        })
+        await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
 
         relay.getCurrentEpochDifficulty.returns(data.chainDifficulty)
         relay.getPrevEpochDifficulty.returns(data.chainDifficulty)

--- a/solidity/test/data/deposit-sweep.ts
+++ b/solidity/test/data/deposit-sweep.ts
@@ -22,9 +22,9 @@ export interface DepositSweepTestData {
       outputVector: BytesLike
       locktime: BytesLike
     }
+    depositor: string
     reveal: {
       fundingOutputIndex: BigNumberish
-      depositor: string
       blindingFactor: BytesLike
       walletPubKeyHash: BytesLike
       refundPubKeyHash: BytesLike
@@ -116,9 +116,9 @@ export const SingleP2SHDeposit: DepositSweepTestData = {
           "ed",
         locktime: "0x00000000",
       },
+      depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
         blindingFactor: "0xf9f0c90d00039523",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -217,9 +217,9 @@ export const SingleP2WSHDeposit: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0xf4292022F75ADD9b079b0573d0FD63C376a85F41",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0xf4292022F75ADD9b079b0573d0FD63C376a85F41",
         blindingFactor: "0xb0bb0e4d6083951d",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -366,9 +366,10 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
+
         blindingFactor: "0x4a6f267c3bfaba7c",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -392,9 +393,9 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
           "26",
         locktime: "0x00000000",
       },
+      depositor: "0x6749bc3837b23da76ccAF0051aa64202f5dDEed3",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x6749bc3837b23da76ccAF0051aa64202f5dDEed3",
         blindingFactor: "0x2c8b4d267ff1d505",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -418,9 +419,9 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0x640EdB9b80ED9FEAc6D20cc80156D71e3eEDc11b",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x640EdB9b80ED9FEAc6D20cc80156D71e3eEDc11b",
         blindingFactor: "0x8448912a89f4bf26",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -444,9 +445,9 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
           "26",
         locktime: "0x00000000",
       },
+      depositor: "0xC92FC70710558103BD90B6BC9041137c43F86ed7",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0xC92FC70710558103BD90B6BC9041137c43F86ed7",
         blindingFactor: "0x90fb21f8f58d235a",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -470,9 +471,9 @@ export const MultipleDepositsNoMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0xEe080E869F094e251E135294539a05b267041122",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0xEe080E869F094e251E135294539a05b267041122",
         blindingFactor: "0xdd66710eefa37a42",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -569,9 +570,9 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0x7F62CddE8A86328d63B9517BC70B255017f25EEa",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x7F62CddE8A86328d63B9517BC70B255017f25EEa",
         blindingFactor: "0x1d5c0a1bc9528ea2",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -595,9 +596,9 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
           "26",
         locktime: "0x00000000",
       },
+      depositor: "0x2219eAC966FbC0454C4A2e122717e4429Dd7608F",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x2219eAC966FbC0454C4A2e122717e4429Dd7608F",
         blindingFactor: "0x251c7239917eae29",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -623,9 +624,9 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0x208fF63189DF8749780917Cb5901183075Dbabc1",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x208fF63189DF8749780917Cb5901183075Dbabc1",
         blindingFactor: "0x8bdbb150483eb2f2",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -649,9 +650,9 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
           "26",
         locktime: "0x00000000",
       },
+      depositor: "0x35D54bC29e0a5170c3Ac73E64c7fA539A867f0FE",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x35D54bC29e0a5170c3Ac73E64c7fA539A867f0FE",
         blindingFactor: "0xdfe75a3a6ed52db6",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",
@@ -675,9 +676,9 @@ export const MultipleDepositsWithMainUtxo: DepositSweepTestData = {
           "89dfb8095ca95ed2140d2726",
         locktime: "0x00000000",
       },
+      depositor: "0x462418b7495561bF2872A0786109A11f5d494aA2",
       reveal: {
         fundingOutputIndex: 0,
-        depositor: "0x462418b7495561bF2872A0786109A11f5d494aA2",
         blindingFactor: "0xeca429ef209bf500",
         // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
         walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",

--- a/solidity/test/integration/data/integration.ts
+++ b/solidity/test/integration/data/integration.ts
@@ -38,9 +38,9 @@ export const revealDepositData = {
       "120fb077fbed",
     locktime: "0x00000000",
   },
+  depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
   reveal: {
     fundingOutputIndex: 0,
-    depositor: "0x934B98637cA318a4D6E7CA6ffd1690b8e77df637",
     blindingFactor: "0xf9f0c90d00039523",
     // HASH160 of 03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9.
     walletPubKeyHash: "0x8db50eb52063ea9d98b3eac91489a90f738986f6",

--- a/solidity/test/maintainer/MaintainerProxy.test.ts
+++ b/solidity/test/maintainer/MaintainerProxy.test.ts
@@ -3582,9 +3582,14 @@ describe("MaintainerProxy", () => {
     relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
 
     for (let i = 0; i < data.deposits.length; i++) {
-      const { fundingTx, reveal } = data.deposits[i]
+      const { fundingTx, depositor, reveal } = data.deposits[i]
       // eslint-disable-next-line no-await-in-loop
-      await bridge.revealDeposit(fundingTx, reveal)
+      const depositorSigner = await impersonateAccount(depositor, {
+        from: governance,
+        value: 10,
+      })
+      // eslint-disable-next-line no-await-in-loop
+      await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
     }
 
     if (beforeProofActions) {


### PR DESCRIPTION
Closes: #439 

Consider this scenario:
- Alice reveals her Bitcoin deposit and routes it to vault 0xABC
- Eve notices Alice's TX in the mempool and front-runs it with the same data but the vault 0xDEF

As a result, Alice's deposit lands in vault 0xDEF and not in vault 0xABC. Both 0xDEF and 0xABC have to be trusted vaults but it is still an issue given it is not what Alice was asking for.

Here we change the validation requirements of Bridge.revealDeposit function. From now on, this function must be called by the same Ethereum address as the one used in the P2(W)SH BTC deposit transaction as a depositor.