### PR TITLE
Request redemption in one transaction

### DIFF
--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -1,4 +1,4 @@
-import bcoin, { TX } from "bcoin"
+import bcoin, { TX, Script } from "bcoin"
 import wif from "wif"
 import bufio from "bufio"
 import hash160 from "bcrypto/lib/hash160"
@@ -602,4 +602,13 @@ export function isPublicKeyHashLength(publicKeyHash: string): boolean {
 export function locktimeToNumber(locktimeLE: Buffer | string): number {
   const locktimeBE: Buffer = Hex.from(locktimeLE).reverse().toBuffer()
   return BigNumber.from(locktimeBE).toNumber()
+}
+
+/**
+ * Creates the output script from the BTC address.
+ * @param address BTC address.
+ * @returns The un-prefixed and not prepended with length otput script.
+ */
+export function createOutputScriptFromAddress(address: string): string {
+  return Script.fromAddress(address).toRaw().toString("hex")
 }

--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -607,7 +607,7 @@ export function locktimeToNumber(locktimeLE: Buffer | string): number {
 /**
  * Creates the output script from the BTC address.
  * @param address BTC address.
- * @returns The un-prefixed and not prepended with length otput script.
+ * @returns The un-prefixed and not prepended with length output script.
  */
 export function createOutputScriptFromAddress(address: string): string {
   return Script.fromAddress(address).toRaw().toString("hex")

--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -609,6 +609,6 @@ export function locktimeToNumber(locktimeLE: Buffer | string): number {
  * @param address BTC address.
  * @returns The un-prefixed and not prepended with length output script.
  */
-export function createOutputScriptFromAddress(address: string): string {
-  return Script.fromAddress(address).toRaw().toString("hex")
+export function createOutputScriptFromAddress(address: string): Hex {
+  return Hex.from(Script.fromAddress(address).toRaw().toString("hex"))
 }

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -244,26 +244,6 @@ export interface Bridge {
    * Returns the attached WalletRegistry instance.
    */
   walletRegistry(): Promise<WalletRegistry>
-
-  /**
-   * Builds the redemption data required to request a redemption via
-   * @see TBTCToken#approveAndCall - the built data should be passed as
-   * `extraData` the @see TBTCToken#approveAndCall function.
-   * @param redeemer On-chain identifier of the redeemer.
-   * @param walletPublicKey The Bitcoin public key of the wallet. Must be in the
-   *        compressed form (33 bytes long with 02 or 03 prefix).
-   * @param mainUtxo The main UTXO of the wallet. Must match the main UTXO
-   *        held by the on-chain Bridge contract.
-   * @param redeemerOutputScript The output script that the redeemed funds will
-   *        be locked to. Must be un-prefixed and not prepended with length.
-   * @returns The
-   */
-  buildRedemptionData(
-    redeemer: Identifier,
-    walletPublicKey: string,
-    mainUtxo: UnspentTransactionOutput,
-    redeemerOutputScript: string
-  ): Hex
 }
 
 /**
@@ -402,6 +382,40 @@ export interface TBTCVault {
 }
 
 /**
+ * Represnts data required to request redemption.
+ */
+export interface RequestRedemptionData {
+  /**
+   * On-chain identifier of the redeemer.
+   */
+  redeemer: Identifier
+  /**
+   * The Bitcoin public key of the wallet. Must be in the compressed form (33
+   * bytes long with 02 or 03 prefix).
+   */
+  walletPublicKey: string
+  /**
+   * The main UTXO of the wallet. Must match the main UTXO held by the on-chain
+   * Bridge contract.
+   */
+  mainUtxo: UnspentTransactionOutput
+  /**
+   * The output script that the redeemed funds will be locked to. Must be
+   * un-prefixed and not prepended with length.
+   */
+  redeemerOutputScript: string
+  /**
+   * The amount to be redeemed with the precision of the tBTC on-chain token
+   * contract.
+   */
+  amount: BigNumber
+  /**
+   * The vault address.
+   */
+  vault: Identifier
+}
+
+/**
  * Interface for communication with the TBTC v2 token on-chain contract.
  */
 export interface TBTCToken {
@@ -418,18 +432,13 @@ export interface TBTCToken {
   totalSupply(blockNumber?: number): Promise<BigNumber>
 
   /**
-   * Calls `receiveApproval` function on spender previously approving the spender
-   * to withdraw from the caller multiple times, up to the `amount` amount. If
-   * this function is called again, it overwrites the current allowance with
-   * `amount`.
-   * @param spender Address of contract authorized to spend.
-   * @param amount The max amount they can spend.
-   * @param extraData Extra information to send to the approved contract.
+   * Requests redemption in one transacion using the `approveAndCall` function
+   * from the tBTC on-chain token contract. Then the tBTC token contract calls
+   * the `receiveApproval` function from the `TBTCVault` contract which burns
+   * tBTC tokens and requests redemption.
+   * @param requestRedemptionData Data required to request redemption @see
+   *        {@link RequestRedemptionData}.
    * @returns Transaction hash of the approve and call transaction.
    */
-  approveAndCall(
-    spender: Identifier,
-    amount: BigNumber,
-    extraData: Hex
-  ): Promise<Hex>
+  requestRedemption(requestRedemptionData: RequestRedemptionData): Promise<Hex>
 }

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -244,6 +244,26 @@ export interface Bridge {
    * Returns the attached WalletRegistry instance.
    */
   walletRegistry(): Promise<WalletRegistry>
+
+  /**
+   * Builds the redemption data required to request a redemption via
+   * @see TBTCToken#approveAndCall - the built data should be passed as
+   * `extraData` the @see TBTCToken#approveAndCall function.
+   * @param redeemer On-chain identifier of the redeemer.
+   * @param walletPublicKey The Bitcoin public key of the wallet. Must be in the
+   *        compressed form (33 bytes long with 02 or 03 prefix).
+   * @param mainUtxo The main UTXO of the wallet. Must match the main UTXO
+   *        held by the on-chain Bridge contract.
+   * @param redeemerOutputScript The output script that the redeemed funds will
+   *        be locked to. Must be un-prefixed and not prepended with length.
+   * @returns The
+   */
+  buildRedemptionData(
+    redeemer: Identifier,
+    walletPublicKey: string,
+    mainUtxo: UnspentTransactionOutput,
+    redeemerOutputScript: string
+  ): Hex
 }
 
 /**

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -396,4 +396,20 @@ export interface TBTCToken {
   // TODO: Consider adding a custom type to handle conversion from ERC with 1e18
   //       precision to Bitcoin in 1e8 precision (satoshi).
   totalSupply(blockNumber?: number): Promise<BigNumber>
+
+  /**
+   * Calls `receiveApproval` function on spender previously approving the spender
+   * to withdraw from the caller multiple times, up to the `amount` amount. If
+   * this function is called again, it overwrites the current allowance with
+   * `amount`.
+   * @param spender Address of contract authorized to spend.
+   * @param amount The max amount they can spend.
+   * @param extraData Extra information to send to the approved contract.
+   * @returns Transaction hash of the approve and call transaction.
+   */
+  approveAndCall(
+    spender: Identifier,
+    amount: BigNumber,
+    extraData: Hex
+  ): Promise<Hex>
 }

--- a/typescript/src/chain.ts
+++ b/typescript/src/chain.ts
@@ -382,40 +382,6 @@ export interface TBTCVault {
 }
 
 /**
- * Represnts data required to request redemption.
- */
-export interface RequestRedemptionData {
-  /**
-   * On-chain identifier of the redeemer.
-   */
-  redeemer: Identifier
-  /**
-   * The Bitcoin public key of the wallet. Must be in the compressed form (33
-   * bytes long with 02 or 03 prefix).
-   */
-  walletPublicKey: string
-  /**
-   * The main UTXO of the wallet. Must match the main UTXO held by the on-chain
-   * Bridge contract.
-   */
-  mainUtxo: UnspentTransactionOutput
-  /**
-   * The output script that the redeemed funds will be locked to. Must be
-   * un-prefixed and not prepended with length.
-   */
-  redeemerOutputScript: string
-  /**
-   * The amount to be redeemed with the precision of the tBTC on-chain token
-   * contract.
-   */
-  amount: BigNumber
-  /**
-   * The vault address.
-   */
-  vault: Identifier
-}
-
-/**
  * Interface for communication with the TBTC v2 token on-chain contract.
  */
 export interface TBTCToken {
@@ -436,9 +402,21 @@ export interface TBTCToken {
    * from the tBTC on-chain token contract. Then the tBTC token contract calls
    * the `receiveApproval` function from the `TBTCVault` contract which burns
    * tBTC tokens and requests redemption.
-   * @param requestRedemptionData Data required to request redemption @see
-   *        {@link RequestRedemptionData}.
+   * @param walletPublicKey - The Bitcoin public key of the wallet. Must be in
+   *        the compressed form (33 bytes long with 02 or 03 prefix).
+   * @param mainUtxo - The main UTXO of the wallet. Must match the main UTXO
+   *        held by the on-chain Bridge contract.
+   * @param redeemerOutputScript - The output script that the redeemed funds
+   *        will be locked to. Must be un-prefixed and not prepended with
+   *        length.
+   * @param amount - The amount to be redeemed with the precision of the tBTC
+   *        on-chain token contract.
    * @returns Transaction hash of the approve and call transaction.
    */
-  requestRedemption(requestRedemptionData: RequestRedemptionData): Promise<Hex>
+  requestRedemption(
+    walletPublicKey: string,
+    mainUtxo: UnspentTransactionOutput,
+    redeemerOutputScript: string,
+    amount: BigNumber
+  ): Promise<Hex>
 }

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -1099,4 +1099,20 @@ export class TBTCToken
       blockTag: blockNumber ?? "latest",
     })
   }
+
+  async approveAndCall(
+    spender: ChainIdentifier,
+    amount: BigNumber,
+    extraData: Hex
+  ): Promise<Hex> {
+    const tx = await sendWithRetry<ContractTransaction>(async () => {
+      return await this._instance.approveAndCall(
+        spender.identifierHex,
+        amount,
+        extraData.toPrefixedString()
+      )
+    }, this._totalRetryAttempts)
+
+    return Hex.from(tx.hash)
+  }
 }

--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -1112,7 +1112,7 @@ export class TBTCToken
   ): Promise<Hex> {
     const redeemer = await this._instance?.signer?.getAddress()
     if (!redeemer) {
-      throw new Error("Signer not provided.")
+      throw new Error("Signer not provided")
     }
 
     const vault = await this._instance.owner()

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -66,7 +66,6 @@ export interface RedemptionRequest {
  * @param amount - The amount to be redeemed with the precision of the tBTC
  *        on-chain token contract.
  * @param vault - The vault address.
- * @param bridge - Handle to the Bridge on-chain contract.
  * @param tBTCToken - Handle to the TBTCToken on-chain contract.
  * @returns Transaction hash of the request redemption transaction.
  */
@@ -77,17 +76,16 @@ export async function requestRedemption(
   redeemerOutputScript: string,
   amount: BigNumber,
   vault: Identifier,
-  bridge: Bridge,
   tBTCToken: TBTCToken
 ): Promise<Hex> {
-  const redemptionData = bridge.buildRedemptionData(
+  return await tBTCToken.requestRedemption({
     redeemer,
     walletPublicKey,
     mainUtxo,
-    redeemerOutputScript
-  )
-
-  return await tBTCToken.approveAndCall(vault, amount, redemptionData)
+    redeemerOutputScript,
+    amount,
+    vault,
+  })
 }
 
 /**

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -8,8 +8,9 @@ import {
   Client as BitcoinClient,
   TransactionHash,
 } from "./bitcoin"
-import { Bridge, Identifier } from "./chain"
+import { Bridge, Identifier, TBTCToken } from "./chain"
 import { assembleTransactionProof } from "./proof"
+import { Hex } from "./hex"
 
 /**
  * Represents a redemption request.
@@ -55,29 +56,39 @@ export interface RedemptionRequest {
 
 /**
  * Requests a redemption from the on-chain Bridge contract.
+ * @param redeemer - On-chain identifier of the redeemer.
  * @param walletPublicKey - The Bitcoin public key of the wallet. Must be in the
  *        compressed form (33 bytes long with 02 or 03 prefix).
- * @param mainUtxo - The main UTXO of the wallet. Must match the main UTXO
- *        held by the on-chain Bridge contract.
+ * @param mainUtxo - The main UTXO of the wallet. Must match the main UTXO held
+ *        by the on-chain Bridge contract.
  * @param redeemerOutputScript - The output script that the redeemed funds will
  *        be locked to. Must be un-prefixed and not prepended with length.
- * @param amount - The amount to be redeemed in satoshis.
+ * @param amount - The amount to be redeemed with the precision of the tBTC
+ *        on-chain token contract.
+ * @param vault - The vault address.
  * @param bridge - Handle to the Bridge on-chain contract.
- * @returns Empty promise.
+ * @param tBTCToken - Handle to the TBTCToken on-chain contract.
+ * @returns Transaction hash of the request redemption transaction.
  */
 export async function requestRedemption(
+  redeemer: Identifier,
   walletPublicKey: string,
   mainUtxo: UnspentTransactionOutput,
   redeemerOutputScript: string,
   amount: BigNumber,
-  bridge: Bridge
-): Promise<void> {
-  await bridge.requestRedemption(
+  vault: Identifier,
+  bridge: Bridge,
+  tBTCToken: TBTCToken
+): Promise<Hex> {
+  const redemptionData = bridge.buildRedemptionData(
+    redeemer,
     walletPublicKey,
     mainUtxo,
-    redeemerOutputScript,
-    amount
+    // TODO: We should pass `redeemerOutputScript` in that form.
+    bcoin.Script.fromAddress(redeemerOutputScript).toRaw().toString("hex")
   )
+
+  return await tBTCToken.approveAndCall(vault, amount, redemptionData)
 }
 
 /**

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -55,8 +55,7 @@ export interface RedemptionRequest {
 }
 
 /**
- * Requests a redemption from the on-chain Bridge contract.
- * @param redeemer - On-chain identifier of the redeemer.
+ * Requests a redemption of tBTC into BTC.
  * @param walletPublicKey - The Bitcoin public key of the wallet. Must be in the
  *        compressed form (33 bytes long with 02 or 03 prefix).
  * @param mainUtxo - The main UTXO of the wallet. Must match the main UTXO held
@@ -65,27 +64,22 @@ export interface RedemptionRequest {
  *        be locked to. Must be un-prefixed and not prepended with length.
  * @param amount - The amount to be redeemed with the precision of the tBTC
  *        on-chain token contract.
- * @param vault - The vault address.
  * @param tBTCToken - Handle to the TBTCToken on-chain contract.
  * @returns Transaction hash of the request redemption transaction.
  */
 export async function requestRedemption(
-  redeemer: Identifier,
   walletPublicKey: string,
   mainUtxo: UnspentTransactionOutput,
   redeemerOutputScript: string,
   amount: BigNumber,
-  vault: Identifier,
   tBTCToken: TBTCToken
 ): Promise<Hex> {
-  return await tBTCToken.requestRedemption({
-    redeemer,
+  return await tBTCToken.requestRedemption(
     walletPublicKey,
     mainUtxo,
     redeemerOutputScript,
-    amount,
-    vault,
-  })
+    amount
+  )
 }
 
 /**

--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -84,8 +84,7 @@ export async function requestRedemption(
     redeemer,
     walletPublicKey,
     mainUtxo,
-    // TODO: We should pass `redeemerOutputScript` in that form.
-    bcoin.Script.fromAddress(redeemerOutputScript).toRaw().toString("hex")
+    redeemerOutputScript
   )
 
   return await tBTCToken.approveAndCall(vault, amount, redemptionData)

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -471,50 +471,30 @@ describe("Bitcoin", () => {
       const btcAddresses = {
         P2PKH: {
           address: "mjc2zGWypwpNyDi4ZxGbBNnUA84bfgiwYc",
-          redeemerOutputScript:
-            "0x1976a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
           outputScript: "76a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
         },
         P2WPKH: {
           address: "tb1qumuaw3exkxdhtut0u85latkqfz4ylgwstkdzsx",
-          redeemerOutputScript:
-            "0x160014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
           outputScript: "0014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
         },
         P2SH: {
           address: "2MsM67NLa71fHvTUBqNENW15P68nHB2vVXb",
-          redeemerOutputScript:
-            "0x17a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
           outputScript: "a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
         },
         P2WSH: {
           address:
             "tb1qau95mxzh2249aa3y8exx76ltc2sq0e7kw8hj04936rdcmnynhswqqz02vv",
-          redeemerOutputScript:
-            "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
           outputScript:
             "0020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
         },
       }
 
       Object.entries(btcAddresses).forEach(
-        ([
-          addressType,
-          {
-            address,
-            redeemerOutputScript: expectedRedeemerOutputScript,
-            outputScript: expectedOutputScript,
-          },
-        ]) => {
+        ([addressType, { address, outputScript: expectedOutputScript }]) => {
           it(`should create correct output script for ${addressType} address type`, () => {
             const result = createOutputScriptFromAddress(address)
 
             expect(result.toString()).to.eq(expectedOutputScript)
-            // Check if we can build the prefixed raw redeemer output script based
-            // on the result.
-            expect(buildRawPrefixedOutputScript(result.toString())).to.eq(
-              expectedRedeemerOutputScript
-            )
           })
         }
       )
@@ -524,63 +504,33 @@ describe("Bitcoin", () => {
       const btcAddresses = {
         P2PKH: {
           address: "12higDjoCCNXSA95xZMWUdPvXNmkAduhWv",
-          redeemerOutputScript:
-            "0x1976a91412ab8dc588ca9d5787dde7eb29569da63c3a238c88ac",
           outputScript: "76a91412ab8dc588ca9d5787dde7eb29569da63c3a238c88ac",
         },
         P2WPKH: {
           address: "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c",
-          redeemerOutputScript:
-            "0x1600148d7a0a3461e3891723e5fdf8129caa0075060cff",
           outputScript: "00148d7a0a3461e3891723e5fdf8129caa0075060cff",
         },
         P2SH: {
           address: "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey",
-          redeemerOutputScript:
-            "0x17a91419a7d869032368fd1f1e26e5e73a4ad0e474960e87",
           outputScript: "a91419a7d869032368fd1f1e26e5e73a4ad0e474960e87",
         },
         P2WSH: {
           address:
             "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak",
-          redeemerOutputScript:
-            "0x220020cdbf909e935c855d3e8d1b61aeb9c5e3c03ae8021b286839b1a72f2e48fdba70",
           outputScript:
             "0020cdbf909e935c855d3e8d1b61aeb9c5e3c03ae8021b286839b1a72f2e48fdba70",
         },
       }
 
       Object.entries(btcAddresses).forEach(
-        ([
-          addressType,
-          {
-            address,
-            redeemerOutputScript: expectedRedeemerOutputScript,
-            outputScript: expectedOutputScript,
-          },
-        ]) => {
+        ([addressType, { address, outputScript: expectedOutputScript }]) => {
           it(`should create correct output script for ${addressType} address type`, () => {
             const result = createOutputScriptFromAddress(address)
 
             expect(result.toString()).to.eq(expectedOutputScript)
-            // Check if we can build the prefixed raw redeemer output script based
-            // on the result.
-            expect(buildRawPrefixedOutputScript(result.toString())).to.eq(
-              expectedRedeemerOutputScript
-            )
           })
         }
       )
     })
   })
 })
-
-const buildRawPrefixedOutputScript = (outputScript: string) => {
-  // Convert the output script to raw bytes buffer.
-  const rawRedeemerOutputScript = Buffer.from(outputScript.toString(), "hex")
-  // Prefix the output script bytes buffer with 0x and its own length.
-  return `0x${Buffer.concat([
-    Buffer.from([rawRedeemerOutputScript.length]),
-    rawRedeemerOutputScript,
-  ]).toString("hex")}`
-}

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -467,53 +467,120 @@ describe("Bitcoin", () => {
   })
 
   describe("createOutputScriptFromAddress", () => {
-    const btcAddresses = {
-      P2PKH: {
-        address: "mjc2zGWypwpNyDi4ZxGbBNnUA84bfgiwYc",
-        redeemerOutputScript:
-          "0x1976a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
-      },
-      P2WPKH: {
-        address: "tb1qumuaw3exkxdhtut0u85latkqfz4ylgwstkdzsx",
-        redeemerOutputScript:
-          "0x160014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
-      },
-      P2SH: {
-        address: "2MsM67NLa71fHvTUBqNENW15P68nHB2vVXb",
-        redeemerOutputScript:
-          "0x17a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
-      },
-      P2WSH: {
-        address:
-          "tb1qau95mxzh2249aa3y8exx76ltc2sq0e7kw8hj04936rdcmnynhswqqz02vv",
-        redeemerOutputScript:
-          "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
-      },
-    }
-
-    Object.entries(btcAddresses).forEach(
-      ([
-        addressType,
-        { address, redeemerOutputScript: expectedRedeemerOutputScript },
-      ]) => {
-        it(`should create correct output script for ${addressType} address type`, () => {
-          const result = createOutputScriptFromAddress(address)
-
-          // Check if we can build the prefixed raw redeemer output script based
-          // on the result.
-          // Convert the output script to raw bytes buffer.
-          const rawRedeemerOutputScript = Buffer.from(result.toString(), "hex")
-          // Prefix the output script bytes buffer with 0x and its own length.
-          const prefixedRawRedeemerOutputScript = `0x${Buffer.concat([
-            Buffer.from([rawRedeemerOutputScript.length]),
-            rawRedeemerOutputScript,
-          ]).toString("hex")}`
-
-          expect(prefixedRawRedeemerOutputScript).to.eq(
-            expectedRedeemerOutputScript
-          )
-        })
+    context("with testnet addresses", () => {
+      const btcAddresses = {
+        P2PKH: {
+          address: "mjc2zGWypwpNyDi4ZxGbBNnUA84bfgiwYc",
+          redeemerOutputScript:
+            "0x1976a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
+          outputScript: "76a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
+        },
+        P2WPKH: {
+          address: "tb1qumuaw3exkxdhtut0u85latkqfz4ylgwstkdzsx",
+          redeemerOutputScript:
+            "0x160014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
+          outputScript: "0014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
+        },
+        P2SH: {
+          address: "2MsM67NLa71fHvTUBqNENW15P68nHB2vVXb",
+          redeemerOutputScript:
+            "0x17a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
+          outputScript: "a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
+        },
+        P2WSH: {
+          address:
+            "tb1qau95mxzh2249aa3y8exx76ltc2sq0e7kw8hj04936rdcmnynhswqqz02vv",
+          redeemerOutputScript:
+            "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
+          outputScript:
+            "0020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
+        },
       }
-    )
+
+      Object.entries(btcAddresses).forEach(
+        ([
+          addressType,
+          {
+            address,
+            redeemerOutputScript: expectedRedeemerOutputScript,
+            outputScript: expectedOutputScript,
+          },
+        ]) => {
+          it(`should create correct output script for ${addressType} address type`, () => {
+            const result = createOutputScriptFromAddress(address)
+
+            expect(result.toString()).to.eq(expectedOutputScript)
+            // Check if we can build the prefixed raw redeemer output script based
+            // on the result.
+            expect(buildRawPrefixedOutputScript(result.toString())).to.eq(
+              expectedRedeemerOutputScript
+            )
+          })
+        }
+      )
+    })
+
+    context("with mainnet addresses", () => {
+      const btcAddresses = {
+        P2PKH: {
+          address: "12higDjoCCNXSA95xZMWUdPvXNmkAduhWv",
+          redeemerOutputScript:
+            "0x1976a91412ab8dc588ca9d5787dde7eb29569da63c3a238c88ac",
+          outputScript: "76a91412ab8dc588ca9d5787dde7eb29569da63c3a238c88ac",
+        },
+        P2WPKH: {
+          address: "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c",
+          redeemerOutputScript:
+            "0x1600148d7a0a3461e3891723e5fdf8129caa0075060cff",
+          outputScript: "00148d7a0a3461e3891723e5fdf8129caa0075060cff",
+        },
+        P2SH: {
+          address: "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey",
+          redeemerOutputScript:
+            "0x17a91419a7d869032368fd1f1e26e5e73a4ad0e474960e87",
+          outputScript: "a91419a7d869032368fd1f1e26e5e73a4ad0e474960e87",
+        },
+        P2WSH: {
+          address:
+            "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak",
+          redeemerOutputScript:
+            "0x220020cdbf909e935c855d3e8d1b61aeb9c5e3c03ae8021b286839b1a72f2e48fdba70",
+          outputScript:
+            "0020cdbf909e935c855d3e8d1b61aeb9c5e3c03ae8021b286839b1a72f2e48fdba70",
+        },
+      }
+
+      Object.entries(btcAddresses).forEach(
+        ([
+          addressType,
+          {
+            address,
+            redeemerOutputScript: expectedRedeemerOutputScript,
+            outputScript: expectedOutputScript,
+          },
+        ]) => {
+          it(`should create correct output script for ${addressType} address type`, () => {
+            const result = createOutputScriptFromAddress(address)
+
+            expect(result.toString()).to.eq(expectedOutputScript)
+            // Check if we can build the prefixed raw redeemer output script based
+            // on the result.
+            expect(buildRawPrefixedOutputScript(result.toString())).to.eq(
+              expectedRedeemerOutputScript
+            )
+          })
+        }
+      )
+    })
   })
 })
+
+const buildRawPrefixedOutputScript = (outputScript: string) => {
+  // Convert the output script to raw bytes buffer.
+  const rawRedeemerOutputScript = Buffer.from(outputScript.toString(), "hex")
+  // Prefix the output script bytes buffer with 0x and its own length.
+  return `0x${Buffer.concat([
+    Buffer.from([rawRedeemerOutputScript.length]),
+    rawRedeemerOutputScript,
+  ]).toString("hex")}`
+}

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -502,7 +502,7 @@ describe("Bitcoin", () => {
           // Check if we can build the prefixed raw redeemer output script based
           // on the result.
           // Convert the output script to raw bytes buffer.
-          const rawRedeemerOutputScript = Buffer.from(result, "hex")
+          const rawRedeemerOutputScript = Buffer.from(result.toString(), "hex")
           // Prefix the output script bytes buffer with 0x and its own length.
           const prefixedRawRedeemerOutputScript = `0x${Buffer.concat([
             Buffer.from([rawRedeemerOutputScript.length]),

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -11,6 +11,7 @@ import {
   hashLEToBigNumber,
   bitsToTarget,
   targetToDifficulty,
+  createOutputScriptFromAddress,
 } from "../src/bitcoin"
 import { calculateDepositRefundLocktime } from "../src/deposit"
 import { BitcoinNetwork } from "../src/bitcoin-network"
@@ -463,5 +464,56 @@ describe("Bitcoin", () => {
       const expectedDifficulty = BigNumber.from("1")
       expect(targetToDifficulty(target)).to.equal(expectedDifficulty)
     })
+  })
+
+  describe("createOutputScriptFromAddress", () => {
+    const btcAddresses = {
+      P2PKH: {
+        address: "mjc2zGWypwpNyDi4ZxGbBNnUA84bfgiwYc",
+        redeemerOutputScript:
+          "0x1976a9142cd680318747b720d67bf4246eb7403b476adb3488ac",
+      },
+      P2WPKH: {
+        address: "tb1qumuaw3exkxdhtut0u85latkqfz4ylgwstkdzsx",
+        redeemerOutputScript:
+          "0x160014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0",
+      },
+      P2SH: {
+        address: "2MsM67NLa71fHvTUBqNENW15P68nHB2vVXb",
+        redeemerOutputScript:
+          "0x17a914011beb6fb8499e075a57027fb0a58384f2d3f78487",
+      },
+      P2WSH: {
+        address:
+          "tb1qau95mxzh2249aa3y8exx76ltc2sq0e7kw8hj04936rdcmnynhswqqz02vv",
+        redeemerOutputScript:
+          "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c",
+      },
+    }
+
+    Object.entries(btcAddresses).forEach(
+      ([
+        addressType,
+        { address, redeemerOutputScript: expectedRedeemerOutputScript },
+      ]) => {
+        it(`should create correct output script for ${addressType} address type`, () => {
+          const result = createOutputScriptFromAddress(address)
+
+          // Check if we can build the prefixed raw redeemer output script based
+          // on the result.
+          // Convert the output script to raw bytes buffer.
+          const rawRedeemerOutputScript = Buffer.from(result, "hex")
+          // Prefix the output script bytes buffer with 0x and its own length.
+          const prefixedRawRedeemerOutputScript = `0x${Buffer.concat([
+            Buffer.from([rawRedeemerOutputScript.length]),
+            rawRedeemerOutputScript,
+          ]).toString("hex")}`
+
+          expect(prefixedRawRedeemerOutputScript).to.eq(
+            expectedRedeemerOutputScript
+          )
+        })
+      }
+    )
   })
 })

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -46,7 +46,6 @@ describe("Redemption", () => {
     const redeemerOutputScript =
       data.pendingRedemptions[0].pendingRedemption.redeemerOutputScript
     const amount = data.pendingRedemptions[0].pendingRedemption.requestedAmount
-    const bridge: MockBridge = new MockBridge()
     const vault = Address.from("0xb622eA9D678ddF15135a20d59Ff26D28eC246bfB")
     const token: MockTBTCToken = new MockTBTCToken()
     const redeemer = Address.from("0x117284D8C50f334a1E2b7712649cB23C7a04Ae74")
@@ -61,26 +60,22 @@ describe("Redemption", () => {
         redeemerOutputScript,
         amount,
         vault,
-        bridge,
         token
       )
     })
 
     it("should submit redemption proof with correct arguments", () => {
-      const bridgeLog = bridge.buildRedemptionDataLog
-      const tokenLog = token.approveAndCallLog
-
-      expect(bridgeLog.length).to.equal(1)
-      expect(bridgeLog[0].walletPublicKey).to.equal(
-        redemptionProof.expectedRedemptionProof.walletPublicKey
-      )
-      expect(bridgeLog[0].mainUtxo).to.equal(mainUtxo)
-      expect(bridgeLog[0].redeemerOutputScript).to.equal(redeemerOutputScript)
-      expect(bridgeLog[0].redeemer).to.equal(redeemer)
+      const tokenLog = token.requestRedemptionLog
 
       expect(tokenLog.length).to.equal(1)
-      expect(tokenLog[0].spender).to.equal(vault)
-      expect(tokenLog[0].amount).to.equal(amount)
+      expect(tokenLog[0]).to.deep.equal({
+        redeemer,
+        walletPublicKey,
+        mainUtxo,
+        redeemerOutputScript,
+        amount,
+        vault,
+      })
     })
   })
 

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -34,7 +34,6 @@ import * as chai from "chai"
 import chaiAsPromised from "chai-as-promised"
 import { expect } from "chai"
 import { BigNumberish, BigNumber } from "ethers"
-import { Address } from "../src/ethereum"
 import { MockTBTCToken } from "./utils/mock-tbtc-token"
 
 chai.use(chaiAsPromised)
@@ -46,20 +45,16 @@ describe("Redemption", () => {
     const redeemerOutputScript =
       data.pendingRedemptions[0].pendingRedemption.redeemerOutputScript
     const amount = data.pendingRedemptions[0].pendingRedemption.requestedAmount
-    const vault = Address.from("0xb622eA9D678ddF15135a20d59Ff26D28eC246bfB")
     const token: MockTBTCToken = new MockTBTCToken()
-    const redeemer = Address.from("0x117284D8C50f334a1E2b7712649cB23C7a04Ae74")
 
     beforeEach(async () => {
       bcoin.set("testnet")
 
       await requestRedemption(
-        redeemer,
         walletPublicKey,
         mainUtxo,
         redeemerOutputScript,
         amount,
-        vault,
         token
       )
     })
@@ -69,12 +64,10 @@ describe("Redemption", () => {
 
       expect(tokenLog.length).to.equal(1)
       expect(tokenLog[0]).to.deep.equal({
-        redeemer,
         walletPublicKey,
         mainUtxo,
         redeemerOutputScript,
         amount,
-        vault,
       })
     })
   })

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -43,13 +43,6 @@ interface RedemptionProofLogEntry {
   walletPublicKey: string
 }
 
-interface BuildRedemptionDataLogEntry {
-  redeemer: Identifier
-  walletPublicKey: string
-  mainUtxo: UnspentTransactionOutput
-  redeemerOutputScript: string
-}
-
 /**
  * Mock Bridge used for test purposes.
  */
@@ -63,7 +56,6 @@ export class MockBridge implements Bridge {
   private _redemptionProofLog: RedemptionProofLogEntry[] = []
   private _deposits = new Map<BigNumberish, RevealedDeposit>()
   private _activeWalletPublicKey: string | undefined
-  private _buildRedemptionDataLog: BuildRedemptionDataLogEntry[] = []
 
   setPendingRedemptions(value: Map<BigNumberish, RedemptionRequest>) {
     this._pendingRedemptions = value
@@ -87,10 +79,6 @@ export class MockBridge implements Bridge {
 
   get redemptionProofLog(): RedemptionProofLogEntry[] {
     return this._redemptionProofLog
-  }
-
-  get buildRedemptionDataLog(): BuildRedemptionDataLogEntry[] {
-    return this._buildRedemptionDataLog
   }
 
   setDeposits(value: Map<BigNumberish, RevealedDeposit>) {

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -326,40 +326,4 @@ export class MockBridge implements Bridge {
   walletRegistry(): Promise<WalletRegistry> {
     throw new Error("not implemented")
   }
-
-  buildRedemptionData(
-    redeemer: Identifier,
-    walletPublicKey: string,
-    mainUtxo: UnspentTransactionOutput,
-    redeemerOutputScript: string
-  ): Hex {
-    this._buildRedemptionDataLog.push({
-      redeemer,
-      walletPublicKey,
-      mainUtxo,
-      redeemerOutputScript,
-    })
-
-    // Convert the output script to raw bytes buffer.
-    const rawRedeemerOutputScript = Buffer.from(redeemerOutputScript, "hex")
-    // Prefix the output script bytes buffer with 0x and its own length.
-    const prefixedRawRedeemerOutputScript = `0x${Buffer.concat([
-      Buffer.from([rawRedeemerOutputScript.length]),
-      rawRedeemerOutputScript,
-    ]).toString("hex")}`
-
-    return Hex.from(
-      utils.defaultAbiCoder.encode(
-        ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
-        [
-          redeemer.identifierHex,
-          `0x${computeHash160(walletPublicKey)}`,
-          mainUtxo.transactionHash.reverse().toPrefixedString(),
-          mainUtxo.outputIndex,
-          mainUtxo.value,
-          prefixedRawRedeemerOutputScript,
-        ]
-      )
-    )
-  }
 }

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -43,6 +43,13 @@ interface RedemptionProofLogEntry {
   walletPublicKey: string
 }
 
+interface BuildRedemptionDataLogEntry {
+  redeemer: Identifier
+  walletPublicKey: string
+  mainUtxo: UnspentTransactionOutput
+  redeemerOutputScript: string
+}
+
 /**
  * Mock Bridge used for test purposes.
  */
@@ -56,6 +63,7 @@ export class MockBridge implements Bridge {
   private _redemptionProofLog: RedemptionProofLogEntry[] = []
   private _deposits = new Map<BigNumberish, RevealedDeposit>()
   private _activeWalletPublicKey: string | undefined
+  private _buildRedemptionDataLog: BuildRedemptionDataLogEntry[] = []
 
   setPendingRedemptions(value: Map<BigNumberish, RedemptionRequest>) {
     this._pendingRedemptions = value
@@ -79,6 +87,10 @@ export class MockBridge implements Bridge {
 
   get redemptionProofLog(): RedemptionProofLogEntry[] {
     return this._redemptionProofLog
+  }
+
+  get buildRedemptionDataLog(): BuildRedemptionDataLogEntry[] {
+    return this._buildRedemptionDataLog
   }
 
   setDeposits(value: Map<BigNumberish, RevealedDeposit>) {
@@ -313,5 +325,41 @@ export class MockBridge implements Bridge {
 
   walletRegistry(): Promise<WalletRegistry> {
     throw new Error("not implemented")
+  }
+
+  buildRedemptionData(
+    redeemer: Identifier,
+    walletPublicKey: string,
+    mainUtxo: UnspentTransactionOutput,
+    redeemerOutputScript: string
+  ): Hex {
+    this._buildRedemptionDataLog.push({
+      redeemer,
+      walletPublicKey,
+      mainUtxo,
+      redeemerOutputScript,
+    })
+
+    // Convert the output script to raw bytes buffer.
+    const rawRedeemerOutputScript = Buffer.from(redeemerOutputScript, "hex")
+    // Prefix the output script bytes buffer with 0x and its own length.
+    const prefixedRawRedeemerOutputScript = `0x${Buffer.concat([
+      Buffer.from([rawRedeemerOutputScript.length]),
+      rawRedeemerOutputScript,
+    ]).toString("hex")}`
+
+    return Hex.from(
+      utils.defaultAbiCoder.encode(
+        ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
+        [
+          redeemer.identifierHex,
+          `0x${computeHash160(walletPublicKey)}`,
+          mainUtxo.transactionHash.reverse().toPrefixedString(),
+          mainUtxo.outputIndex,
+          mainUtxo.value,
+          prefixedRawRedeemerOutputScript,
+        ]
+      )
+    )
   }
 }

--- a/typescript/test/utils/mock-tbtc-token.ts
+++ b/typescript/test/utils/mock-tbtc-token.ts
@@ -1,0 +1,33 @@
+import { Identifier, TBTCToken } from "../../src/chain"
+import { Hex } from "../../src/hex"
+import { BigNumber } from "ethers"
+
+interface ApproveAndCallLog {
+  spender: Identifier
+  amount: BigNumber
+  extraData: Hex
+}
+
+export class MockTBTCToken implements TBTCToken {
+  private _approveAndCallLog: ApproveAndCallLog[] = []
+
+  get approveAndCallLog() {
+    return this._approveAndCallLog
+  }
+
+  totalSupply(blockNumber?: number | undefined): Promise<BigNumber> {
+    throw new Error("Method not implemented.")
+  }
+  async approveAndCall(
+    spender: Identifier,
+    amount: BigNumber,
+    extraData: Hex
+  ): Promise<Hex> {
+    this._approveAndCallLog.push({ spender, amount, extraData })
+
+    // Random tx hash
+    return Hex.from(
+      "0xf7d0c92c8de4d117d915c2a8a54ee550047f926bc00b91b651c40628751cfe29"
+    )
+  }
+}

--- a/typescript/test/utils/mock-tbtc-token.ts
+++ b/typescript/test/utils/mock-tbtc-token.ts
@@ -1,31 +1,25 @@
-import { Identifier, TBTCToken } from "../../src/chain"
+import { RequestRedemptionData, TBTCToken } from "../../src/chain"
 import { Hex } from "../../src/hex"
 import { BigNumber } from "ethers"
 
-interface ApproveAndCallLog {
-  spender: Identifier
-  amount: BigNumber
-  extraData: Hex
-}
+interface RequestRedemptionLog extends RequestRedemptionData {}
 
 export class MockTBTCToken implements TBTCToken {
-  private _approveAndCallLog: ApproveAndCallLog[] = []
+  private _requestRedemptionLog: RequestRedemptionLog[] = []
 
-  get approveAndCallLog() {
-    return this._approveAndCallLog
+  get requestRedemptionLog() {
+    return this._requestRedemptionLog
   }
 
   totalSupply(blockNumber?: number | undefined): Promise<BigNumber> {
     throw new Error("Method not implemented.")
   }
-  async approveAndCall(
-    spender: Identifier,
-    amount: BigNumber,
-    extraData: Hex
-  ): Promise<Hex> {
-    this._approveAndCallLog.push({ spender, amount, extraData })
 
-    // Random tx hash
+  async requestRedemption(
+    requestRedemptionData: RequestRedemptionData
+  ): Promise<Hex> {
+    this._requestRedemptionLog.push(requestRedemptionData)
+
     return Hex.from(
       "0xf7d0c92c8de4d117d915c2a8a54ee550047f926bc00b91b651c40628751cfe29"
     )

--- a/typescript/test/utils/mock-tbtc-token.ts
+++ b/typescript/test/utils/mock-tbtc-token.ts
@@ -1,8 +1,14 @@
-import { RequestRedemptionData, TBTCToken } from "../../src/chain"
+import { TBTCToken } from "../../src/chain"
 import { Hex } from "../../src/hex"
 import { BigNumber } from "ethers"
+import { UnspentTransactionOutput } from "../../src/bitcoin"
 
-interface RequestRedemptionLog extends RequestRedemptionData {}
+interface RequestRedemptionLog {
+  walletPublicKey: string
+  mainUtxo: UnspentTransactionOutput
+  redeemerOutputScript: string
+  amount: BigNumber
+}
 
 export class MockTBTCToken implements TBTCToken {
   private _requestRedemptionLog: RequestRedemptionLog[] = []
@@ -16,9 +22,17 @@ export class MockTBTCToken implements TBTCToken {
   }
 
   async requestRedemption(
-    requestRedemptionData: RequestRedemptionData
+    walletPublicKey: string,
+    mainUtxo: UnspentTransactionOutput,
+    redeemerOutputScript: string,
+    amount: BigNumber
   ): Promise<Hex> {
-    this._requestRedemptionLog.push(requestRedemptionData)
+    this._requestRedemptionLog.push({
+      walletPublicKey,
+      mainUtxo,
+      redeemerOutputScript,
+      amount,
+    })
 
     return Hex.from(
       "0xf7d0c92c8de4d117d915c2a8a54ee550047f926bc00b91b651c40628751cfe29"


### PR DESCRIPTION
This PR refactors the `requestRedemption` function to request redemption in one transaction(instead of 2: approve + requestRedemption) using the [`approveAndCall` ](https://github.com/thesis/solidity-contracts/blob/main/contracts/token/ERC20WithPermit.sol#L207) function from tBTC token contract. Then the tBTC token contract calls the [`receiveApproval`](https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/vault/TBTCVault.sol#L193) function from the `TBTCVault` contract which [burns tBTC tokens and requests redemption](https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/vault/TBTCVault.sol#L338).