### PR TITLE
Treasury address made governable

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1506,6 +1506,7 @@ contract Bridge is
     /// @notice Updates treasury address. The treasury receives the system fees.
     /// @param treasury New value of the treasury address.
     /// @dev The treasury address must not be 0x0.
+    // slither-disable-next-line shadowing-local
     function updateTreasury(address treasury) external onlyGovernance {
         self.updateTreasury(treasury);
     }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -234,6 +234,8 @@ contract Bridge is
         uint32 fraudNotifierRewardMultiplier
     );
 
+    event TreasuryUpdated(address treasury);
+
     modifier onlySpvMaintainer() {
         require(
             self.isSpvMaintainer[msg.sender],
@@ -1499,6 +1501,13 @@ contract Bridge is
             fraudSlashingAmount,
             fraudNotifierRewardMultiplier
         );
+    }
+
+    /// @notice Updates treasury address. The treasury receives the system fees.
+    /// @param treasury New value of the treasury address.
+    /// @dev The treasury address must not be 0x0.
+    function updateTreasury(address treasury) external onlyGovernance {
+        self.updateTreasury(treasury);
     }
 
     /// @notice Collection of all revealed deposits indexed by

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -31,12 +31,14 @@ contract BridgeGovernance is Ownable {
     using BridgeGovernanceParameters for BridgeGovernanceParameters.MovingFundsData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.WalletData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.FraudData;
+    using BridgeGovernanceParameters for BridgeGovernanceParameters.TreasuryData;
 
     BridgeGovernanceParameters.DepositData internal depositData;
     BridgeGovernanceParameters.RedemptionData internal redemptionData;
     BridgeGovernanceParameters.MovingFundsData internal movingFundsData;
     BridgeGovernanceParameters.WalletData internal walletData;
     BridgeGovernanceParameters.FraudData internal fraudData;
+    BridgeGovernanceParameters.TreasuryData internal treasuryData;
 
     Bridge internal bridge;
 
@@ -282,6 +284,9 @@ contract BridgeGovernance is Ownable {
     event FraudNotifierRewardMultiplierUpdated(
         uint32 fraudNotifierRewardMultiplier
     );
+
+    event TreasuryUpdateStarted(address newTreasury, uint256 timestamp);
+    event TreasuryUpdated(address treasury);
 
     constructor(Bridge _bridge, uint256 _governanceDelay) {
         bridge = _bridge;
@@ -1717,6 +1722,23 @@ contract BridgeGovernance is Ownable {
         fraudData.finalizeFraudNotifierRewardMultiplierUpdate(
             governanceDelay()
         );
+    }
+
+    /// @notice Begins the treasury address update process.
+    /// @dev Can be called only by the contract owner. It does not perform
+    ///      any parameter validation.
+    /// @param _newTreasury New treasury address.
+    function beginTreasuryUpdate(address _newTreasury) external onlyOwner {
+        treasuryData.beginTreasuryUpdate(_newTreasury);
+    }
+
+    /// @notice Finalizes the treasury address update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeTreasuryUpdate() external onlyOwner {
+        address newTreasury = treasuryData.newTreasury;
+        treasuryData.finalizeTreasuryUpdate(governanceDelay());
+        bridge.updateTreasury(newTreasury);
     }
 
     /// @notice Gets the governance delay parameter.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -372,6 +372,8 @@ library BridgeState {
         uint32 fraudNotifierRewardMultiplier
     );
 
+    event TreasuryUpdated(address treasury);
+
     /// @notice Updates parameters of deposits.
     /// @param _depositDustThreshold New value of the deposit dust threshold in
     ///        satoshis. It is the minimal amount that can be requested to
@@ -818,5 +820,15 @@ library BridgeState {
             _fraudSlashingAmount,
             _fraudNotifierRewardMultiplier
         );
+    }
+
+    /// @notice Updates treasury address. The treasury receives the system fees.
+    /// @param _treasury New value of the treasury address.
+    /// @dev The treasury address must not be 0x0.
+    function updateTreasury(Storage storage self, address _treasury) internal {
+        require(_treasury != address(0), "Treasury address must not be 0x0");
+
+        self.treasury = _treasury;
+        emit TreasuryUpdated(_treasury);
     }
 }

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -4329,7 +4329,7 @@ describe("Bridge - Governance", () => {
     )
   })
 
