### PR TITLE
Begin solidity 1.4.0-dev version

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.3.0-dev",
+  "version": "1.4.0-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
v1.3.0 was already released so we need to start a new version development.