### PR TITLE
Wallet coordination: rework the ACL to submit proposals

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -17,7 +17,6 @@ pragma solidity 0.8.17;
 
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
-import {IWalletRegistry as EcdsaWalletRegistry} from "@keep-network/ecdsa/contracts/api/IWalletRegistry.sol";
 import "@keep-network/random-beacon/contracts/Reimbursable.sol";
 import "@keep-network/random-beacon/contracts/ReimbursementPool.sol";
 
@@ -120,9 +119,6 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
     /// @notice Handle to the Bridge contract.
     Bridge public bridge;
 
-    /// @notice Handle to the WalletRegistry contract.
-    EcdsaWalletRegistry public walletRegistry;
-
     /// @notice Determines the deposit sweep proposal validity time. In other
     ///         words, this is the worst-case time for a deposit sweep during
     ///         which the wallet is busy and cannot take another actions. This
@@ -222,7 +218,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
         bridge = _bridge;
         // Pre-fetch addresses to save gas later.
-        (, , walletRegistry, reimbursementPool) = _bridge.contractReferences();
+        (, , , reimbursementPool) = _bridge.contractReferences();
 
         depositSweepProposalValidity = 4 hours;
         depositMinAge = 2 hours;


### PR DESCRIPTION
This changeset renames the role of *a proposal submitter* to *a coordinator*. Also, it removes the ACL rule allowing wallet members to submit sweep proposals.

We [want to add the functionality](https://github.com/keep-network/keep-core/pull/3521#discussion_r1173652203) of requesting heartbeats through the `WalletCoordinator` contract. Once we add heartbeat requests, *a proposal submitter* role will no longer sound good. For this reason, *a proposal submitter* role has been renamed to *a coordinator* role.

Having every wallet member be able to submit sweep proposals to the wallet [enables the risk](https://github.com/keep-network/tbtc-v2/pull/575#discussion_r1151564813) of griefing the coordination protocol. The address authorized to submit proposals can keep submitting proposals that wallet members will reject off-chain. Given that we do not perform the validation on-chain during the proposal submission to optimize gas coordination costs, every address eligible to submit a proposal can block the wallet for a certain timeout specific to the proposed action. 

Addresses appointed by the DAO as coordinators can be stripped of the coordinator role if they abuse the protocol. It is impossible to remove the address from the wallet member list. A possible solution for the problem of a malicious wallet member griefing the coordination is introducing a rotating role of a wallet member coordinator, [as proposed in RFC 7: Sweeping coordination](https://github.com/keep-network/tbtc-v2/blob/main/docs/rfc/rfc-7.adoc#221-coordinator).

Given that we will not use this mechanism in the first iteration of sweeping and redemptions and that the `WalletCoordinator` contract is supposed to be deployed behind an upgradeable transparent proxy, the ACL allowing wallet members to submit proposals has been removed. If we decide to enable wallet members to submit proposals in the future, we will probably do it as specified in RFC 7: Sweeping coordination, by introducing a rotating wallet member coordination role.