### PR TITLE
Expose additional event getters required by the monitoring system

### DIFF
--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -11,6 +11,7 @@ import {
   RevealedDeposit,
 } from "./deposit"
 import {
+  OptimisticMintingCancelledEvent,
   OptimisticMintingRequest,
   OptimisticMintingRequestedEvent,
 } from "./optimistic-minting"
@@ -309,4 +310,10 @@ export interface TBTCVault {
    * @see GetEventsFunction
    */
   getOptimisticMintingRequestedEvents: GetEvents.Function<OptimisticMintingRequestedEvent>
+
+  /**
+   * Get emitted OptimisticMintingCancelled events.
+   * @see GetEventsFunction
+   */
+  getOptimisticMintingCancelledEvents: GetEvents.Function<OptimisticMintingCancelledEvent>
 }

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -17,6 +17,7 @@ import {
 } from "./optimistic-minting"
 import { Hex } from "./hex"
 import { RedemptionRequest } from "./redemption"
+import { NewWalletRegisteredEvent } from "./wallet"
 
 /**
  * Represents a generic chain identifier.
@@ -217,6 +218,12 @@ export interface Bridge {
    *          is returned.
    */
   activeWalletPublicKey(): Promise<string | undefined>
+
+  /**
+   * Get emitted NewWalletRegisteredEvent events.
+   * @see GetEventsFunction
+   */
+  getNewWalletRegisteredEvents: GetEvents.Function<NewWalletRegisteredEvent>
 }
 
 /**

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -577,8 +577,6 @@ export class Bridge
       .reverse()
       .toPrefixedString()
 
-    // TODO: Return a BigNumber to reflect how the deposit key is represented
-    //       in the Bridge contract.
     return utils.solidityKeccak256(
       ["bytes32", "uint32"],
       [prefixedReversedDepositTxHash, depositOutputIndex]
@@ -888,7 +886,9 @@ export class TBTCVault
         blockHash: Hex.from(event.blockHash),
         transactionHash: Hex.from(event.transactionHash),
         minter: new Address(event.args!.minter),
-        depositKey: BigNumber.from(event.args!.depositKey),
+        depositKey: Hex.from(
+          BigNumber.from(event.args!.depositKey).toHexString()
+        ),
         depositor: new Address(event.args!.depositor),
         amount: BigNumber.from(event.args!.amount),
         fundingTxHash: TransactionHash.from(
@@ -921,7 +921,9 @@ export class TBTCVault
         blockHash: Hex.from(event.blockHash),
         transactionHash: Hex.from(event.transactionHash),
         guardian: new Address(event.args!.guardian),
-        depositKey: BigNumber.from(event.args!.depositKey),
+        depositKey: Hex.from(
+          BigNumber.from(event.args!.depositKey).toHexString()
+        ),
       }
     })
   }

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -567,7 +567,7 @@ export class Bridge
    * @param depositTxHash The revealed deposit transaction's hash.
    * @param depositOutputIndex Index of the deposit transaction output that
    *        funds the revealed deposit.
-   * @returns Revealed deposit data.
+   * @returns Deposit key.
    */
   static buildDepositKey(
     depositTxHash: TransactionHash,
@@ -577,6 +577,8 @@ export class Bridge
       .reverse()
       .toPrefixedString()
 
+    // TODO: Return a BigNumber to reflect how the deposit key is represented
+    //       in the Bridge contract.
     return utils.solidityKeccak256(
       ["bytes32", "uint32"],
       [prefixedReversedDepositTxHash, depositOutputIndex]

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -47,6 +47,7 @@ import type {
 import type { WalletRegistry as ContractWalletRegistry } from "../typechain/WalletRegistry"
 import type { TBTCVault as ContractTBTCVault } from "../typechain/TBTCVault"
 import { Hex } from "./hex"
+import { NewWalletRegisteredEvent } from "./wallet"
 
 type ContractDepositRequest = ContractDeposit.DepositRequestStructOutput
 
@@ -633,6 +634,31 @@ export class Bridge
     )
 
     return compressPublicKey(uncompressedPublicKey)
+  }
+
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * @see {ChainBridge#getNewWalletRegisteredEvents}
+   */
+  async getNewWalletRegisteredEvents(
+    options?: GetEvents.Options,
+    ...filterArgs: Array<unknown>
+  ): Promise<NewWalletRegisteredEvent[]> {
+    const events: EthersEvent[] = await this.getEvents(
+      "NewWalletRegistered",
+      options,
+      ...filterArgs
+    )
+
+    return events.map<NewWalletRegisteredEvent>((event) => {
+      return {
+        blockNumber: BigNumber.from(event.blockNumber).toNumber(),
+        blockHash: Hex.from(event.blockHash),
+        transactionHash: Hex.from(event.transactionHash),
+        ecdsaWalletID: Hex.from(event.args!.ecdsaWalletID),
+        walletPublicKeyHash: Hex.from(event.args!.walletPubKeyHash),
+      }
+    })
   }
 
   private async walletRegistry(): Promise<WalletRegistry> {

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -34,6 +34,7 @@ import {
   UnspentTransactionOutput,
 } from "./bitcoin"
 import type {
+  OptimisticMintingCancelledEvent,
   OptimisticMintingRequest,
   OptimisticMintingRequestedEvent,
 } from "./optimistic-minting"
@@ -868,6 +869,31 @@ export class TBTCVault
         fundingOutputIndex: BigNumber.from(
           event.args!.fundingOutputIndex
         ).toNumber(),
+      }
+    })
+  }
+
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * @see {ChainBridge#getOptimisticMintingCancelledEvents}
+   */
+  async getOptimisticMintingCancelledEvents(
+    options?: GetEvents.Options,
+    ...filterArgs: Array<any>
+  ): Promise<OptimisticMintingCancelledEvent[]> {
+    const events = await this.getEvents(
+      "OptimisticMintingCancelled",
+      options,
+      ...filterArgs
+    )
+
+    return events.map<OptimisticMintingCancelledEvent>((event) => {
+      return {
+        blockNumber: BigNumber.from(event.blockNumber).toNumber(),
+        blockHash: Hex.from(event.blockHash),
+        transactionHash: Hex.from(event.transactionHash),
+        guardian: new Address(event.args!.guardian),
+        depositKey: BigNumber.from(event.args!.depositKey),
       }
     })
   }

--- a/typescript/src/optimistic-minting.ts
+++ b/typescript/src/optimistic-minting.ts
@@ -40,6 +40,22 @@ export type OptimisticMintingRequestedEvent = {
 } & Event
 
 /**
+ * Represents an event that is emitted when an optimistic minting request
+ * is cancelled on chain.
+ */
+export type OptimisticMintingCancelledEvent = {
+  /**
+   * Guardian's chain identifier.
+   */
+  guardian: Identifier
+  /**
+   * Unique deposit identifier.
+   * @see Bridge.buildDepositKey
+   */
+  depositKey: BigNumber
+} & Event
+
+/**
  * Represents optimistic minting request for the given deposit revealed to the
  * Bridge.
  */

--- a/typescript/src/optimistic-minting.ts
+++ b/typescript/src/optimistic-minting.ts
@@ -16,7 +16,7 @@ export type OptimisticMintingRequestedEvent = {
    * Unique deposit identifier.
    * @see Bridge.buildDepositKey
    */
-  depositKey: BigNumber
+  depositKey: Hex
   /**
    * Depositor's chain identifier.
    */
@@ -52,7 +52,7 @@ export type OptimisticMintingCancelledEvent = {
    * Unique deposit identifier.
    * @see Bridge.buildDepositKey
    */
-  depositKey: BigNumber
+  depositKey: Hex
 } & Event
 
 /**

--- a/typescript/src/wallet.ts
+++ b/typescript/src/wallet.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "ethers"
 import { Hex } from "./hex"
+import { Event } from "./chain"
 
 /* eslint-disable no-unused-vars */
 export enum WalletState {
@@ -98,3 +99,18 @@ export interface Wallet {
    */
   movingFundsTargetWalletsCommitmentHash: Hex
 }
+
+/**
+ * Represents an event emitted when new wallet is registered on the on-chain bridge.
+ */
+export type NewWalletRegisteredEvent = {
+  /**
+   * Identifier of a ECDSA Wallet registered in the ECDSA Wallet Registry.
+   */
+  ecdsaWalletID: Hex
+  /**
+   * 20-byte public key hash of the ECDSA Wallet. It is computed by applying
+   * hash160 on the compressed public key of the ECDSA Wallet.
+   */
+  walletPublicKeyHash: Hex
+} & Event

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -15,6 +15,7 @@ import { computeHash160, TransactionHash } from "../../src/bitcoin"
 import { depositSweepWithNoMainUtxoAndWitnessOutput } from "../data/deposit-sweep"
 import { Address } from "../../src/ethereum"
 import { Hex } from "../../src/hex"
+import { NewWalletRegisteredEvent } from "../../src/wallet"
 
 interface DepositSweepProofLogEntry {
   sweepTx: DecomposedRawTransaction
@@ -301,5 +302,12 @@ export class MockBridge implements Bridge {
 
   async activeWalletPublicKey(): Promise<string | undefined> {
     return this._activeWalletPublicKey
+  }
+
+  async getNewWalletRegisteredEvents(
+    options?: GetEvents.Options,
+    ...filterArgs: Array<unknown>
+  ): Promise<NewWalletRegisteredEvent[]> {
+    throw new Error("not implemented")
   }
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/pm/issues/33

Here we expose some additional getters in the `typescript` library: `TBTCVault.getOptimisticMintingCancelledEvents` and `Bridge.getNewWalletRegisteredEvents`. The monitoring system is interested in these events but the library has not exposed them so far.