### PR TITLE
Bridge governance tests fixes

### DIFF
--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -448,10 +448,9 @@ contract BridgeGovernance is Ownable {
             uint64 depositTxMaxFee,
             uint32 depositRevealAheadPeriod
         ) = bridge.depositParameters();
-        // slither-disable-next-line reentrancy-no-eth
         bridge.updateDepositParameters(
             depositDustThreshold,
-            depositData.getNewDepositTreasuryFeeDivisor(),
+            depositData.newDepositTreasuryFeeDivisor,
             depositTxMaxFee,
             depositRevealAheadPeriod
         );
@@ -509,12 +508,11 @@ contract BridgeGovernance is Ownable {
             uint64 depositTxMaxFee,
 
         ) = bridge.depositParameters();
-        // slither-disable-next-line reentrancy-no-eth
         bridge.updateDepositParameters(
             depositDustThreshold,
             depositTreasuryFeeDivisor,
             depositTxMaxFee,
-            depositData.getNewDepositRevealAheadPeriod()
+            depositData.newDepositRevealAheadPeriod
         );
         depositData.finalizeDepositRevealAheadPeriodUpdate(governanceDelay());
     }
@@ -586,7 +584,7 @@ contract BridgeGovernance is Ownable {
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
-            redemptionData.getNewRedemptionTreasuryFeeDivisor(),
+            redemptionData.newRedemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
@@ -622,17 +620,15 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
-            redemptionData.getNewRedemptionTxMaxFee(),
+            redemptionData.newRedemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
-
         redemptionData.finalizeRedemptionTxMaxFeeUpdate(governanceDelay());
     }
 
