### PR TITLE
Set addresses for Goerli deployment to 0

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -182,39 +182,39 @@ const config: HardhatUserConfig = {
     },
     governance: {
       default: 2,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     chaosnetOwner: {
       default: 3,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       // Not used for mainnet deployment scripts of `@keepn-network/tbtc-v2`.
       // Used by `@keep-network/random-beacon` and `@keep-network/ecdsa`
       // when deploying `SortitionPool`s.
     },
     esdm: {
       default: 4,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
     },
     keepTechnicalWalletTeam: {
       default: 5,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       mainnet: "0xB3726E69Da808A689F2607939a2D9E958724FC2A",
     },
     keepCommunityMultiSig: {
       default: 6,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       mainnet: "0x19FcB32347ff4656E4E6746b4584192D185d640d",
     },
     treasury: {
       default: 7,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       mainnet: "0x87F005317692D05BAA4193AB0c961c69e175f45f", // Token Holder DAO
     },
     spvMaintainer: {
       default: 8,
-      goerli: "0xCac19049825F370dB0836cB0d8E4D024F78eb2eB", // Dev team
+      goerli: 0,
       // We are not setting SPV maintainer for mainnet in deployment scripts.
     },
   },


### PR DESCRIPTION
This PR sets all the named account addresses to `0` for Goerli deployment.