### PR TITLE
Changing Council address on Optimism

### DIFF
--- a/cross-chain/optimism/hardhat.config.ts
+++ b/cross-chain/optimism/hardhat.config.ts
@@ -117,7 +117,7 @@ const config: HardhatUserConfig = {
       goerli: 0,
       optimismGoerli: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
-      optimism: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
+      optimism: "0x7fB50BBabeDEE52b8760Ba15c0c199aF33Fc2EfA",
     },
   },
   mocha: {


### PR DESCRIPTION
The old Council address should not be used due to the problems in Safe UI when on Optimism network. The Council has reported that the old address is unusable because a different Gnosis Safe factory is required for Optimism. The Council is now using a new address [0x7fB50BBabeDEE52b8760Ba15c0c199aF33Fc2EfA](https://app.safe.global/settings/setup?safe=oeth:0x7fB50BBabeDEE52b8760Ba15c0c199aF33Fc2EfA).