### PR TITLE
Retries for Ethereum requests

### DIFF
--- a/typescript/src/backoff.ts
+++ b/typescript/src/backoff.ts
@@ -11,13 +11,35 @@ export function retryAll(error: any): true {
 }
 
 /**
+ * A matcher to specify list of error messages that should abort the retry loop
+ * and throw immediately.
+ * @param matchers List of patterns for error matching.
+ * @returns Matcher function that returns false if error matches one of the patterns.
+ *          True is returned if no matches are found and retry loop should continue
+ */
+export function skipRetryWhenMatched(
+  matchers: Array<string | RegExp>
+): ErrorMatcherFn {
+  return (err: unknown): boolean => {
+    if (err instanceof Error) {
+      for (const matcher of matchers) {
+        if (err.message.match(matcher)) {
+          return false
+        }
+      }
+    }
+    return true
+  }
+}
+
+/**
  * @callback ErrorMatcherFn A function that returns true if the passed error
  *           matches and false otherwise. Used to determine if a given error is
  *           eligible for retry in `withBackoffRetries`.
  * @param {Error} error The error to check for eligibility.
  * @return {boolean} True if the error matches, false otherwise.
  */
-type ErrorMatcherFn = (err: unknown) => boolean
+export type ErrorMatcherFn = (err: unknown) => boolean
 
 /**
  * @callback RetrierFn A function that can retry any function passed to it a
@@ -30,7 +52,7 @@ type ErrorMatcherFn = (err: unknown) => boolean
 /**
  * A function that is called with execution status messages.
  */
-type ExecutionLoggerFn = (msg: string) => void
+export type ExecutionLoggerFn = (msg: string) => void
 
 /**
  * Returns a retrier that can be passed a function to be retried `retries`
@@ -92,6 +114,6 @@ export function backoffRetrier<T>(
     }
 
     // Last attempt, unguarded.
-    return await fn()
+    return fn()
   }
 }

--- a/typescript/src/backoff.ts
+++ b/typescript/src/backoff.ts
@@ -76,6 +76,8 @@ export type ExecutionLoggerFn = (msg: string) => void
  *
  * @param {number} retries The number of retries to perform before bubbling the
  *        failure out.
+ * @param {number} backoffStepMs Initial backoff step in milliseconds that will
+ *        be increased exponentially for subsequent retry attempts. (default = 1000 ms)
  * @param {ExecutionLoggerFn} logger A logger function to pass execution messages.
  * @param {ErrorMatcherFn} [errorMatcher=retryAll] A matcher function that
  *        receives the error when an exception is thrown, and returns true if
@@ -85,6 +87,7 @@ export type ExecutionLoggerFn = (msg: string) => void
  */
 export function backoffRetrier<T>(
   retries: number,
+  backoffStepMs = 1000,
   logger: ExecutionLoggerFn = console.debug,
   errorMatcher: ErrorMatcherFn = retryAll
 ) {
@@ -100,7 +103,7 @@ export function backoffRetrier<T>(
           throw error
         }
 
-        const backoffMillis = Math.pow(2, attempt) * 1000
+        const backoffMillis = Math.pow(2, attempt) * backoffStepMs
         const jitterMillis = Math.floor(Math.random() * 100)
         const waitMillis = backoffMillis + jitterMillis
 

--- a/typescript/src/backoff.ts
+++ b/typescript/src/backoff.ts
@@ -1,0 +1,97 @@
+/**
+ * A convenience matcher for withBackoffRetries that retries irrespective of
+ * the error.
+ *
+ * @param error The error to match against. Not necessarily an Error
+ *        instance, since the retriable function may throw a non-Error.
+ * @returns Always returns true.
+ */
+export function retryAll(error: any): true {
+  return true
+}
+
+/**
+ * @callback ErrorMatcherFn A function that returns true if the passed error
+ *           matches and false otherwise. Used to determine if a given error is
+ *           eligible for retry in `withBackoffRetries`.
+ * @param {Error} error The error to check for eligibility.
+ * @return {boolean} True if the error matches, false otherwise.
+ */
+type ErrorMatcherFn = (err: unknown) => boolean
+
+/**
+ * @callback RetrierFn A function that can retry any function passed to it a
+ *           set number of times, returning its result when it succeeds. Created
+ *           using `backoffRetrier`.
+ * @param {function(): Promise<T>} fn The function to be retried.
+ * @return {Promise<T>}
+ */
+
+/**
+ * A function that is called with execution status messages.
+ */
+type ExecutionLoggerFn = (msg: string) => void
+
+/**
+ * Returns a retrier that can be passed a function to be retried `retries`
+ * number of times, with exponential backoff. The result will return the
+ * function's return value if no exceptions are thrown. It will only retry if
+ * the function throws an exception matched by `matcher`; {@see retryAll } can
+ * be used to retry no matter the exception, though this is not necessarily
+ * recommended in production.
+ *
+ * Example usage:
+ *
+ *      await url.get("https://example.com/") // may transiently fail
+ *      // Retries 3 times with exponential backoff, no matter what error is
+ *      // reported by `url.get`.
+ *      backoffRetrier(3)(async () => url.get("https://example.com"))
+ *      // Retries 3 times with exponential backoff, but only if the error
+ *      // message includes "server unavailable".
+ *      backoffRetrier(3, (_) => _.message.includes('server unavailable'))(
+ *        async () => url.get("https://example.com"))
+ *      )
+ *
+ * @param {number} retries The number of retries to perform before bubbling the
+ *        failure out.
+ * @param {ExecutionLoggerFn} logger A logger function to pass execution messages.
+ * @param {ErrorMatcherFn} [errorMatcher=retryAll] A matcher function that
+ *        receives the error when an exception is thrown, and returns true if
+ *        the error should lead to a retry. A false return will rethrow the
+ *        error and terminate the retry loop.
+ * @returns {RetrierFn<T>} A function that can retry any function.
+ */
+export function backoffRetrier<T>(
+  retries: number,
+  logger: ExecutionLoggerFn = console.debug,
+  errorMatcher: ErrorMatcherFn = retryAll
+) {
+  return async (fn: () => Promise<T>): Promise<T> => {
+    for (let attempt = 0; attempt < retries; attempt++) {
+      try {
+        logger(`making attempt number ${attempt}`)
+
+        return await fn()
+      } catch (error: unknown) {
+        if (!errorMatcher(error)) {
+          // If the matcher doesn't match this error, rethrow and stop.
+          throw error
+        }
+
+        const backoffMillis = Math.pow(2, attempt) * 1000
+        const jitterMillis = Math.floor(Math.random() * 100)
+        const waitMillis = backoffMillis + jitterMillis
+
+        logger(
+          `attempt ${attempt} failed: ${error}; ` +
+            `retrying after ${waitMillis} milliseconds`
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, waitMillis))
+      }
+    }
+
+    // Last attempt, unguarded.
+    return await fn()
+  }
+}

