### PR TITLE
Expose TBTC v2 token total supply getter

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "typechain/"
   ],
   "config": {
-    "contracts": "./node_modules/@keep-network/ecdsa/artifacts/WalletRegistry.json ./node_modules/@keep-network/tbtc-v2/artifacts/{Bridge,TBTCVault}.json"
+    "contracts": "./node_modules/@keep-network/ecdsa/artifacts/WalletRegistry.json ./node_modules/@keep-network/tbtc-v2/artifacts/{Bridge,TBTCVault,TBTC}.json"
   },
   "dependencies": {
     "@keep-network/ecdsa": "development",

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -331,3 +331,20 @@ export interface TBTCVault {
    */
   getOptimisticMintingFinalizedEvents: GetEvents.Function<OptimisticMintingFinalizedEvent>
 }
+
+/**
+ * Interface for communication with the TBTC v2 token on-chain contract.
+ */
+export interface TBTCToken {
+  /**
+   * Gets the total supply of the TBTC v2 token. The returned value is in
+   * ERC 1e18 precision, it has to be converted before using as Bitcoin value
+   * with 1e8 precision in satoshi.
+   * @param blockNumber Optional parameter determining the block the total
+   *        supply should be fetched for. If this parameter is not set, the
+   *        total supply is taken for the latest block.
+   */
+  // TODO: Consider adding a custom type to handle conversion from ERC with 1e18
+  //       precision to Bitcoin in 1e8 precision (satoshi).
+  totalSupply(blockNumber?: number): Promise<BigNumber>
+}

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -1,6 +1,7 @@
 import {
   Bridge as ChainBridge,
   TBTCVault as ChainTBTCVault,
+  TBTCToken as ChainTBTCToken,
   Identifier as ChainIdentifier,
   GetEvents,
 } from "./chain"
@@ -17,6 +18,7 @@ import {
 import BridgeDeployment from "@keep-network/tbtc-v2/artifacts/Bridge.json"
 import WalletRegistryDeployment from "@keep-network/ecdsa/artifacts/WalletRegistry.json"
 import TBTCVaultDeployment from "@keep-network/tbtc-v2/artifacts/TBTCVault.json"
+import TBTCDeployment from "@keep-network/tbtc-v2/artifacts/TBTC.json"
 import { backoffRetrier } from "./backoff"
 import {
   DepositScriptParameters,
@@ -47,6 +49,7 @@ import type {
 } from "../typechain/Bridge"
 import type { WalletRegistry as ContractWalletRegistry } from "../typechain/WalletRegistry"
 import type { TBTCVault as ContractTBTCVault } from "../typechain/TBTCVault"
+import type { TBTC as ContractTBTC } from "../typechain/TBTC"
 import { Hex } from "./hex"
 import { NewWalletRegisteredEvent } from "./wallet"
 
@@ -957,6 +960,28 @@ export class TBTCVault
           event.args!.optimisticMintingDebt
         ),
       }
+    })
+  }
+}
+
+/**
+ * Implementation of the Ethereum TBTC v2 token handle.
+ */
+export class TBTCToken
+  extends EthereumContract<ContractTBTC>
+  implements ChainTBTCToken
+{
+  constructor(config: ContractConfig) {
+    super(config, TBTCDeployment)
+  }
+
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * @see {ChainTBTCToken#totalSupply}
+   */
+  async totalSupply(blockNumber?: number): Promise<BigNumber> {
+    return this._instance.totalSupply({
+      blockTag: blockNumber ?? "latest",
     })
   }
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -58,6 +58,7 @@ export {
   Bridge as EthereumBridge,
   Address as EthereumAddress,
   TBTCVault as EthereumTBTCVault,
+  TBTCToken as EthereumTBTCToken,
 } from "./ethereum"
 
 export { Hex } from "./hex"


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/552

Here we expose a way of getting the total supply of the TBTC v2 token for an arbitrary block, using the `tbtc-v2.ts` library. This ability will be leveraged by the monitoring system to raise alerts in case of significant supply changes.