### PR TITLE
Adjust deployment scripts for testnet

### DIFF
--- a/solidity/deploy/11_deploy_bridge_governance.ts
+++ b/solidity/deploy/11_deploy_bridge_governance.ts
@@ -17,7 +17,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  const GOVERNANCE_DELAY = 604800 // 1 week
+  // 60 seconds for Goerli. 1 week otherwise.
+  const GOVERNANCE_DELAY = hre.network.name === "goerli" ? 60 : 604800
 
   const BridgeGovernance = await deploy("BridgeGovernance", {
     from: deployer,

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -172,35 +172,35 @@ const config: HardhatUserConfig = {
     //       Inspect usages and rename.
     governance: {
       default: 2,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
     },
     chaosnetOwner: {
       default: 3,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       // mainnet: ""
     },
     esdm: {
       default: 4,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       // mainnet: ""
     },
     keepTechnicalWalletTeam: {
       default: 5,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       mainnet: "0xB3726E69Da808A689F2607939a2D9E958724FC2A",
     },
     keepCommunityMultiSig: {
       default: 6,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
       mainnet: "0x19FcB32347ff4656E4E6746b4584192D185d640d",
     },
     treasury: {
       default: 7,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
     },
     spvMaintainer: {
       default: 8,
-      goerli: 0,
+      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
     },
   },
   dependencyCompiler: {


### PR DESCRIPTION
Closes: #456 

Here we make some adjustments to increase the flexibility of testnet deployments. The main goal is to have a short test feedback cycle that will allow checking multiple scenarios using different combinations of the contract's governance parameters. In order to achieve that, we must be able to change governable parameters quickly. This change sets a 60-second governance delay for testnet and passes the governance over testnet contracts to an address controlled by the dev team.