--- a/typescript/src/backoff.ts
+++ b/typescript/src/backoff.ts
@@ -48,6 +48,7 @@ export type ErrorMatcherFn = (err: unknown) => boolean
  * @param {function(): Promise<T>} fn The function to be retried.
  * @return {Promise<T>}
  */
+export type RetrierFn<T> = (fn: () => Promise<T>) => Promise<T>
 
 /**
  * A function that is called with execution status messages.
@@ -90,7 +91,7 @@ export function backoffRetrier<T>(
   backoffStepMs = 1000,
   logger: ExecutionLoggerFn = console.debug,
   errorMatcher: ErrorMatcherFn = retryAll
-) {
+): RetrierFn<T> {
   return async (fn: () => Promise<T>): Promise<T> => {
     for (let attempt = 0; attempt < retries; attempt++) {
       try {

--- a/typescript/src/backoff.ts
+++ b/typescript/src/backoff.ts
@@ -88,7 +88,7 @@ export type ExecutionLoggerFn = (msg: string) => void
  */
 export function backoffRetrier<T>(
   retries: number,
-  backoffStepMs = 1000,
+  backoffStepMs: number = 1000,
   logger: ExecutionLoggerFn = console.debug,
   errorMatcher: ErrorMatcherFn = retryAll
 ): RetrierFn<T> {

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -51,22 +51,39 @@ export interface Event {
   transactionHash: Hex
 }
 
-/**
- * Represents a generic function to get events emitted on the chain.
- */
-export interface GetEventsFunction<T extends Event> {
+export namespace GetEvents {
   /**
-   * Get emitted events.
-   * @param fromBlock Block number from which events should be queried.
-   *        If not defined a block number of a contract deployment is used.
-   * @param toBlock Block number to which events should be queried.
-   *        If not defined the latest block number will be used.
-   * @param filterArgs Arguments for events filtering.
-   * @returns Array of found events.
+   * Represents generic options used for getting events from the chain.
    */
-  (fromBlock?: number, toBlock?: number, ...filterArgs: Array<any>): Promise<
-    T[]
-  >
+  export interface Options {
+    /**
+     * Block number from which events should be queried.
+     * If not defined a block number of a contract deployment is used.
+     */
+    fromBlock?: number
+    /**
+     * Block number to which events should be queried.
+     * If not defined the latest block number will be used.
+     */
+    toBlock?: number
+    /**
+     * Number of retries in case of an error getting the events.
+     */
+    retries?: number
+  }
+
+  /**
+   * Represents a generic function to get events emitted on the chain.
+   */
+  export interface Function<T extends Event> {
+    /**
+     * Get emitted events.
+     * @param options Options for getting events.
+     * @param filterArgs Arguments for events filtering.
+     * @returns Array of found events.
+     */
+    (options?: Options, ...filterArgs: Array<any>): Promise<T[]>
+  }
 }
 
 /**
@@ -77,7 +94,7 @@ export interface Bridge {
    * Get emitted DepositRevealed events.
    * @see GetEventsFunction
    */
-  getDepositRevealedEvents: GetEventsFunction<DepositRevealedEvent>
+  getDepositRevealedEvents: GetEvents.Function<DepositRevealedEvent>
 
   /**
    * Submits a deposit sweep transaction proof to the on-chain contract.
@@ -291,5 +308,5 @@ export interface TBTCVault {
    * Get emitted OptimisticMintingRequested events.
    * @see GetEventsFunction
    */
-  getOptimisticMintingRequestedEvents: GetEventsFunction<OptimisticMintingRequestedEvent>
+  getOptimisticMintingRequestedEvents: GetEvents.Function<OptimisticMintingRequestedEvent>
 }

--- a/typescript/src/ethereum-helpers.ts
+++ b/typescript/src/ethereum-helpers.ts
@@ -1,0 +1,34 @@
+import {
+  backoffRetrier,
+  skipRetryWhenMatched,
+  ExecutionLoggerFn,
+} from "./backoff"
+
+/**
+ * Sends ethereum transaction with retries.
+ * @param fn Function to execute with retries.
+ * @param retries The number of retries to perform before bubbling the failure out.
+ * @param logger A logger function to pass execution messages.
+ * @param nonRetryableErrors List of error messages that if returned from executed
+ *        function, should break the retry loop and return immediately.
+ * @returns Result of function execution.
+ * @throws An error returned by function execution.
+ */
+export async function sendWithRetry<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  logger?: ExecutionLoggerFn,
+  nonRetryableErrors?: Array<string | RegExp>
+): Promise<T> {
+  return backoffRetrier<T>(
+    retries,
+    logger,
+    nonRetryableErrors ? skipRetryWhenMatched(nonRetryableErrors) : undefined
+  )(async () => {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      throw err
+    }
+  })
+}

