### PR TITLE
Explicitly rebuild bcrypto and use node 14

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -14,7 +14,7 @@
     "typechain": "rm -rf ./typechain && for i in $npm_package_config_contracts; do typechain --target ethers-v5 --out-dir ./typechain $i; done && rm ./typechain/index.ts",
     "build": "npm run typechain && tsc --project tsconfig.build.json",
     "dev": "tsc --project tsconfig.build.json --watch",
-    "postinstall": "npm rebuild"
+    "postinstall": "npm rebuild bcrypto"
   },
   "files": [
     "dist/",
@@ -57,7 +57,7 @@
     "commander": "^9.4.0"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">=14 <15"
   },
   "browser": {
     "bcoin": "bcoin/lib/bcoin-browser"


### PR DESCRIPTION
In 0e1f62414b5c804c690fd32d4270b8de8a5d4cb3 we added a requirement to rebuild on postinstall. In this commit we make it explicit that we need to rebuild bcrypto.

Also the rebuild works only on node 14, which is confusing (see: https://github.com/keep-network/tbtc-v2/issues/509) so we update engines to be explicit that node 14 is required.