@@ -745,7 +741,7 @@ contract BridgeGovernance is Ownable {
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
-            redemptionData.getNewRedemptionTimeoutSlashingAmount(),
+            redemptionData.newRedemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
 
@@ -792,7 +788,7 @@ contract BridgeGovernance is Ownable {
             redemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
-            redemptionData.getNewRedemptionTimeoutNotifierRewardMultiplier()
+            redemptionData.newRedemptionTimeoutNotifierRewardMultiplier
         );
 
         redemptionData.finalizeRedemptionTimeoutNotifierRewardMultiplierUpdate(
@@ -1029,7 +1025,7 @@ contract BridgeGovernance is Ownable {
             movingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
-            movingFundsData.getNewMovingFundsTimeoutSlashingAmount(),
+            movingFundsData.newMovingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
@@ -1083,7 +1079,7 @@ contract BridgeGovernance is Ownable {
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
-            movingFundsData.getNewMovingFundsTimeoutNotifierRewardMultiplier(),
+            movingFundsData.newMovingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
@@ -1133,7 +1129,7 @@ contract BridgeGovernance is Ownable {
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
-            movingFundsData.getNewMovingFundsCommitmentGasOffset(),
+            movingFundsData.newMovingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
@@ -1283,7 +1279,7 @@ contract BridgeGovernance is Ownable {
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
-            movingFundsData.getNewMovedFundsSweepTimeoutSlashingAmount(),
+            movingFundsData.newMovedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
         );
         movingFundsData.finalizeMovedFundsSweepTimeoutSlashingAmountUpdate(
@@ -1337,8 +1333,7 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
-            movingFundsData
-                .getNewMovedFundsSweepTimeoutNotifierRewardMultiplier()
+            movingFundsData.newMovedFundsSweepTimeoutNotifierRewardMultiplier
         );
         movingFundsData
             .finalizeMovedFundsSweepTimeoutNotifierRewardMultiplierUpdate(
@@ -1373,7 +1368,7 @@ contract BridgeGovernance is Ownable {
         ) = bridge.walletParameters();
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateWalletParameters(
-            walletData.getNewWalletCreationPeriod(),
+            walletData.newWalletCreationPeriod,
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
@@ -1411,7 +1406,7 @@ contract BridgeGovernance is Ownable {
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateWalletParameters(
             walletCreationPeriod,
-            walletData.getNewWalletCreationMinBtcBalance(),
+            walletData.newWalletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
             walletMaxAge,
@@ -1527,7 +1522,7 @@ contract BridgeGovernance is Ownable {
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
-            walletData.getNewWalletMaxAge(),
+            walletData.newWalletMaxAge,
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
@@ -1631,7 +1626,7 @@ contract BridgeGovernance is Ownable {
         ) = bridge.fraudParameters();
         // slither-disable-next-line reentrancy-no-eth
         bridge.updateFraudParameters(
-            fraudData.getNewFraudChallengeDepositAmount(),
+            fraudData.newFraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
             fraudSlashingAmount,
             fraudNotifierRewardMultiplier
@@ -1694,7 +1689,7 @@ contract BridgeGovernance is Ownable {
         bridge.updateFraudParameters(
             fraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
-            fraudData.getNewFraudSlashingAmount(),
+            fraudData.newFraudSlashingAmount,
             fraudNotifierRewardMultiplier
         );
         fraudData.finalizeFraudSlashingAmountUpdate(governanceDelay());
@@ -1726,7 +1721,7 @@ contract BridgeGovernance is Ownable {
             fraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
             fraudSlashingAmount,
-            fraudData.getNewFraudNotifierRewardMultiplier()
+            fraudData.newFraudNotifierRewardMultiplier
         );
         fraudData.finalizeFraudNotifierRewardMultiplierUpdate(
             governanceDelay()

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -448,13 +448,15 @@ contract BridgeGovernance is Ownable {
             uint64 depositTxMaxFee,
             uint32 depositRevealAheadPeriod
         ) = bridge.depositParameters();
+        uint64 newDepositTreasuryFeeDivisor = depositData
+            .newDepositTreasuryFeeDivisor;
+        depositData.finalizeDepositTreasuryFeeDivisorUpdate(governanceDelay());
         bridge.updateDepositParameters(
             depositDustThreshold,
-            depositData.newDepositTreasuryFeeDivisor,
+            newDepositTreasuryFeeDivisor,
             depositTxMaxFee,
             depositRevealAheadPeriod
         );
-        depositData.finalizeDepositTreasuryFeeDivisorUpdate(governanceDelay());
     }
 
     /// @notice Begins the deposit tx max fee amount update process.
@@ -508,13 +510,15 @@ contract BridgeGovernance is Ownable {
             uint64 depositTxMaxFee,
 
         ) = bridge.depositParameters();
+        uint32 newDepositRevealAheadPeriod = depositData
+            .newDepositRevealAheadPeriod;
+        depositData.finalizeDepositRevealAheadPeriodUpdate(governanceDelay());
         bridge.updateDepositParameters(
             depositDustThreshold,
             depositTreasuryFeeDivisor,
             depositTxMaxFee,
-            depositData.newDepositRevealAheadPeriod
+            newDepositRevealAheadPeriod
         );
-        depositData.finalizeDepositRevealAheadPeriodUpdate(governanceDelay());
     }
 
     // --- Redemption
@@ -582,18 +586,19 @@ contract BridgeGovernance is Ownable {
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
         // slither-disable-next-line reentrancy-no-eth
+        uint64 newRedemptionTreasuryFeeDivisor = redemptionData
+            .newRedemptionTreasuryFeeDivisor;
+        redemptionData.finalizeRedemptionTreasuryFeeDivisorUpdate(
+            governanceDelay()
+        );
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
-            redemptionData.newRedemptionTreasuryFeeDivisor,
+            newRedemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
-        );
-
-        redemptionData.finalizeRedemptionTreasuryFeeDivisorUpdate(
-            governanceDelay()
         );
     }
 
@@ -620,16 +625,17 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
+        uint64 newRedemptionTxMaxFee = redemptionData.newRedemptionTxMaxFee;
+        redemptionData.finalizeRedemptionTxMaxFeeUpdate(governanceDelay());
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
-            redemptionData.newRedemptionTxMaxFee,
+            newRedemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
-        redemptionData.finalizeRedemptionTxMaxFeeUpdate(governanceDelay());
     }
 
     /// @notice Begins the redemption tx max total fee amount update process.
@@ -734,19 +740,19 @@ contract BridgeGovernance is Ownable {
             ,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint96 newRedemptionTimeoutSlashingAmount = redemptionData
+            .newRedemptionTimeoutSlashingAmount;
+        redemptionData.finalizeRedemptionTimeoutSlashingAmountUpdate(
+            governanceDelay()
+        );
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
             redemptionTimeout,
-            redemptionData.newRedemptionTimeoutSlashingAmount,
+            newRedemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
-        );
-
-        redemptionData.finalizeRedemptionTimeoutSlashingAmountUpdate(
-            governanceDelay()
         );
     }
 
@@ -780,7 +786,11 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
 
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newRedemptionTimeoutNotifierRewardMultiplier = redemptionData
+            .newRedemptionTimeoutNotifierRewardMultiplier;
+        redemptionData.finalizeRedemptionTimeoutNotifierRewardMultiplierUpdate(
+            governanceDelay()
+        );
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
@@ -788,11 +798,7 @@ contract BridgeGovernance is Ownable {
             redemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
-            redemptionData.newRedemptionTimeoutNotifierRewardMultiplier
-        );
-
-        redemptionData.finalizeRedemptionTimeoutNotifierRewardMultiplierUpdate(
-            governanceDelay()
+            newRedemptionTimeoutNotifierRewardMultiplier
         );
     }
 
@@ -1019,22 +1025,23 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint96 newMovingFundsTimeoutSlashingAmount = movingFundsData
+            .newMovingFundsTimeoutSlashingAmount;
+        movingFundsData.finalizeMovingFundsTimeoutSlashingAmountUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
-            movingFundsData.newMovingFundsTimeoutSlashingAmount,
+            newMovingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovingFundsTimeoutSlashingAmountUpdate(
-            governanceDelay()
         );
     }
 
@@ -1072,24 +1079,25 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newMovingFundsTimeoutNotifierRewardMultiplier = movingFundsData
+            .newMovingFundsTimeoutNotifierRewardMultiplier;
+        movingFundsData
+            .finalizeMovingFundsTimeoutNotifierRewardMultiplierUpdate(
+                governanceDelay()
+            );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
-            movingFundsData.newMovingFundsTimeoutNotifierRewardMultiplier,
+            newMovingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
         );
-        movingFundsData
-            .finalizeMovingFundsTimeoutNotifierRewardMultiplierUpdate(
-                governanceDelay()
-            );
     }
 
     /// @notice Begins the moving funds commitment gas offset update process.
@@ -1121,7 +1129,11 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint16 newMovingFundsCommitmentGasOffset = movingFundsData
+            .newMovingFundsCommitmentGasOffset;
+        movingFundsData.finalizeMovingFundsCommitmentGasOffsetUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
@@ -1129,14 +1141,11 @@ contract BridgeGovernance is Ownable {
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
-            movingFundsData.newMovingFundsCommitmentGasOffset,
+            newMovingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovingFundsCommitmentGasOffsetUpdate(
-            governanceDelay()
         );
     }
 
@@ -1268,7 +1277,11 @@ contract BridgeGovernance is Ownable {
             ,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint96 newMovedFundsSweepTimeoutSlashingAmount = movingFundsData
+            .newMovedFundsSweepTimeoutSlashingAmount;
+        movingFundsData.finalizeMovedFundsSweepTimeoutSlashingAmountUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
@@ -1279,11 +1292,8 @@ contract BridgeGovernance is Ownable {
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
-            movingFundsData.newMovedFundsSweepTimeoutSlashingAmount,
+            newMovedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovedFundsSweepTimeoutSlashingAmountUpdate(
-            governanceDelay()
         );
     }
 
@@ -1322,6 +1332,12 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
 
         ) = bridge.movingFundsParameters();
+        uint32 newMovedFundsSweepTimeoutNotifierRewardMultiplier = movingFundsData
+                .newMovedFundsSweepTimeoutNotifierRewardMultiplier;
+        movingFundsData
+            .finalizeMovedFundsSweepTimeoutNotifierRewardMultiplierUpdate(
+                governanceDelay()
+            );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
@@ -1333,12 +1349,8 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
-            movingFundsData.newMovedFundsSweepTimeoutNotifierRewardMultiplier
+            newMovedFundsSweepTimeoutNotifierRewardMultiplier
         );
-        movingFundsData
-            .finalizeMovedFundsSweepTimeoutNotifierRewardMultiplierUpdate(
-                governanceDelay()
-            );
     }
 
     // --- Wallet creation
@@ -1366,9 +1378,10 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newWalletCreationPeriod = walletData.newWalletCreationPeriod;
+        walletData.finalizeWalletCreationPeriodUpdate(governanceDelay());
         bridge.updateWalletParameters(
-            walletData.newWalletCreationPeriod,
+            newWalletCreationPeriod,
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
@@ -1376,7 +1389,6 @@ contract BridgeGovernance is Ownable {
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletCreationPeriodUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet creation min btc balance update process.
@@ -1403,17 +1415,18 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newWalletCreationMinBtcBalance = walletData
+            .newWalletCreationMinBtcBalance;
+        walletData.finalizeWalletCreationMinBtcBalanceUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
-            walletData.newWalletCreationMinBtcBalance,
+            newWalletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
             walletMaxAge,
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletCreationMinBtcBalanceUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet creation max btc balance update process.
@@ -1516,17 +1529,17 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newWalletMaxAge = walletData.newWalletMaxAge;
+        walletData.finalizeWalletMaxAgeUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
-            walletData.newWalletMaxAge,
+            newWalletMaxAge,
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletMaxAgeUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet max btc transfer amount update process.
@@ -1624,14 +1637,15 @@ contract BridgeGovernance is Ownable {
             uint96 fraudSlashingAmount,
             uint32 fraudNotifierRewardMultiplier
         ) = bridge.fraudParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint96 newFraudChallengeDepositAmount = fraudData
+            .newFraudChallengeDepositAmount;
+        fraudData.finalizeFraudChallengeDepositAmountUpdate(governanceDelay());
         bridge.updateFraudParameters(
-            fraudData.newFraudChallengeDepositAmount,
+            newFraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
             fraudSlashingAmount,
             fraudNotifierRewardMultiplier
         );
-        fraudData.finalizeFraudChallengeDepositAmountUpdate(governanceDelay());
     }
 
     /// @notice Begins the fraud challenge defeat timeout update process.
@@ -1686,13 +1700,14 @@ contract BridgeGovernance is Ownable {
             ,
             uint32 fraudNotifierRewardMultiplier
         ) = bridge.fraudParameters();
+        uint96 newFraudSlashingAmount = fraudData.newFraudSlashingAmount;
+        fraudData.finalizeFraudSlashingAmountUpdate(governanceDelay());
         bridge.updateFraudParameters(
             fraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
-            fraudData.newFraudSlashingAmount,
+            newFraudSlashingAmount,
             fraudNotifierRewardMultiplier
         );
-        fraudData.finalizeFraudSlashingAmountUpdate(governanceDelay());
     }
 
     /// @notice Begins the fraud notifier reward multiplier update process.
@@ -1717,14 +1732,16 @@ contract BridgeGovernance is Ownable {
             uint96 fraudSlashingAmount,
 
         ) = bridge.fraudParameters();
+        uint32 newFraudNotifierRewardMultiplier = fraudData
+            .newFraudNotifierRewardMultiplier;
+        fraudData.finalizeFraudNotifierRewardMultiplierUpdate(
+            governanceDelay()
+        );
         bridge.updateFraudParameters(
             fraudChallengeDepositAmount,
             fraudChallengeDefeatTimeout,
             fraudSlashingAmount,
-            fraudData.newFraudNotifierRewardMultiplier
-        );
-        fraudData.finalizeFraudNotifierRewardMultiplierUpdate(
-            governanceDelay()
+            newFraudNotifierRewardMultiplier
         );
     }
 

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -417,13 +417,14 @@ contract BridgeGovernance is Ownable {
             uint64 depositTxMaxFee,
             uint32 depositRevealAheadPeriod
         ) = bridge.depositParameters();
+        uint64 newDepositDustThreshold = depositData.newDepositDustThreshold;
+        depositData.finalizeDepositDustThresholdUpdate(governanceDelay());
         bridge.updateDepositParameters(
-            depositData.getNewDepositDustThreshold(),
+            newDepositDustThreshold,
             depositTreasuryFeeDivisor,
             depositTxMaxFee,
             depositRevealAheadPeriod
         );
-        depositData.finalizeDepositDustThresholdUpdate(governanceDelay());
     }
 
     /// @notice Begins the deposit treasury fee divisor amount update process.
