### PR TITLE
Monitor minters health

### DIFF
--- a/monitoring/docs/monitoring-and-telemetry.adoc
+++ b/monitoring/docs/monitoring-and-telemetry.adoc
@@ -115,7 +115,11 @@ events produced by the monitoring component are:
 * large deposit revealed,
 * optimistic minting canceled,
 * optimistic minting requested too early,
-* optimistic minting requested for undetermined Bitcoin transaction.
+* optimistic minting requested for undetermined Bitcoin transaction,
+* optimistic minting not requested by designated minter,
+* optimistic minting not finalized by designated minter,
+* optimistic minting not requested by any minter,
+* optimistic minting not finalized by any minter.
 
 ==== Deposit revealed
 
@@ -160,6 +164,40 @@ hub and requires an immediate team’s action. The default action is checking
 why the Bitcoin transaction cannot be determined as that event may indicate
 problems with the underlying Bitcoin client used by the monitoring component
 or flag a malicious minter that should be evicted from the system.
+
+==== Optimistic minting not requested by designated minter
+
+A *warning system event* indicating that an optimistic minting request was not
+issued by the designated minter and another minter did that job. This event is
+sent to Sentry hub and should get team’s attention. The default action is
+investigating the cause of the designated minter idleness as the designated
+minter may be unhealthy/malicious or there may be a bug in the minters
+bot code.
+
+==== Optimistic minting not finalized by designated minter
+
+A *warning system event* indicating that an optimistic minting request was not
+finalized by the designated minter and another minter did that job. This event
+is sent to Sentry hub and should get team’s attention. The default action is
+investigating the cause of the designated minter idleness as the designated
+minter may be unhealthy/malicious or there may be a bug in the minters
+bot code.
+
+==== Optimistic minting not requested by any minter
+
+A *warning system event* indicating that an optimistic minting request was not
+issued by any minter. This event is sent to Sentry hub and should get team’s
+attention. The default action is investigating the cause of the minters idleness
+as the underlying deposit may be invalid, minters may be unhealthy/malicious or
+there may be a bug in the minters bot code.
+
+==== Optimistic minting not finalized by any minter
+
+A *warning system event* indicating that an optimistic minting request was not
+finalized by any minter. This event is sent to Sentry hub and should get team’s
+attention. The default action is investigating the cause of the minters idleness
+as the underlying deposit may be invalid, minters may be unhealthy/malicious or
+there may be a bug in the minters bot code.
 
 == Sentry hub
 

