### PR TITLE
Fix wrong configuration of the `Bump up package version` CI step

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -124,7 +124,7 @@ jobs:
         id: npm-version-bump
         uses: keep-network/npm-version-bump@v2
         with:
-          work-dir: solidity
+          work-dir: typescript
           environment: ${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}


### PR DESCRIPTION
We were incorrectly executing the action with `work-dir` set to `solidity`.