### PR TITLE
Run system tests weekly

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -2,7 +2,7 @@ name: System tests
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0" #weekly, at 00:00 on Sunday
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We're decreasing frequency of running the tests (we do not develop contracts as actively as we used to so running them every 24h is too aggressive, especially that the tests use testnet funds). From now on we will run tests weekly (every Sunday at 0:00). We can still trigger the tests manually if needed.