@@ -477,14 +478,14 @@ contract BridgeGovernance is Ownable {
             ,
             uint32 depositRevealAheadPeriod
         ) = bridge.depositParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newDepositTxMaxFee = depositData.newDepositTxMaxFee;
+        depositData.finalizeDepositTxMaxFeeUpdate(governanceDelay());
         bridge.updateDepositParameters(
             depositDustThreshold,
             depositTreasuryFeeDivisor,
-            depositData.getNewDepositTxMaxFee(),
+            newDepositTxMaxFee,
             depositRevealAheadPeriod
         );
-        depositData.finalizeDepositTxMaxFeeUpdate(governanceDelay());
     }
 
     /// @notice Begins the deposit reveal ahead period update process.
@@ -544,9 +545,11 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newRedemptionDustThreshold = redemptionData
+            .newRedemptionDustThreshold;
+        redemptionData.finalizeRedemptionDustThresholdUpdate(governanceDelay());
         bridge.updateRedemptionParameters(
-            redemptionData.getNewRedemptionDustThreshold(),
+            newRedemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
@@ -554,8 +557,6 @@ contract BridgeGovernance is Ownable {
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
-
-        redemptionData.finalizeRedemptionDustThresholdUpdate(governanceDelay());
     }
 
     /// @notice Begins the redemption treasury fee divisor amount update process.
@@ -659,18 +660,18 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newRedemptionTxMaxTotalFee = redemptionData
+            .newRedemptionTxMaxTotalFee;
+        redemptionData.finalizeRedemptionTxMaxTotalFeeUpdate(governanceDelay());
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
-            redemptionData.getNewRedemptionTxMaxTotalFee(),
+            newRedemptionTxMaxTotalFee,
             redemptionTimeout,
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
-
-        redemptionData.finalizeRedemptionTxMaxTotalFeeUpdate(governanceDelay());
     }
 
     /// @notice Begins the redemption timeout amount update process.
