### PR TITLE
Update version to `1.0.1-dev`

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.0.0-dev",
+  "version": "1.0.1-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
We've published the 1.0.0 version (for mainnet), we need to update the version in `package.json` to a higher version.