### PR TITLE
Bumping up version to 1.0.2-dev

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.0.1-dev",
+  "version": "1.0.2-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
The latest NPM package published for mainnet is 1.0.1. Bumping up the version number for development.