### PR TITLE
Deploy LightRelay for all networks but goerli and system_tests

### DIFF
--- a/solidity/contracts/test/SystemTestRelay.sol
+++ b/solidity/contracts/test/SystemTestRelay.sol
@@ -6,7 +6,8 @@ import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 
 import "../bridge/Bridge.sol";
 
-contract TestRelay is IRelay {
+/// @notice Used only for system tests.
+contract SystemTestRelay is IRelay {
     using BTCUtils for bytes;
     using BTCUtils for uint256;
 

--- a/solidity/deploy/01_deploy_light_relay.ts
+++ b/solidity/deploy/01_deploy_light_relay.ts
@@ -5,19 +5,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
 
-  // LightRelay is the real-world relay and is deployed for mainnet.
-  // GoerliLightRelay is a stub version with immutable difficulties and is
-  // deployed for goerli.
-  // TestRelay is a stub version with mutable difficulties and is deployed for
-  // hardhat.
   function resolveRelayContract() {
-    if (hre.network.name === "mainnet") {
-      return "LightRelay"
-    }
     if (hre.network.name === "goerli") {
       return "GoerliLightRelay"
     }
-    return "TestRelay"
+    if (hre.network.name === "system_tests") {
+      return "SystemTestRelay"
+    }
+
+    return "LightRelay"
   }
 
   const lightRelay = await deployments.deploy("LightRelay", {

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -99,6 +99,10 @@ const config: HardhatUserConfig = {
       // deploy stub contracts in tests.
       allowUnlimitedContractSize: process.env.TEST_USE_STUBS_TBTC === "true",
     },
+    system_tests: {
+      url: "http://localhost:8545",
+      tags: ["allowStubs"],
+    },
     development: {
       url: "http://localhost:8545",
       chainId: 1101,


### PR DESCRIPTION
The tBTC Go client can be built for four networks/environments:
- `make all environment=local`: Build with contract packages deployed locally.
- `make all environment=development`: Build with contract packages published to the NPM registry and tagged `@development`.
- `make all environment=goerli`:  Build with contract packages published to the NPM registry and tagged `@goerli`.
- `make all environment=mainnet`: Build with contract packages published to the NPM registry and tagged `@mainnet`.

No matter the environment, we have an assumption in the Go code: the Ethereum implementation for the relay chain expects the contract to expose some functions available on the `LightRelay` contract.

It means that for all published NPM packages, tagged with `@mainnet`, `@goerli`, or `@development`, we need to have the `LightRelay` contract artifact.

Goerli is a special case. Since on testnet we work against Bitcoin testnet where the difficulty often drops to 1, a special variation of `LightRelay` contract must be deployed there: `GoerliLightRelay`. That contract extends the `LightRelay` so tBTC Go client generates the required bindings properly and the previous and current epoch difficulty is always 1.

System tests are another special case. System tests use functions in the stub relay contract to `setCurrentEpochDifficultyFromHeaders` and `setPrevEpochDifficultyFromHeaders`. System tests - in the current form - do not require tBTC Go client to run. For this reason, we deploy there a `SystemTestRelay` for them. I have renamed the `TestRelay` contract to `SystemTestRelay` to make it supper-explicit it is used only for system tests and named the network that is supposed to be used for system tests as `system_tests` network.

Unit tests work just fine with `LightRelay` deployed because they use Smock fake:
https://github.com/keep-network/tbtc-v2/blob/ee2e8ff8a06a358fabbd1c49028f28739972b040/solidity/test/bridge/Bridge.Redemption.test.ts#L59
https://github.com/keep-network/tbtc-v2/blob/ee2e8ff8a06a358fabbd1c49028f28739972b040/solidity/test/fixtures/bridge.ts#L63-L65