--- a/typescript/src/ethereum-helpers.ts
+++ b/typescript/src/ethereum-helpers.ts
@@ -24,6 +24,7 @@ export async function sendWithRetry<T>(
 ): Promise<T> {
   return backoffRetrier<T>(
     retries,
+    1000,
     logger,
     nonRetryableErrors ? skipRetryWhenMatched(nonRetryableErrors) : undefined
   )(async () => {

--- a/typescript/src/ethereum-helpers.ts
+++ b/typescript/src/ethereum-helpers.ts
@@ -12,7 +12,9 @@ import {
  * @param nonRetryableErrors List of error messages that if returned from executed
  *        function, should break the retry loop and return immediately.
  * @returns Result of function execution.
- * @throws An error returned by function execution.
+ * @throws An error returned by function execution. An error thrown by the executed
+ *         function is processed by {@link resolveEthersError} function to resolve
+ *         the revert message in case of a transaction revert.
  */
 export async function sendWithRetry<T>(
   fn: () => Promise<T>,
@@ -28,7 +30,44 @@ export async function sendWithRetry<T>(
     try {
       return await fn()
     } catch (err: unknown) {
-      throw err
+      throw resolveEthersError(err)
     }
   })
+}
+
+/**
+ * Represents an interface that matches the errors structure thrown by ethers library.
+ * {@see {@link https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/logger/src.ts/index.ts#L268-L277 ethers source code}}
+ */
+interface EthersError extends Error {
+  reason: string
+  code: string
+  error: unknown
+}
+
+/**
+ * Takes an error and tries to resolve a revert message if the error is related
+ * to reverted transaction.
+ * @param err Error to process.
+ * @returns Error with a revert message or the input error when the error could
+ *          not be resolved successfully.
+ */
+function resolveEthersError(err: unknown): unknown {
+  const isEthersError = (obj: any): obj is EthersError => {
+    return "reason" in obj && "code" in obj && "error" in obj
+  }
+
+  if (isEthersError(err) && err !== null) {
+    // Ethers errors are nested. The parent UNPREDICTABLE_GAS_LIMIT has a general
+    // reason "cannot estimate gas; transaction may fail or may require manual gas limit",
+    if (err.code === "UNPREDICTABLE_GAS_LIMIT") {
+      if (typeof isEthersError(err["error"]) && err["error"] !== null) {
+        // The nested error is expected to contain a reason property with a message
+        // of the transaction revert.
+        return new Error((err["error"] as EthersError).reason)
+      }
+    }
+  }
+
+  return err
 }

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -1,4 +1,4 @@
-import { Bridge, Identifier } from "../../src/chain"
+import { Bridge, GetEvents, Identifier } from "../../src/chain"
 import {
   DecomposedRawTransaction,
   Proof,
@@ -89,8 +89,7 @@ export class MockBridge implements Bridge {
   }
 
   getDepositRevealedEvents(
-    fromBlock?: number,
-    toBlock?: number,
+    options?: GetEvents.Options,
     ...filterArgs: Array<any>
   ): Promise<DepositRevealedEvent[]> {
     const deposit = depositSweepWithNoMainUtxoAndWitnessOutput.deposits[0]


### PR DESCRIPTION
We noticed that requests to ethereum endpoints are failing to due server errors. In this PR we wrap all ethereum requests with a backoff retrier.

The backoff retrier is an implementation used in `tbtc.js` library (https://github.com/keep-network/tbtc.js/blob/9838c06f21082cc050fab5f1304b95d6fa3db6a7/src/lib/backoff.js).

Closes: https://github.com/keep-network/tbtc-v2/issues/499