### PR TITLE
Cross-chain Tokenized Threshold BTC: Generic L2 ERC20 implementation

### DIFF
--- a/solidity/contracts/l2/L2TBTC.sol
+++ b/solidity/contracts/l2/L2TBTC.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+// TODO:
+// * Be paused by any one of `n` guardians, allowing avoidance of contagion in case
+//  of a chain- or bridge-specific incident.
+// * Mint by minter.
+// * Proper documentation.
+// * Test initialization
+contract L2TBTC is ERC20Upgradeable, OwnableUpgradeable {
+    /// @notice Indicates if the given address is a Minter. Only Minters can
+    ///         mint the token.
+    mapping(address => bool) public isMinter;
+
+    /// @notice List of all Minters.
+    address[] public minters;
+
+    event MinterAdded(address indexed minter);
+    event MinterRemoved(address indexed minter);
+
+    modifier onlyMinter() {
+        require(isMinter[msg.sender], "Caller is not a minter");
+        _;
+    }
+
+    function initialize(string memory _name, string memory _symbol)
+        external
+        initializer
+    {
+        __Ownable_init();
+        __ERC20_init(_name, _symbol);
+    }
+
+    /// @notice Adds the address to the Minter list.
+    function addMinter(address minter) external onlyOwner {
+        require(!isMinter[minter], "This address is already a minter");
+        isMinter[minter] = true;
+        minters.push(minter);
+        emit MinterAdded(minter);
+    }
+
+    /// @notice Removes the address from the Minter list.
+    function removeMinter(address minter) external onlyOwner {
+        require(isMinter[minter], "This address is not a minter");
+        delete isMinter[minter];
+
+        // We do not expect too many Minters so a simple loop is safe.
+        for (uint256 i = 0; i < minters.length; i++) {
+            if (minters[i] == minter) {
+                minters[i] = minters[minters.length - 1];
+                // slither-disable-next-line costly-loop
+                minters.pop();
+                break;
+            }
+        }
+
+        emit MinterRemoved(minter);
+    }
+
+    /// @notice Allows to fetch a list of all Minters.
+    function getMinters() external view returns (address[] memory) {
+        return minters;
+    }
+}

