### PR TITLE
Added coordinator's address to HeartbeatRequestSubmitted

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -196,7 +196,11 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         uint32 heartbeatRequestGasOffset
     );
 
-    event HeartbeatRequestSubmitted(bytes20 walletPubKeyHash, bytes message);
+    event HeartbeatRequestSubmitted(
+        bytes20 walletPubKeyHash,
+        bytes message,
+        address indexed coordinator
+    );
 
     event DepositSweepProposalParametersUpdated(
         uint32 depositSweepProposalValidity,
@@ -361,7 +365,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
             WalletAction.Heartbeat
         );
 
-        emit HeartbeatRequestSubmitted(walletPubKeyHash, message);
+        emit HeartbeatRequestSubmitted(walletPubKeyHash, message, msg.sender);
     }
 
     /// @notice Wraps `requestHeartbeat` call and reimburses the caller's

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -586,7 +586,11 @@ describe("WalletCoordinator", () => {
           it("should emit the HeartbeatRequestSubmitted event", async () => {
             await expect(tx)
               .to.emit(walletCoordinator, "HeartbeatRequestSubmitted")
-              .withArgs(walletPubKeyHash, "0xffffffffffffffff1111111111111111")
+              .withArgs(
+                walletPubKeyHash,
+                "0xffffffffffffffff1111111111111111",
+                thirdParty.address
+              )
           })
         })
       })


### PR DESCRIPTION
We missed the coordinator's address in `HeartbeatRequestSubmittedEvent` emitted by the `WalletCoordinator` contract. Adding it now. It is important to be able to track easily which coordinator posted the given proposal in case it did not meet the expectations/needs.