### PR TITLE
Wallet coordination: Heartbeat action

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -238,12 +238,13 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         (, , , reimbursementPool) = _bridge.contractReferences();
 
         heartbeatRequestValidity = 1 hours; // TODO: Check this value!
+        heartbeatRequestGasOffset = 5_000;
 
         depositSweepProposalValidity = 4 hours;
         depositMinAge = 2 hours;
         depositRefundSafetyMargin = 24 hours;
         depositSweepMaxSize = 5;
-        depositSweepProposalSubmissionGasOffset = 25000;
+        depositSweepProposalSubmissionGasOffset = 5_000;
     }
 
     /// @notice Adds the given address to the set of coordinator addresses.
@@ -309,7 +310,6 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
     /// @param _depositMinAge The new value of `depositMinAge`.
     /// @param _depositRefundSafetyMargin The new value of `depositRefundSafetyMargin`.
     /// @param _depositSweepMaxSize The new value of `depositSweepMaxSize`.
-
     /// @dev Requirements:
     ///      - The caller must be the owner.
     function updateDepositSweepProposalParameters(

--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -237,7 +237,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         // Pre-fetch addresses to save gas later.
         (, , , reimbursementPool) = _bridge.contractReferences();
 
-        heartbeatRequestValidity = 1 hours; // TODO: Check this value!
+        heartbeatRequestValidity = 1 hours;
         heartbeatRequestGasOffset = 5_000;
 
         depositSweepProposalValidity = 4 hours;

--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -134,7 +134,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
     /// @notice Gas that is meant to balance the heartbeat request overall cost.
     ///         Can be updated by the owner based on the current conditions.
-    uint32 public heartbeatRequestGasOffset; // TODO: allow to update it
+    uint32 public heartbeatRequestGasOffset;
 
     /// @notice Determines the deposit sweep proposal validity time. In other
     ///         words, this is the worst-case time for a deposit sweep during
@@ -198,17 +198,11 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
     event HeartbeatRequestSubmitted(bytes20 walletPubKeyHash, bytes message);
 
-    event DepositSweepProposalValidityUpdated(
-        uint32 depositSweepProposalValidity
-    );
-
-    event DepositMinAgeUpdated(uint32 depositMinAge);
-
-    event DepositRefundSafetyMarginUpdated(uint32 depositRefundSafetyMargin);
-
-    event DepositSweepMaxSizeUpdated(uint16 depositSweepMaxSize);
-
-    event DepositSweepProposalSubmissionGasOffsetUpdated(
+    event DepositSweepProposalParametersUpdated(
+        uint32 depositSweepProposalValidity,
+        uint32 depositMinAge,
+        uint32 depositRefundSafetyMargin,
+        uint16 depositSweepMaxSize,
         uint32 depositSweepProposalSubmissionGasOffset
     );
 
@@ -219,7 +213,6 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
     modifier onlyCoordinator() {
         require(isCoordinator[msg.sender], "Caller is not a coordinator");
-
         _;
     }
 
@@ -294,9 +287,11 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         emit WalletManuallyUnlocked(walletPubKeyHash);
     }
 
-    /// @notice Updates values related to heartbeat request.
-    /// @param _heartbeatRequestValidity The new value of heartbeatRequestValidity.
-    /// @param _heartbeatRequestGasOffset The new value of heartbeatRequestGasOffset.
+    /// @notice Updates parameters related to heartbeat request.
+    /// @param _heartbeatRequestValidity The new value of `heartbeatRequestValidity`.
+    /// @param _heartbeatRequestGasOffset The new value of `heartbeatRequestGasOffset`.
+    /// @dev Requirements:
+    ///      - The caller must be the owner.
     function updateHeartbeatRequestParameters(
         uint32 _heartbeatRequestValidity,
         uint32 _heartbeatRequestGasOffset
@@ -309,62 +304,32 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         );
     }
 
