### PR TITLE
GoerliLightRelay contract

### DIFF
--- a/solidity/contracts/relay/LightRelay.sol
+++ b/solidity/contracts/relay/LightRelay.sol
@@ -537,14 +537,19 @@ contract LightRelay is Ownable, ILightRelay {
     /// @notice Returns the difficulty of the current epoch.
     /// @dev returns 0 if the relay is not ready.
     /// @return The difficulty of the current epoch.
-    function getCurrentEpochDifficulty() external view returns (uint256) {
+    function getCurrentEpochDifficulty()
+        external
+        view
+        virtual
+        returns (uint256)
+    {
         return currentEpochDifficulty;
     }
 
     /// @notice Returns the difficulty of the previous epoch.
     /// @dev Returns 0 if the relay is not ready or has not had a retarget.
     /// @return The difficulty of the previous epoch.
-    function getPrevEpochDifficulty() external view returns (uint256) {
+    function getPrevEpochDifficulty() external view virtual returns (uint256) {
         return prevEpochDifficulty;
     }
 

--- a/solidity/contracts/test/GoerliLightRelay.sol
+++ b/solidity/contracts/test/GoerliLightRelay.sol
@@ -18,15 +18,17 @@ pragma solidity 0.8.17;
 import "../relay/LightRelay.sol";
 
 /// @title Goerli Light Relay
-/// @notice GoerliLightRelay is a stub version of `LightRelay` intended to be
+/// @notice GoerliLightRelay is a stub version of LightRelay intended to be
 ///         used on the Goerli test network. It always returns `1` as the current
 ///         and previous difficulties making it possible to bypass validation of
 ///         difficulties of Bitcoin testnet blocks. Since difficulty in Bitcoin
 ///         testnet often falls to `1` it would not be possible to validate
-///         blocks with the real `LightRelay`.
+///         blocks with the real LightRelay.
 /// @dev Since the returned difficulties are fixed and impossible to be modified
 ///      with any setters, it is safe to use GoerliLightRelay without risking
 ///      somebody may change the difficulties and block the test network.
+///      Notice that GoerliLightRelay is derived from LightRelay so that the two
+///      contracts have the same API and correct bindings can be generated.
 contract GoerliLightRelay is LightRelay {
     /// @notice Returns `1` as the difficulty of the previous epoch.
     function getPrevEpochDifficulty() external view override returns (uint256) {

--- a/solidity/contracts/test/GoerliLightRelay.sol
+++ b/solidity/contracts/test/GoerliLightRelay.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "../relay/LightRelay.sol";
+
+/// @title Goerli Light Relay
+/// @notice GoerliLightRelay is a stub version of `LightRelay` intended to be
+///         used on the Goerli test network. It always returns `1` as the current
+///         and previous difficulties making it possible to bypass validation of
+///         difficulties of Bitcoin testnet blocks. Since difficulty in Bitcoin
+///         testnet often falls to `1` it would not be possible to validate
+///         blocks with the real `LightRelay`.
+/// @dev Since the returned difficulties are fixed and impossible to be modified
+///      with any setters, it is safe to use GoerliLightRelay without risking
+///      somebody may change the difficulties and block the test network.
+contract GoerliLightRelay is LightRelay {
+    /// @notice Returns `1` as the difficulty of the previous epoch.
+    function getPrevEpochDifficulty() external view override returns (uint256) {
+        return 1;
+    }
+
+    /// @notice Returns `1` as the difficulty of the current epoch.
+    function getCurrentEpochDifficulty()
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return 1;
+    }
+}

--- a/solidity/deploy/01_deploy_light_relay.ts
+++ b/solidity/deploy/01_deploy_light_relay.ts
@@ -5,11 +5,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
-  // LightRelay is deployed only for mainnet. For all other networks (Hardhat,
-  // Goerli) we use TestRelay contract. LightRelay will work properly only with
-  // Bitcoin Mainnet headers.
+  // LightRelay is the real-world relay and is deployed for mainnet.
+  // GoerliLightRelay is a stub version with immutable difficulties and is
+  // deployed for goerli.
+  // TestRelay is a stub version with mutable difficulties and is deployed for
+  // hardhat.
+  function resolveRelayName() {
+    if (hre.network.name === "mainnet") {
+      return "LightRelay"
+    }
+    if (hre.network.name === "goerli") {
+      return "GoerliLightRelay"
+    }
+    return "TestRelay"
+  }
+
   const lightRelay = await deployments.deploy("LightRelay", {
-    contract: hre.network.name === "mainnet" ? "LightRelay" : "TestRelay",
+    contract: resolveRelayName(),
     from: deployer,
     log: true,
     waitConfirmations: 1,

--- a/solidity/deploy/01_deploy_light_relay.ts
+++ b/solidity/deploy/01_deploy_light_relay.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // deployed for goerli.
   // TestRelay is a stub version with mutable difficulties and is deployed for
   // hardhat.
-  function resolveRelayName() {
+  function resolveRelayContract() {
     if (hre.network.name === "mainnet") {
       return "LightRelay"
     }
@@ -21,7 +21,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   const lightRelay = await deployments.deploy("LightRelay", {
-    contract: resolveRelayName(),
+    contract: resolveRelayContract(),
     from: deployer,
     log: true,
     waitConfirmations: 1,


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3467.

This PR adds the `GoerliLightRelay` smart contract that is intended to be used on the goerli network.
The contract is derived from the real-world `LightRelay` and overrides functions for returning previous
and current difficulties - the functions always return `1`.
 
The relay deployment script was modified accordingly.