### PR TITLE
Import include `src/` dir in package exports

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "dist/",
+    "src/",
     "typechain/"
   ],
   "config": {


### PR DESCRIPTION
We need to export the `src/` directory for `sourceMap` to work.
See: https://www.typescriptlang.org/tsconfig#sourceMap