-    // TODO: Introduce updateDepositSweepParameters to save on contract size (?)
+    /// @notice Updates parameters related to deposit sweep proposal.
+    /// @param _depositSweepProposalValidity The new value of `depositSweepProposalValidity`.
+    /// @param _depositMinAge The new value of `depositMinAge`.
+    /// @param _depositRefundSafetyMargin The new value of `depositRefundSafetyMargin`.
+    /// @param _depositSweepMaxSize The new value of `depositSweepMaxSize`.
 
-    /// @notice Updates the value of the depositSweepProposalValidity parameter.
-    /// @param _depositSweepProposalValidity New value.
     /// @dev Requirements:
     ///      - The caller must be the owner.
-    function updateDepositSweepProposalValidity(
-        uint32 _depositSweepProposalValidity
-    ) external onlyOwner {
-        depositSweepProposalValidity = _depositSweepProposalValidity;
-        emit DepositSweepProposalValidityUpdated(_depositSweepProposalValidity);
-    }
-
-    /// @notice Updates the value of the depositMinAge parameter.
-    /// @param _depositMinAge New value.
-    /// @dev Requirements:
-    ///      - The caller must be the owner.
-    function updateDepositMinAge(uint32 _depositMinAge) external onlyOwner {
-        depositMinAge = _depositMinAge;
-        emit DepositMinAgeUpdated(_depositMinAge);
-    }
-
-    /// @notice Updates the value of the depositRefundSafetyMargin parameter.
-    /// @param _depositRefundSafetyMargin New value.
-    /// @dev Requirements:
-    ///      - The caller must be the owner.
-    function updateDepositRefundSafetyMargin(uint32 _depositRefundSafetyMargin)
-        external
-        onlyOwner
-    {
-        depositRefundSafetyMargin = _depositRefundSafetyMargin;
-        emit DepositRefundSafetyMarginUpdated(_depositRefundSafetyMargin);
-    }
-
-    /// @notice Updates the value of the depositSweepMaxSize parameter.
-    /// @param _depositSweepMaxSize New value.
-    /// @dev Requirements:
-    ///      - The caller must be the owner.
-    function updateDepositSweepMaxSize(uint16 _depositSweepMaxSize)
-        external
-        onlyOwner
-    {
-        depositSweepMaxSize = _depositSweepMaxSize;
-        emit DepositSweepMaxSizeUpdated(_depositSweepMaxSize);
-    }
-
-    /// @notice Updates the value of the depositSweepProposalSubmissionGasOffset
-    ///         parameter.
-    /// @param _depositSweepProposalSubmissionGasOffset New value.
-    /// @dev Requirements:
-    ///      - The caller must be the owner.
-    function updateDepositSweepProposalSubmissionGasOffset(
+    function updateDepositSweepProposalParameters(
+        uint32 _depositSweepProposalValidity,
+        uint32 _depositMinAge,
+        uint32 _depositRefundSafetyMargin,
+        uint16 _depositSweepMaxSize,
         uint32 _depositSweepProposalSubmissionGasOffset
     ) external onlyOwner {
+        depositSweepProposalValidity = _depositSweepProposalValidity;
+        depositMinAge = _depositMinAge;
+        depositRefundSafetyMargin = _depositRefundSafetyMargin;
+        depositSweepMaxSize = _depositSweepMaxSize;
         depositSweepProposalSubmissionGasOffset = _depositSweepProposalSubmissionGasOffset;
-        emit DepositSweepProposalSubmissionGasOffsetUpdated(
+
+        emit DepositSweepProposalParametersUpdated(
+            _depositSweepProposalValidity,
+            _depositMinAge,
+            _depositRefundSafetyMargin,
+            _depositSweepMaxSize,
             _depositSweepProposalSubmissionGasOffset
         );
     }

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -320,7 +320,7 @@ describe("WalletCoordinator", () => {
     })
   })
 
