### PR TITLE
V1.5.0 bump

### DIFF
--- a/solidity/.openzeppelin/mainnet.json
+++ b/solidity/.openzeppelin/mainnet.json
@@ -9,6 +9,11 @@
       "address": "0x5e4861a80B55f035D899f66772117F00FA0E8e7B",
       "txHash": "0x932eda38cc1fdf7d68bfa6ff11c8bbd443ef32ccdad4ebc55afc7f25fa4398ef",
       "kind": "transparent"
+    },
+    {
+      "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+      "txHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -1408,6 +1413,236 @@
           "t_uint96": {
             "label": "uint96",
             "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "b8a091d7318541da80a4a032ca1660f9ef5aa923c5203d70ae367fdbae462567": {
+      "address": "0x9eAE6e8e99d27D377F1EA0659b0CB16ce8aD32bA",
+      "txHash": "0x4882729501029ce404d379009e8e339c1aaf62b035b6c9df5be88efd0420ee4b",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "reimbursementPool",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ReimbursementPool)5481",
+            "contract": "Reimbursable",
+            "src": "@keep-network/random-beacon/contracts/Reimbursable.sol:51"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "Reimbursable",
+            "src": "@keep-network/random-beacon/contracts/Reimbursable.sol:51"
+          },
+          {
+            "label": "isCoordinator",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:136"
+          },
+          {
+            "label": "walletLock",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_mapping(t_bytes20,t_struct(WalletLock)22127_storage)",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:138"
+          },
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_contract(Bridge)16800",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:140"
+          },
+          {
+            "label": "heartbeatRequestValidity",
+            "offset": 20,
+            "slot": "153",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:151"
+          },
+          {
+            "label": "heartbeatRequestGasOffset",
+            "offset": 24,
+            "slot": "153",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:155"
+          },
+          {
+            "label": "depositSweepProposalValidity",
+            "offset": 28,
+            "slot": "153",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:167"
+          },
+          {
+            "label": "depositMinAge",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:177"
+          },
+          {
+            "label": "depositRefundSafetyMargin",
+            "offset": 4,
+            "slot": "154",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:198"
+          },
+          {
+            "label": "depositSweepMaxSize",
+            "offset": 8,
+            "slot": "154",
+            "type": "t_uint16",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:202"
+          },
+          {
+            "label": "depositSweepProposalSubmissionGasOffset",
+            "offset": 10,
+            "slot": "154",
+            "type": "t_uint32",
+            "contract": "WalletCoordinator",
+            "src": "contracts/bridge/WalletCoordinator.sol:211"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes20": {
+            "label": "bytes20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(Bridge)16800": {
+            "label": "contract Bridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ReimbursementPool)5481": {
+            "label": "contract ReimbursementPool",
+            "numberOfBytes": "20"
+          },
+          "t_enum(WalletAction)22119": {
+            "label": "enum WalletCoordinator.WalletAction",
+            "members": [
+              "Idle",
+              "Heartbeat",
+              "DepositSweep",
+              "Redemption",
+              "MovingFunds",
+              "MovedFundsSweep"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes20,t_struct(WalletLock)22127_storage)": {
+            "label": "mapping(bytes20 => struct WalletCoordinator.WalletLock)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(WalletLock)22127_storage": {
+            "label": "struct WalletCoordinator.WalletLock",
+            "members": [
+              {
+                "label": "expiresAt",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cause",
+                "type": "t_enum(WalletAction)22119",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
           }
         }
       }

--- a/solidity/deployments/mainnet/WalletCoordinator.json
+++ b/solidity/deployments/mainnet/WalletCoordinator.json
@@ -1,0 +1,840 @@
+{
+  "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "CoordinatorAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "CoordinatorRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "depositSweepProposalValidity",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "depositMinAge",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "depositRefundSafetyMargin",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint16",
+          "name": "depositSweepMaxSize",
+          "type": "uint16"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "depositSweepProposalSubmissionGasOffset",
+          "type": "uint32"
+        }
+      ],
+      "name": "DepositSweepProposalParametersUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "fundingTxHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "fundingOutputIndex",
+                  "type": "uint32"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositKey[]",
+              "name": "depositsKeys",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sweepTxFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "depositsRevealBlocks",
+              "type": "uint256[]"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct WalletCoordinator.DepositSweepProposal",
+          "name": "proposal",
+          "type": "tuple"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "DepositSweepProposalSubmitted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "heartbeatRequestValidity",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "heartbeatRequestGasOffset",
+          "type": "uint32"
+        }
+      ],
+      "name": "HeartbeatRequestParametersUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes20",
+          "name": "walletPubKeyHash",
+          "type": "bytes20"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "message",
+          "type": "bytes"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "HeartbeatRequestSubmitted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newReimbursementPool",
+          "type": "address"
+        }
+      ],
+      "name": "ReimbursementPoolUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes20",
+          "name": "walletPubKeyHash",
+          "type": "bytes20"
+        }
+      ],
+      "name": "WalletManuallyUnlocked",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "addCoordinator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "bridge",
+      "outputs": [
+        {
+          "internalType": "contract Bridge",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositMinAge",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositRefundSafetyMargin",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositSweepMaxSize",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositSweepProposalSubmissionGasOffset",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositSweepProposalValidity",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "heartbeatRequestGasOffset",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "heartbeatRequestValidity",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract Bridge",
+          "name": "_bridge",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "isCoordinator",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "reimbursementPool",
+      "outputs": [
+        {
+          "internalType": "contract ReimbursementPool",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "coordinator",
+          "type": "address"
+        }
+      ],
+      "name": "removeCoordinator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes20",
+          "name": "walletPubKeyHash",
+          "type": "bytes20"
+        },
+        {
+          "internalType": "bytes",
+          "name": "message",
+          "type": "bytes"
+        }
+      ],
+      "name": "requestHeartbeat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes20",
+          "name": "walletPubKeyHash",
+          "type": "bytes20"
+        },
+        {
+          "internalType": "bytes",
+          "name": "message",
+          "type": "bytes"
+        }
+      ],
+      "name": "requestHeartbeatWithReimbursement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "fundingTxHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "fundingOutputIndex",
+                  "type": "uint32"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositKey[]",
+              "name": "depositsKeys",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sweepTxFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "depositsRevealBlocks",
+              "type": "uint256[]"
+            }
+          ],
+          "internalType": "struct WalletCoordinator.DepositSweepProposal",
+          "name": "proposal",
+          "type": "tuple"
+        }
+      ],
+      "name": "submitDepositSweepProposal",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "fundingTxHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "fundingOutputIndex",
+                  "type": "uint32"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositKey[]",
+              "name": "depositsKeys",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sweepTxFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "depositsRevealBlocks",
+              "type": "uint256[]"
+            }
+          ],
+          "internalType": "struct WalletCoordinator.DepositSweepProposal",
+          "name": "proposal",
+          "type": "tuple"
+        }
+      ],
+      "name": "submitDepositSweepProposalWithReimbursement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes20",
+          "name": "walletPubKeyHash",
+          "type": "bytes20"
+        }
+      ],
+      "name": "unlockWallet",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_depositSweepProposalValidity",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "_depositMinAge",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "_depositRefundSafetyMargin",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_depositSweepMaxSize",
+          "type": "uint16"
+        },
+        {
+          "internalType": "uint32",
+          "name": "_depositSweepProposalSubmissionGasOffset",
+          "type": "uint32"
+        }
+      ],
+      "name": "updateDepositSweepProposalParameters",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_heartbeatRequestValidity",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "_heartbeatRequestGasOffset",
+          "type": "uint32"
+        }
+      ],
+      "name": "updateHeartbeatRequestParameters",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ReimbursementPool",
+          "name": "_reimbursementPool",
+          "type": "address"
+        }
+      ],
+      "name": "updateReimbursementPool",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "fundingTxHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "fundingOutputIndex",
+                  "type": "uint32"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositKey[]",
+              "name": "depositsKeys",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sweepTxFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "depositsRevealBlocks",
+              "type": "uint256[]"
+            }
+          ],
+          "internalType": "struct WalletCoordinator.DepositSweepProposal",
+          "name": "proposal",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes4",
+                  "name": "version",
+                  "type": "bytes4"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "inputVector",
+                  "type": "bytes"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "outputVector",
+                  "type": "bytes"
+                },
+                {
+                  "internalType": "bytes4",
+                  "name": "locktime",
+                  "type": "bytes4"
+                }
+              ],
+              "internalType": "struct BitcoinTx.Info",
+              "name": "fundingTx",
+              "type": "tuple"
+            },
+            {
+              "internalType": "bytes8",
+              "name": "blindingFactor",
+              "type": "bytes8"
+            },
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "internalType": "bytes20",
+              "name": "refundPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "internalType": "bytes4",
+              "name": "refundLocktime",
+              "type": "bytes4"
+            }
+          ],
+          "internalType": "struct WalletCoordinator.DepositExtraInfo[]",
+          "name": "depositsExtraInfo",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "validateDepositSweepProposal",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes20",
+          "name": "",
+          "type": "bytes20"
+        }
+      ],
+      "name": "walletLock",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "expiresAt",
+          "type": "uint32"
+        },
+        {
+          "internalType": "enum WalletCoordinator.WalletAction",
+          "name": "cause",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+  "receipt": {
+    "to": null,
+    "from": "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+    "contractAddress": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+    "transactionIndex": 35,
+    "gasUsed": "723585",
+    "logsBloom": "0x00000000000000000000000000000000400000000000000000800000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000020040000000002000001000000000000000000000000000000000000020000002000000000000800000000800000000000000000000000400000000000000000000000000000000000000000000080000000000000800000000000000000000020000000000400000000000000000004000000400000000000000020000000000000000000440000000000000400000000000000000020000000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x13d48fd27c9bc628d729cd2b79b4791b2ae0039fdbc4a7cfa823b9a04e628b19",
+    "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+    "logs": [
+      {
+        "transactionIndex": 35,
+        "blockNumber": 17285662,
+        "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+        "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+        "topics": [
+          "0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b",
+          "0x0000000000000000000000009eae6e8e99d27d377f1ea0659b0cb16ce8ad32ba"
+        ],
+        "data": "0x",
+        "logIndex": 188,
+        "blockHash": "0x13d48fd27c9bc628d729cd2b79b4791b2ae0039fdbc4a7cfa823b9a04e628b19"
+      },
+      {
+        "transactionIndex": 35,
+        "blockNumber": 17285662,
+        "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+        "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x000000000000000000000000123694886dbf5ac94dda07135349534536d14caf"
+        ],
+        "data": "0x",
+        "logIndex": 189,
+        "blockHash": "0x13d48fd27c9bc628d729cd2b79b4791b2ae0039fdbc4a7cfa823b9a04e628b19"
+      },
+      {
+        "transactionIndex": 35,
+        "blockNumber": 17285662,
+        "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+        "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+        "topics": [
+          "0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498"
+        ],
+        "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "logIndex": 190,
+        "blockHash": "0x13d48fd27c9bc628d729cd2b79b4791b2ae0039fdbc4a7cfa823b9a04e628b19"
+      },
+      {
+        "transactionIndex": 35,
+        "blockNumber": 17285662,
+        "transactionHash": "0x0a8cd2034987664518ad1583c484fb43031f73edcd8e5e3d38dafc08de6f6bb1",
+        "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+        "topics": [
+          "0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f"
+        ],
+        "data": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016a76d3cd3c1e3ce843c6680d6b37e9116b5c706",
+        "logIndex": 191,
+        "blockHash": "0x13d48fd27c9bc628d729cd2b79b4791b2ae0039fdbc4a7cfa823b9a04e628b19"
+      }
+    ],
+    "blockNumber": 17285662,
+    "cumulativeGasUsed": "7053979",
+    "status": 1,
+    "byzantium": true
+  },
+  "numDeployments": 1,
+  "implementation": "0x9eAE6e8e99d27D377F1EA0659b0CB16ce8aD32bA",
+  "devdoc": "Contract deployed as upgradable proxy"
+}

