### PR TITLE
Export ClientOptions type

### DIFF
--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -49,9 +49,9 @@ type Action<T> = (electrum: any) => Promise<T>
  */
 export class Client implements BitcoinClient {
   private credentials: Credentials
-  private options?: Options
+  private options?: ClientOptions
 
-  constructor(credentials: Credentials, options?: Options) {
+  constructor(credentials: Credentials, options?: ClientOptions) {
     this.credentials = credentials
     this.options = options
   }
@@ -62,7 +62,7 @@ export class Client implements BitcoinClient {
    * @param options - Additional options used by the Electrum server.
    * @returns Electrum client instance.
    */
-  static fromUrl(url: string, options?: Options): Client {
+  static fromUrl(url: string, options?: ClientOptions): Client {
     const credentials = this.parseElectrumCredentials(url)
     return new Client(credentials, options)
   }

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -35,7 +35,7 @@ export interface Credentials {
 /**
  * Additional options used by the Electrum server.
  */
-type Options = object
+export type ClientOptions = object
 
 /**
  * Represents an action that makes use of the Electrum connection. An action


### PR DESCRIPTION
We want to use that type in the dApp and to be able to do that we need this variable to be exported.

We also change the name of it from `Options` to `ClientOptions` as the `Options` seems to generic.