### PR TITLE
Arbitrum module small fixes

### DIFF
--- a/cross-chain/arbitrum/README.adoc
+++ b/cross-chain/arbitrum/README.adoc
@@ -45,7 +45,5 @@ an `export.json` file containing contract deployment info. Note that for the
 chains other than `hardhat` the following environment variables are needed:
 
 - `L2_CHAIN_API_URL` - URL to access blockchain services, e.g. `https://arb-goerli.g.alchemy.com/v2/<alchemy_api_key>`
-- `L2_CONTRACT_OWNER_ADDRESS` - Deployer / Contract Owner address
-- `L2_THRESHOLD_COUNCIL_ADDRESS` - Council / Governance address
 - `L2_ACCOUNTS_PRIVATE_KEYS` - Private keys for the deployer and council `<0xOwnerPrivKey,0xCouncilPrivKey>`
 - `ARBISCAN_API_KEY` - Arbiscan API key

--- a/cross-chain/arbitrum/external/arbitrumGoerli/ArbitrumWormholeTBTC.json
+++ b/cross-chain/arbitrum/external/arbitrumGoerli/ArbitrumWormholeTBTC.json
@@ -1,3 +1,3 @@
 {
-  "address": "0x8bbe5476cf0178d1fd7a3f9ea1d43c2de9fc7ddb"
+  "address": "0x97b5fe27a82b2b187d9a19c5782d9eb93b82dac3"
 }


### PR DESCRIPTION
- Removed unused env. vars from the README
- The previous wormhole token was a T token instead of TBTC token. The attestation was done one more time with the correct TBTC address on Goerli Ethereum and now the new address of wormholeTBTC token is put in `ArbitrumWormholeTBTC.json`. Creation of a wrapped token [tx](https://goerli.arbiscan.io/tx/0x71c341cd3f3fc8c6816bdca36fe4e0dee990e85ef375b99f046dddc25ff0c7d0), new address [0x97b5fe27a82b2b187d9a19c5782d9eb93b82dac3](https://goerli.arbiscan.io/address/0x97b5fe27a82b2b187d9a19c5782d9eb93b82dac3)