### PR TITLE
Don't run postinstall script separately from yarn install

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -24,8 +24,7 @@ COPY package.json yarn.lock ./
 COPY tsconfig.json ./
 COPY src ./src
 
-RUN yarn install --frozen-lockfile --ignore-scripts
-RUN yarn run postinstall
+RUN yarn install --frozen-lockfile
 
 RUN yarn build
 


### PR DESCRIPTION
Background:
Previously we've been running postinstall script in a separate step from the `yarn install` command. We've been doing that as a workaround for a problem we had with the postinstall script in the `@threshold-network/solidity-contracts` package (the script in that package often randomly failed). Running `yarn upgrade` with `--ignore-scripts` flag prevented the execution of postinstall script in the main project and its depandencies. And running `yarn run postinstall` after did execute the postinstall script in the main project.

The change:
Recently we have refactored the `@threshold-network/solidity-contracts` project and got rid of the problematic script. We can go back to executing `yarn install` without the `--ignore-scripts` flag.

Ref:
https://github.com/threshold-network/solidity-contracts/issues/142
https://github.com/threshold-network/solidity-contracts/pull/143
https://github.com/threshold-network/token-dashboard/pull/531