### PR TITLE
Exclude typechain script from postinstall

### DIFF
--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -35,11 +35,6 @@ jobs:
       - name: Resolve latest contracts
         run: yarn upgrade @keep-network/tbtc-v2 --exact
 
-      # The `typescript` postinstall scripts do not get executed during `yarn
-      # upgrade ...`, so we need to invoke them as a separate step.
-      - name: Run typescript post-install script
-        run: yarn run postinstall
-
       - name: Compile
         run: yarn build
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "eslint . --ext .js,.ts --fix",
     "test": "mocha --exit --recursive 'test/**/*.test.ts'",
-    "build": "tsc --project tsconfig.build.json",
-    "postinstall": "npm rebuild && npm run typechain",
-    "typechain": "rm -rf ./typechain && for i in $npm_package_config_contracts; do typechain --target ethers-v5 --out-dir ./typechain $i; done && rm ./typechain/index.ts"
+    "typechain": "rm -rf ./typechain && for i in $npm_package_config_contracts; do typechain --target ethers-v5 --out-dir ./typechain $i; done && rm ./typechain/index.ts",
+    "build": "npm run typechain && tsc --project tsconfig.build.json",
+    "postinstall": "npm rebuild"
   },
   "files": [
     "dist/**/*"


### PR DESCRIPTION
We use typechain script to generate TS bindings for contracts that we install as dependencies. With postinall script the bindings were generated always when we installed the dependencies. Unfortunatelly if this package was being used in another project as dependency this postinstall script was also executed, which doesn't make sense as we publish the generated bindings as part of the package.

With this change here we move the typechain bindings geneartion to the build script so they are generated when building the package before publication.