### PR TITLE
Arbitrum: Add artifacts export script

### DIFF
--- a/cross-chain/arbitrum/hardhat.config.ts
+++ b/cross-chain/arbitrum/hardhat.config.ts
@@ -88,6 +88,13 @@ const config: HardhatUserConfig = {
     },
   },
 
+  deploymentArtifactsExport: {
+    goerli: "artifacts/l1",
+    mainnet: "artifacts/l1",
+    arbitrumGoerli: "artifacts/l2",
+    arbitrumOne: "artifacts/l2",
+  },
+
   etherscan: {
     apiKey: {
       goerli: process.env.ETHERSCAN_API_KEY,

--- a/cross-chain/arbitrum/hardhat.config.ts
+++ b/cross-chain/arbitrum/hardhat.config.ts
@@ -1,8 +1,8 @@
 import type { HardhatUserConfig } from "hardhat/config"
 
+import "@nomiclabs/hardhat-etherscan"
 import "@keep-network/hardhat-helpers"
 import "@nomiclabs/hardhat-waffle"
-import "@nomiclabs/hardhat-etherscan"
 import "hardhat-gas-reporter"
 import "hardhat-contract-sizer"
 import "hardhat-deploy"

--- a/cross-chain/arbitrum/package.json
+++ b/cross-chain/arbitrum/package.json
@@ -41,7 +41,7 @@
     "@openzeppelin/contracts-upgradeable": "^4.8.1"
   },
   "devDependencies": {
-    "@keep-network/hardhat-helpers": "^0.6.0-pre.18",
+    "@keep-network/hardhat-helpers": "^0.6.0-pre.20",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "2.0.3",

--- a/cross-chain/arbitrum/package.json
+++ b/cross-chain/arbitrum/package.json
@@ -30,7 +30,9 @@
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
-    "prepublishOnly": "echo TODO: Copy deployment artifacts to artifacts directory",
+    "export-artifacts:goerli": "yarn hardhat export-deployment-artifacts --network arbitrumGoerli",
+    "export-artifacts:mainnet": "yarn hardhat export-deployment-artifacts --network arbitrumOne",
+    "prepublishOnly": "npm run export-artifacts:$npm_config_network",
     "test": "hardhat test"
   },
   "dependencies": {

--- a/cross-chain/arbitrum/yarn.lock
+++ b/cross-chain/arbitrum/yarn.lock
@@ -707,10 +707,10 @@
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" "1.3.0-dev.3"
 
-"@keep-network/hardhat-helpers@^0.6.0-pre.18":
-  version "0.6.0-pre.19"
-  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.19.tgz#a33b9cf6844222fc2529f771214fdbf9ee9e8d32"
-  integrity sha512-a/rMJ01+7w4zp9E1iAWf0lIUQ0GzwrMJnd+haVQpWVBhGu4Sqk/tCr18hijoR5y7+Sq8QvziKCBhmLJCWwSzkA==
+"@keep-network/hardhat-helpers@^0.6.0-pre.20":
+  version "0.6.0-pre.20"
+  resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.20.tgz#9634c9f013df653f7dfbf2c70307e1a5d0748d1e"
+  integrity sha512-Qz1waJM3nRo7mrm9+7RbsSL3CtL44i6WN/R6X6+2g9l9vWxWjQMeWW5lBKT6WAxBZYsFQ1opFTm5MxFlcUHB3Q==
 
 "@keep-network/keep-core@1.8.1-goerli.0":
   version "1.8.1-goerli.0"


### PR DESCRIPTION
We want the artifacts to be exported to `artifacts/l1` and `artifacts/l2` directories. Here we implement automatic export on package publication, with a helper task defined in https://github.com/keep-network/hardhat-helpers/pull/40.

To prepare the artifacts export run a command for a given network, e.g.:
```
yarn run export-artifacts:goerli
```
or to export and publish:
```
npm run prepublishOnly --network=goerli
```

----

Depends on: https://github.com/keep-network/hardhat-helpers/pull/40