--- a/solidity/export.json
+++ b/solidity/export.json
@@ -11190,6 +11190,775 @@
         }
       ]
     },
+    "WalletCoordinator": {
+      "address": "0x64EA4b84e2BdfD313428b96658260E495a420093",
+      "abi": [
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "CoordinatorAdded",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "CoordinatorRemoved",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "depositSweepProposalValidity",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "depositMinAge",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "depositRefundSafetyMargin",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint16",
+              "name": "depositSweepMaxSize",
+              "type": "uint16"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "depositSweepProposalSubmissionGasOffset",
+              "type": "uint32"
+            }
+          ],
+          "name": "DepositSweepProposalParametersUpdated",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes20",
+                  "name": "walletPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32",
+                      "name": "fundingTxHash",
+                      "type": "bytes32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "fundingOutputIndex",
+                      "type": "uint32"
+                    }
+                  ],
+                  "internalType": "struct WalletCoordinator.DepositKey[]",
+                  "name": "depositsKeys",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "sweepTxFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "depositsRevealBlocks",
+                  "type": "uint256[]"
+                }
+              ],
+              "indexed": false,
+              "internalType": "struct WalletCoordinator.DepositSweepProposal",
+              "name": "proposal",
+              "type": "tuple"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "DepositSweepProposalSubmitted",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "heartbeatRequestValidity",
+              "type": "uint32"
+            },
+            {
+              "indexed": false,
+              "internalType": "uint32",
+              "name": "heartbeatRequestGasOffset",
+              "type": "uint32"
+            }
+          ],
+          "name": "HeartbeatRequestParametersUpdated",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "HeartbeatRequestSubmitted",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "uint8",
+              "name": "version",
+              "type": "uint8"
+            }
+          ],
+          "name": "Initialized",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "previousOwner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "OwnershipTransferred",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": false,
+              "internalType": "address",
+              "name": "newReimbursementPool",
+              "type": "address"
+            }
+          ],
+          "name": "ReimbursementPoolUpdated",
+          "type": "event"
+        },
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            }
+          ],
+          "name": "WalletManuallyUnlocked",
+          "type": "event"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "addCoordinator",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "bridge",
+          "outputs": [
+            {
+              "internalType": "contract Bridge",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "depositMinAge",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "depositRefundSafetyMargin",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "depositSweepMaxSize",
+          "outputs": [
+            {
+              "internalType": "uint16",
+              "name": "",
+              "type": "uint16"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "depositSweepProposalSubmissionGasOffset",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "depositSweepProposalValidity",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "heartbeatRequestGasOffset",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "heartbeatRequestValidity",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "contract Bridge",
+              "name": "_bridge",
+              "type": "address"
+            }
+          ],
+          "name": "initialize",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "name": "isCoordinator",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "owner",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "reimbursementPool",
+          "outputs": [
+            {
+              "internalType": "contract ReimbursementPool",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "coordinator",
+              "type": "address"
+            }
+          ],
+          "name": "removeCoordinator",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "renounceOwnership",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            }
+          ],
+          "name": "requestHeartbeat",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            }
+          ],
+          "name": "requestHeartbeatWithReimbursement",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes20",
+                  "name": "walletPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32",
+                      "name": "fundingTxHash",
+                      "type": "bytes32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "fundingOutputIndex",
+                      "type": "uint32"
+                    }
+                  ],
+                  "internalType": "struct WalletCoordinator.DepositKey[]",
+                  "name": "depositsKeys",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "sweepTxFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "depositsRevealBlocks",
+                  "type": "uint256[]"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositSweepProposal",
+              "name": "proposal",
+              "type": "tuple"
+            }
+          ],
+          "name": "submitDepositSweepProposal",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes20",
+                  "name": "walletPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32",
+                      "name": "fundingTxHash",
+                      "type": "bytes32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "fundingOutputIndex",
+                      "type": "uint32"
+                    }
+                  ],
+                  "internalType": "struct WalletCoordinator.DepositKey[]",
+                  "name": "depositsKeys",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "sweepTxFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "depositsRevealBlocks",
+                  "type": "uint256[]"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositSweepProposal",
+              "name": "proposal",
+              "type": "tuple"
+            }
+          ],
+          "name": "submitDepositSweepProposalWithReimbursement",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "transferOwnership",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes20",
+              "name": "walletPubKeyHash",
+              "type": "bytes20"
+            }
+          ],
+          "name": "unlockWallet",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "_depositSweepProposalValidity",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_depositMinAge",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_depositRefundSafetyMargin",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "_depositSweepMaxSize",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_depositSweepProposalSubmissionGasOffset",
+              "type": "uint32"
+            }
+          ],
+          "name": "updateDepositSweepProposalParameters",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "_heartbeatRequestValidity",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "_heartbeatRequestGasOffset",
+              "type": "uint32"
+            }
+          ],
+          "name": "updateHeartbeatRequestParameters",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "contract ReimbursementPool",
+              "name": "_reimbursementPool",
+              "type": "address"
+            }
+          ],
+          "name": "updateReimbursementPool",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "components": [
+                {
+                  "internalType": "bytes20",
+                  "name": "walletPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes32",
+                      "name": "fundingTxHash",
+                      "type": "bytes32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "fundingOutputIndex",
+                      "type": "uint32"
+                    }
+                  ],
+                  "internalType": "struct WalletCoordinator.DepositKey[]",
+                  "name": "depositsKeys",
+                  "type": "tuple[]"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "sweepTxFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "depositsRevealBlocks",
+                  "type": "uint256[]"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositSweepProposal",
+              "name": "proposal",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "components": [
+                    {
+                      "internalType": "bytes4",
+                      "name": "version",
+                      "type": "bytes4"
+                    },
+                    {
+                      "internalType": "bytes",
+                      "name": "inputVector",
+                      "type": "bytes"
+                    },
+                    {
+                      "internalType": "bytes",
+                      "name": "outputVector",
+                      "type": "bytes"
+                    },
+                    {
+                      "internalType": "bytes4",
+                      "name": "locktime",
+                      "type": "bytes4"
+                    }
+                  ],
+                  "internalType": "struct BitcoinTx.Info",
+                  "name": "fundingTx",
+                  "type": "tuple"
+                },
+                {
+                  "internalType": "bytes8",
+                  "name": "blindingFactor",
+                  "type": "bytes8"
+                },
+                {
+                  "internalType": "bytes20",
+                  "name": "walletPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "internalType": "bytes20",
+                  "name": "refundPubKeyHash",
+                  "type": "bytes20"
+                },
+                {
+                  "internalType": "bytes4",
+                  "name": "refundLocktime",
+                  "type": "bytes4"
+                }
+              ],
+              "internalType": "struct WalletCoordinator.DepositExtraInfo[]",
+              "name": "depositsExtraInfo",
+              "type": "tuple[]"
+            }
+          ],
+          "name": "validateDepositSweepProposal",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes20",
+              "name": "",
+              "type": "bytes20"
+            }
+          ],
+          "name": "walletLock",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "expiresAt",
+              "type": "uint32"
+            },
+            {
+              "internalType": "enum WalletCoordinator.WalletAction",
+              "name": "cause",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+    },
     "Wallets": {
       "address": "0xC67913137429985416DbCe28D9fa9ec960BA47BF",
       "abi": [

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.4.0-dev",
+  "version": "1.5.0-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
Adding deployment artifacts for the newly deployed `solidity/v1.4.0` version with the `WalletCoordinator` contract. Bumping up the version to `v1.5.0-dev`.