@@ -696,18 +697,17 @@ contract BridgeGovernance is Ownable {
             uint96 redemptionTimeoutSlashingAmount,
             uint32 redemptionTimeoutNotifierRewardMultiplier
         ) = bridge.redemptionParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newRedemptionTimeout = redemptionData.newRedemptionTimeout;
+        redemptionData.finalizeRedemptionTimeoutUpdate(governanceDelay());
         bridge.updateRedemptionParameters(
             redemptionDustThreshold,
             redemptionTreasuryFeeDivisor,
             redemptionTxMaxFee,
             redemptionTxMaxTotalFee,
-            redemptionData.getNewRedemptionTimeout(),
+            newRedemptionTimeout,
             redemptionTimeoutSlashingAmount,
             redemptionTimeoutNotifierRewardMultiplier
         );
-
-        redemptionData.finalizeRedemptionTimeoutUpdate(governanceDelay());
     }
 
     /// @notice Begins the redemption timeout slashing amount update process.
@@ -830,9 +830,13 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newMovingFundsTxMaxTotalFee = movingFundsData
+            .newMovingFundsTxMaxTotalFee;
+        movingFundsData.finalizeMovingFundsTxMaxTotalFeeUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
-            movingFundsData.getNewMovingFundsTxMaxTotalFee(),
+            newMovingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
@@ -843,9 +847,6 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovingFundsTxMaxTotalFeeUpdate(
-            governanceDelay()
         );
     }
 
@@ -877,10 +878,14 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newMovingFundsDustThreshold = movingFundsData
+            .newMovingFundsDustThreshold;
+        movingFundsData.finalizeMovingFundsDustThresholdUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
-            movingFundsData.getNewMovingFundsDustThreshold(),
+            newMovingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
@@ -890,9 +895,6 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovingFundsDustThresholdUpdate(
-            governanceDelay()
         );
     }
 
@@ -925,11 +927,15 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newMovingFundsTimeoutResetDelay = movingFundsData
+            .newMovingFundsTimeoutResetDelay;
+        movingFundsData.finalizeMovingFundsTimeoutResetDelayUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
-            movingFundsData.getNewMovingFundsTimeoutResetDelay(),
+            newMovingFundsTimeoutResetDelay,
             movingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
@@ -938,9 +944,6 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovingFundsTimeoutResetDelayUpdate(
-            governanceDelay()
         );
     }
 
@@ -971,12 +974,13 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newMovingFundsTimeout = movingFundsData.newMovingFundsTimeout;
+        movingFundsData.finalizeMovingFundsTimeoutUpdate(governanceDelay());
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
             movingFundsTimeoutResetDelay,
-            movingFundsData.getNewMovingFundsTimeout(),
+            newMovingFundsTimeout,
             movingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
@@ -985,7 +989,6 @@ contract BridgeGovernance is Ownable {
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
         );
-        movingFundsData.finalizeMovingFundsTimeoutUpdate(governanceDelay());
     }
 
     /// @notice Begins the moving funds timeout slashing amount update process.
@@ -1170,7 +1173,11 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newMovedFundsSweepTxMaxTotalFee = movingFundsData
+            .newMovedFundsSweepTxMaxTotalFee;
+        movingFundsData.finalizeMovedFundsSweepTxMaxTotalFeeUpdate(
+            governanceDelay()
+        );
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
@@ -1179,13 +1186,10 @@ contract BridgeGovernance is Ownable {
             movingFundsTimeoutSlashingAmount,
             movingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
-            movingFundsData.getNewMovedFundsSweepTxMaxTotalFee(),
+            newMovedFundsSweepTxMaxTotalFee,
             movedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
-        );
-        movingFundsData.finalizeMovedFundsSweepTxMaxTotalFeeUpdate(
-            governanceDelay()
         );
     }
 