-  describe("beingTreasuryUpdate", () => {
+  describe("beginTreasuryUpdate", () => {
     const newTreasury = "0x8A71228c19A3531384FC203F56290D3aF01B16bD"
 
     context("when the caller is not the owner", () => {

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -298,6 +298,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -542,6 +544,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -788,6 +792,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -1050,6 +1056,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         // If the update was not initialized, the transaction will fail because
@@ -1181,6 +1189,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -1563,6 +1573,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -1691,6 +1703,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -1822,6 +1836,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -1945,6 +1961,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -2472,6 +2490,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -2599,6 +2619,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -3237,6 +3259,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -3370,6 +3394,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -3606,6 +3632,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -3728,6 +3756,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -3976,6 +4006,8 @@ describe("Bridge - Governance", () => {
       })
     })
 
+    // FIXME: This test is not covering the behavior described!
+    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
@@ -4292,6 +4324,125 @@ describe("Bridge - Governance", () => {
           await expect(tx)
             .to.emit(bridgeGovernance, "FraudNotifierRewardMultiplierUpdated")
             .withArgs(42)
+        })
+      }
+    )
+  })
+
+  describe("beingTreasuryUpdate", () => {
+    const newTreasury = "0x8A71228c19A3531384FC203F56290D3aF01B16bD"
+
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance.connect(thirdParty).beginTreasuryUpdate(newTreasury)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let oldTreasury: string
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        oldTreasury = await bridge.treasury()
+
+        tx = await bridgeGovernance
+          .connect(governance)
+          .beginTreasuryUpdate(newTreasury)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should not update the treasury address", async () => {
+        expect(await bridge.treasury()).to.be.equal(oldTreasury)
+      })
+
+      it("should emit TreasuryUpdateStarted event", async () => {
+        const blockTimestamp = await helpers.time.lastBlockTime()
+        await expect(tx)
+          .to.emit(bridgeGovernance, "TreasuryUpdateStarted")
+          .withArgs(newTreasury, blockTimestamp)
+      })
+    })
+  })
+
+  describe("finalizeTreasuryUpdate", () => {
+    const newTreasury = "0x8A71228c19A3531384FC203F56290D3aF01B16bD"
+
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance.connect(thirdParty).finalizeTreasuryUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initialized", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance.connect(governance).finalizeTreasuryUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+
+    context("when the governance delay has not passed", () => {
+      before(async () => {
+        await createSnapshot()
+
+        await bridgeGovernance
+          .connect(governance)
+          .beginTreasuryUpdate(newTreasury)
+
+        await helpers.time.increaseTime(constants.governanceDelay - 60) // -1min
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance.connect(governance).finalizeTreasuryUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+      })
+    })
+
+    context(
+      "when the update process is initialized and governance delay passed",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await bridgeGovernance
+            .connect(governance)
+            .beginTreasuryUpdate(newTreasury)
+
+          await helpers.time.increaseTime(constants.governanceDelay)
+
+          tx = await bridgeGovernance
+            .connect(governance)
+            .finalizeTreasuryUpdate()
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should update the treasury address", async () => {
+          expect(await bridge.treasury()).to.be.equal(newTreasury)
+        })
+
+        it("should emit TreasuryUpdated event", async () => {
+          await expect(tx)
+            .to.emit(bridgeGovernance, "TreasuryUpdated")
+            .withArgs(newTreasury)
         })
       }
     )

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -1,4 +1,4 @@
-import { helpers, waffle } from "hardhat"
+import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
 import { ContractTransaction } from "ethers"
@@ -7,6 +7,8 @@ import { constants } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+const ZERO_ADDRESS = ethers.constants.AddressZero
 
 describe("Bridge - Parameters", () => {
   let governance: SignerWithAddress
@@ -1765,6 +1767,67 @@ describe("Bridge - Parameters", () => {
               constants.fraudSlashingAmount,
               constants.fraudNotifierRewardMultiplier
             )
+        ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+  })
+
+  describe("updateTreasury", () => {
+    const newTreasury = "0x4EDCe37af1c6e2CDfe086D7940C5a8AAde9c72e3"
+
+    context("when caller is the contract guvnor", () => {
+      before(async () => {
+        // TODO: We transfer the ownership of the Bridge governance from the
+        // BridgeGovernance contract to a simple address. This allows testing
+        // the Bridge contract directly, without going through the
+        // BridgeGovernance contract. This should be the preferred approach for
+        // all other tests in this file.
+        await bridgeGovernance
+          .connect(governance)
+          .beginBridgeGovernanceTransfer(governance.address)
+        await helpers.time.increaseTime(constants.governanceDelay)
+        await bridgeGovernance
+          .connect(governance)
+          .finalizeBridgeGovernanceTransfer()
+      })
+
+      context("when the new treasury address is non-zero", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await bridge.connect(governance).updateTreasury(newTreasury)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should set the new treasury address", async () => {
+          expect(await bridge.treasury()).to.equal(newTreasury)
+        })
+
+        it("should emit TreasuryUpdated event", async () => {
+          await expect(tx)
+            .to.emit(bridge, "TreasuryUpdated")
+            .withArgs(newTreasury)
+        })
+      })
+
+      context("when the new treasury address is zero", () => {
+        it("should revert", async () => {
+          await expect(
+            bridge.connect(governance).updateTreasury(ZERO_ADDRESS)
+          ).to.be.revertedWith("Treasury address must not be 0x0")
+        })
+      })
+    })
+
+    context("when caller is not the contract guvnor", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge.connect(thirdParty).updateTreasury(newTreasury)
         ).to.be.revertedWith("Caller is not the governance")
       })
     })


### PR DESCRIPTION
Refs #455 

The treasury address was not governable before. Making it governable now via `BridgeGovernance` contract, with the same delay as other `Bridge` parameters.

The Treasury will be initially set to the Token Holder DAO. If it proves unwieldy to make use of the fees via DAO voting, the DAO may decide to transfer the Treasury address to the Council or one of the Guilds.