### PR TITLE
Add cause of the wallet time lock

### DIFF
--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -10,7 +10,7 @@ import type {
   ReimbursementPool,
   IWalletRegistry,
 } from "../../typechain"
-import { walletState } from "../fixtures"
+import { walletAction, walletState } from "../fixtures"
 
 chai.use(smock.matchers)
 
@@ -267,9 +267,10 @@ describe("WalletCoordinator", () => {
       })
 
       it("should unlock the wallet", async () => {
-        expect(
-          await walletCoordinator.walletLock(walletPubKeyHash)
-        ).to.be.equal(0)
+        const walletLock = await walletCoordinator.walletLock(walletPubKeyHash)
+
+        expect(walletLock.expiresAt).to.be.equal(0)
+        expect(walletLock.cause).to.be.equal(walletAction.Idle)
       })
 
       it("should emit the WalletManuallyUnlocked event", async () => {
@@ -763,9 +764,12 @@ describe("WalletCoordinator", () => {
                 (await lastBlockTime()) +
                 (await walletCoordinator.depositSweepProposalValidity())
 
-              expect(
-                await walletCoordinator.walletLock(walletPubKeyHash)
-              ).to.be.equal(lockedUntil)
+              const walletLock = await walletCoordinator.walletLock(
+                walletPubKeyHash
+              )
+
+              expect(walletLock.expiresAt).to.be.equal(lockedUntil)
+              expect(walletLock.cause).to.be.equal(walletAction.DepositSweep)
             })
 
             it("should emit the DepositSweepProposalSubmitted event", async () => {

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -48,6 +48,14 @@ export const walletState = {
   Terminated: 5,
 }
 
+export const walletAction = {
+  Idle: 0,
+  DepositSweep: 1,
+  Redemption: 2,
+  MovingFunds: 3,
+  MovedFundsSweep: 4,
+}
+
 export const ecdsaDkgState = {
   IDLE: 0,
   AWAITING_SEED: 1,


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

Here we enhance the wallet time lock mechanism with information about the cause. This facilitates off-chain integration and allows easier confirmation of events emitted by the wallet coordinator contract.

### Gas consumption impact

**Before**
```
······································································|···························|··············|······························
|  Methods                                                                                                                                     │
······················|···············································|·············|·············|··············|···············|··············
|  Contract           ·  Method                                       ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
······················|···············································|·············|·············|··············|···············|··············
|  WalletCoordinator  ·  submitDepositSweepProposal                   ·      37566  ·      65338  ·       48857  ·            7  ·          -  │
······················|···············································|·············|·············|··············|···············|··············
|  WalletCoordinator  ·  submitDepositSweepProposalWithReimbursement  ·          -  ·          -  ·       59796  ·            1  ·          -  │
······················|···············································|·············|·············|··············|···············|··············
```

**After**
```
········································································|···························|··············|······························
|  Methods                                                                                                                                       │
······················|·················································|·············|·············|··············|···············|··············
|  Contract           ·  Method                                         ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
······················|·················································|·············|·············|··············|···············|··············
|  WalletCoordinator  ·  submitDepositSweepProposal                     ·      37836  ·      65602  ·       49126  ·            7  ·          -  │
······················|·················································|·············|·············|··············|···············|··············
|  WalletCoordinator  ·  submitDepositSweepProposalWithReimbursement    ·          -  ·          -  ·       62250  ·            1  ·          -  │
······················|·················································|·············|·············|··············|···············|··············

```