### PR TITLE
Remove the `etherscan` tag for `goerli` environment

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -114,7 +114,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.ACCOUNTS_PRIVATE_KEYS
         ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
-      tags: ["etherscan", "tenderly"],
+      tags: ["tenderly"],
     },
     mainnet: {
       url: process.env.CHAIN_API_URL || "",


### PR DESCRIPTION
Currently in the CI we use `hardhat-deploy` to verify contracts on Goerli, for which we don't need to use tags. Tags are used for verification using `@nomiclabs/hardhat-etherscan` - we would need to adjust CI and hardhat config to support it.