### PR TITLE
Deployment scripts for `WalletCoordinator` contract

### DIFF
--- a/solidity/deploy/34_deploy_wallet_coordinator.ts
+++ b/solidity/deploy/34_deploy_wallet_coordinator.ts
@@ -1,0 +1,43 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, ethers, getNamedAccounts, helpers } = hre
+  const { deployer } = await getNamedAccounts()
+
+  const Bridge = await deployments.get("Bridge")
+
+  const [walletCoordinator, proxyDeployment] =
+    await helpers.upgrades.deployProxy("WalletCoordinator", {
+      contractName: "WalletCoordinator",
+      initializerArgs: [Bridge.address],
+      factoryOpts: {
+        signer: await ethers.getSigner(deployer),
+      },
+      proxyOpts: {
+        kind: "transparent",
+      },
+    })
+
+  if (hre.network.tags.etherscan) {
+    // We use `verify` instead of `verify:verify` as the `verify` task is defined
+    // in "@openzeppelin/hardhat-upgrades" to perform Etherscan verification
+    // of Proxy and Implementation contracts.
+    await hre.run("verify", {
+      address: proxyDeployment.address,
+      constructorArgsParams: proxyDeployment.args,
+    })
+  }
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "WalletCoordinator",
+      address: walletCoordinator.address,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["WalletCoordinator"]
+func.dependencies = ["Bridge"]

--- a/solidity/deploy/35_transfer_wallet_coordinator_ownership.ts
+++ b/solidity/deploy/35_transfer_wallet_coordinator_ownership.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, governance } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership(
+    "WalletCoordinator",
+    governance,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["TransferWalletCoordinatorOwnership"]
+func.dependencies = ["WalletCoordinator"]
+func.runAtTheEnd = true


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

In #575, we introduced the `WalletCoordinator` contract. Here we add some Hardhat deployment scripts allowing us to deploy that contract.