@@ -1217,7 +1221,9 @@ contract BridgeGovernance is Ownable {
             uint96 movedFundsSweepTimeoutSlashingAmount,
             uint32 movedFundsSweepTimeoutNotifierRewardMultiplier
         ) = bridge.movingFundsParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newMovedFundsSweepTimeout = movingFundsData
+            .newMovedFundsSweepTimeout;
+        movingFundsData.finalizeMovedFundsSweepTimeoutUpdate(governanceDelay());
         bridge.updateMovingFundsParameters(
             movingFundsTxMaxTotalFee,
             movingFundsDustThreshold,
@@ -1227,11 +1233,10 @@ contract BridgeGovernance is Ownable {
             movingFundsTimeoutNotifierRewardMultiplier,
             movingFundsCommitmentGasOffset,
             movedFundsSweepTxMaxTotalFee,
-            movingFundsData.getNewMovedFundsSweepTimeout(),
+            newMovedFundsSweepTimeout,
             movedFundsSweepTimeoutSlashingAmount,
             movedFundsSweepTimeoutNotifierRewardMultiplier
         );
-        movingFundsData.finalizeMovedFundsSweepTimeoutUpdate(governanceDelay());
     }
 
     /// @notice Begins the moved funds sweep timeout slashing amount update process.
@@ -1441,17 +1446,18 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newWalletCreationMaxBtcBalance = walletData
+            .newWalletCreationMaxBtcBalance;
+        walletData.finalizeWalletCreationMaxBtcBalanceUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
             walletCreationMinBtcBalance,
-            walletData.getNewWalletCreationMaxBtcBalance(),
+            newWalletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
             walletMaxAge,
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletCreationMaxBtcBalanceUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet closure min btc balance update process.
@@ -1478,17 +1484,18 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newWalletClosureMinBtcBalance = walletData
+            .newWalletClosureMinBtcBalance;
+        walletData.finalizeWalletClosureMinBtcBalanceUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
-            walletData.getNewWalletClosureMinBtcBalance(),
+            newWalletClosureMinBtcBalance,
             walletMaxAge,
             walletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletClosureMinBtcBalanceUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet max age update process.
@@ -1550,17 +1557,17 @@ contract BridgeGovernance is Ownable {
             ,
             uint32 walletClosingPeriod
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint64 newWalletMaxBtcTransfer = walletData.newWalletMaxBtcTransfer;
+        walletData.finalizeWalletMaxBtcTransferUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
             walletCreationMinBtcBalance,
             walletCreationMaxBtcBalance,
             walletClosureMinBtcBalance,
             walletMaxAge,
-            walletData.getNewWalletMaxBtcTransfer(),
+            newWalletMaxBtcTransfer,
             walletClosingPeriod
         );
-        walletData.finalizeWalletMaxBtcTransferUpdate(governanceDelay());
     }
 
     /// @notice Begins the wallet closing period update process.
@@ -1586,7 +1593,8 @@ contract BridgeGovernance is Ownable {
             uint64 walletMaxBtcTransfer,
 
         ) = bridge.walletParameters();
-        // slither-disable-next-line reentrancy-no-eth
+        uint32 newWalletClosingPeriod = walletData.newWalletClosingPeriod;
+        walletData.finalizeWalletClosingPeriodUpdate(governanceDelay());
         bridge.updateWalletParameters(
             walletCreationPeriod,
             walletCreationMinBtcBalance,
@@ -1594,9 +1602,8 @@ contract BridgeGovernance is Ownable {
             walletClosureMinBtcBalance,
             walletMaxAge,
             walletMaxBtcTransfer,
-            walletData.getNewWalletClosingPeriod()
+            newWalletClosingPeriod
         );
-        walletData.finalizeWalletClosingPeriodUpdate(governanceDelay());
     }
 
     // --- Fraud
@@ -1653,13 +1660,15 @@ contract BridgeGovernance is Ownable {
             uint96 fraudSlashingAmount,
             uint32 fraudNotifierRewardMultiplier
         ) = bridge.fraudParameters();
+        uint32 newFraudChallengeDefeatTimeout = fraudData
+            .newFraudChallengeDefeatTimeout;
+        fraudData.finalizeFraudChallengeDefeatTimeoutUpdate(governanceDelay());
         bridge.updateFraudParameters(
             fraudChallengeDepositAmount,
-            fraudData.getNewFraudChallengeDefeatTimeout(),
+            newFraudChallengeDefeatTimeout,
             fraudSlashingAmount,
             fraudNotifierRewardMultiplier
         );