-  describe("updateDepositSweepProposalValidity", () => {
+  describe("updateDepositSweepProposalParameters", () => {
     before(async () => {
       await createSnapshot()
     })
@@ -334,7 +334,7 @@ describe("WalletCoordinator", () => {
         await expect(
           walletCoordinator
             .connect(thirdParty)
-            .updateDepositSweepProposalValidity(120)
+            .updateDepositSweepProposalParameters(101, 102, 103, 104, 105)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -347,208 +347,31 @@ describe("WalletCoordinator", () => {
 
         tx = await walletCoordinator
           .connect(owner)
-          .updateDepositSweepProposalValidity(120)
+          .updateDepositSweepProposalParameters(101, 102, 103, 104, 105)
       })
 
       after(async () => {
         await restoreSnapshot()
       })
 
-      it("should update the parameter", async () => {
+      it("should update deposit sweep proposal parameters", async () => {
         expect(
           await walletCoordinator.depositSweepProposalValidity()
-        ).to.be.equal(120)
-      })
-
-      it("should emit the DepositSweepProposalValidityUpdated event", async () => {
-        await expect(tx)
-          .to.emit(walletCoordinator, "DepositSweepProposalValidityUpdated")
-          .withArgs(120)
-      })
-    })
-  })
-
-  describe("updateDepositMinAge", () => {
-    before(async () => {
-      await createSnapshot()
-    })
-
-    after(async () => {
-      await restoreSnapshot()
-    })
-
-    context("when called by a third party", () => {
-      it("should revert", async () => {
-        await expect(
-          walletCoordinator.connect(thirdParty).updateDepositMinAge(140)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the owner", () => {
-      let tx: ContractTransaction
-
-      before(async () => {
-        await createSnapshot()
-
-        tx = await walletCoordinator.connect(owner).updateDepositMinAge(140)
-      })
-
-      after(async () => {
-        await restoreSnapshot()
-      })
-
-      it("should update the parameter", async () => {
-        expect(await walletCoordinator.depositMinAge()).to.be.equal(140)
-      })
-
-      it("should emit the DepositMinAgeUpdated event", async () => {
-        await expect(tx)
-          .to.emit(walletCoordinator, "DepositMinAgeUpdated")
-          .withArgs(140)
-      })
-    })
-  })
-
-  describe("updateDepositRefundSafetyMargin", () => {
-    before(async () => {
-      await createSnapshot()
-    })
-
-    after(async () => {
-      await restoreSnapshot()
-    })
-
-    context("when called by a third party", () => {
-      it("should revert", async () => {
-        await expect(
-          walletCoordinator
-            .connect(thirdParty)
-            .updateDepositRefundSafetyMargin(160)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the owner", () => {
-      let tx: ContractTransaction
-
-      before(async () => {
-        await createSnapshot()
-
-        tx = await walletCoordinator
-          .connect(owner)
-          .updateDepositRefundSafetyMargin(160)
-      })
-
-      after(async () => {
-        await restoreSnapshot()
-      })
-
-      it("should update the parameter", async () => {
+        ).to.be.equal(101)
+        expect(await walletCoordinator.depositMinAge()).to.be.equal(102)
         expect(await walletCoordinator.depositRefundSafetyMargin()).to.be.equal(
-          160
+          103
         )
-      })
-
-      it("should emit the DepositRefundSafetyMarginUpdated event", async () => {
-        await expect(tx)
-          .to.emit(walletCoordinator, "DepositRefundSafetyMarginUpdated")
-          .withArgs(160)
-      })
-    })
-  })
-
-  describe("updateDepositSweepMaxSize", () => {
-    before(async () => {
-      await createSnapshot()
-    })
-
-    after(async () => {
-      await restoreSnapshot()
-    })
-
-    context("when called by a third party", () => {
-      it("should revert", async () => {
-        await expect(
-          walletCoordinator.connect(thirdParty).updateDepositSweepMaxSize(15)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the owner", () => {
-      let tx: ContractTransaction
-
-      before(async () => {
-        await createSnapshot()
-
-        tx = await walletCoordinator
-          .connect(owner)
-          .updateDepositSweepMaxSize(15)
-      })
-
-      after(async () => {
-        await restoreSnapshot()
-      })
-
-      it("should update the parameter", async () => {
-        expect(await walletCoordinator.depositSweepMaxSize()).to.be.equal(15)
-      })
-
-      it("should emit the DepositSweepMaxSizeUpdated event", async () => {
-        await expect(tx)
-          .to.emit(walletCoordinator, "DepositSweepMaxSizeUpdated")
-          .withArgs(15)
-      })
-    })
-  })
-
-  describe("updateDepositSweepProposalSubmissionGasOffset", () => {
-    before(async () => {
-      await createSnapshot()
-    })
-
-    after(async () => {
-      await restoreSnapshot()
-    })
-
-    context("when called by a third party", () => {
-      it("should revert", async () => {
-        await expect(
-          walletCoordinator
-            .connect(thirdParty)
-            .updateDepositSweepProposalSubmissionGasOffset(1000000)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when called by the owner", () => {
-      let tx: ContractTransaction
-
-      before(async () => {
-        await createSnapshot()
-
-        tx = await walletCoordinator
-          .connect(owner)
-          .updateDepositSweepProposalSubmissionGasOffset(1000000)
-      })
-
-      after(async () => {
-        await restoreSnapshot()
-      })
-
-      it("should update the parameter", async () => {
+        expect(await walletCoordinator.depositSweepMaxSize()).to.be.equal(104)
         expect(
           await walletCoordinator.depositSweepProposalSubmissionGasOffset()
-        ).to.be.equal(1000000)
+        ).to.be.equal(105)
       })
 
-      it("should emit the DepositSweepProposalSubmissionGasOffsetUpdated event", async () => {
+      it("should emit the DepositSweepProposalParametersUpdated event", async () => {
         await expect(tx)
-          .to.emit(
-            walletCoordinator,
-            "DepositSweepProposalSubmissionGasOffsetUpdated"
-          )
-          .withArgs(1000000)
+          .to.emit(walletCoordinator, "DepositSweepProposalParametersUpdated")
+          .withArgs(101, 102, 103, 104, 105)
       })
     })
   })

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -50,10 +50,11 @@ export const walletState = {
 
 export const walletAction = {
   Idle: 0,
-  DepositSweep: 1,
-  Redemption: 2,
-  MovingFunds: 3,
-  MovedFundsSweep: 4,
+  Heartbeat: 1,
+  DepositSweep: 2,
+  Redemption: 3,
+  MovingFunds: 4,
+  MovedFundsSweep: 5,
 }
 
 export const ecdsaDkgState = {


### PR DESCRIPTION
~~Depends on #607~~

# Heartbeat action

With the existing, pretty computationally-expensive tECDSA signing algorithm, [we would prefer](https://github.com/keep-network/keep-core/pull/3521#discussion_r1173652203) not to execute heartbeats at the same time as other wallet actions (sweeping, redemptions, moving funds). Moreover, we would prefer not to execute heartbeats from multiple wallets at the same time.

Such coordination is complicated off-chain for the same reason as the coordination of sweeps and redemptions. We could - as we do now - execute heartbeats at fixed hours but it does not help with coordination between heartbeats and sweeps. Also, it does not solve the problem of multiple heartbeats simultaneously.

For this reason, the heartbeat has been made a first-class wallet action coordinated in the on-chain contract just like the rest of the wallet actions.

# Goodies

There are two other goodies introduced in this PR.

## Aggregate updates

I aggregated deposit sweep proposal update parameter functions into one. This approach allows to reduce the contract size by 0.3KB and makes the contract future-proof for numerous future move funds and redemption parameters. If we were updating parameters in separate functions, we'd probably stumble upon contract size problems in the future. Aggregating deposit sweep parameter update functions into one with an upgrade could be problematic given the `*Updated` events already potentially emitted. 

## Testing with Reimbursement Pool

Instead of testing ether refunds with smock mocks we now test with a real `ReimbursementPool` contract. This change allows to fine-tune the gas offset parameters. The previous ones were not very accurate it seems. The other problem was that we did not take into consideration that the first call will always cost more given that the contract fields have to be set to
non-default values.