### PR TITLE
TransactionHash as Hex class

### DIFF
--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -3,6 +3,7 @@ import wif from "wif"
 import bufio from "bufio"
 import hash160 from "bcrypto/lib/hash160"
 import { BigNumber } from "ethers"
+import { Hex } from "./hex"
 
 /**
  * Represents a transaction hash (or transaction ID) as an un-prefixed hex
@@ -11,7 +12,7 @@ import { BigNumber } from "ethers"
  * by the Bitcoin protocol internally. That means the hash must be reversed in
  * the use cases that expect the Bitcoin internal byte order.
  */
-export type TransactionHash = string
+export class TransactionHash extends Hex {}
 
 /**
  * Represents a raw transaction.

--- a/typescript/src/deposit-sweep.ts
+++ b/typescript/src/deposit-sweep.ts
@@ -200,7 +200,7 @@ export async function assembleDepositSweepTransaction(
 
     const utxoWithDeposit = utxosWithDeposits.find(
       (u) =>
-        u.transactionHash === previousOutpoint.txid() &&
+        u.transactionHash.toString() === previousOutpoint.txid() &&
         u.outputIndex == previousOutpoint.index
     )
     if (!utxoWithDeposit) {
@@ -223,7 +223,7 @@ export async function assembleDepositSweepTransaction(
     }
   }
 
-  const transactionHash = transaction.txid()
+  const transactionHash = TransactionHash.from(transaction.txid())
 
   return {
     transactionHash,

--- a/typescript/src/deposit.ts
+++ b/typescript/src/deposit.ts
@@ -223,7 +223,7 @@ export async function assembleDepositTransaction(
 
   transaction.sign(depositorKeyRing)
 
-  const transactionHash = transaction.txid()
+  const transactionHash = TransactionHash.from(transaction.txid())
 
   return {
     transactionHash,

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -126,7 +126,7 @@ export class Client implements BitcoinClient {
           )
 
         return unspentTransactions.reverse().map((tx: any) => ({
-          transactionHash: tx.tx_hash,
+          transactionHash: TransactionHash.from(tx.tx_hash),
           outputIndex: tx.tx_pos,
           value: BigNumber.from(tx.value),
         }))
@@ -141,13 +141,13 @@ export class Client implements BitcoinClient {
   getTransaction(transactionHash: TransactionHash): Promise<Transaction> {
     return this.withElectrum<Transaction>(async (electrum: any) => {
       const transaction = await electrum.blockchain_transaction_get(
-        transactionHash,
+        transactionHash.toString(),
         true
       )
 
       const inputs = transaction.vin.map(
         (input: any): TransactionInput => ({
-          transactionHash: input.txid,
+          transactionHash: TransactionHash.from(input.txid),
           outputIndex: input.vout,
           scriptSig: input.scriptSig,
         })
@@ -163,7 +163,7 @@ export class Client implements BitcoinClient {
       )
 
       return {
-        transactionHash: transaction.txid,
+        transactionHash: TransactionHash.from(transaction.txid),
         inputs: inputs,
         outputs: outputs,
       }
@@ -177,7 +177,7 @@ export class Client implements BitcoinClient {
   getRawTransaction(transactionHash: TransactionHash): Promise<RawTransaction> {
     return this.withElectrum<RawTransaction>(async (electrum: any) => {
       const transaction = await electrum.blockchain_transaction_get(
-        transactionHash,
+        transactionHash.toString(),
         true
       )
 
@@ -196,7 +196,7 @@ export class Client implements BitcoinClient {
   ): Promise<number> {
     return this.withElectrum<number>(async (electrum: any) => {
       const transaction = await electrum.blockchain_transaction_get(
-        transactionHash,
+        transactionHash.toString(),
         true
       )
 
@@ -241,7 +241,7 @@ export class Client implements BitcoinClient {
   ): Promise<TransactionMerkleBranch> {
     return this.withElectrum<TransactionMerkleBranch>(async (electrum: any) => {
       const merkle = await electrum.blockchain_transaction_getMerkle(
-        transactionHash,
+        transactionHash.toString(),
         blockHeight
       )
 

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -208,9 +208,7 @@ export class Bridge implements ChainBridge {
     const mainUtxoParam = {
       // The Ethereum Bridge expects this hash to be in the Bitcoin internal
       // byte order.
-      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
-        .reverse()
-        .toString("hex")}`,
+      txHash: mainUtxo.transactionHash.reverse().toPrefixedString(),
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }
@@ -252,9 +250,7 @@ export class Bridge implements ChainBridge {
     const mainUtxoParam = {
       // The Ethereum Bridge expects this hash to be in the Bitcoin internal
       // byte order.
-      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
-        .reverse()
-        .toString("hex")}`,
+      txHash: mainUtxo.transactionHash.reverse().toPrefixedString(),
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }
@@ -301,9 +297,7 @@ export class Bridge implements ChainBridge {
     const mainUtxoParam = {
       // The Ethereum Bridge expects this hash to be in the Bitcoin internal
       // byte order.
-      txHash: `0x${Buffer.from(mainUtxo.transactionHash, "hex")
-        .reverse()
-        .toString("hex")}`,
+      txHash: mainUtxo.transactionHash.reverse().toPrefixedString(),
       txOutputIndex: mainUtxo.outputIndex,
       txOutputValue: mainUtxo.value,
     }
@@ -344,9 +338,9 @@ export class Bridge implements ChainBridge {
     depositTxHash: TransactionHash,
     depositOutputIndex: number
   ): string {
-    const prefixedReversedDepositTxHash = `0x${Buffer.from(depositTxHash, "hex")
+    const prefixedReversedDepositTxHash = depositTxHash
       .reverse()
-      .toString("hex")}`
+      .toPrefixedString()
 
     return utils.solidityKeccak256(
       ["bytes32", "uint32"],

--- a/typescript/src/hex.ts
+++ b/typescript/src/hex.ts
@@ -4,7 +4,7 @@
 export class Hex {
   protected readonly _hex: Buffer
 
-  constructor(value: Buffer | string) {
+  protected constructor(value: Buffer | string) {
     if (typeof value === "string") {
       if (!value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {
         throw new Error(`invalid format of hex string`)

--- a/typescript/src/hex.ts
+++ b/typescript/src/hex.ts
@@ -1,0 +1,57 @@
+/**
+ * Represents a hexadecimal value.
+ */
+export class Hex {
+  protected readonly _hex: Buffer
+
+  constructor(value: Buffer | string) {
+    if (typeof value === "string") {
+      if (!value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {
+        throw new Error(`invalid format of hex string`)
+      }
+
+      if (value.length % 2 !== 0) {
+        throw new Error(`invalid length of hex string: ${value.length}`)
+      }
+
+      value = value.replace(/^(0x|0X)/, "")
+
+      this._hex = Buffer.from(value, "hex")
+    } else {
+      this._hex = Buffer.from(value)
+    }
+  }
+
+  static from(value: Buffer | string): Hex {
+    return new Hex(value)
+  }
+
+  /**
+   * @returns Hexadecimal value as a Buffer.
+   */
+  toBuffer(): Buffer {
+    return Buffer.from(this._hex)
+  }
+
+  /**
+   * @returns Unprefixed hexadecimal string.
+   */
+  toString(): string {
+    return this._hex.toString("hex")
+  }
+
+  /**
+   * @returns Hexadecimal string prefixed with '0x'.
+   */
+  toPrefixedString(): string {
+    const str = this.toString()
+    return str.length > 0 ? "0x" + str : ""
+  }
+
+  /**
+   * @returns Reversed hexadecimal value.
+   */
+  reverse(): Hex {
+    return Hex.from(Buffer.from(this._hex).reverse())
+  }
+}

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -316,7 +316,7 @@ export async function assembleRedemptionTransaction(
 
   transaction.sign(walletKeyRing)
 
-  const transactionHash = transaction.txid()
+  const transactionHash = TransactionHash.from(transaction.txid())
   // If there is a change output, it will be the new wallet's main UTXO.
   const newMainUtxo = changeOutputValue.gt(0)
     ? {

--- a/typescript/test/data/deposit-sweep.ts
+++ b/typescript/test/data/deposit-sweep.ts
@@ -11,7 +11,7 @@ import { calculateDepositRefundLocktime, Deposit } from "../../src/deposit"
 import { BigNumber } from "ethers"
 
 export const NO_MAIN_UTXO = {
-  transactionHash: "",
+  transactionHash: TransactionHash.from(""),
   outputIndex: 0,
   value: BigNumber.from(0),
   transactionHex: "",
@@ -43,8 +43,9 @@ export const depositSweepWithNoMainUtxoAndWitnessOutput: DepositSweepTestData =
     deposits: [
       {
         utxo: {
-          transactionHash:
-            "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc",
+          transactionHash: TransactionHash.from(
+            "74d0e353cdba99a6c17ce2cfeab62a26c09b5eb756eccdcfb83dbc12e67b18bc"
+          ),
           outputIndex: 0,
           value: BigNumber.from(25000),
           transactionHex:
@@ -71,8 +72,9 @@ export const depositSweepWithNoMainUtxoAndWitnessOutput: DepositSweepTestData =
       },
       {
         utxo: {
-          transactionHash:
-            "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc",
+          transactionHash: TransactionHash.from(
+            "5c54ecdf946382fab2236f78423ddc22a757776fb8492671c588667b737e55dc"
+          ),
           outputIndex: 0,
           value: BigNumber.from(12000),
           transactionHex:
@@ -101,8 +103,9 @@ export const depositSweepWithNoMainUtxoAndWitnessOutput: DepositSweepTestData =
     mainUtxo: NO_MAIN_UTXO,
     witness: true,
     expectedSweep: {
-      transactionHash:
-        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+      transactionHash: TransactionHash.from(
+        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668"
+      ),
       transaction: {
         transactionHex:
           "01000000000102bc187be612bc3db8cfcdec56b75e9bc0262ab6eacfe27cc1a699" +
@@ -135,8 +138,9 @@ export const depositSweepWithNoMainUtxoAndNonWitnessOutput: DepositSweepTestData
     deposits: [
       {
         utxo: {
-          transactionHash:
-            "4cdd899d7133cd681bdc4e80b3af09d34da1f7450c5b19167aa8a8223c7a8426",
+          transactionHash: TransactionHash.from(
+            "4cdd899d7133cd681bdc4e80b3af09d34da1f7450c5b19167aa8a8223c7a8426"
+          ),
           outputIndex: 0,
           value: BigNumber.from(15000),
           transactionHex:
@@ -159,8 +163,9 @@ export const depositSweepWithNoMainUtxoAndNonWitnessOutput: DepositSweepTestData
     mainUtxo: NO_MAIN_UTXO,
     witness: false,
     expectedSweep: {
-      transactionHash:
-        "1c42b0568d88bb4d21ae138769fd06199dd3ec689911972792e678be8516d58d",
+      transactionHash: TransactionHash.from(
+        "1c42b0568d88bb4d21ae138769fd06199dd3ec689911972792e678be8516d58d"
+      ),
       transaction: {
         transactionHex:
           "010000000126847a3c22a8a87a16195b0c45f7a14dd309afb3804edc1b68cd33719d89dd4c00000000c9483045022100d0e9c2e38db714c29c6b48eaf6369adb4b33fbc73fe63fbc03d28bebf3a41122022051bdfd31829571b69b788f84defcb256a7de7db3b7bdb2356100ccfd1c16378f012103989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d94c5c14934b98637ca318a4d6e7ca6ffd1690b8e77df6377508f9f0c90d000395237576a9148db50eb52063ea9d98b3eac91489a90f738986f68763ac6776a914e257eccafbc07c381642ce6e7e55120fb077fbed880448f2b262b175ac68ffffffff0158340000000000001976a9148db50eb52063ea9d98b3eac91489a90f738986f688ac00000000",
@@ -180,8 +185,9 @@ export const depositSweepWithWitnessMainUtxoAndWitnessOutput: DepositSweepTestDa
       {
         // P2SH deposit
         utxo: {
-          transactionHash:
-            "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed",
+          transactionHash: TransactionHash.from(
+            "d4fe2ef9068d039eae2210e893db518280d4757696fe9db8f3c696a94de90aed"
+          ),
           outputIndex: 0,
           value: BigNumber.from(17000),
           transactionHex:
@@ -209,8 +215,9 @@ export const depositSweepWithWitnessMainUtxoAndWitnessOutput: DepositSweepTestDa
       {
         // P2WSH deposit
         utxo: {
-          transactionHash:
-            "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3",
+          transactionHash: TransactionHash.from(
+            "b86ef64f8aff19778535e7c6e45ff82bc2f5f5eec800fd2b03a03fc22f557fe3"
+          ),
           outputIndex: 0,
           value: BigNumber.from(10000),
           transactionHex:
@@ -238,8 +245,9 @@ export const depositSweepWithWitnessMainUtxoAndWitnessOutput: DepositSweepTestDa
     ],
     mainUtxo: {
       // P2WPKH
-      transactionHash:
-        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+      transactionHash: TransactionHash.from(
+        "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668"
+      ),
       outputIndex: 0,
       value: BigNumber.from(35400),
       transactionHex:
@@ -262,8 +270,9 @@ export const depositSweepWithWitnessMainUtxoAndWitnessOutput: DepositSweepTestDa
     },
     witness: true,
     expectedSweep: {
-      transactionHash:
-        "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e",
+      transactionHash: TransactionHash.from(
+        "435d4aff6d4bc34134877bd3213c17970142fdd04d4113d534120033b9eecb2e"
+      ),
       transaction: {
         transactionHex:
           "010000000001036896f9abcac13ce6bd2b80d125bedf997ff6330e999f2f605ea1" +
@@ -301,8 +310,9 @@ export const depositSweepWithNonWitnessMainUtxoAndWitnessOutput: DepositSweepTes
     deposits: [
       {
         utxo: {
-          transactionHash:
-            "fda2323b4075a0311767ae8db07f4387bb53663a304278cd8c2c7a591f203a17",
+          transactionHash: TransactionHash.from(
+            "fda2323b4075a0311767ae8db07f4387bb53663a304278cd8c2c7a591f203a17"
+          ),
           outputIndex: 0,
           value: BigNumber.from(19000),
           transactionHex:
@@ -330,8 +340,9 @@ export const depositSweepWithNonWitnessMainUtxoAndWitnessOutput: DepositSweepTes
       },
     ],
     mainUtxo: {
-      transactionHash:
-        "c8a2c407309b9434cb73d4788ce4ac895084240eec7bb440e7f76b75be1296e1",
+      transactionHash: TransactionHash.from(
+        "c8a2c407309b9434cb73d4788ce4ac895084240eec7bb440e7f76b75be1296e1"
+      ),
       outputIndex: 0,
       value: BigNumber.from(16400),
       transactionHex:
@@ -347,8 +358,9 @@ export const depositSweepWithNonWitnessMainUtxoAndWitnessOutput: DepositSweepTes
     },
     witness: true,
     expectedSweep: {
-      transactionHash:
-        "7831d0dfde7e160f3b9bb66c433710f0d3110d73ea78b9db65e81c091a6718a0",
+      transactionHash: TransactionHash.from(
+        "7831d0dfde7e160f3b9bb66c433710f0d3110d73ea78b9db65e81c091a6718a0"
+      ),
       transaction: {
         transactionHex:
           "01000000000102173a201f597a2c8ccd7842303a6653bb87437fb08dae671731a0" +
@@ -395,30 +407,35 @@ export interface DepositSweepProofTestData {
 export const depositSweepProof: DepositSweepProofTestData = {
   bitcoinChainData: {
     transaction: {
-      transactionHash:
-        "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753",
+      transactionHash: TransactionHash.from(
+        "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753"
+      ),
       inputs: [
         {
-          transactionHash:
-            "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f",
+          transactionHash: TransactionHash.from(
+            "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd",
+          transactionHash: TransactionHash.from(
+            "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473",
+          transactionHash: TransactionHash.from(
+            "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378",
+          transactionHash: TransactionHash.from(
+            "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },

--- a/typescript/test/data/deposit.ts
+++ b/typescript/test/data/deposit.ts
@@ -1,4 +1,8 @@
-import { RawTransaction, UnspentTransactionOutput } from "../../src/bitcoin"
+import {
+  RawTransaction,
+  TransactionHash,
+  UnspentTransactionOutput,
+} from "../../src/bitcoin"
 import { BigNumber } from "ethers"
 
 /**
@@ -16,8 +20,9 @@ export const testnetPrivateKey =
 /**
  * Hash of one of the transactions originating from testnetAddress.
  */
-export const testnetTransactionHash =
+export const testnetTransactionHash = TransactionHash.from(
   "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883"
+)
 
 /**
  * Transaction corresponding to testnetTransactionHash and originating

--- a/typescript/test/data/electrum.ts
+++ b/typescript/test/data/electrum.ts
@@ -3,6 +3,7 @@ import {
   RawTransaction,
   UnspentTransactionOutput,
   TransactionMerkleBranch,
+  TransactionHash,
 } from "../../src/bitcoin"
 import { BigNumber } from "ethers"
 
@@ -16,13 +17,15 @@ export const testnetAddress: string =
  * A testnet transaction originating from {@link testnetAddress}
  */
 export const testnetTransaction: Transaction = {
-  transactionHash:
-    "72e7fd57c2adb1ed2305c4247486ff79aec363296f02ec65be141904f80d214e",
+  transactionHash: TransactionHash.from(
+    "72e7fd57c2adb1ed2305c4247486ff79aec363296f02ec65be141904f80d214e"
+  ),
 
   inputs: [
     {
-      transactionHash:
-        "c6ffe9e0f8cca057acad211023ff6b9d46604fbbcb76c6dd669c20b22985f802",
+      transactionHash: TransactionHash.from(
+        "c6ffe9e0f8cca057acad211023ff6b9d46604fbbcb76c6dd669c20b22985f802"
+      ),
       outputIndex: 1,
       scriptSig: {
         asm: "",

--- a/typescript/test/data/proof.ts
+++ b/typescript/test/data/proof.ts
@@ -2,6 +2,7 @@ import {
   Proof,
   RawTransaction,
   Transaction,
+  TransactionHash,
   TransactionMerkleBranch,
 } from "../../src/bitcoin"
 import { BigNumber } from "ethers"
@@ -30,12 +31,14 @@ export const singleInputProofTestData: ProofTestData = {
   requiredConfirmations: 6,
   bitcoinChainData: {
     transaction: {
-      transactionHash:
-        "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473",
+      transactionHash: TransactionHash.from(
+        "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473"
+      ),
       inputs: [
         {
-          transactionHash:
-            "8ee67b585eeb682bf6907ea311282540ee53edf605e0f09757226a4dc3e72a67",
+          transactionHash: TransactionHash.from(
+            "8ee67b585eeb682bf6907ea311282540ee53edf605e0f09757226a4dc3e72a67"
+          ),
           outputIndex: 0,
           scriptSig: {
             asm: "",
@@ -105,12 +108,14 @@ export const singleInputProofTestData: ProofTestData = {
     },
   },
   expectedProof: {
-    transactionHash:
-      "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473",
+    transactionHash: TransactionHash.from(
+      "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473"
+    ),
     inputs: [
       {
-        transactionHash:
-          "8ee67b585eeb682bf6907ea311282540ee53edf605e0f09757226a4dc3e72a67",
+        transactionHash: TransactionHash.from(
+          "8ee67b585eeb682bf6907ea311282540ee53edf605e0f09757226a4dc3e72a67"
+        ),
         outputIndex: 0,
         scriptSig: {
           asm: "",
@@ -170,30 +175,35 @@ export const multipleInputsProofTestData: ProofTestData = {
 
   bitcoinChainData: {
     transaction: {
-      transactionHash:
-        "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753",
+      transactionHash: TransactionHash.from(
+        "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753"
+      ),
       inputs: [
         {
-          transactionHash:
-            "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f",
+          transactionHash: TransactionHash.from(
+            "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd",
+          transactionHash: TransactionHash.from(
+            "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473",
+          transactionHash: TransactionHash.from(
+            "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
         {
-          transactionHash:
-            "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378",
+          transactionHash: TransactionHash.from(
+            "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378"
+          ),
           outputIndex: 0,
           scriptSig: { asm: "", hex: "" },
         },
@@ -278,30 +288,35 @@ export const multipleInputsProofTestData: ProofTestData = {
     },
   },
   expectedProof: {
-    transactionHash:
-      "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753",
+    transactionHash: TransactionHash.from(
+      "5083822ed0b8d0bc661362b778e666cb572ff6d5152193992dd69d3207995753"
+    ),
     inputs: [
       {
-        transactionHash:
-          "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f",
+        transactionHash: TransactionHash.from(
+          "ea4d9e45f8c1b8a187c007f36ba1e9b201e8511182c7083c4edcaf9325b2998f"
+        ),
         outputIndex: 0,
         scriptSig: { asm: "", hex: "" },
       },
       {
-        transactionHash:
-          "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd",
+        transactionHash: TransactionHash.from(
+          "c844ff4c1781c884bb5e80392398b81b984d7106367ae16675f132bd1a7f33fd"
+        ),
         outputIndex: 0,
         scriptSig: { asm: "", hex: "" },
       },
       {
-        transactionHash:
-          "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473",
+        transactionHash: TransactionHash.from(
+          "44c568bc0eac07a2a9c2b46829be5b5d46e7d00e17bfb613f506a75ccf86a473"
+        ),
         outputIndex: 0,
         scriptSig: { asm: "", hex: "" },
       },
       {
-        transactionHash:
-          "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378",
+        transactionHash: TransactionHash.from(
+          "f548c00e464764e112826450a00cf005ca771a6108a629b559b6c60a519e4378"
+        ),
         outputIndex: 0,
         scriptSig: { asm: "", hex: "" },
       },

--- a/typescript/test/data/redemption.ts
+++ b/typescript/test/data/redemption.ts
@@ -56,8 +56,9 @@ export interface RedemptionTestData {
  */
 export const singleP2PKHRedemptionWithWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "523e4bfb71804e5ed3b76c8933d733339563e560311c1bf835934ee7aae5db20",
+    transactionHash: TransactionHash.from(
+      "523e4bfb71804e5ed3b76c8933d733339563e560311c1bf835934ee7aae5db20"
+    ),
     outputIndex: 1,
     value: BigNumber.from(1481680),
     transactionHex:
@@ -89,8 +90,9 @@ export const singleP2PKHRedemptionWithWitnessChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "c437f1117db977682334b53a71fbe63a42aab42f6e0976c35b69977f86308c20",
+    transactionHash: TransactionHash.from(
+      "c437f1117db977682334b53a71fbe63a42aab42f6e0976c35b69977f86308c20"
+    ),
     transaction: {
       transactionHex:
         "0100000000010120dbe5aae74e9335f81b1c3160e563953333d733896cb7d35e4e80" +
@@ -111,8 +113,9 @@ export const singleP2PKHRedemptionWithWitnessChange: RedemptionTestData = {
  */
 export const singleP2WPKHRedemptionWithWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "c437f1117db977682334b53a71fbe63a42aab42f6e0976c35b69977f86308c20",
+    transactionHash: TransactionHash.from(
+      "c437f1117db977682334b53a71fbe63a42aab42f6e0976c35b69977f86308c20"
+    ),
     outputIndex: 1,
     value: BigNumber.from(1472680),
     transactionHex:
@@ -143,8 +146,9 @@ export const singleP2WPKHRedemptionWithWitnessChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "925e61dc31396e7f2cbcc8bc9b4009b4f24ba679257762df078b7e9b875ea110",
+    transactionHash: TransactionHash.from(
+      "925e61dc31396e7f2cbcc8bc9b4009b4f24ba679257762df078b7e9b875ea110"
+    ),
     transaction: {
       transactionHex:
         "01000000000101208c30867f97695bc376096e2fb4aa423ae6fb713ab534236877b9" +
@@ -165,8 +169,9 @@ export const singleP2WPKHRedemptionWithWitnessChange: RedemptionTestData = {
  */
 export const singleP2SHRedemptionWithWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "925e61dc31396e7f2cbcc8bc9b4009b4f24ba679257762df078b7e9b875ea110",
+    transactionHash: TransactionHash.from(
+      "925e61dc31396e7f2cbcc8bc9b4009b4f24ba679257762df078b7e9b875ea110"
+    ),
     outputIndex: 1,
     value: BigNumber.from(1458780),
     transactionHex:
@@ -197,8 +202,9 @@ export const singleP2SHRedemptionWithWitnessChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "ef25c9c8f4df673def035c0c1880278c90030b3c94a56668109001a591c2c521",
+    transactionHash: TransactionHash.from(
+      "ef25c9c8f4df673def035c0c1880278c90030b3c94a56668109001a591c2c521"
+    ),
     transaction: {
       transactionHex:
         "0100000000010110a15e879b7e8b07df62772579a64bf2b409409bbcc8bc2c7f6e3" +
@@ -219,8 +225,9 @@ export const singleP2SHRedemptionWithWitnessChange: RedemptionTestData = {
  */
 export const singleP2WSHRedemptionWithWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "ef25c9c8f4df673def035c0c1880278c90030b3c94a56668109001a591c2c521",
+    transactionHash: TransactionHash.from(
+      "ef25c9c8f4df673def035c0c1880278c90030b3c94a56668109001a591c2c521"
+    ),
     outputIndex: 1,
     value: BigNumber.from(1446580),
     transactionHex:
@@ -252,8 +259,9 @@ export const singleP2WSHRedemptionWithWitnessChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3",
+    transactionHash: TransactionHash.from(
+      "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3"
+    ),
     transaction: {
       transactionHex:
         "0100000000010121c5c291a50190106866a5943c0b03908c2780180c5c03ef3d67d" +
@@ -274,8 +282,9 @@ export const singleP2WSHRedemptionWithWitnessChange: RedemptionTestData = {
  */
 export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3",
+    transactionHash: TransactionHash.from(
+      "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3"
+    ),
     outputIndex: 1,
     value: BigNumber.from(1429580),
     transactionHex:
@@ -353,8 +362,9 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7",
+    transactionHash: TransactionHash.from(
+      "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7"
+    ),
     transaction: {
       transactionHex:
         "01000000000101e30b907d077893bd0ed819c66644027b1dd30e4d3f68bc51da793" +
@@ -378,8 +388,9 @@ export const multipleRedemptionsWithWitnessChange: RedemptionTestData = {
  */
 export const multipleRedemptionsWithoutChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "7dd38b48cb626580d317871c5b716eaf4a952ceb67ba3aa4ca76e3dc7cdcc65b",
+    transactionHash: TransactionHash.from(
+      "7dd38b48cb626580d317871c5b716eaf4a952ceb67ba3aa4ca76e3dc7cdcc65b"
+    ),
     outputIndex: 1,
     value: BigNumber.from(10000),
     transactionHex:
@@ -426,8 +437,9 @@ export const multipleRedemptionsWithoutChange: RedemptionTestData = {
   ],
   witness: true,
   expectedRedemption: {
-    transactionHash:
-      "afcdf8f91273b73abc40018873978c22bbb7c3d8d669ef2faffa0c4b0898c8eb",
+    transactionHash: TransactionHash.from(
+      "afcdf8f91273b73abc40018873978c22bbb7c3d8d669ef2faffa0c4b0898c8eb"
+    ),
     transaction: {
       transactionHex:
         "010000000001015bc6dc7cdce376caa43aba67eb2c954aaf6e715b1c8717d380656" +
@@ -448,8 +460,9 @@ export const multipleRedemptionsWithoutChange: RedemptionTestData = {
  */
 export const singleP2SHRedemptionWithNonWitnessChange: RedemptionTestData = {
   mainUtxo: {
-    transactionHash:
-      "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7",
+    transactionHash: TransactionHash.from(
+      "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7"
+    ),
     outputIndex: 4,
     value: BigNumber.from(1375180),
     transactionHex:
@@ -483,8 +496,9 @@ export const singleP2SHRedemptionWithNonWitnessChange: RedemptionTestData = {
   ],
   witness: false, // False will result in a P2PKH output
   expectedRedemption: {
-    transactionHash:
-      "0fec22d0fecd6607a0429210d04e9465681507d514f3edf0f07def96eda0f89d",
+    transactionHash: TransactionHash.from(
+      "0fec22d0fecd6607a0429210d04e9465681507d514f3edf0f07def96eda0f89d"
+    ),
     transaction: {
       transactionHex:
         "01000000000101b772d923456fb61a15c6a0dcd15df057f4f0c53c14b8e4836122b" +
@@ -525,12 +539,14 @@ export interface RedemptionProofTestData {
 export const redemptionProof: RedemptionProofTestData = {
   bitcoinChainData: {
     transaction: {
-      transactionHash:
-        "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7",
+      transactionHash: TransactionHash.from(
+        "f70ff89fd2b6226183e4b8143cc5f0f457f05dd1dca0c6151ab66f4523d972b7"
+      ),
       inputs: [
         {
-          transactionHash:
-            "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3",
+          transactionHash: TransactionHash.from(
+            "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3"
+          ),
           outputIndex: 1,
           scriptSig: { asm: "", hex: "" },
         },
@@ -682,8 +698,9 @@ export const redemptionProof: RedemptionProofTestData = {
         "69eab449fb51823d58835a4aed9a5e62341f5c192fd94baa",
     },
     mainUtxo: {
-      transactionHash:
-        "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3",
+      transactionHash: TransactionHash.from(
+        "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3"
+      ),
       outputIndex: 1,
       value: BigNumber.from(1429580),
     },

--- a/typescript/test/deposit-sweep.test.ts
+++ b/typescript/test/deposit-sweep.test.ts
@@ -4,7 +4,7 @@ import {
   TransactionHash,
   UnspentTransactionOutput,
   Transaction,
-} from "./bitcoin"
+} from "../src/bitcoin"
 import {
   testnetDepositScripthashAddress,
   testnetDepositWitnessScripthashAddress,

--- a/typescript/test/deposit-sweep.test.ts
+++ b/typescript/test/deposit-sweep.test.ts
@@ -54,7 +54,7 @@ describe("Sweep", () => {
           // set the mapping in the mock Bitcoin client
           const rawTransactions = new Map<string, RawTransaction>()
           for (const deposit of depositSweepWithNoMainUtxoAndWitnessOutput.deposits) {
-            rawTransactions.set(deposit.utxo.transactionHash, {
+            rawTransactions.set(deposit.utxo.transactionHash.toString(), {
               transactionHex: deposit.utxo.transactionHex,
             })
           }
@@ -92,7 +92,7 @@ describe("Sweep", () => {
         })
 
         it("should return the proper transaction hash", async () => {
-          expect(transactionHash).to.be.equal(
+          expect(transactionHash).to.be.deep.equal(
             depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep
               .transactionHash
           )
@@ -121,15 +121,14 @@ describe("Sweep", () => {
             // set the mapping in the mock Bitcoin client
             const rawTransactions = new Map<string, RawTransaction>()
             for (const deposit of depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits) {
-              rawTransactions.set(deposit.utxo.transactionHash, {
+              rawTransactions.set(deposit.utxo.transactionHash.toString(), {
                 transactionHex: deposit.utxo.transactionHex,
               })
             }
             // The main UTXO resulting from another data set was used as input.
             // Set raw data of that main UTXO as well.
             rawTransactions.set(
-              depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep
-                .transactionHash,
+              depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep.transactionHash.toString(),
               depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep
                 .transaction
             )
@@ -176,7 +175,7 @@ describe("Sweep", () => {
           })
 
           it("should return the proper transaction hash", async () => {
-            expect(transactionHash).to.be.equal(
+            expect(transactionHash).to.be.deep.equal(
               depositSweepWithWitnessMainUtxoAndWitnessOutput.expectedSweep
                 .transactionHash
             )
@@ -206,13 +205,12 @@ describe("Sweep", () => {
               // set the mapping in the mock Bitcoin client
               const rawTransactions = new Map<string, RawTransaction>()
               for (const deposit of depositSweepWithNonWitnessMainUtxoAndWitnessOutput.deposits) {
-                rawTransactions.set(deposit.utxo.transactionHash, {
+                rawTransactions.set(deposit.utxo.transactionHash.toString(), {
                   transactionHex: deposit.utxo.transactionHex,
                 })
               }
               rawTransactions.set(
-                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo
-                  .transactionHash,
+                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo.transactionHash.toString(),
                 {
                   transactionHex:
                     depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo
@@ -262,7 +260,7 @@ describe("Sweep", () => {
             })
 
             it("should return the proper transaction hash", async () => {
-              expect(transactionHash).to.be.equal(
+              expect(transactionHash).to.be.deep.equal(
                 depositSweepWithNonWitnessMainUtxoAndWitnessOutput.expectedSweep
                   .transactionHash
               )
@@ -296,7 +294,7 @@ describe("Sweep", () => {
         // set the mapping in the mock Bitcoin client
         const rawTransactions = new Map<string, RawTransaction>()
         for (const deposit of depositSweepWithNoMainUtxoAndNonWitnessOutput.deposits) {
-          rawTransactions.set(deposit.utxo.transactionHash, {
+          rawTransactions.set(deposit.utxo.transactionHash.toString(), {
             transactionHex: deposit.utxo.transactionHex,
           })
         }
@@ -335,7 +333,7 @@ describe("Sweep", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(
+        expect(transactionHash).to.be.deep.equal(
           depositSweepWithNoMainUtxoAndNonWitnessOutput.expectedSweep
             .transactionHash
         )
@@ -400,8 +398,7 @@ describe("Sweep", () => {
           const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
           expect(txJSON.hash).to.be.equal(
-            depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep
-              .transactionHash
+            depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep.transactionHash.toString()
           )
           expect(txJSON.version).to.be.equal(1)
 
@@ -410,8 +407,7 @@ describe("Sweep", () => {
 
           const p2shInput = txJSON.inputs[0]
           expect(p2shInput.prevout.hash).to.be.equal(
-            depositSweepWithNoMainUtxoAndWitnessOutput.deposits[0].utxo
-              .transactionHash
+            depositSweepWithNoMainUtxoAndWitnessOutput.deposits[0].utxo.transactionHash.toString()
           )
           expect(p2shInput.prevout.index).to.be.equal(
             depositSweepWithNoMainUtxoAndWitnessOutput.deposits[0].utxo
@@ -427,8 +423,7 @@ describe("Sweep", () => {
 
           const p2wshInput = txJSON.inputs[1]
           expect(p2wshInput.prevout.hash).to.be.equal(
-            depositSweepWithNoMainUtxoAndWitnessOutput.deposits[1].utxo
-              .transactionHash
+            depositSweepWithNoMainUtxoAndWitnessOutput.deposits[1].utxo.transactionHash.toString()
           )
           expect(p2wshInput.prevout.index).to.be.equal(
             depositSweepWithNoMainUtxoAndWitnessOutput.deposits[1].utxo
@@ -461,7 +456,7 @@ describe("Sweep", () => {
         })
 
         it("should return the proper transaction hash", async () => {
-          expect(transactionHash).to.be.equal(
+          expect(transactionHash).to.be.deep.equal(
             depositSweepWithNoMainUtxoAndWitnessOutput.expectedSweep
               .transactionHash
           )
@@ -534,8 +529,7 @@ describe("Sweep", () => {
             const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
             expect(txJSON.hash).to.be.equal(
-              depositSweepWithWitnessMainUtxoAndWitnessOutput.expectedSweep
-                .transactionHash
+              depositSweepWithWitnessMainUtxoAndWitnessOutput.expectedSweep.transactionHash.toString()
             )
             expect(txJSON.version).to.be.equal(1)
 
@@ -544,8 +538,7 @@ describe("Sweep", () => {
 
             const p2wkhInput = txJSON.inputs[0]
             expect(p2wkhInput.prevout.hash).to.be.equal(
-              depositSweepWithWitnessMainUtxoAndWitnessOutput.mainUtxo
-                .transactionHash
+              depositSweepWithWitnessMainUtxoAndWitnessOutput.mainUtxo.transactionHash.toString()
             )
             expect(p2wkhInput.prevout.index).to.be.equal(
               depositSweepWithWitnessMainUtxoAndWitnessOutput.mainUtxo
@@ -561,8 +554,7 @@ describe("Sweep", () => {
 
             const p2shInput = txJSON.inputs[1]
             expect(p2shInput.prevout.hash).to.be.equal(
-              depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[0].utxo
-                .transactionHash
+              depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[0].utxo.transactionHash.toString()
             )
             expect(p2shInput.prevout.index).to.be.equal(
               depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[0].utxo
@@ -580,8 +572,7 @@ describe("Sweep", () => {
 
             const p2wshInput = txJSON.inputs[2]
             expect(p2wshInput.prevout.hash).to.be.equal(
-              depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[1].utxo
-                .transactionHash
+              depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[1].utxo.transactionHash.toString()
             )
             expect(p2wshInput.prevout.index).to.be.equal(
               depositSweepWithWitnessMainUtxoAndWitnessOutput.deposits[1].utxo
@@ -614,7 +605,7 @@ describe("Sweep", () => {
           })
 
           it("should return the proper transaction hash", async () => {
-            expect(transactionHash).to.be.equal(
+            expect(transactionHash).to.be.deep.equal(
               depositSweepWithWitnessMainUtxoAndWitnessOutput.expectedSweep
                 .transactionHash
             )
@@ -688,8 +679,7 @@ describe("Sweep", () => {
               const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
               expect(txJSON.hash).to.be.equal(
-                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.expectedSweep
-                  .transactionHash
+                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.expectedSweep.transactionHash.toString()
               )
               expect(txJSON.version).to.be.equal(1)
 
@@ -698,8 +688,7 @@ describe("Sweep", () => {
 
               const p2wshInput = txJSON.inputs[0]
               expect(p2wshInput.prevout.hash).to.be.equal(
-                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.deposits[0]
-                  .utxo.transactionHash
+                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.deposits[0].utxo.transactionHash.toString()
               )
               expect(p2wshInput.prevout.index).to.be.equal(
                 depositSweepWithNonWitnessMainUtxoAndWitnessOutput.deposits[0]
@@ -717,8 +706,7 @@ describe("Sweep", () => {
 
               const p2pkhInput = txJSON.inputs[1] // main UTXO
               expect(p2pkhInput.prevout.hash).to.be.equal(
-                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo
-                  .transactionHash
+                depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo.transactionHash.toString()
               )
               expect(p2pkhInput.prevout.index).to.be.equal(
                 depositSweepWithNonWitnessMainUtxoAndWitnessOutput.mainUtxo
@@ -751,7 +739,7 @@ describe("Sweep", () => {
             })
 
             it("should return the proper transaction hash", async () => {
-              expect(transactionHash).to.be.equal(
+              expect(transactionHash).to.be.deep.equal(
                 depositSweepWithNonWitnessMainUtxoAndWitnessOutput.expectedSweep
                   .transactionHash
               )
@@ -823,8 +811,7 @@ describe("Sweep", () => {
         const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
         expect(txJSON.hash).to.be.equal(
-          depositSweepWithNoMainUtxoAndNonWitnessOutput.expectedSweep
-            .transactionHash
+          depositSweepWithNoMainUtxoAndNonWitnessOutput.expectedSweep.transactionHash.toString()
         )
         expect(txJSON.version).to.be.equal(1)
 
@@ -833,8 +820,7 @@ describe("Sweep", () => {
 
         const p2shInput = txJSON.inputs[0]
         expect(p2shInput.prevout.hash).to.be.equal(
-          depositSweepWithNoMainUtxoAndNonWitnessOutput.deposits[0].utxo
-            .transactionHash
+          depositSweepWithNoMainUtxoAndNonWitnessOutput.deposits[0].utxo.transactionHash.toString()
         )
         expect(p2shInput.prevout.index).to.be.equal(
           depositSweepWithNoMainUtxoAndNonWitnessOutput.deposits[0].utxo
@@ -869,7 +855,7 @@ describe("Sweep", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(
+        expect(transactionHash).to.be.deep.equal(
           depositSweepWithNoMainUtxoAndNonWitnessOutput.expectedSweep
             .transactionHash
         )
@@ -884,7 +870,7 @@ describe("Sweep", () => {
           value: BigNumber.from(13400),
         }
 
-        expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+        expect(newMainUtxo).to.be.deep.equal(expectedNewMainUtxo)
       })
     })
 
@@ -966,8 +952,9 @@ describe("Sweep", () => {
 
       // The UTXO below does not belong to the wallet
       const mainUtxoWithRaw = {
-        transactionHash:
-          "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883",
+        transactionHash: TransactionHash.from(
+          "2f952bdc206bf51bb745b967cb7166149becada878d3191ffe341155ebcd4883"
+        ),
         outputIndex: 1,
         value: BigNumber.from(3933200),
         transactionHex:
@@ -1023,8 +1010,9 @@ describe("Sweep", () => {
     context("when the type of UTXO is unsupported", () => {
       // Use coinbase transaction of some block
       const utxoWithRaw = {
-        transactionHash:
-          "025de155e6f2ffbbf4851493e0d28dad54020db221a3f38bf63c1f65e3d3595b",
+        transactionHash: TransactionHash.from(
+          "025de155e6f2ffbbf4851493e0d28dad54020db221a3f38bf63c1f65e3d3595b"
+        ),
         outputIndex: 0,
         value: BigNumber.from(5000000000),
         transactionHex:
@@ -1064,14 +1052,14 @@ describe("Sweep", () => {
         depositSweepProof.bitcoinChainData.transaction.transactionHash
       const transactions = new Map<string, Transaction>()
       transactions.set(
-        transactionHash,
+        transactionHash.toString(),
         depositSweepProof.bitcoinChainData.transaction
       )
       bitcoinClient.transactions = transactions
 
       const rawTransactions = new Map<string, RawTransaction>()
       rawTransactions.set(
-        transactionHash,
+        transactionHash.toString(),
         depositSweepProof.bitcoinChainData.rawTransaction
       )
       bitcoinClient.rawTransactions = rawTransactions
@@ -1084,7 +1072,7 @@ describe("Sweep", () => {
         depositSweepProof.bitcoinChainData.transactionMerkleBranch
       const confirmations = new Map<string, number>()
       confirmations.set(
-        transactionHash,
+        transactionHash.toString(),
         depositSweepProof.bitcoinChainData.accumulatedTxConfirmations
       )
       bitcoinClient.confirmations = confirmations

--- a/typescript/test/deposit.test.ts
+++ b/typescript/test/deposit.test.ts
@@ -55,8 +55,9 @@ describe("Deposit", () => {
 
   // Expected data of created deposit in P2WSH scenarios.
   const expectedP2WSHDeposit = {
-    transactionHash:
-      "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a",
+    transactionHash: TransactionHash.from(
+      "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
+    ),
 
     // HEX of the expected P2WSH deposit transaction. It can be decoded with:
     // https://live.blockcypher.com/btc-testnet/decodetx.
@@ -84,8 +85,9 @@ describe("Deposit", () => {
 
   // Expected data of created deposit in P2SH scenarios.
   const expectedP2SHDeposit = {
-    transactionHash:
-      "f21a9922c0c136c6d288cf1258b732d0f84a7d50d14a01d7d81cb6cd810f3517",
+    transactionHash: TransactionHash.from(
+      "f21a9922c0c136c6d288cf1258b732d0f84a7d50d14a01d7d81cb6cd810f3517"
+    ),
 
     // HEX of the expected P2SH deposit transaction. It can be decoded with:
     // https://live.blockcypher.com/btc-testnet/decodetx.
@@ -230,7 +232,7 @@ describe("Deposit", () => {
       // Tie testnetTransaction to testnetUTXO. This is needed since
       // submitDepositTransaction attach transaction data to each UTXO.
       const rawTransactions = new Map<string, RawTransaction>()
-      rawTransactions.set(testnetTransactionHash, testnetTransaction)
+      rawTransactions.set(testnetTransactionHash.toString(), testnetTransaction)
       bitcoinClient.rawTransactions = rawTransactions
     })
 
@@ -255,7 +257,7 @@ describe("Deposit", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(
+        expect(transactionHash).to.be.deep.equal(
           expectedP2WSHDeposit.transactionHash
         )
       })
@@ -292,7 +294,9 @@ describe("Deposit", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(expectedP2SHDeposit.transactionHash)
+        expect(transactionHash).to.be.deep.equal(
+          expectedP2SHDeposit.transactionHash
+        )
       })
 
       it("should return the proper deposit UTXO", () => {
@@ -336,7 +340,9 @@ describe("Deposit", () => {
         const buffer = Buffer.from(transaction.transactionHex, "hex")
         const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
-        expect(txJSON.hash).to.be.equal(expectedP2WSHDeposit.transactionHash)
+        expect(txJSON.hash).to.be.equal(
+          expectedP2WSHDeposit.transactionHash.toString()
+        )
         expect(txJSON.version).to.be.equal(1)
 
         // Validate inputs.
@@ -344,7 +350,9 @@ describe("Deposit", () => {
 
         const input = txJSON.inputs[0]
 
-        expect(input.prevout.hash).to.be.equal(testnetUTXO.transactionHash)
+        expect(input.prevout.hash).to.be.equal(
+          testnetUTXO.transactionHash.toString()
+        )
         expect(input.prevout.index).to.be.equal(testnetUTXO.outputIndex)
         // Transaction should be signed but this is SegWit input so the `script`
         // field should be empty and the `witness` field should be filled instead.
@@ -387,7 +395,7 @@ describe("Deposit", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(
+        expect(transactionHash).to.be.deep.equal(
           expectedP2WSHDeposit.transactionHash
         )
       })
@@ -431,7 +439,9 @@ describe("Deposit", () => {
         const buffer = Buffer.from(transaction.transactionHex, "hex")
         const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
-        expect(txJSON.hash).to.be.equal(expectedP2SHDeposit.transactionHash)
+        expect(txJSON.hash).to.be.equal(
+          expectedP2SHDeposit.transactionHash.toString()
+        )
         expect(txJSON.version).to.be.equal(1)
 
         // Validate inputs.
@@ -439,7 +449,9 @@ describe("Deposit", () => {
 
         const input = txJSON.inputs[0]
 
-        expect(input.prevout.hash).to.be.equal(testnetUTXO.transactionHash)
+        expect(input.prevout.hash).to.be.equal(
+          testnetUTXO.transactionHash.toString()
+        )
         expect(input.prevout.index).to.be.equal(testnetUTXO.outputIndex)
         // Transaction should be signed but this is SegWit input so the `script`
         // field should be empty and the `witness` field should be filled instead.
@@ -482,7 +494,9 @@ describe("Deposit", () => {
       })
 
       it("should return the proper transaction hash", async () => {
-        expect(transactionHash).to.be.equal(expectedP2SHDeposit.transactionHash)
+        expect(transactionHash).to.be.deep.equal(
+          expectedP2SHDeposit.transactionHash
+        )
       })
 
       it("should return the proper deposit UTXO", () => {
@@ -492,7 +506,7 @@ describe("Deposit", () => {
           value: deposit.amount,
         }
 
-        expect(depositUtxo).to.be.eql(expectedDepositUtxo)
+        expect(depositUtxo).to.be.deep.equal(expectedDepositUtxo)
       })
     })
   })
@@ -707,7 +721,7 @@ describe("Deposit", () => {
       // data for the given deposit UTXO.
       bitcoinClient = new MockBitcoinClient()
       const rawTransactions = new Map<string, RawTransaction>()
-      rawTransactions.set(depositUtxo.transactionHash, transaction)
+      rawTransactions.set(depositUtxo.transactionHash.toString(), transaction)
       bitcoinClient.rawTransactions = rawTransactions
 
       // Initialize the mock Bridge.

--- a/typescript/test/ethereum.test.ts
+++ b/typescript/test/ethereum.test.ts
@@ -9,6 +9,7 @@ import { abi as BridgeABI } from "@keep-network/tbtc-v2/artifacts/Bridge.json"
 import { abi as WalletRegistryABI } from "@keep-network/tbtc-v2/artifacts/WalletRegistry.json"
 import { MockProvider } from "@ethereum-waffle/provider"
 import { waffleChai } from "@ethereum-waffle/chai"
+import { TransactionHash } from "../src/bitcoin"
 
 chai.use(waffleChai)
 
@@ -190,8 +191,9 @@ describe("Ethereum", () => {
             bitcoinHeaders: "66666666",
           },
           {
-            transactionHash:
-              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+            transactionHash: TransactionHash.from(
+              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668"
+            ),
             outputIndex: 8,
             value: BigNumber.from(9999),
           },
@@ -244,8 +246,9 @@ describe("Ethereum", () => {
         await bridgeHandle.requestRedemption(
           "03989d253b17a6a0f41838b84ff0d20e8898f9d7b1a98f2564da4cc29dcf8581d9",
           {
-            transactionHash:
-              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+            transactionHash: TransactionHash.from(
+              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668"
+            ),
             outputIndex: 8,
             value: BigNumber.from(9999),
           },
@@ -286,8 +289,9 @@ describe("Ethereum", () => {
             bitcoinHeaders: "66666666",
           },
           {
-            transactionHash:
-              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668",
+            transactionHash: TransactionHash.from(
+              "f8eaf242a55ea15e602f9f990e33f67f99dfbe25d1802bbde63cc1caabf99668"
+            ),
             outputIndex: 8,
             value: BigNumber.from(9999),
           },
@@ -343,7 +347,9 @@ describe("Ethereum", () => {
         it("should return the revealed deposit", async () => {
           expect(
             await bridgeHandle.deposits(
-              "c1082c460527079a84e39ec6481666db72e5a22e473a78db03b996d26fd1dc83",
+              TransactionHash.from(
+                "c1082c460527079a84e39ec6481666db72e5a22e473a78db03b996d26fd1dc83"
+              ),
               0
             )
           ).to.be.eql({
@@ -384,7 +390,9 @@ describe("Ethereum", () => {
         it("should return the revealed deposit", async () => {
           expect(
             await bridgeHandle.deposits(
-              "c1082c460527079a84e39ec6481666db72e5a22e473a78db03b996d26fd1dc83",
+              TransactionHash.from(
+                "c1082c460527079a84e39ec6481666db72e5a22e473a78db03b996d26fd1dc83"
+              ),
               0
             )
           ).to.be.eql({

--- a/typescript/test/hex.test.ts
+++ b/typescript/test/hex.test.ts
@@ -1,0 +1,159 @@
+import { assert } from "chai"
+import { Hex } from "../src/hex"
+
+describe("Hex", () => {
+  const stringUnprefixed =
+    "6e30e6da7a7881a70de2a1cf67b77f2f643e58eb0d055b0f5ef85802a9167727"
+  const stringPrefixed =
+    "0x6e30e6da7a7881a70de2a1cf67b77f2f643e58eb0d055b0f5ef85802a9167727"
+  const stringReversed =
+    "277716a90258f85e0f5b050deb583e642f7fb767cfa1e20da781787adae6306e"
+
+  const initializers = [
+    {
+      name: "constructor",
+      initFn: function (input: any) {
+        return new Hex(input)
+      },
+    },
+    {
+      name: "static from function",
+      initFn: function (input: any) {
+        return Hex.from(input)
+      },
+    },
+  ]
+
+  initializers.forEach(({ name: initializerName, initFn }) => {
+    describe(`initialized with ${initializerName}`, () => {
+      const validInputTests = [
+        {
+          name: "unprefixed string",
+          input: stringUnprefixed,
+          expectedString: stringUnprefixed,
+          expectedPrefixedString: stringPrefixed,
+        },
+        {
+          name: "prefixed string",
+          input: stringPrefixed,
+          expectedString: stringUnprefixed,
+          expectedPrefixedString: stringPrefixed,
+        },
+        {
+          name: "prefixed uppercase string",
+          input: stringPrefixed.toUpperCase(),
+          expectedString: stringUnprefixed,
+          expectedPrefixedString: stringPrefixed,
+        },
+        {
+          name: "string with leading and trailing zeros",
+          input: "00000a12d073c00000",
+          expectedString: "00000a12d073c00000",
+          expectedPrefixedString: "0x00000a12d073c00000",
+        },
+        {
+          name: "empty string",
+          input: "",
+          expectedString: "",
+          expectedPrefixedString: "",
+        },
+        {
+          name: "unprefixed buffer",
+          input: Buffer.from(stringUnprefixed, "hex"),
+          expectedString: stringUnprefixed,
+          expectedPrefixedString: stringPrefixed,
+        },
+        {
+          name: "unprefixed uppercase buffer",
+          input: Buffer.from(stringUnprefixed.toUpperCase(), "hex"),
+          expectedString: stringUnprefixed,
+          expectedPrefixedString: stringPrefixed,
+        },
+        {
+          name: "empty buffer",
+          input: Buffer.from("", "hex"),
+          expectedString: "",
+          expectedPrefixedString: "",
+        },
+      ]
+
+      const invalidInputTests = [
+        {
+          name: "string with a character out of 0-9,a-z,A-Z",
+          input: "3a9f5G",
+          expectedErrorMessage: "invalid format of hex string",
+        },
+        {
+          name: "string of odd length",
+          input: "ab12345",
+          expectedErrorMessage: "invalid length of hex string: 7",
+        },
+      ]
+
+      validInputTests.forEach(
+        ({ name, input, expectedString, expectedPrefixedString }) => {
+          context(`with input as ${name}`, () => {
+            const hex = initFn(input)
+
+            describe("toString", () => {
+              it("should output expected string", () => {
+                const actual = hex.toString()
+                assert.equal(actual, expectedString)
+              })
+            })
+
+            describe("toString", () => {
+              it("should output expected string", () => {
+                const actual = hex.toPrefixedString()
+                assert.equal(actual, expectedPrefixedString)
+              })
+            })
+          })
+        }
+      )
+
+      invalidInputTests.forEach(({ name, input, expectedErrorMessage }) => {
+        context(`with input as ${name}`, () => {
+          it(`should throw error with message: ${expectedErrorMessage}`, () => {
+            assert.throws(
+              () => {
+                initFn(input)
+              },
+              Error,
+              expectedErrorMessage
+            )
+          })
+        })
+      })
+
+      describe("reverse", () => {
+        const hex = initFn(stringPrefixed)
+        const hexReversed = hex.reverse()
+
+        it("should not modify source hex", () => {
+          assert.equal(hex.toString(), stringUnprefixed)
+        })
+
+        it("should reverse target hex", () => {
+          assert.equal(hexReversed.toString(), stringReversed)
+        })
+      })
+
+      describe("toBuffer", () => {
+        const hex = initFn(stringPrefixed)
+        const expectedBuffer = Buffer.from(stringUnprefixed, "hex")
+
+        it("should output a buffer", () => {
+          assert.deepEqual(hex.toBuffer(), expectedBuffer)
+        })
+
+        it("should not modify source hex when target buffer is changed", () => {
+          const buffer = hex.toBuffer()
+          buffer.reverse()
+
+          assert.equal(hex.toString(), stringUnprefixed)
+        })
+      })
+    })
+  })
+})

--- a/typescript/test/hex.test.ts
+++ b/typescript/test/hex.test.ts
@@ -9,151 +9,132 @@ describe("Hex", () => {
   const stringReversed =
     "277716a90258f85e0f5b050deb583e642f7fb767cfa1e20da781787adae6306e"
 
-  const initializers = [
+  const validInputTests = [
     {
-      name: "constructor",
-      initFn: function (input: any) {
-        return new Hex(input)
-      },
+      name: "unprefixed string",
+      input: stringUnprefixed,
+      expectedString: stringUnprefixed,
+      expectedPrefixedString: stringPrefixed,
     },
     {
-      name: "static from function",
-      initFn: function (input: any) {
-        return Hex.from(input)
-      },
+      name: "prefixed string",
+      input: stringPrefixed,
+      expectedString: stringUnprefixed,
+      expectedPrefixedString: stringPrefixed,
+    },
+    {
+      name: "prefixed uppercase string",
+      input: stringPrefixed.toUpperCase(),
+      expectedString: stringUnprefixed,
+      expectedPrefixedString: stringPrefixed,
+    },
+    {
+      name: "string with leading and trailing zeros",
+      input: "00000a12d073c00000",
+      expectedString: "00000a12d073c00000",
+      expectedPrefixedString: "0x00000a12d073c00000",
+    },
+    {
+      name: "empty string",
+      input: "",
+      expectedString: "",
+      expectedPrefixedString: "",
+    },
+    {
+      name: "unprefixed buffer",
+      input: Buffer.from(stringUnprefixed, "hex"),
+      expectedString: stringUnprefixed,
+      expectedPrefixedString: stringPrefixed,
+    },
+    {
+      name: "unprefixed uppercase buffer",
+      input: Buffer.from(stringUnprefixed.toUpperCase(), "hex"),
+      expectedString: stringUnprefixed,
+      expectedPrefixedString: stringPrefixed,
+    },
+    {
+      name: "empty buffer",
+      input: Buffer.from("", "hex"),
+      expectedString: "",
+      expectedPrefixedString: "",
     },
   ]
 
-  initializers.forEach(({ name: initializerName, initFn }) => {
-    describe(`initialized with ${initializerName}`, () => {
-      const validInputTests = [
-        {
-          name: "unprefixed string",
-          input: stringUnprefixed,
-          expectedString: stringUnprefixed,
-          expectedPrefixedString: stringPrefixed,
-        },
-        {
-          name: "prefixed string",
-          input: stringPrefixed,
-          expectedString: stringUnprefixed,
-          expectedPrefixedString: stringPrefixed,
-        },
-        {
-          name: "prefixed uppercase string",
-          input: stringPrefixed.toUpperCase(),
-          expectedString: stringUnprefixed,
-          expectedPrefixedString: stringPrefixed,
-        },
-        {
-          name: "string with leading and trailing zeros",
-          input: "00000a12d073c00000",
-          expectedString: "00000a12d073c00000",
-          expectedPrefixedString: "0x00000a12d073c00000",
-        },
-        {
-          name: "empty string",
-          input: "",
-          expectedString: "",
-          expectedPrefixedString: "",
-        },
-        {
-          name: "unprefixed buffer",
-          input: Buffer.from(stringUnprefixed, "hex"),
-          expectedString: stringUnprefixed,
-          expectedPrefixedString: stringPrefixed,
-        },
-        {
-          name: "unprefixed uppercase buffer",
-          input: Buffer.from(stringUnprefixed.toUpperCase(), "hex"),
-          expectedString: stringUnprefixed,
-          expectedPrefixedString: stringPrefixed,
-        },
-        {
-          name: "empty buffer",
-          input: Buffer.from("", "hex"),
-          expectedString: "",
-          expectedPrefixedString: "",
-        },
-      ]
+  const invalidInputTests = [
+    {
+      name: "string with a character out of 0-9,a-z,A-Z",
+      input: "3a9f5G",
+      expectedErrorMessage: "invalid format of hex string",
+    },
+    {
+      name: "string of odd length",
+      input: "ab12345",
+      expectedErrorMessage: "invalid length of hex string: 7",
+    },
+  ]
 
-      const invalidInputTests = [
-        {
-          name: "string with a character out of 0-9,a-z,A-Z",
-          input: "3a9f5G",
-          expectedErrorMessage: "invalid format of hex string",
-        },
-        {
-          name: "string of odd length",
-          input: "ab12345",
-          expectedErrorMessage: "invalid length of hex string: 7",
-        },
-      ]
+  validInputTests.forEach(
+    ({ name, input, expectedString, expectedPrefixedString }) => {
+      context(`with input as ${name}`, () => {
+        const hex = Hex.from(input)
 
-      validInputTests.forEach(
-        ({ name, input, expectedString, expectedPrefixedString }) => {
-          context(`with input as ${name}`, () => {
-            const hex = initFn(input)
-
-            describe("toString", () => {
-              it("should output expected string", () => {
-                const actual = hex.toString()
-                assert.equal(actual, expectedString)
-              })
-            })
-
-            describe("toString", () => {
-              it("should output expected string", () => {
-                const actual = hex.toPrefixedString()
-                assert.equal(actual, expectedPrefixedString)
-              })
-            })
+        describe("toString", () => {
+          it("should output expected string", () => {
+            const actual = hex.toString()
+            assert.equal(actual, expectedString)
           })
-        }
-      )
+        })
 
-      invalidInputTests.forEach(({ name, input, expectedErrorMessage }) => {
-        context(`with input as ${name}`, () => {
-          it(`should throw error with message: ${expectedErrorMessage}`, () => {
-            assert.throws(
-              () => {
-                initFn(input)
-              },
-              Error,
-              expectedErrorMessage
-            )
+        describe("toString", () => {
+          it("should output expected string", () => {
+            const actual = hex.toPrefixedString()
+            assert.equal(actual, expectedPrefixedString)
           })
         })
       })
+    }
+  )
 
-      describe("reverse", () => {
-        const hex = initFn(stringPrefixed)
-        const hexReversed = hex.reverse()
-
-        it("should not modify source hex", () => {
-          assert.equal(hex.toString(), stringUnprefixed)
-        })
-
-        it("should reverse target hex", () => {
-          assert.equal(hexReversed.toString(), stringReversed)
-        })
+  invalidInputTests.forEach(({ name, input, expectedErrorMessage }) => {
+    context(`with input as ${name}`, () => {
+      it(`should throw error with message: ${expectedErrorMessage}`, () => {
+        assert.throws(
+          () => {
+            Hex.from(input)
+          },
+          Error,
+          expectedErrorMessage
+        )
       })
+    })
+  })
 
-      describe("toBuffer", () => {
-        const hex = initFn(stringPrefixed)
-        const expectedBuffer = Buffer.from(stringUnprefixed, "hex")
+  describe("reverse", () => {
+    const hex = Hex.from(stringPrefixed)
+    const hexReversed = hex.reverse()
 
-        it("should output a buffer", () => {
-          assert.deepEqual(hex.toBuffer(), expectedBuffer)
-        })
+    it("should not modify source hex", () => {
+      assert.equal(hex.toString(), stringUnprefixed)
+    })
 
-        it("should not modify source hex when target buffer is changed", () => {
-          const buffer = hex.toBuffer()
-          buffer.reverse()
+    it("should reverse target hex", () => {
+      assert.equal(hexReversed.toString(), stringReversed)
+    })
+  })
 
-          assert.equal(hex.toString(), stringUnprefixed)
-        })
-      })
+  describe("toBuffer", () => {
+    const hex = Hex.from(stringPrefixed)
+    const expectedBuffer = Buffer.from(stringUnprefixed, "hex")
+
+    it("should output a buffer", () => {
+      assert.deepEqual(hex.toBuffer(), expectedBuffer)
+    })
+
+    it("should not modify source hex when target buffer is changed", () => {
+      const buffer = hex.toBuffer()
+      buffer.reverse()
+
+      assert.equal(hex.toString(), stringUnprefixed)
     })
   })
 })

--- a/typescript/test/proof.test.ts
+++ b/typescript/test/proof.test.ts
@@ -28,7 +28,9 @@ describe("Proof", () => {
 
       it("should return the correct value of the proof", async () => {
         const expectedProof = singleInputProofTestData.expectedProof
-        expect(proof.transactionHash).to.equal(expectedProof.transactionHash)
+        expect(proof.transactionHash).to.be.deep.equal(
+          expectedProof.transactionHash
+        )
         expect(proof.inputs).to.deep.equal(expectedProof.inputs)
         expect(proof.outputs).to.deep.equal(expectedProof.outputs)
         expect(proof.merkleProof).to.equal(expectedProof.merkleProof)
@@ -46,7 +48,9 @@ describe("Proof", () => {
 
       it("should return the correct value of the proof", async () => {
         const expectedProof = multipleInputsProofTestData.expectedProof
-        expect(proof.transactionHash).to.equal(expectedProof.transactionHash)
+        expect(proof.transactionHash).to.deep.equal(
+          expectedProof.transactionHash
+        )
         expect(proof.inputs).to.deep.equal(expectedProof.inputs)
         expect(proof.outputs).to.deep.equal(expectedProof.outputs)
         expect(proof.merkleProof).to.equal(expectedProof.merkleProof)
@@ -77,7 +81,10 @@ describe("Proof", () => {
     ): Promise<Transaction & Proof> {
       const transactions = new Map<string, Transaction>()
       const transactionHash = data.bitcoinChainData.transaction.transactionHash
-      transactions.set(transactionHash, data.bitcoinChainData.transaction)
+      transactions.set(
+        transactionHash.toString(),
+        data.bitcoinChainData.transaction
+      )
       bitcoinClient.transactions = transactions
       bitcoinClient.latestHeight = data.bitcoinChainData.latestBlockHeight
       bitcoinClient.headersChain = data.bitcoinChainData.headersChain
@@ -85,7 +92,7 @@ describe("Proof", () => {
         data.bitcoinChainData.transactionMerkleBranch
       const confirmations = new Map<string, number>()
       confirmations.set(
-        transactionHash,
+        transactionHash.toString(),
         data.bitcoinChainData.accumulatedTxConfirmations
       )
       bitcoinClient.confirmations = confirmations

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -114,7 +114,7 @@ describe("Redemption", () => {
                     })
 
                     it("should return the proper transaction hash", async () => {
-                      expect(transactionHash).to.be.equal(
+                      expect(transactionHash).to.be.deep.equal(
                         data.expectedRedemption.transactionHash
                       )
                     })
@@ -159,7 +159,7 @@ describe("Redemption", () => {
                     })
 
                     it("should return the proper transaction hash", async () => {
-                      expect(transactionHash).to.be.equal(
+                      expect(transactionHash).to.be.deep.equal(
                         data.expectedRedemption.transactionHash
                       )
                     })
@@ -204,7 +204,7 @@ describe("Redemption", () => {
                     })
 
                     it("should return the proper transaction hash", async () => {
-                      expect(transactionHash).to.be.equal(
+                      expect(transactionHash).to.be.deep.equal(
                         data.expectedRedemption.transactionHash
                       )
                     })
@@ -249,7 +249,7 @@ describe("Redemption", () => {
                     })
 
                     it("should return the proper transaction hash", async () => {
-                      expect(transactionHash).to.be.equal(
+                      expect(transactionHash).to.be.deep.equal(
                         data.expectedRedemption.transactionHash
                       )
                     })
@@ -293,7 +293,7 @@ describe("Redemption", () => {
                 })
 
                 it("should return the proper transaction hash", async () => {
-                  expect(transactionHash).to.be.equal(
+                  expect(transactionHash).to.be.deep.equal(
                     data.expectedRedemption.transactionHash
                   )
                 })
@@ -338,7 +338,7 @@ describe("Redemption", () => {
               })
 
               it("should return the proper transaction hash", async () => {
-                expect(transactionHash).to.be.equal(
+                expect(transactionHash).to.be.deep.equal(
                   data.expectedRedemption.transactionHash
                 )
               })
@@ -381,7 +381,7 @@ describe("Redemption", () => {
             })
 
             it("should return the proper transaction hash", async () => {
-              expect(transactionHash).to.be.equal(
+              expect(transactionHash).to.be.deep.equal(
                 data.expectedRedemption.transactionHash
               )
             })
@@ -400,7 +400,7 @@ describe("Redemption", () => {
 
           beforeEach(async () => {
             const rawTransactions = new Map<string, RawTransaction>()
-            rawTransactions.set(data.mainUtxo.transactionHash, {
+            rawTransactions.set(data.mainUtxo.transactionHash.toString(), {
               transactionHex: data.mainUtxo.transactionHex,
             })
             bitcoinClient.rawTransactions = rawTransactions
@@ -445,7 +445,7 @@ describe("Redemption", () => {
 
       beforeEach(async () => {
         const rawTransactions = new Map<string, RawTransaction>()
-        rawTransactions.set(data.mainUtxo.transactionHash, {
+        rawTransactions.set(data.mainUtxo.transactionHash.toString(), {
           transactionHex: data.mainUtxo.transactionHex,
         })
         bitcoinClient.rawTransactions = rawTransactions
@@ -509,7 +509,7 @@ describe("Redemption", () => {
                   const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
                   expect(txJSON.hash).to.be.equal(
-                    data.expectedRedemption.transactionHash
+                    data.expectedRedemption.transactionHash.toString()
                   )
                   expect(txJSON.version).to.be.equal(1)
 
@@ -519,7 +519,7 @@ describe("Redemption", () => {
                   const input = txJSON.inputs[0]
 
                   expect(input.prevout.hash).to.be.equal(
-                    data.mainUtxo.transactionHash
+                    data.mainUtxo.transactionHash.toString()
                   )
                   expect(input.prevout.index).to.be.equal(
                     data.mainUtxo.outputIndex
@@ -567,7 +567,7 @@ describe("Redemption", () => {
                 })
 
                 it("should return the proper transaction hash", async () => {
-                  expect(transactionHash).to.be.equal(
+                  expect(transactionHash).to.be.deep.equal(
                     data.expectedRedemption.transactionHash
                   )
                 })
@@ -622,7 +622,7 @@ describe("Redemption", () => {
                   const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
                   expect(txJSON.hash).to.be.equal(
-                    data.expectedRedemption.transactionHash
+                    data.expectedRedemption.transactionHash.toString()
                   )
                   expect(txJSON.version).to.be.equal(1)
 
@@ -632,7 +632,7 @@ describe("Redemption", () => {
                   const input = txJSON.inputs[0]
 
                   expect(input.prevout.hash).to.be.equal(
-                    data.mainUtxo.transactionHash
+                    data.mainUtxo.transactionHash.toString()
                   )
                   expect(input.prevout.index).to.be.equal(
                     data.mainUtxo.outputIndex
@@ -679,7 +679,7 @@ describe("Redemption", () => {
                 })
 
                 it("should return the proper transaction hash", async () => {
-                  expect(transactionHash).to.be.equal(
+                  expect(transactionHash).to.be.deep.equal(
                     data.expectedRedemption.transactionHash
                   )
                 })
@@ -734,7 +734,7 @@ describe("Redemption", () => {
                   const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
                   expect(txJSON.hash).to.be.equal(
-                    data.expectedRedemption.transactionHash
+                    data.expectedRedemption.transactionHash.toString()
                   )
                   expect(txJSON.version).to.be.equal(1)
 
@@ -744,7 +744,7 @@ describe("Redemption", () => {
                   const input = txJSON.inputs[0]
 
                   expect(input.prevout.hash).to.be.equal(
-                    data.mainUtxo.transactionHash
+                    data.mainUtxo.transactionHash.toString()
                   )
                   expect(input.prevout.index).to.be.equal(
                     data.mainUtxo.outputIndex
@@ -791,7 +791,7 @@ describe("Redemption", () => {
                 })
 
                 it("should return the proper transaction hash", async () => {
-                  expect(transactionHash).to.be.equal(
+                  expect(transactionHash).to.be.deep.equal(
                     data.expectedRedemption.transactionHash
                   )
                 })
@@ -846,7 +846,7 @@ describe("Redemption", () => {
                   const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
                   expect(txJSON.hash).to.be.equal(
-                    data.expectedRedemption.transactionHash
+                    data.expectedRedemption.transactionHash.toString()
                   )
                   expect(txJSON.version).to.be.equal(1)
 
@@ -856,7 +856,7 @@ describe("Redemption", () => {
                   const input = txJSON.inputs[0]
 
                   expect(input.prevout.hash).to.be.equal(
-                    data.mainUtxo.transactionHash
+                    data.mainUtxo.transactionHash.toString()
                   )
                   expect(input.prevout.index).to.be.equal(
                     data.mainUtxo.outputIndex
@@ -903,7 +903,7 @@ describe("Redemption", () => {
                 })
 
                 it("should return the proper transaction hash", async () => {
-                  expect(transactionHash).to.be.equal(
+                  expect(transactionHash).to.be.deep.equal(
                     data.expectedRedemption.transactionHash
                   )
                 })
@@ -955,7 +955,7 @@ describe("Redemption", () => {
               const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
               expect(txJSON.hash).to.be.equal(
-                data.expectedRedemption.transactionHash
+                data.expectedRedemption.transactionHash.toString()
               )
               expect(txJSON.version).to.be.equal(1)
 
@@ -965,7 +965,7 @@ describe("Redemption", () => {
               const input = txJSON.inputs[0]
 
               expect(input.prevout.hash).to.be.equal(
-                data.mainUtxo.transactionHash
+                data.mainUtxo.transactionHash.toString()
               )
               expect(input.prevout.index).to.be.equal(data.mainUtxo.outputIndex)
               // Transaction should be signed but this is SegWit input so the `script`
@@ -1056,7 +1056,7 @@ describe("Redemption", () => {
             })
 
             it("should return the proper transaction hash", async () => {
-              expect(transactionHash).to.be.equal(
+              expect(transactionHash).to.be.deep.equal(
                 data.expectedRedemption.transactionHash
               )
             })
@@ -1068,7 +1068,7 @@ describe("Redemption", () => {
                 value: BigNumber.from(1375180),
               }
 
-              expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+              expect(newMainUtxo).to.be.deep.equal(expectedNewMainUtxo)
             })
           })
         })
@@ -1112,7 +1112,7 @@ describe("Redemption", () => {
             const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
             expect(txJSON.hash).to.be.equal(
-              data.expectedRedemption.transactionHash
+              data.expectedRedemption.transactionHash.toString()
             )
             expect(txJSON.version).to.be.equal(1)
 
@@ -1122,7 +1122,7 @@ describe("Redemption", () => {
             const input = txJSON.inputs[0]
 
             expect(input.prevout.hash).to.be.equal(
-              data.mainUtxo.transactionHash
+              data.mainUtxo.transactionHash.toString()
             )
             expect(input.prevout.index).to.be.equal(data.mainUtxo.outputIndex)
             // Transaction should be signed but this is SegWit input so the `script`
@@ -1168,7 +1168,7 @@ describe("Redemption", () => {
           })
 
           it("should return the proper transaction hash", async () => {
-            expect(transactionHash).to.be.equal(
+            expect(transactionHash).to.be.deep.equal(
               data.expectedRedemption.transactionHash
             )
           })
@@ -1180,7 +1180,7 @@ describe("Redemption", () => {
               value: BigNumber.from(1364180),
             }
 
-            expect(newMainUtxo).to.be.eql(expectedNewMainUtxo)
+            expect(newMainUtxo).to.be.deep.equal(expectedNewMainUtxo)
           })
         })
       })
@@ -1218,7 +1218,7 @@ describe("Redemption", () => {
           const txJSON = bcoin.TX.fromRaw(buffer).getJSON("testnet")
 
           expect(txJSON.hash).to.be.equal(
-            data.expectedRedemption.transactionHash
+            data.expectedRedemption.transactionHash.toString()
           )
           expect(txJSON.version).to.be.equal(1)
 
@@ -1227,7 +1227,9 @@ describe("Redemption", () => {
 
           const input = txJSON.inputs[0]
 
-          expect(input.prevout.hash).to.be.equal(data.mainUtxo.transactionHash)
+          expect(input.prevout.hash).to.be.equal(
+            data.mainUtxo.transactionHash.toString()
+          )
           expect(input.prevout.index).to.be.equal(data.mainUtxo.outputIndex)
           // Transaction should be signed but this is SegWit input so the `script`
           // field should be empty and the `witness` field should be filled instead.
@@ -1272,7 +1274,7 @@ describe("Redemption", () => {
         })
 
         it("should return the proper transaction hash", async () => {
-          expect(transactionHash).to.be.equal(
+          expect(transactionHash).to.be.deep.equal(
             data.expectedRedemption.transactionHash
           )
         })
@@ -1301,8 +1303,9 @@ describe("Redemption", () => {
 
   describe("submitRedemptionProof", () => {
     const mainUtxo = {
-      transactionHash:
-        "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3",
+      transactionHash: TransactionHash.from(
+        "3d28bb5bf73379da51bc683f4d0ed31d7b024466c619d80ebd9378077d900be3"
+      ),
       outputIndex: 1,
       value: BigNumber.from(1429580),
     }
@@ -1321,14 +1324,14 @@ describe("Redemption", () => {
 
       const transactions = new Map<string, Transaction>()
       transactions.set(
-        transactionHash,
+        transactionHash.toString(),
         redemptionProof.bitcoinChainData.transaction
       )
       bitcoinClient.transactions = transactions
 
       const rawTransactions = new Map<string, RawTransaction>()
       rawTransactions.set(
-        transactionHash,
+        transactionHash.toString(),
         redemptionProof.bitcoinChainData.rawTransaction
       )
       bitcoinClient.rawTransactions = rawTransactions
@@ -1340,7 +1343,7 @@ describe("Redemption", () => {
         redemptionProof.bitcoinChainData.transactionMerkleBranch
       const confirmations = new Map<string, number>()
       confirmations.set(
-        transactionHash,
+        transactionHash.toString(),
         redemptionProof.bitcoinChainData.accumulatedTxConfirmations
       )
       bitcoinClient.confirmations = confirmations
@@ -1441,7 +1444,7 @@ async function runRedemptionScenario(
   newMainUtxo?: UnspentTransactionOutput
 }> {
   const rawTransactions = new Map<string, RawTransaction>()
-  rawTransactions.set(data.mainUtxo.transactionHash, {
+  rawTransactions.set(data.mainUtxo.transactionHash.toString(), {
     transactionHex: data.mainUtxo.transactionHex,
   })
   bitcoinClient.rawTransactions = rawTransactions

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -3,7 +3,7 @@ import {
   RawTransaction,
   TransactionHash,
   UnspentTransactionOutput,
-} from "./bitcoin"
+} from "../src/bitcoin"
 import bcoin from "bcoin"
 import { MockBitcoinClient } from "./utils/mock-bitcoin-client"
 import {

--- a/typescript/test/utils/mock-bitcoin-client.ts
+++ b/typescript/test/utils/mock-bitcoin-client.ts
@@ -75,13 +75,15 @@ export class MockBitcoinClient implements Client {
 
   getTransaction(transactionHash: TransactionHash): Promise<Transaction> {
     return new Promise<Transaction>((resolve, _) => {
-      resolve(this._transactions.get(transactionHash) as Transaction)
+      resolve(this._transactions.get(transactionHash.toString()) as Transaction)
     })
   }
 
   getRawTransaction(transactionHash: TransactionHash): Promise<RawTransaction> {
     return new Promise<RawTransaction>((resolve, _) => {
-      resolve(this._rawTransactions.get(transactionHash) as RawTransaction)
+      resolve(
+        this._rawTransactions.get(transactionHash.toString()) as RawTransaction
+      )
     })
   }
 
@@ -89,7 +91,7 @@ export class MockBitcoinClient implements Client {
     transactionHash: TransactionHash
   ): Promise<number> {
     return new Promise<number>((resolve, _) => {
-      resolve(this._confirmations.get(transactionHash) as number)
+      resolve(this._confirmations.get(transactionHash.toString()) as number)
     })
   }
 

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -7,7 +7,7 @@ import {
 import { BigNumberish, BigNumber, utils, constants } from "ethers"
 import { RedemptionRequest } from "../redemption"
 import { Deposit, RevealedDeposit } from "../../src/deposit"
-import { computeHash160, TransactionHash } from "../../dist/bitcoin"
+import { computeHash160, TransactionHash } from "../../src/bitcoin"
 
 interface DepositSweepProofLogEntry {
   sweepTx: DecomposedRawTransaction
@@ -133,9 +133,9 @@ export class MockBridge implements Bridge {
     depositTxHash: TransactionHash,
     depositOutputIndex: number
   ): string {
-    const prefixedReversedDepositTxHash = `0x${Buffer.from(depositTxHash, "hex")
+    const prefixedReversedDepositTxHash = depositTxHash
       .reverse()
-      .toString("hex")}`
+      .toPrefixedString()
 
     return utils.solidityKeccak256(
       ["bytes32", "uint32"],


### PR DESCRIPTION
Handling TransactionHash as a string causes a lot of confusion when integrating with the `tbtc-v2.ts` library. To be more explicit we introduce a class that expects a hexadecimal string (either prefixed or not). The class exposes functions to output the value as a prefixed or unprefixed string and gives a way to easily reverse the hex.