-        fraudData.finalizeFraudChallengeDefeatTimeoutUpdate(governanceDelay());
     }
 
     /// @notice Begins the fraud slashing amount update process.

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -420,18 +420,7 @@ library BridgeGovernanceParameters {
         self.depositTreasuryFeeDivisorChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewDepositTreasuryFeeDivisor(DepositData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newDepositTreasuryFeeDivisor;
-    }
-
     /// @notice Begins the deposit tx max fee amount update process.
-
     /// @param _newDepositTxMaxFee New deposit tx max fee amount.
     function beginDepositTxMaxFeeUpdate(
         DepositData storage self,
@@ -494,16 +483,6 @@ library BridgeGovernanceParameters {
 
         self.newDepositRevealAheadPeriod = 0;
         self.depositRevealAheadPeriodChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewDepositRevealAheadPeriod(DepositData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newDepositRevealAheadPeriod;
     }
 
     // --- Redemption
@@ -579,16 +558,6 @@ library BridgeGovernanceParameters {
         self.redemptionTreasuryFeeDivisorChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTreasuryFeeDivisor(RedemptionData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newRedemptionTreasuryFeeDivisor;
-    }
-
     /// @notice Begins the redemption tx max fee amount update process.
     /// @param _newRedemptionTxMaxFee New redemption tx max fee amount.
     function beginRedemptionTxMaxFeeUpdate(
@@ -621,16 +590,6 @@ library BridgeGovernanceParameters {
 
         self.newRedemptionTxMaxFee = 0;
         self.redemptionTxMaxFeeChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTxMaxFee(RedemptionData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newRedemptionTxMaxFee;
     }
 
     /// @notice Begins the redemption tx max total fee amount update process.
@@ -740,16 +699,6 @@ library BridgeGovernanceParameters {
         self.redemptionTimeoutSlashingAmountChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTimeoutSlashingAmount(RedemptionData storage self)
-        internal
-        view
-        returns (uint96)
-    {
-        return self.newRedemptionTimeoutSlashingAmount;
-    }
-
     /// @notice Begins the redemption timeout notifier reward multiplier amount
     ///         update process.
     /// @param _newRedemptionTimeoutNotifierRewardMultiplier New redemption
@@ -788,14 +737,6 @@ library BridgeGovernanceParameters {
 
         self.newRedemptionTimeoutNotifierRewardMultiplier = 0;
         self.redemptionTimeoutNotifierRewardMultiplierChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTimeoutNotifierRewardMultiplier(
-        RedemptionData storage self
-    ) internal view returns (uint32) {
-        return self.newRedemptionTimeoutNotifierRewardMultiplier;
     }
 
     // --- Moving funds
@@ -976,14 +917,6 @@ library BridgeGovernanceParameters {
         self.movingFundsTimeoutSlashingAmountChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsTimeoutSlashingAmount(
-        MovingFundsData storage self
-    ) external view returns (uint96) {
-        return self.newMovingFundsTimeoutSlashingAmount;
-    }
-
     /// @notice Begins the moving funds timeout notifier reward multiplier amount
     ///         update process.
     /// @param _newMovingFundsTimeoutNotifierRewardMultiplier New moving funds
@@ -1025,14 +958,6 @@ library BridgeGovernanceParameters {
         self.movingFundsTimeoutNotifierRewardMultiplierChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsTimeoutNotifierRewardMultiplier(
-        MovingFundsData storage self
-    ) internal view returns (uint32) {
-        return self.newMovingFundsTimeoutNotifierRewardMultiplier;
-    }
-
     /// @notice Begins the moving funds commitment gas offset update process.
     /// @param _newMovingFundsCommitmentGasOffset New moving funds commitment
     ///        gas offset.
@@ -1069,16 +994,6 @@ library BridgeGovernanceParameters {
 
         self.newMovingFundsCommitmentGasOffset = 0;
         self.movingFundsCommitmentGasOffsetChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsCommitmentGasOffset(MovingFundsData storage self)
-        internal
-        view
-        returns (uint16)
-    {
-        return self.newMovingFundsCommitmentGasOffset;
     }
 
     /// @notice Begins the moved funds sweep tx max total fee amount update process.
@@ -1194,14 +1109,6 @@ library BridgeGovernanceParameters {
         self.movedFundsSweepTimeoutSlashingAmountChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovedFundsSweepTimeoutSlashingAmount(
-        MovingFundsData storage self
-    ) internal view returns (uint96) {
-        return self.newMovedFundsSweepTimeoutSlashingAmount;
-    }
-
     /// @notice Begins the moved funds sweep timeout notifier reward multiplier
     ///         amount update process.
     /// @param _newMovedFundsSweepTimeoutNotifierRewardMultiplier New moved funds
@@ -1244,14 +1151,6 @@ library BridgeGovernanceParameters {
         self.movedFundsSweepTimeoutNotifierRewardMultiplierChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovedFundsSweepTimeoutNotifierRewardMultiplier(
-        MovingFundsData storage self
-    ) internal view returns (uint32) {
-        return self.newMovedFundsSweepTimeoutNotifierRewardMultiplier;
-    }
-
     // --- Wallet params
 
     /// @notice Begins the wallet creation period amount update process.
@@ -1286,16 +1185,6 @@ library BridgeGovernanceParameters {
 
         self.newWalletCreationPeriod = 0;
         self.walletCreationPeriodChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletCreationPeriod(WalletData storage self)
-        external
-        view
-        returns (uint32)
-    {
-        return self.newWalletCreationPeriod;
     }
 
     /// @notice Begins the wallet creation min btc balance amount update process.
@@ -1333,16 +1222,6 @@ library BridgeGovernanceParameters {
 
         self.newWalletCreationMinBtcBalance = 0;
         self.walletCreationMinBtcBalanceChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletCreationMinBtcBalance(WalletData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newWalletCreationMinBtcBalance;
     }
 
     /// @notice Begins the wallet creation max btc balance amount update process.
@@ -1447,16 +1326,6 @@ library BridgeGovernanceParameters {
 
         self.newWalletMaxAge = 0;
         self.walletMaxAgeChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletMaxAge(WalletData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newWalletMaxAge;
     }
 
     /// @notice Begins the wallet max btc transfer amount update process.
@@ -1565,16 +1434,6 @@ library BridgeGovernanceParameters {
         self.fraudChallengeDepositAmountChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewFraudChallengeDepositAmount(FraudData storage self)
-        internal
-        view
-        returns (uint96)
-    {
-        return self.newFraudChallengeDepositAmount;
-    }
-
     /// @notice Begins the fraud challenge defeat timeout amount update process.
     /// @param _newFraudChallengeDefeatTimeout New fraud challenge defeat timeout
     ///         amount.
@@ -1646,16 +1505,6 @@ library BridgeGovernanceParameters {
         self.fraudSlashingAmountChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewFraudSlashingAmount(FraudData storage self)
-        internal
-        view
-        returns (uint96)
-    {
-        return self.newFraudSlashingAmount;
-    }
-
     /// @notice Begins the fraud notifier reward multiplier amount update process.
     /// @param _newFraudNotifierRewardMultiplier New fraud notifier reward multiplier
     ///         amount.
@@ -1721,15 +1570,5 @@ library BridgeGovernanceParameters {
 
         self.newTreasury = address(0);
         self.treasuryChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewFraudNotifierRewardMultiplier(FraudData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newFraudNotifierRewardMultiplier;
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -384,16 +384,6 @@ library BridgeGovernanceParameters {
         self.depositDustThresholdChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewDepositDustThreshold(DepositData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newDepositDustThreshold;
-    }
-
     /// @notice Begins the deposit treasury fee divisor amount update process.
     /// @param _newDepositTreasuryFeeDivisor New deposit treasury fee divisor amount.
     function beginDepositTreasuryFeeDivisorUpdate(
@@ -470,16 +460,6 @@ library BridgeGovernanceParameters {
 
         self.newDepositTxMaxFee = 0;
         self.depositTxMaxFeeChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewDepositTxMaxFee(DepositData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newDepositTxMaxFee;
     }
 
     /// @notice Begins the deposit reveal ahead period update process.
@@ -560,16 +540,6 @@ library BridgeGovernanceParameters {
 
         self.newRedemptionDustThreshold = 0;
         self.redemptionDustThresholdChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionDustThreshold(RedemptionData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newRedemptionDustThreshold;
     }
 
     /// @notice Begins the redemption treasury fee divisor amount update process.
@@ -697,16 +667,6 @@ library BridgeGovernanceParameters {
         self.redemptionTxMaxTotalFeeChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTxMaxTotalFee(RedemptionData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newRedemptionTxMaxTotalFee;
-    }
-
     /// @notice Begins the redemption timeout amount update process.
     /// @param _newRedemptionTimeout New redemption timeout amount.
     function beginRedemptionTimeoutUpdate(
@@ -740,16 +700,6 @@ library BridgeGovernanceParameters {
 
         self.newRedemptionTimeout = 0;
         self.redemptionTimeoutChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewRedemptionTimeout(RedemptionData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newRedemptionTimeout;
     }
 
     /// @notice Begins the redemption timeout slashing amount update process.
@@ -884,16 +834,6 @@ library BridgeGovernanceParameters {
         self.movingFundsTxMaxTotalFeeChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsTxMaxTotalFee(MovingFundsData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newMovingFundsTxMaxTotalFee;
-    }
-
     /// @notice Begins the moving funds dust threshold amount update process.
     /// @param _newMovingFundsDustThreshold New moving funds dust threshold amount.
     function beginMovingFundsDustThresholdUpdate(
@@ -926,16 +866,6 @@ library BridgeGovernanceParameters {
 
         self.newMovingFundsDustThreshold = 0;
         self.movingFundsDustThresholdChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsDustThreshold(MovingFundsData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newMovingFundsDustThreshold;
     }
 
     /// @notice Begins the moving funds timeout reset delay amount update process.
@@ -975,16 +905,6 @@ library BridgeGovernanceParameters {
         self.movingFundsTimeoutResetDelayChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsTimeoutResetDelay(MovingFundsData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newMovingFundsTimeoutResetDelay;
-    }
-
     /// @notice Begins the moving funds timeout amount update process.
     /// @param _newMovingFundsTimeout New moving funds timeout amount.
     function beginMovingFundsTimeoutUpdate(
@@ -1017,16 +937,6 @@ library BridgeGovernanceParameters {
 
         self.newMovingFundsTimeout = 0;
         self.movingFundsTimeoutChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovingFundsTimeout(MovingFundsData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newMovingFundsTimeout;
     }
 
     /// @notice Begins the moving funds timeout slashing amount update process.
@@ -1209,16 +1119,6 @@ library BridgeGovernanceParameters {
         self.movedFundsSweepTxMaxTotalFeeChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovedFundsSweepTxMaxTotalFee(MovingFundsData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newMovedFundsSweepTxMaxTotalFee;
-    }
-
     /// @notice Begins the moved funds sweep timeout amount update process.
     /// @param _newMovedFundsSweepTimeout New moved funds sweep timeout amount.
     function beginMovedFundsSweepTimeoutUpdate(
@@ -1251,16 +1151,6 @@ library BridgeGovernanceParameters {
 
         self.newMovedFundsSweepTimeout = 0;
         self.movedFundsSweepTimeoutChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewMovedFundsSweepTimeout(MovingFundsData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newMovedFundsSweepTimeout;
     }
 
     /// @notice Begins the moved funds sweep timeout slashing amount update
@@ -1492,16 +1382,6 @@ library BridgeGovernanceParameters {
         self.walletCreationMaxBtcBalanceChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletCreationMaxBtcBalance(WalletData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newWalletCreationMaxBtcBalance;
-    }
-
     /// @notice Begins the wallet closure min btc balance amount update process.
     /// @param _newWalletClosureMinBtcBalance New wallet closure min btc balance amount.
     function beginWalletClosureMinBtcBalanceUpdate(
@@ -1536,16 +1416,6 @@ library BridgeGovernanceParameters {
 
         self.newWalletClosureMinBtcBalance = 0;
         self.walletClosureMinBtcBalanceChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletClosureMinBtcBalance(WalletData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newWalletClosureMinBtcBalance;
     }
 
     /// @notice Begins the wallet max age amount update process.
@@ -1623,16 +1493,6 @@ library BridgeGovernanceParameters {
         self.walletMaxBtcTransferChangeInitiated = 0;
     }
 
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletMaxBtcTransfer(WalletData storage self)
-        internal
-        view
-        returns (uint64)
-    {
-        return self.newWalletMaxBtcTransfer;
-    }
-
     /// @notice Begins the wallet closing period amount update process.
     /// @param _newWalletClosingPeriod New wallet closing period amount.
     function beginWalletClosingPeriodUpdate(
@@ -1665,16 +1525,6 @@ library BridgeGovernanceParameters {
 
         self.newWalletClosingPeriod = 0;
         self.walletClosingPeriodChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewWalletClosingPeriod(WalletData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newWalletClosingPeriod;
     }
 
     // --- Fraud
@@ -1760,16 +1610,6 @@ library BridgeGovernanceParameters {
 
         self.newFraudChallengeDefeatTimeout = 0;
         self.fraudChallengeDefeatTimeoutChangeInitiated = 0;
-    }
-
-    // https://github.com/crytic/slither/issues/1265
-    // slither-disable-next-line dead-code
-    function getNewFraudChallengeDefeatTimeout(FraudData storage self)
-        internal
-        view
-        returns (uint32)
-    {
-        return self.newFraudChallengeDefeatTimeout;
     }
 
     /// @notice Begins the fraud slashing amount update process.

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -298,15 +298,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeDepositDustThresholdUpdate()
-        ).to.be.revertedWith("Deposit dust threshold must be greater than zero")
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -544,15 +542,11 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance.connect(governance).finalizeDepositTxMaxFeeUpdate()
-        ).to.be.revertedWith(
-          "Deposit transaction max fee must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -792,17 +786,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeRedemptionDustThresholdUpdate()
-        ).to.be.revertedWith(
-          "Redemption dust threshold must be greater than moving funds dust threshold"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1056,8 +1046,6 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         // If the update was not initialized, the transaction will fail because
@@ -1068,9 +1056,7 @@ describe("Bridge - Governance", () => {
           bridgeGovernance
             .connect(governance)
             .finalizeRedemptionTxMaxTotalFeeUpdate()
-        ).to.be.revertedWith(
-          "Redemption transaction max total fee must be greater than or equal to the redemption transaction per-request max fee"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1189,13 +1175,11 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance.connect(governance).finalizeRedemptionTimeoutUpdate()
-        ).to.be.revertedWith("Redemption timeout must be greater than zero")
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1573,17 +1557,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovingFundsTxMaxTotalFeeUpdate()
-        ).to.be.revertedWith(
-          "Moving funds transaction max total fee must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1703,17 +1683,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovingFundsDustThresholdUpdate()
-        ).to.be.revertedWith(
-          "Moving funds dust threshold must be greater than zero and lower than redemption dust threshold"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1836,17 +1812,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovingFundsTimeoutResetDelayUpdate()
-        ).to.be.revertedWith(
-          "Moving funds timeout reset delay must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1961,17 +1933,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovingFundsTimeoutUpdate()
-        ).to.be.revertedWith(
-          "Moving funds timeout must be greater than its reset delay"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -1995,9 +1963,7 @@ describe("Bridge - Governance", () => {
           bridgeGovernance
             .connect(governance)
             .finalizeMovingFundsTimeoutUpdate()
-        ).to.be.revertedWith(
-          "Moving funds timeout must be greater than its reset delay"
-        )
+        ).to.be.revertedWith("Governance delay has not elapsed")
       })
     })
 
@@ -2490,17 +2456,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovedFundsSweepTxMaxTotalFeeUpdate()
-        ).to.be.revertedWith(
-          "Moved funds sweep transaction max total fee must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -2619,17 +2581,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeMovedFundsSweepTimeoutUpdate()
-        ).to.be.revertedWith(
-          "Moved funds sweep timeout must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -3259,17 +3217,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeWalletCreationMaxBtcBalanceUpdate()
-        ).to.be.revertedWith(
-          "Wallet creation maximum BTC balance must be greater than the creation minimum BTC balance"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -3394,17 +3348,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeWalletClosureMinBtcBalanceUpdate()
-        ).to.be.revertedWith(
-          "Wallet closure minimum BTC balance must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -3632,17 +3582,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeWalletMaxBtcTransferUpdate()
-        ).to.be.revertedWith(
-          "Wallet maximum BTC transfer must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -3756,15 +3702,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeWalletClosingPeriodUpdate()
-        ).to.be.revertedWith("Wallet closing period must be greater than zero")
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 
@@ -4006,17 +3950,13 @@ describe("Bridge - Governance", () => {
       })
     })
 
-    // FIXME: This test is not covering the behavior described!
-    // The expected revert message should be "Change not initiated".
     context("when the update process is not initialized", () => {
       it("should revert", async () => {
         await expect(
           bridgeGovernance
             .connect(governance)
             .finalizeFraudChallengeDefeatTimeoutUpdate()
-        ).to.be.revertedWith(
-          "Fraud challenge defeat timeout must be greater than zero"
-        )
+        ).to.be.revertedWith("Change not initiated")
       })
     })
 


### PR DESCRIPTION
We had a set of tests where the described behavior of the test didn't reflect the actual return message. The expected revert message should've been "Change not initiated".
The other change is simplifying calls for variables. We do not need to call internal getters to access variables from the `BridgeGovernanceParameters` lib.