--- a/monitoring/src/minting-monitor.ts
+++ b/monitoring/src/minting-monitor.ts
@@ -107,7 +107,7 @@ const OptimisticMintingNotRequestedByDesignatedMinter = (
   chainEvent: OptimisticMintingRequestedChainEvent,
   designatedMinter: Identifier
 ): SystemEvent => ({
-  title: "Optimistic minting was not requested by designated minter",
+  title: "Optimistic minting not requested by designated minter",
   type: SystemEventType.Warning,
   data: {
     actualMinter: `0x${chainEvent.minter.identifierHex}`,
@@ -127,7 +127,7 @@ const OptimisticMintingNotFinalizedByDesignatedMinter = (
   designatedMinter: Identifier | "unknown",
   designatedMinterUnknownCause: string
 ): SystemEvent => ({
-  title: "Optimistic minting was not finalized by designated minter",
+  title: "Optimistic minting not finalized by designated minter",
   type: SystemEventType.Warning,
   data: {
     actualMinter: `0x${chainEvent.minter.identifierHex}`,
@@ -147,7 +147,7 @@ const OptimisticMintingNotFinalizedByDesignatedMinter = (
 const OptimisticMintingNotRequestedByAnyMinter = (
   chainEvent: DepositRevealedChainEvent
 ): SystemEvent => ({
-  title: "Optimistic minting was not requested by any minter",
+  title: "Optimistic minting not requested by any minter",
   type: SystemEventType.Warning,
   data: {
     btcFundingTxHash: chainEvent.fundingTxHash.toString(),
@@ -161,7 +161,7 @@ const OptimisticMintingNotRequestedByAnyMinter = (
 const OptimisticMintingNotFinalizedByAnyMinter = (
   chainEvent: OptimisticMintingRequestedChainEvent
 ): SystemEvent => ({
-  title: "Optimistic minting was not finalized by any minter",
+  title: "Optimistic minting not finalized by any minter",
   type: SystemEventType.Warning,
   data: {
     btcFundingTxHash: chainEvent.fundingTxHash.toString(),

--- a/monitoring/src/minting-monitor.ts
+++ b/monitoring/src/minting-monitor.ts
@@ -225,21 +225,20 @@ export class MintingMonitor implements SystemEventMonitor {
   private checkDesignatedMintersHealth(chainData: ChainDataAggregate) {
     const systemEvents: SystemEvent[] = []
 
-    systemEvents.push(
-      ...chainData.mintingRequestedEvents
-        .map((mre) => ({
-          ...mre,
-          designatedMinter: this.getDesignatedMinter(
-            chainData,
-            mre.depositor,
-            mre.fundingTxHash
-          ),
-        }))
-        .filter((mre) => !mre.minter.equals(mre.designatedMinter))
-        .map((mre) =>
-          DesignatedMinterNotRequestedMinting(mre, mre.designatedMinter)
-        )
-    )
+    chainData.mintingRequestedEvents
+      .map((mre) => ({
+        ...mre,
+        designatedMinter: this.getDesignatedMinter(
+          chainData,
+          mre.depositor,
+          mre.fundingTxHash
+        ),
+      }))
+      .filter((mre) => !mre.minter.equals(mre.designatedMinter))
+      .map((mre) =>
+        DesignatedMinterNotRequestedMinting(mre, mre.designatedMinter)
+      )
+      .forEach((se) => systemEvents.push(se))
 
     // TODO: Detect finalizations done by non-designated minters.
 

--- a/monitoring/src/minting-monitor.ts
+++ b/monitoring/src/minting-monitor.ts
@@ -132,7 +132,7 @@ export class MintingMonitor implements SystemEventMonitor {
 
     systemEvents.push(...(await this.checkMintingRequestsValidity(chainData)))
 
-    systemEvents.push(...this.checkMintersHealth(chainData))
+    systemEvents.push(...this.checkDesignatedMintersHealth(chainData))
 
     // eslint-disable-next-line no-console
     console.log("completed minting monitor check")
@@ -222,7 +222,7 @@ export class MintingMonitor implements SystemEventMonitor {
     return 6
   }
 
-  private checkMintersHealth(chainData: ChainDataAggregate) {
+  private checkDesignatedMintersHealth(chainData: ChainDataAggregate) {
     const systemEvents: SystemEvent[] = []
 
     systemEvents.push(

--- a/monitoring/src/minting-monitor.ts
+++ b/monitoring/src/minting-monitor.ts
@@ -1,9 +1,12 @@
+import { OptimisticMinting } from "@keep-network/tbtc-v2.ts"
+
 import { SystemEventType } from "./system-event"
 
 import type {
   OptimisticMintingCancelledEvent as OptimisticMintingCancelledChainEvent,
   OptimisticMintingRequestedEvent as OptimisticMintingRequestedChainEvent,
 } from "@keep-network/tbtc-v2.ts/dist/src/optimistic-minting"
+import type { DepositRevealedEvent as DepositRevealedChainEvent } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
 import type {
   Bridge,
   Identifier,
@@ -15,6 +18,26 @@ import type { SystemEvent, Monitor as SystemEventMonitor } from "./system-event"
 import type { BigNumber } from "ethers"
 
 const satoshiMultiplier = 1e10
+
+// Number of blocks the monitor gives for minters to create a minting
+// request for the given deposit, counted from the deposit reveal block.
+// The value is 2 hours which is 600 blocks assuming 12 seconds for ETH block.
+// This value aims to include:
+// - worst case 6 BTC confirmations of the deposit, i.e. ~60 min assuming
+//   10 min for BTC block
+// - 20 minutes of the designated minter precedence period
+// - 40 minutes of additional margin
+const mintingRequestTimeoutBlocks = 600
+
+// Number of blocks the monitor gives for minters to finalize the
+// minting request, counted from the minting request block.
+// The value is the current optimistic minting delay plus 1 hour, converted
+// to blocks assuming 12 seconds for ETH block. The value aims to include:
+// - optimistic minting delay
+// - 20 minutes of the designated minter precedence period
+// - 40 minutes of additional margin
+const mintingFinalizationTimeoutBlocks = (optimisticMintingDelay: number) =>
+  optimisticMintingDelay / 12 + 300
 
 const OptimisticMintingCancelled = (
   chainEvent: OptimisticMintingCancelledChainEvent
@@ -79,11 +102,11 @@ const OptimisticMintingRequestedForUndeterminedBtcTx = (
   block: chainEvent.blockNumber,
 })
 
-const DesignatedMinterNotRequestedMinting = (
+const OptimisticMintingNotRequestedByDesignatedMinter = (
   chainEvent: OptimisticMintingRequestedChainEvent,
   designatedMinter: Identifier
 ): SystemEvent => ({
-  title: "Designated minter has not requested minting",
+  title: "Optimistic minting was not requested by designated minter",
   type: SystemEventType.Warning,
   data: {
     actualMinter: `0x${chainEvent.minter.identifierHex}`,
@@ -98,12 +121,27 @@ const DesignatedMinterNotRequestedMinting = (
   block: chainEvent.blockNumber,
 })
 
+const OptimisticMintingNotRequestedByAnyMinter = (
+  chainEvent: DepositRevealedChainEvent
+): SystemEvent => ({
+  title: "Optimistic minting was not requested by any minter",
+  type: SystemEventType.Warning,
+  data: {
+    btcFundingTxHash: chainEvent.fundingTxHash.toString(),
+    btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
+    amountSat: chainEvent.amount.toString(),
+    ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
+  },
+  block: chainEvent.blockNumber,
+})
+
 // Cache that holds some chain data relevant for the minting monitor.
 // Allows fetching the data once and reusing them multiple times across the monitor.
 type ChainDataCache = {
   mintingCancelledEvents: OptimisticMintingCancelledChainEvent[]
   mintingRequestedEvents: OptimisticMintingRequestedChainEvent[]
   minters: Identifier[]
+  optimisticMintingDelay: number
 }
 
 export class MintingMonitor implements SystemEventMonitor {
@@ -129,6 +167,9 @@ export class MintingMonitor implements SystemEventMonitor {
     systemEvents.push(...this.checkMintingCancels(cache))
     systemEvents.push(...(await this.checkMintingRequestsValidity(cache)))
     systemEvents.push(...this.checkDesignatedMintersHealth(cache))
+    systemEvents.push(
+      ...(await this.checkOrphanedMinting(cache, fromBlock, toBlock))
+    )
 
     // eslint-disable-next-line no-console
     console.log("completed minting monitor check")
@@ -151,6 +192,7 @@ export class MintingMonitor implements SystemEventMonitor {
       mintingRequestedEvents:
         await this.tbtcVault.getOptimisticMintingRequestedEvents(options),
       minters: await this.tbtcVault.getMinters(),
+      optimisticMintingDelay: await this.tbtcVault.optimisticMintingDelay(),
     }
   }
 
@@ -232,7 +274,10 @@ export class MintingMonitor implements SystemEventMonitor {
       }))
       .filter((mre) => !mre.minter.equals(mre.designatedMinter))
       .map((mre) =>
-        DesignatedMinterNotRequestedMinting(mre, mre.designatedMinter)
+        OptimisticMintingNotRequestedByDesignatedMinter(
+          mre,
+          mre.designatedMinter
+        )
       )
       .forEach((se) => systemEvents.push(se))
 
@@ -253,5 +298,53 @@ export class MintingMonitor implements SystemEventMonitor {
     const index = (d ^ f) % minters.length
 
     return minters[index]
+  }
+
+  private async checkOrphanedMinting(
+    cache: ChainDataCache,
+    fromBlock: number,
+    toBlock: number
+  ) {
+    const systemEvents: SystemEvent[] = []
+
+    systemEvents.push(
+      ...(await this.checkMintingNotRequested(fromBlock, toBlock))
+    )
+
+    // TODO: Check minting not finalized.
+
+    return systemEvents
+  }
+
+  private async checkMintingNotRequested(fromBlock: number, toBlock: number) {
+    const rewindBlock = (block: number, shift: number) =>
+      block - shift > 0 ? block - shift : 0
+
+    // We need to rewind the block window by the minting request timeout.
+    // This way, we are looking for past deposits whose time for creating
+    // the minting request was already elapsed.
+    const chainEvents = await this.bridge.getDepositRevealedEvents({
+      fromBlock: rewindBlock(fromBlock, mintingRequestTimeoutBlocks),
+      toBlock: rewindBlock(toBlock, mintingRequestTimeoutBlocks),
+    })
+
+    const mintingRequests = await Promise.allSettled(
+      chainEvents.map((ce) =>
+        OptimisticMinting.getOptimisticMintingRequest(
+          ce.fundingTxHash,
+          ce.fundingOutputIndex,
+          this.tbtcVault
+        )
+      )
+    )
+
+    return chainEvents
+      .filter((ce, index) => {
+        const request = mintingRequests[index]
+        const requestExists =
+          request.status === "fulfilled" && request.value.requestedAt !== 0
+        return !requestExists
+      })
+      .map(OptimisticMintingNotRequestedByAnyMinter)
   }
 }

--- a/monitoring/yarn.lock
+++ b/monitoring/yarn.lock
@@ -741,9 +741,9 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.1.0-dev.9"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.9.tgz#a55c278cb542253a19a211bbb7c585f7ead60b19"
-  integrity sha512-ikmcJinCMHVNP7fTUM2jQ9kFrkc9rE7aeeu+O3PjFxoQz+UDL8BFxM9MzJqB3fXBY1NxgxW+znvfgRZQh6895Q==
+  version "1.1.0-dev.11"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.11.tgz#a6df2d7915ea7dcd3d34ce9dcedbfc0d164b2932"
+  integrity sha512-6HDL8R0VKokEpfbyoP+D8hYifJ5DJbTCrQ5DgIIPhPM6aUUdOUBTCjoIs+1PoEdzho/BTgoQE1NBV5fEjukvTw==
   dependencies:
     "@keep-network/ecdsa" "2.1.0-dev.6"
     "@keep-network/tbtc-v2" "1.0.3-dev.0"
@@ -752,6 +752,7 @@
     bufio "^1.0.6"
     electrum-client-js "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1"
     ethers "^5.5.2"
+    p-timeout "^4.1.0"
     wif "2.0.6"
 
 "@keep-network/tbtc-v2@1.0.3-dev.0":
@@ -1234,9 +1235,9 @@
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
-  version "18.13.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
-  integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
+  version "18.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.1.tgz#90dad8476f1e42797c49d6f8b69aaf9f876fc69f"
+  integrity sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -1933,7 +1934,7 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0, bn.js@^5.2.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
-body-parser@1.20.1, body-parser@^1.16.0:
+body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
   integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
@@ -1948,6 +1949,24 @@ body-parser@1.20.1, body-parser@^1.16.0:
     on-finished "2.4.1"
     qs "6.11.0"
     raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@^1.16.0:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
+  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
 
@@ -2402,7 +2421,7 @@ content-hash@^2.5.2:
     multicodec "^0.5.5"
     multihashes "^0.4.15"
 
-content-type@~1.0.4:
+content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -5272,6 +5291,11 @@ p-timeout@^1.1.1:
   dependencies:
     p-finally "^1.0.0"
 
+p-timeout@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-4.1.0.tgz#788253c0452ab0ffecf18a62dff94ff1bd09ca0a"
+  integrity sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -5553,15 +5577,25 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-body@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
+  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 readable-stream@^2.3.0, readable-stream@^2.3.5:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -5572,9 +5606,9 @@ readable-stream@^2.3.0, readable-stream@^2.3.5:
     util-deprecate "~1.0.1"
 
 readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.1.tgz#f9f9b5f536920253b3d26e7660e7da4ccff9bb62"
+  integrity sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"

--- a/monitoring/yarn.lock
+++ b/monitoring/yarn.lock
@@ -741,9 +741,9 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.1.0-dev.11"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.11.tgz#a6df2d7915ea7dcd3d34ce9dcedbfc0d164b2932"
-  integrity sha512-6HDL8R0VKokEpfbyoP+D8hYifJ5DJbTCrQ5DgIIPhPM6aUUdOUBTCjoIs+1PoEdzho/BTgoQE1NBV5fEjukvTw==
+  version "1.1.0-dev.12"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.12.tgz#5c3949dd8ec80e6f376a26d909323ba2da95d802"
+  integrity sha512-Ko+F7HfzVRrFqowW3Zg7Aa+gZjnzOUfi4Tmdq8nwBHpGMwUVgKHHrWFzSqc1qE7FNAVPcZWRT92VWQ2q85/6yw==
   dependencies:
     "@keep-network/ecdsa" "2.1.0-dev.6"
     "@keep-network/tbtc-v2" "1.0.3-dev.0"
@@ -1235,9 +1235,9 @@
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
-  version "18.14.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.1.tgz#90dad8476f1e42797c49d6f8b69aaf9f876fc69f"
-  integrity sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==
+  version "18.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
+  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
 
 "@types/node@10.12.18":
   version "10.12.18"


### PR DESCRIPTION
Closes: https://github.com/keep-network/optimistic-minting/issues/71

Here we add four system events that can be produced by the minting monitor:

###  Optimistic minting not requested by designated minter

A **warning system event** indicating that an optimistic minting request was not issued by the designated minter and another minter did that job. This event is sent to Sentry hub and should get team’s attention. The default action is investigating the cause of the designated minter idleness as the designated minter may be unhealthy/malicious or there may be a bug in the minters bot code.

### Optimistic minting not finalized by designated minter

A **warning system event** indicating that an optimistic minting request was not finalized by the designated minter and another minter did that job. This event is sent to Sentry hub and should get team’s attention. The default action is investigating the cause of the designated minter idleness as the designated minter may be unhealthy/malicious or there may be a bug in the minters bot code.

### Optimistic minting not requested by any minter

A **warning system event** indicating that an optimistic minting request was not issued by any minter. This event is sent to Sentry hub and should get team’s attention. The default action is investigating the cause of the minters idleness as the underlying deposit may be invalid, minters may be unhealthy/malicious or there may be a bug in the minters bot code.

### Optimistic minting not finalized by any minter

A **warning system event** indicating that an optimistic minting request was not finalized by any minter. This event is sent to Sentry hub and should get team’s attention. The default action is investigating the cause of the minters idleness as the underlying deposit may be invalid, minters may be unhealthy/malicious or there may be a bug in the minters bot code.

### Testing

The code was tested against mainnet using a local instance. Testing of such events is not straightforward and requires some temporary hacks in the code.

To test "Optimistic minting not requested/finalized by designated minter" events, you need to:
- Find minting requested and minting finalized transactions done by non-designated minters (e.g https://etherscan.io/tx/0x4821e028fb08c9e190a5292593f2468c7867a8ff8e2984f1432402db01abf8c4 and https://etherscan.io/tx/0xe285868a4a9100bd1cf174a8a0503028ebb2f98f92c5b84fb6e010f729202b13)
- Set the monitored block window manually to enclose those transactions. This can be done by modifying the `checkpointBlock` stored in the persistence and `contracts.latestBlock` function in the code.

To test "Optimistic minting not requested/finalized by any minter", you need to:
- Find a deposit revealed transaction and a minting requested transaction
- Set the monitored block window manually in a way that the block window rewound by `mintingRequestTimeoutBlocks` encloses the deposit revealed transaction and the block window rewound by `mintingFinalizationTimeoutBlocks` encloses the minting requested transaction.
- Locate the `OptimisticMinting.getOptimisticMintingRequest` calls. Inject a `TBTCVault` mock that will return `requestedAt === 0` for the deposit revealed transaction and `finalizedAt === 0` for minting requested transaction