### PR TITLE
Yarn postinstall scripts after `yarn upgrade...`

### DIFF
--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Resolve latest contracts
         run: yarn upgrade @keep-network/tbtc-v2 --exact
 
+      # The `typescript` postinstall scripts do not get executed during `yarn
+      # upgrade ...`, so we need to invoke them as a separate step.
+      - name: Run typescript post-install script
+        run: yarn run postinstall
+
       - name: Compile
         run: yarn build
 


### PR DESCRIPTION
In the `package.json` for `typescript` we have defined a postinstall script which runs `typechain` script. When we run `yarn upgrade...` in the CI workflow publishing NPM package, the specified in the command dependencies get updated, other get installed, but the postinstall scripts do not get executed. If we want to run the scripts we can either run `yarn install` before `yarn upgrade ...` or run `yarn run postinstall` after the `yarn upgrade ...` step. We've opted for the second option.
Without running the postinstall scripts, the workflow was failing with the following message duing `yarn build`:
```
$ tsc --project tsconfig.build.json
Error: src/ethereum.ts(23,47): error TS2307: Cannot find module
'../typechain/Bridge' or its corresponding type declarations.
Error: src/ethereum.ts(24,63): error TS2307: Cannot find module
'../typechain/WalletRegistry' or its corresponding type declarations.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this
command.
Error: Process completed with exit code 2.
```