### PR TITLE
Set wallet closure minimum BTC balance to zero

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1449,7 +1449,6 @@ contract Bridge is
     /// @dev Requirements:
     ///      - Wallet maximum BTC balance must be greater than the wallet
     ///        minimum BTC balance,
-    ///      - Wallet closure BTC balance must be greater than zero,
     ///      - Wallet maximum BTC transfer must be greater than zero,
     ///      - Wallet closing period must be greater than zero.
     function updateWalletParameters(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -726,7 +726,6 @@ library BridgeState {
     /// @dev Requirements:
     ///      - Wallet maximum BTC balance must be greater than the wallet
     ///        minimum BTC balance,
-    ///      - Wallet closure BTC balance must be greater than zero,
     ///      - Wallet maximum BTC transfer must be greater than zero,
     ///      - Wallet closing period must be greater than zero.
     function updateWalletParameters(
@@ -742,10 +741,6 @@ library BridgeState {
         require(
             _walletCreationMaxBtcBalance > _walletCreationMinBtcBalance,
             "Wallet creation maximum BTC balance must be greater than the creation minimum BTC balance"
-        );
-        require(
-            _walletClosureMinBtcBalance > 0,
-            "Wallet closure minimum BTC balance must be greater than zero"
         );
         require(
             _walletMaxBtcTransfer > 0,

--- a/solidity/deploy/18_disable_moving_funds.ts
+++ b/solidity/deploy/18_disable_moving_funds.ts
@@ -28,12 +28,8 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // become "closeable" if both of the following is true:
   // - walletMaxAge is set to the maximum value allowed for uint32 type (2^32-1 = 4294967295)
   // - walletClosureMinBtcBalance is zero
-  //
-  // In practice, walletClosureMinBtcBalance's minimum value enforced by the
-  // contract is 1. That should do the trick because only non-active wallets
-  // with 0 BTC (no funds to move) can become "closeable" in that case.
   const walletMaxAge = ethers.BigNumber.from("4294967295")
-  const walletClosureMinBtcBalance = ethers.BigNumber.from("1")
+  const walletClosureMinBtcBalance = ethers.BigNumber.from("0")
 
   // Fetch the current values of other wallet parameters to keep them unchanged.
   const walletParameters = await read("Bridge", "walletParameters")

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -1518,24 +1518,6 @@ describe("Bridge - Parameters", () => {
         }
       )
 
-      context("when new closure minimum BTC balance is zero", () => {
-        it("should revert", async () => {
-          await bridgeGovernance
-            .connect(governance)
-            .beginWalletClosureMinBtcBalanceUpdate(0)
-
-          await helpers.time.increaseTime(constants.governanceDelay)
-
-          await expect(
-            bridgeGovernance
-              .connect(governance)
-              .finalizeWalletClosureMinBtcBalanceUpdate()
-          ).to.be.revertedWith(
-            "Wallet closure minimum BTC balance must be greater than zero"
-          )
-        })
-      })
-
       context("when new maximum BTC transfer is zero", () => {
         it("should revert", async () => {
           await bridgeGovernance


### PR DESCRIPTION
For the initial release, we want to prevent wallets from entering into the `MOVING_FUNDS`, `CLOSING` and `CLOSED` states. Wallets must remain `LIVE` to be able to sweep funds when the time comes. So far, the `walletClosureMinBtcBalance` governable parameter was set to its minimal value of `1` satoshi. That value means a wallet can be directly moved to the `CLOSING` state if their balance in the `Bridge` is `0` satoshi and the wallet is no longer the latest one (i.e. active). This is a problem for optimistic minting because all wallets will have `0` satoshi in the `Bridge` until sweeping is implemented. Here we fix that by allowing to set `0` as a value of the `walletClosureMinBtcBalance` parameter and use that value as default in the deployment scripts.