### PR TITLE
Add a possibility to pass options to the Electrum client

### DIFF
--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -30,11 +30,12 @@ export interface Credentials {
    * Protocol used by the Electrum server.
    */
   protocol: "tcp" | "tls" | "ssl" | "ws" | "wss"
-  /**
-   * Additional options used by the Electrum server.
-   */
-  options?: any
 }
+
+/**
+ * Additional options used by the Electrum server.
+ */
+type Options = object
 
 /**
  * Represents an action that makes use of the Electrum connection. An action
@@ -48,19 +49,22 @@ type Action<T> = (electrum: any) => Promise<T>
  */
 export class Client implements BitcoinClient {
   private credentials: Credentials
+  private options?: Options
 
-  constructor(credentials: Credentials) {
+  constructor(credentials: Credentials, options?: Options) {
     this.credentials = credentials
+    this.options = options
   }
 
   /**
    * Creates an Electrum client instance from a URL.
    * @param url - Connection URL.
+   * @param options - Additional options used by the Electrum server.
    * @returns Electrum client instance.
    */
-  static fromUrl(url: string): Client {
+  static fromUrl(url: string, options?: Options): Client {
     const credentials = this.parseElectrumCredentials(url)
-    return new Client(credentials)
+    return new Client(credentials, options)
   }
 
   /**
@@ -94,7 +98,7 @@ export class Client implements BitcoinClient {
       this.credentials.host,
       this.credentials.port,
       this.credentials.protocol,
-      this.credentials.options
+      this.options
     )
 
     try {

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -30,6 +30,10 @@ export interface Credentials {
    * Protocol used by the Electrum server.
    */
   protocol: "tcp" | "tls" | "ssl" | "ws" | "wss"
+  /**
+   * Additional options used by the Electrum server.
+   */
+  options?: any
 }
 
 /**
@@ -89,7 +93,8 @@ export class Client implements BitcoinClient {
     const electrum = new Electrum(
       this.credentials.host,
       this.credentials.port,
-      this.credentials.protocol
+      this.credentials.protocol,
+      this.credentials.options
     )
 
     try {


### PR DESCRIPTION
We need to have a possibility to add `options` object to Electrum client and we couldn't do that through tbtc-v2.ts lib. This is why we introduce additional and optional property `options` in `Credentials` interface.