### PR TITLE
Adjust WalletCoordinator gas offsets

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -252,13 +252,13 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         (, , , reimbursementPool) = _bridge.contractReferences();
 
         heartbeatRequestValidity = 1 hours;
-        heartbeatRequestGasOffset = 5_000;
+        heartbeatRequestGasOffset = 10_000;
 
         depositSweepProposalValidity = 4 hours;
         depositMinAge = 2 hours;
         depositRefundSafetyMargin = 24 hours;
         depositSweepMaxSize = 5;
-        depositSweepProposalSubmissionGasOffset = 5_000;
+        depositSweepProposalSubmissionGasOffset = 20_000; // optimized for 10 inputs
     }
 
     /// @notice Adds the given address to the set of coordinator addresses.

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -677,7 +677,7 @@ describe("WalletCoordinator", () => {
       it("should do the refund", async () => {
         const diff = coordinatorBalanceAfter.sub(coordinatorBalanceBefore)
         expect(diff).to.be.gt(0)
-        expect(diff).to.be.lt(ethers.utils.parseUnits("1000000", "gwei")) // 0,001 ETH
+        expect(diff).to.be.lt(ethers.utils.parseUnits("2000000", "gwei")) // 0,002 ETH
       })
     })
   })
@@ -982,7 +982,7 @@ describe("WalletCoordinator", () => {
       it("should do the refund", async () => {
         const diff = coordinatorBalanceAfter.sub(coordinatorBalanceBefore)
         expect(diff).to.be.gt(0)
-        expect(diff).to.be.lt(ethers.utils.parseUnits("1000000", "gwei")) // 0,001 ETH
+        expect(diff).to.be.lt(ethers.utils.parseUnits("4000000", "gwei")) // 0,004 ETH
       })
     })
   })


### PR DESCRIPTION
Two gas offsets have been adjusted as a result of User Acceptance Tests execution on Goerli.

`heartbeatRequestGasOffset` has been updated from `5_000` to `10_000`. Looking at the heartbeat request TX
(https://goerli.etherscan.io/tx/0x0b76d88351a7e8d85fea53be4e17931d2a753ffddd90e73bcc734230c9ac84c8) the difference between ETH burned and reimbursed is 0.00000349514053395 eth which is 3495 Gwei. Assuming the gas price was ~1 Gwei, we should increase the offset by ~3500 Gwei so 8_500. We add an additional 1_500 as a safety margin.

For `depositSweepProposalSubmissionGasOffset`, the situation is more complex because the cost of the transaction depends on the number of inputs. We decided to optimize for 10 inputs. This transaction was expected with the offset set to `20_000` and 10 inputs:
https://goerli.etherscan.io/tx/0x3c9df2ff00b533fc4b94f905a9c5bba5c70e9594e97ec215a6cf87aa0686902a