### PR TITLE
Expose `OptimisticMintingFinalized` events getter

### DIFF
--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -12,6 +12,7 @@ import {
 } from "./deposit"
 import {
   OptimisticMintingCancelledEvent,
+  OptimisticMintingFinalizedEvent,
   OptimisticMintingRequest,
   OptimisticMintingRequestedEvent,
 } from "./optimistic-minting"
@@ -323,4 +324,10 @@ export interface TBTCVault {
    * @see GetEventsFunction
    */
   getOptimisticMintingCancelledEvents: GetEvents.Function<OptimisticMintingCancelledEvent>
+
+  /**
+   * Get emitted OptimisticMintingFinalized events.
+   * @see GetEventsFunction
+   */
+  getOptimisticMintingFinalizedEvents: GetEvents.Function<OptimisticMintingFinalizedEvent>
 }

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -35,6 +35,7 @@ import {
 } from "./bitcoin"
 import type {
   OptimisticMintingCancelledEvent,
+  OptimisticMintingFinalizedEvent,
   OptimisticMintingRequest,
   OptimisticMintingRequestedEvent,
 } from "./optimistic-minting"
@@ -923,6 +924,37 @@ export class TBTCVault
         guardian: new Address(event.args!.guardian),
         depositKey: Hex.from(
           BigNumber.from(event.args!.depositKey).toHexString()
+        ),
+      }
+    })
+  }
+
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * @see {ChainBridge#getOptimisticMintingFinalizedEvents}
+   */
+  async getOptimisticMintingFinalizedEvents(
+    options?: GetEvents.Options,
+    ...filterArgs: Array<any>
+  ): Promise<OptimisticMintingFinalizedEvent[]> {
+    const events = await this.getEvents(
+      "OptimisticMintingFinalized",
+      options,
+      ...filterArgs
+    )
+
+    return events.map<OptimisticMintingFinalizedEvent>((event) => {
+      return {
+        blockNumber: BigNumber.from(event.blockNumber).toNumber(),
+        blockHash: Hex.from(event.blockHash),
+        transactionHash: Hex.from(event.transactionHash),
+        minter: new Address(event.args!.minter),
+        depositKey: Hex.from(
+          BigNumber.from(event.args!.depositKey).toHexString()
+        ),
+        depositor: new Address(event.args!.depositor),
+        optimisticMintingDebt: BigNumber.from(
+          event.args!.optimisticMintingDebt
         ),
       }
     })

--- a/typescript/src/optimistic-minting.ts
+++ b/typescript/src/optimistic-minting.ts
@@ -27,7 +27,7 @@ export type OptimisticMintingRequestedEvent = {
    * as Bitcoin value with 1e8 precision in satoshi.
    */
   // TODO: Consider adding a custom type to handle conversion from ERC with 1e18
-  // precision to Bitcoin in 1e8 precision (satoshi).
+  //       precision to Bitcoin in 1e8 precision (satoshi).
   amount: BigNumber
   /**
    * Hash of a Bitcoin transaction made to fund the deposit.
@@ -53,6 +53,34 @@ export type OptimisticMintingCancelledEvent = {
    * @see Bridge.buildDepositKey
    */
   depositKey: Hex
+} & Event
+
+/**
+ * Represents an event that is emitted when an optimistic minting request
+ * is finalized on chain.
+ */
+export type OptimisticMintingFinalizedEvent = {
+  /**
+   * Minter's chain identifier.
+   */
+  minter: Identifier
+  /**
+   * Unique deposit identifier.
+   * @see Bridge.buildDepositKey
+   */
+  depositKey: Hex
+  /**
+   * Depositor's chain identifier.
+   */
+  depositor: Identifier
+  /**
+   * Value of the new optimistic minting debt of the depositor.
+   * This value is in ERC 1e18 precision, it has to be converted before using
+   * as Bitcoin value with 1e8 precision in satoshi.
+   */
+  // TODO: Consider adding a custom type to handle conversion from ERC with 1e18
+  //       precision to Bitcoin in 1e8 precision (satoshi).
+  optimisticMintingDebt: BigNumber
 } & Event
 
 /**


### PR DESCRIPTION
Refs: https://github.com/keep-network/optimistic-minting/issues/71

Here we expose a getter allowing to fetch past `OptimisticMintingFinalized` events.