### PR TITLE
Make `decodeBitcoinAddress` throw on non-PKH addresses

### DIFF
--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -389,13 +389,21 @@ export function encodeToBitcoinAddress(
 }
 
 /**
- * Decodes P2PKH or P2WPKH address into a public key hash.
+ * Decodes P2PKH or P2WPKH address into a public key hash. Throws if the
+ * provided address is not PKH-based.
  * @param address - P2PKH or P2WPKH address that will be decoded.
  * @returns Public key hash decoded from the address. This will be an unprefixed
  *        hex string (without 0x prefix).
  */
 export function decodeBitcoinAddress(address: string): string {
   const addressObject = new bcoin.Address(address)
+
+  const isPKH =
+    addressObject.isPubkeyhash() || addressObject.isWitnessPubkeyhash()
+  if (!isPKH) {
+    throw new Error("address must be P2PKH or P2WPKH")
+  }
+
   return addressObject.getHash("hex")
 }
 

--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -401,7 +401,7 @@ export function decodeBitcoinAddress(address: string): string {
   const isPKH =
     addressObject.isPubkeyhash() || addressObject.isWitnessPubkeyhash()
   if (!isPKH) {
-    throw new Error("address must be P2PKH or P2WPKH")
+    throw new Error("Address must be P2PKH or P2WPKH")
   }
 
   return addressObject.getHash("hex")

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -129,6 +129,24 @@ describe("Bitcoin", () => {
             expect(() => decodeBitcoinAddress(bitcoinAddress)).to.throw()
           })
         })
+
+        context("when unsupported P2SH address is provided", () => {
+          it("should throw", () => {
+            expect(() =>
+              decodeBitcoinAddress("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX")
+            ).to.throw("address must be P2PKH or P2WPKH")
+          })
+        })
+
+        context("when unsupported P2WSH address is provided", () => {
+          it("should throw", () => {
+            expect(() =>
+              decodeBitcoinAddress(
+                "bc1qma629cu92skg0t86lftyaf9uflzwhp7jk63h6mpmv3ezh6puvdhsdxuv4m"
+              )
+            ).to.throw("address must be P2PKH or P2WPKH")
+          })
+        })
       })
 
       context("when network is testnet", () => {
@@ -153,6 +171,24 @@ describe("Bitcoin", () => {
             const bitcoinAddress = "123" + P2PKHAddressTestnet
 
             expect(() => decodeBitcoinAddress(bitcoinAddress)).to.throw()
+          })
+        })
+
+        context("when unsupported P2SH address is provided", () => {
+          it("should throw", () => {
+            expect(() =>
+              decodeBitcoinAddress("2MyxShnGQ5NifGb8CHYrtmzosRySxZ9pZo5")
+            ).to.throw("address must be P2PKH or P2WPKH")
+          })
+        })
+
+        context("when unsupported P2WSH address is provided", () => {
+          it("should throw", () => {
+            expect(() =>
+              decodeBitcoinAddress(
+                "tb1qma629cu92skg0t86lftyaf9uflzwhp7jk63h6mpmv3ezh6puvdhs6w2r05"
+              )
+            ).to.throw("address must be P2PKH or P2WPKH")
           })
         })
       })

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -134,7 +134,7 @@ describe("Bitcoin", () => {
           it("should throw", () => {
             expect(() =>
               decodeBitcoinAddress("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX")
-            ).to.throw("address must be P2PKH or P2WPKH")
+            ).to.throw("Address must be P2PKH or P2WPKH")
           })
         })
 
@@ -144,7 +144,7 @@ describe("Bitcoin", () => {
               decodeBitcoinAddress(
                 "bc1qma629cu92skg0t86lftyaf9uflzwhp7jk63h6mpmv3ezh6puvdhsdxuv4m"
               )
-            ).to.throw("address must be P2PKH or P2WPKH")
+            ).to.throw("Address must be P2PKH or P2WPKH")
           })
         })
       })
@@ -178,7 +178,7 @@ describe("Bitcoin", () => {
           it("should throw", () => {
             expect(() =>
               decodeBitcoinAddress("2MyxShnGQ5NifGb8CHYrtmzosRySxZ9pZo5")
-            ).to.throw("address must be P2PKH or P2WPKH")
+            ).to.throw("Address must be P2PKH or P2WPKH")
           })
         })
 
@@ -188,7 +188,7 @@ describe("Bitcoin", () => {
               decodeBitcoinAddress(
                 "tb1qma629cu92skg0t86lftyaf9uflzwhp7jk63h6mpmv3ezh6puvdhs6w2r05"
               )
-            ).to.throw("address must be P2PKH or P2WPKH")
+            ).to.throw("Address must be P2PKH or P2WPKH")
           })
         })
       })


### PR DESCRIPTION
Refs: https://github.com/threshold-network/token-dashboard/issues/393

The `decodeBitcoinAddress` documentation says that this function decodes P2PKH and P2WPKH addresses into a public key hash. However, this requirement is not enforced by the function code. Here we add a validation that makes the function throw if the passed address is not PKH-based. That means the function will throw an exception if the passed address is, for example, P2SH or P2WSH.