### PR TITLE
Optimistic minting debt calculation fix

### DIFF
--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -334,13 +334,12 @@ abstract contract TBTCOptimisticMinting is Ownable {
         uint256 optimisticMintFee = optimisticMintingFeeDivisor > 0
             ? amountToMint / optimisticMintingFeeDivisor
             : 0;
-        amountToMint -= optimisticMintFee;
 
         uint256 newDebt = optimisticMintingDebt[deposit.depositor] +
             amountToMint;
         optimisticMintingDebt[deposit.depositor] = newDebt;
 
-        _mint(deposit.depositor, amountToMint);
+        _mint(deposit.depositor, amountToMint - optimisticMintFee);
         if (optimisticMintFee > 0) {
             _mint(bridge.treasury(), optimisticMintFee);
         }

--- a/solidity/contracts/vault/TBTCOptimisticMinting.sol
+++ b/solidity/contracts/vault/TBTCOptimisticMinting.sol
@@ -335,6 +335,11 @@ abstract contract TBTCOptimisticMinting is Ownable {
             ? amountToMint / optimisticMintingFeeDivisor
             : 0;
 
+        // Both the optimistic minting fee and the share that goes to the
+        // depositor are optimistically minted. All TBTC that is optimistically
+        // minted should be added to the optimistic minting debt. When the
+        // deposit is swept, it is paying off both the depositor's share and the
+        // treasury's share (optimistic minting fee).
         uint256 newDebt = optimisticMintingDebt[deposit.depositor] +
             amountToMint;
         optimisticMintingDebt[deposit.depositor] = newDebt;


### PR DESCRIPTION
The optimistic debt is explained in the documentation in the following way:

> The debt represents the total value of all depositor's deposits revealed to the Bridge that has not been yet swept and led to the optimistic minting of TBTC. (...)

This explanation is perfectly correct but it is not how the debt was calculated for a non-zero optimistic minting fee. Previously, the optimistic minting fee was deducted from the debt. This is not correct - the fee is also optimistically minted and goes to the treasury address. All TBTC that is optimistically minted: the part that goes to the depositor and the part that goes to the treasury should be added to the optimistic minting debt. When the deposit is swept, it is paying off both the depositor's part and the treasury's part.