### PR TITLE
Introduce temporary retry mechanism to system tests Electrum calls

### DIFF
--- a/system-tests/test/deposit-redemption.test.ts
+++ b/system-tests/test/deposit-redemption.test.ts
@@ -176,10 +176,7 @@ describe("System Test - Deposit and redemption", () => {
         // Unlike in the deposit transaction case, we must wait for the sweep
         // transaction to have an enough number of confirmations. This is
         // because the bridge performs the SPV proof of that transaction.
-        await waitTransactionConfirmed(
-          bitcoinClient,
-          sweepUtxo.transactionHash
-        )
+        await waitTransactionConfirmed(bitcoinClient, sweepUtxo.transactionHash)
 
         await fakeRelayDifficulty(
           relay,

--- a/system-tests/test/utils/bitcoin.ts
+++ b/system-tests/test/utils/bitcoin.ts
@@ -169,7 +169,9 @@ export class RetryingBitcoinClient implements BitcoinClient {
         // eslint-disable-next-line no-await-in-loop
         return await fn()
       } catch (error) {
-        const backoffMillis = 2 ** attempt * 1000
+        // Use 10k millis as multiplier to get longer delays that are more
+        // suitable for this use case.
+        const backoffMillis = 2 ** attempt * 10000
         const jitterMillis = Math.floor(Math.random() * 100)
         const waitMillis = backoffMillis + jitterMillis
 


### PR DESCRIPTION
The testnet Electrum instances are often unreliable and cause failures of system test scenarios. Here we aim to mitigate that problem by wrapping all Electrum calls done by system tests with a temporary retry mechanism. Eventually, this mechanism should be replaced with a full-fledged retry support built-in in the `ElectrumClient` at the `tbtc-v2.ts` level.