### PR TITLE
Use Human Readable Outputs in Deposit Monitoring

### DIFF
--- a/monitoring/src/deposit-monitor.ts
+++ b/monitoring/src/deposit-monitor.ts
@@ -12,19 +12,18 @@ const satsToRoundedBTC = (sats: BigNumber): string =>
 
 const hashUrls = (chainEvent: DepositRevealedChainEvent) => {
   let fundingHashUrlPrefix = ""
-  if (context.environment === Environment.Mainnet) {
-    fundingHashUrlPrefix = "https://mempool.space/tx/"
-  }
-  if (context.environment === Environment.Testnet) {
-    fundingHashUrlPrefix = "https://mempool.space/testnet/tx/"
-  }
-
   let revealHashUrlPrefix = ""
-  if (context.environment === Environment.Mainnet) {
-    revealHashUrlPrefix = "https://etherscan.io/tx/"
-  }
-  if (context.environment === Environment.Testnet) {
-    revealHashUrlPrefix = "https://goerli.etherscan.io/tx/"
+  switch (context.environment) {
+    case Environment.Mainnet: {
+      fundingHashUrlPrefix = "https://mempool.space/tx/"
+      revealHashUrlPrefix = "https://etherscan.io/tx/"
+      break
+    }
+    case Environment.Testnet: {
+      fundingHashUrlPrefix = "https://mempool.space/testnet/tx/"
+      revealHashUrlPrefix = "https://goerli.etherscan.io/tx/"
+      break
+    }
   }
 
   const fundingHash = chainEvent.fundingTxHash.toString()

--- a/monitoring/src/deposit-monitor.ts
+++ b/monitoring/src/deposit-monitor.ts
@@ -14,7 +14,7 @@ function satsToRoundedBTC(sats: BigNumber): string {
 const DepositRevealed = (
   chainEvent: DepositRevealedChainEvent
 ): SystemEvent => ({
-  title: "Deposit Revealed",
+  title: "Deposit revealed",
   type: SystemEventType.Informational,
   data: {
     btcFundingTxHash: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,
@@ -28,7 +28,7 @@ const DepositRevealed = (
 const LargeDepositRevealed = (
   chainEvent: DepositRevealedChainEvent
 ): SystemEvent => ({
-  title: "Large Deposit Revealed",
+  title: "Large deposit revealed",
   type: SystemEventType.Warning,
   data: {
     btcFundingTx: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,

--- a/monitoring/src/deposit-monitor.ts
+++ b/monitoring/src/deposit-monitor.ts
@@ -7,16 +7,18 @@ import type { SystemEvent, Monitor as SystemEventMonitor } from "./system-event"
 import type { DepositRevealedEvent as DepositRevealedChainEvent } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
 import type { Bridge } from "@keep-network/tbtc-v2.ts/dist/src/chain"
 
+const SATS_PER_BTC = 1e8
+
 const DepositRevealed = (
   chainEvent: DepositRevealedChainEvent
 ): SystemEvent => ({
-  title: "Deposit revealed",
+  title: "Deposit Revealed",
   type: SystemEventType.Informational,
   data: {
-    btcFundingTxHash: chainEvent.fundingTxHash.toString(),
+    btcFundingTxHash: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,
     btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
-    amountSat: chainEvent.amount.toString(),
-    ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
+    amountBTC: (chainEvent.amount / SATS_PER_BTC).toFixed(2),
+    ethRevealTxHash: `https://etherscan.io/tx/${chainEvent.transactionHash.toPrefixedString()}`,
   },
   block: chainEvent.blockNumber,
 })
@@ -24,12 +26,13 @@ const DepositRevealed = (
 const LargeDepositRevealed = (
   chainEvent: DepositRevealedChainEvent
 ): SystemEvent => ({
-  title: "Large deposit revealed",
+  title: "Large Deposit Revealed",
   type: SystemEventType.Warning,
   data: {
-    btcFundingTxHash: chainEvent.fundingTxHash.toString(),
+    btcFundingTx: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,
     btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
-    amountSat: chainEvent.amount.toString(),
+    amountBTC: (chainEvent.amount / SATS_PER_BTC).toFixed(2),
+    ethRevealTxHash: `https://etherscan.io/tx/${chainEvent.transactionHash.toPrefixedString()}`,
     ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
   },
   block: chainEvent.blockNumber,

--- a/monitoring/src/deposit-monitor.ts
+++ b/monitoring/src/deposit-monitor.ts
@@ -7,7 +7,9 @@ import type { SystemEvent, Monitor as SystemEventMonitor } from "./system-event"
 import type { DepositRevealedEvent as DepositRevealedChainEvent } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
 import type { Bridge } from "@keep-network/tbtc-v2.ts/dist/src/chain"
 
-const SATS_PER_BTC = 1e8
+function satsToRoundedBTC(sats: BigNumber): string {
+  return (sats.div(BigNumber.from(1e6)).toNumber() / 100).toFixed(2)
+}
 
 const DepositRevealed = (
   chainEvent: DepositRevealedChainEvent
@@ -17,7 +19,7 @@ const DepositRevealed = (
   data: {
     btcFundingTxHash: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,
     btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
-    amountBTC: (chainEvent.amount / SATS_PER_BTC).toFixed(2),
+    amountBTC: satsToRoundedBTC(chainEvent.amount),
     ethRevealTxHash: `https://etherscan.io/tx/${chainEvent.transactionHash.toPrefixedString()}`,
   },
   block: chainEvent.blockNumber,
@@ -31,9 +33,8 @@ const LargeDepositRevealed = (
   data: {
     btcFundingTx: `https://mempool.space/tx/${chainEvent.fundingTxHash.toString()}`,
     btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
-    amountBTC: (chainEvent.amount / SATS_PER_BTC).toFixed(2),
+    amountBTC: satsToRoundedBTC(chainEvent.amount),
     ethRevealTxHash: `https://etherscan.io/tx/${chainEvent.transactionHash.toPrefixedString()}`,
-    ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
   },
   block: chainEvent.blockNumber,
 })

--- a/monitoring/src/deposit-monitor.ts
+++ b/monitoring/src/deposit-monitor.ts
@@ -44,9 +44,11 @@ const DepositRevealed = (
     title: "Deposit revealed",
     type: SystemEventType.Informational,
     data: {
+      btcFundingTxHash: chainEvent.fundingTxHash.toString(),
       btcFundingTxHashURL,
       btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
       amountBTC: satsToRoundedBTC(chainEvent.amount),
+      ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
       ethRevealTxHashURL,
     },
     block: chainEvent.blockNumber,
@@ -62,9 +64,11 @@ const LargeDepositRevealed = (
     title: "Large deposit revealed",
     type: SystemEventType.Warning,
     data: {
+      btcFundingTxHash: chainEvent.fundingTxHash.toString(),
       btcFundingTxHashURL,
       btcFundingOutputIndex: chainEvent.fundingOutputIndex.toString(),
       amountBTC: satsToRoundedBTC(chainEvent.amount),
+      ethRevealTxHash: chainEvent.transactionHash.toPrefixedString(),
       ethRevealTxHashURL,
     },
     block: chainEvent.blockNumber,


### PR DESCRIPTION
We currently have discord alerts that look like this:

<img width="511" alt="image" src="https://user-images.githubusercontent.com/1045160/235762295-c632f320-1840-4a5b-b697-529a96a92ea7.png">

This is serviceable on a laptop where one can paste the fields into a block explorer, or copy the sats and divide by 1e8, but *very* annoying on a phone. In either case, I would prefer to have a block explorer link and the BTC amount in BTC rather than sats, for easy viewing.

This PR makes that change!

Tagging @nkuba and @lukasz-zimnoch for review.

Notably, I don't see how to test this and I'm not sure how to deploy it, but I checked around in the code and I don't see anything downstream that cares about the names of these fields, so I think we'd be fine.