### PR TITLE
Return bool from `validateDepositSweepProposal` function

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -410,6 +410,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
     ///         supposed to do that check on their own.
     /// @param proposal The sweeping proposal to validate.
     /// @param depositsExtraInfo Deposits extra data required to perform the validation.
+    /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
     ///      - The target wallet must be in the Live state,
     ///      - The number of deposits included in the sweep must be in
@@ -435,7 +436,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
     function validateDepositSweepProposal(
         DepositSweepProposal calldata proposal,
         DepositExtraInfo[] calldata depositsExtraInfo
-    ) external view {
+    ) external view returns (bool) {
         require(
             bridge.wallets(proposal.walletPubKeyHash).state ==
                 Wallets.WalletState.Live,
@@ -515,6 +516,8 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
                 "Deposit targets different vault"
             );
         }
+
+        return true;
     }
 
     /// @notice Validates the sweep tx fee by checking if the part of the fee

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -2014,12 +2014,14 @@ describe("WalletCoordinator", () => {
                                       depositTwo.extraInfo,
                                     ]
 
-                                    await expect(
-                                      walletCoordinator.validateDepositSweepProposal(
+                                    const result =
+                                      await walletCoordinator.validateDepositSweepProposal(
                                         proposal,
                                         depositsExtraInfo
                                       )
-                                    ).to.not.be.reverted
+
+                                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                                    expect(result).to.be.true
                                   })
                                 }
                               )


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-core/issues/3512

Here we add a return type for the `validateDepositSweepProposal` function. This is needed by the contract binding generator that doesn't handle non-returning view functions properly.