--- a/solidity/test/l2/L2TBTC.test.ts
+++ b/solidity/test/l2/L2TBTC.test.ts
@@ -1,0 +1,261 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { randomBytes } from "crypto"
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import { expect } from "chai"
+import { ContractTransaction } from "ethers"
+
+import type { L2TBTC } from "../../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("L2TBTC", () => {
+  const fixture = async () => {
+    const { deployer, governance } = await helpers.signers.getNamedSigners()
+
+    const accounts = await getUnnamedAccounts()
+    const minter = await ethers.getSigner(accounts[1])
+    const thirdParty = await ethers.getSigner(accounts[2])
+
+    const deployment = await helpers.upgrades.deployProxy(
+      // Hacky workaround allowing to deploy proxy contract any number of times
+      // without clearing `deployments/hardhat` directory.
+      // See: https://github.com/keep-network/hardhat-helpers/issues/38
+      `L2TBTC_${randomBytes(8).toString("hex")}`,
+      {
+        contractName: "L2TBTC",
+        initializerArgs: ["ArbitrumTBTC", "ArbTBTC"],
+        factoryOpts: { signer: deployer },
+        proxyOpts: {
+          kind: "transparent",
+        },
+      }
+    )
+    token = deployment[0] as L2TBTC
+
+    await token.connect(deployer).transferOwnership(governance.address)
+
+    return {
+      governance,
+      minter,
+      thirdParty,
+      token,
+    }
+  }
+
+  let token: L2TBTC
+
+  let governance: SignerWithAddress
+  let minter: SignerWithAddress
+  let thirdParty: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ governance, minter, thirdParty, token } = await waffle.loadFixture(
+      fixture
+    ))
+  })
+
+  describe("addMinter", () => {
+    context("when called not by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(thirdParty).addMinter(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      context("when address is not a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await token.connect(governance).addMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add address as a minter", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await token.isMinter(minter.address)).to.be.true
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(token, "MinterAdded")
+            .withArgs(minter.address)
+        })
+      })
+
+      context("when address is a minter", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await token.connect(governance).addMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            token.connect(governance).addMinter(minter.address)
+          ).to.be.revertedWith("This address is already a minter")
+        })
+      })
+
+      context("when there are multiple minters", () => {
+        const minters = [
+          "0x54DeA8194aaF652Cd296B162A2809dd95529f775",
+          "0x575E6d8802e7b6A7E8F940640804385D8Bbe2ce0",
+          "0x66ac131D339704902aECCaBDf55e15daAE8B238f",
+        ]
+
+        before(async () => {
+          await createSnapshot()
+
+          await token.connect(governance).addMinter(minters[0])
+          await token.connect(governance).addMinter(minters[1])
+          await token.connect(governance).addMinter(minters[2])
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add them into the list", async () => {
+          expect(await token.getMinters()).to.deep.equal(minters)
+        })
+      })
+    })
+  })
+
+  describe("removeMinter", () => {
+    context("when called not by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(thirdParty).removeMinter(minter.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      context("when address is not a minter", () => {
+        it("should revert", async () => {
+          await expect(
+            token.connect(governance).removeMinter(thirdParty.address)
+          ).to.be.revertedWith("This address is not a minter")
+        })
+      })
+
+      context("when address is a minter", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await token.connect(governance).addMinter(minter.address)
+          tx = await token.connect(governance).removeMinter(minter.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should take minter role from the address", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await token.isMinter(minter.address)).to.be.false
+        })
+
+        it("should emit an event", async () => {
+          await expect(tx)
+            .to.emit(token, "MinterRemoved")
+            .withArgs(minter.address)
+        })
+      })
+
+      context("when there are multiple minters", () => {
+        const minters = [
+          "0x54DeA8194aaF652Cd296B162A2809dd95529f775",
+          "0x575E6d8802e7b6A7E8F940640804385D8Bbe2ce0",
+          "0x66ac131D339704902aECCaBDf55e15daAE8B238f",
+          "0xF844A3a4dA34fDDf51A0Ec7A0a89d1ed5A105e40",
+        ]
+
+        before(async () => {
+          await createSnapshot()
+
+          await token.connect(governance).addMinter(minters[0])
+          await token.connect(governance).addMinter(minters[1])
+          await token.connect(governance).addMinter(minters[2])
+          await token.connect(governance).addMinter(minters[3])
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        context("when deleting the first minter", () => {
+          before(async () => {
+            await createSnapshot()
+            await token.connect(governance).removeMinter(minters[0])
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should update the minters list", async () => {
+            expect(await token.getMinters()).to.deep.equal([
+              "0xF844A3a4dA34fDDf51A0Ec7A0a89d1ed5A105e40",
+              "0x575E6d8802e7b6A7E8F940640804385D8Bbe2ce0",
+              "0x66ac131D339704902aECCaBDf55e15daAE8B238f",
+            ])
+          })
+        })
+
+        context("when deleting the last minter", () => {
+          before(async () => {
+            await createSnapshot()
+            await token.connect(governance).removeMinter(minters[3])
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should update the minters list", async () => {
+            expect(await token.getMinters()).to.deep.equal([
+              "0x54DeA8194aaF652Cd296B162A2809dd95529f775",
+              "0x575E6d8802e7b6A7E8F940640804385D8Bbe2ce0",
+              "0x66ac131D339704902aECCaBDf55e15daAE8B238f",
+            ])
+          })
+        })
+
+        context("when deleting minter from the middle of the list", () => {
+          before(async () => {
+            await createSnapshot()
+            await token.connect(governance).removeMinter(minters[1])
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should update the minters list", async () => {
+            expect(await token.getMinters()).to.deep.equal([
+              "0x54DeA8194aaF652Cd296B162A2809dd95529f775",
+              "0xF844A3a4dA34fDDf51A0Ec7A0a89d1ed5A105e40",
+              "0x66ac131D339704902aECCaBDf55e15daAE8B238f",
+            ])
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #543 

This is the first step for the implementation of a generic L2/sidechain token contract.

The L2/sidechain token will be upgradeable, owned by Threshold Council, will delegate the minting authority to multiple parties, and have a pause functionality for mints and burns. Individual L2/sidechain token implementations will inherit from this contract setting only the token name and symbol.

So far, adding and removing minters was implemented. More to come!