### PR TITLE
Don't include stub contracts in NPM packages

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -128,7 +128,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Deploy contracts
-        run: yarn deploy:test
+        run: yarn deploy:local
 
   contracts-deployment-testnet:
     needs: [contracts-build-and-test]

--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -45,9 +45,9 @@ jobs:
             @keep-network/tbtc
 
       # Deploy contracts to a local network to generate deployment artifacts that
-      # are required by dashboard compilation.
+      # are required by client compilation.
       - name: Deploy contracts
-        run: yarn deploy:test --network hardhat --write true
+        run: yarn deploy:local --network hardhat --write true
 
       - name: Bump up package version
         id: npm-version-bump

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -16,7 +16,7 @@
     "clean": "hardhat clean && rm -rf cache/ export/ external/npm export.json",
     "build": "hardhat compile",
     "deploy": "hardhat deploy --export export.json",
-    "deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat deploy",
+    "deploy:local": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
     "format": "npm run lint && prettier --check .",
     "format:fix": "npm run lint:fix && prettier --write .",
     "lint": "npm run lint:eslint && npm run lint:sol",


### PR DESCRIPTION
If `hardhat deploy` is run with `TEST_USE_STUBS_TBTC` environment variable set to `true`, the deployment will include deployment of stub contracts, which are needed for testing purposes (execution of unit tests). So far we've been running `hardhat deploy TEST_USE_STUBS_ECDSA=true` together with `USE_EXTERNAL_DEPLOY=true` in `tbtc-v2` in the `deploy:test` script. The `USE_EXTERNAL_DEPLOY` variable specifies how the contracts of the dependencies should be deployed - whether to deploy them from scratch (`true`) or reuse the already deployed artifacts (`false`).
We were using the `deploy:test` script in `tbtc-v2` in two places - when running `contracts-deployment-dry-run` job (test of deployment on `hardhat` local network) and in `npm-compile-publish-contracts` job (publishing of `development`-tagged NPM package). This second use can be problematic, as the `development`-tagged package is used to generate the client bindings when running `make all`, resulting in the presence of unneeded (and unwanted) functionalities. The first use is not causing such problems, but it should still be modified, as it's better to run the dry-run of deploy on the real contracts and not on the stubs.
What we decided to do is to replace
```
"deploy:test": "USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat deploy",
```
with
```
"deploy:local": "USE_EXTERNAL_DEPLOY=true hardhat deploy",
```
and use the new `deploy:local` script in both jobs that previously used `deploy:test`.
This way we'll no longer include stub functionalities in NPM packages (and hence in the client bindings) and we'll execute dry-run of the unmodified contracts.

Refs:
https://github.com/keep-network/keep-core/issues/3531
https://github.com/keep-network/keep-core/pull/3569