### PR TITLE
Redemptions prototype: On-chain coordination

### DIFF
--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -336,7 +336,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
         depositSweepMaxSize = 5;
         depositSweepProposalSubmissionGasOffset = 20_000; // optimized for 10 inputs
 
-        redemptionProposalValidity = 1 hours;
+        redemptionProposalValidity = 2 hours;
         redemptionRequestMinAge = 600; // 10 minutes or ~50 blocks.
         redemptionRequestTimeoutSafetyMargin = 2 hours;
         redemptionMaxSize = 20;

--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -923,6 +923,7 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
                 )
             );
 
+            // slither-disable-next-line calls-loop
             Redemption.RedemptionRequest memory redemptionRequest = bridge
                 .pendingRedemptions(redemptionKey);
 

--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -581,7 +581,9 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
         address proposalVault = address(0);
 
-        uint256[] memory processedDepositKeys = new uint256[](proposal.depositsKeys.length);
+        uint256[] memory processedDepositKeys = new uint256[](
+            proposal.depositsKeys.length
+        );
 
         for (uint256 i = 0; i < proposal.depositsKeys.length; i++) {
             DepositKey memory depositKey = proposal.depositsKeys[i];

--- a/solidity/contracts/bridge/WalletCoordinator.sol
+++ b/solidity/contracts/bridge/WalletCoordinator.sol
@@ -789,7 +789,12 @@ contract WalletCoordinator is OwnableUpgradeable, Reimbursable {
 
     /// @notice Updates parameters related to redemption proposal.
     /// @param _redemptionProposalValidity The new value of `redemptionProposalValidity`.
-    /// @param _redemptionProposalSubmissionGasOffset The new value of `redemptionProposalSubmissionGasOffset`.
+    /// @param _redemptionRequestMinAge The new value of `redemptionRequestMinAge`.
+    /// @param _redemptionRequestTimeoutSafetyMargin The new value of
+    ///        `redemptionRequestTimeoutSafetyMargin`.
+    /// @param _redemptionMaxSize The new value of `redemptionMaxSize`.
+    /// @param _redemptionProposalSubmissionGasOffset The new value of
+    ///        `redemptionProposalSubmissionGasOffset`.
     /// @dev Requirements:
     ///      - The caller must be the owner.
     function updateRedemptionProposalParameters(

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -2019,7 +2019,7 @@ describe("WalletCoordinator", () => {
                                         await restoreSnapshot()
                                       })
 
-                                      it("should succeed", async () => {
+                                      it("should revert", async () => {
                                         const proposal = {
                                           walletPubKeyHash,
                                           depositsKeys: [
@@ -2323,7 +2323,7 @@ describe("WalletCoordinator", () => {
           await restoreSnapshot()
         })
 
-        it("should time lock the wallet", async () => {
+        it("should time-lock the wallet", async () => {
           const lockedUntil =
             (await lastBlockTime()) +
             (await walletCoordinator.redemptionProposalValidity())

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -2644,6 +2644,11 @@ describe("WalletCoordinator", () => {
                 })
               }
             )
+
+            // The context block covering the per-redemption fee checks is
+            // declared at the end of the `validateRedemptionProposal` test suite
+            // due to the actual order of checks performed by this function.
+            // See: "when there is a request that incurs an unacceptable tx fee share"
           })
 
           context("when proposed redemption tx fee is valid", () => {

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -2362,6 +2362,613 @@ describe("WalletCoordinator", () => {
       })
     })
   })
+
+  describe("validateRedemptionProposal", () => {
+    const walletPubKeyHash = "0x7ac2d9378a1c47e589dfb8095ca95ed2140d2726"
+    const ecdsaWalletID =
+      "0x4ad6b3ccbca81645865d8d0d575797a15528e98ced22f29a6f906d3259569863"
+
+    const bridgeRedemptionTxMaxTotalFee = 10000
+    const bridgeRedemptionTimeout = 5 * 86400 // 5 days
+
+    before(async () => {
+      await createSnapshot()
+
+      bridge.redemptionParameters.returns([
+        0,
+        0,
+        0,
+        bridgeRedemptionTxMaxTotalFee,
+        bridgeRedemptionTimeout,
+        0,
+        0,
+      ])
+    })
+
+    after(async () => {
+      bridge.redemptionParameters.reset()
+
+      await restoreSnapshot()
+    })
+
+    context("when wallet is not Live", () => {
+      const testData = [
+        {
+          testName: "when wallet state is Unknown",
+          walletState: walletState.Unknown,
+        },
+        {
+          testName: "when wallet state is MovingFunds",
+          walletState: walletState.MovingFunds,
+        },
+        {
+          testName: "when wallet state is Closing",
+          walletState: walletState.Closing,
+        },
+        {
+          testName: "when wallet state is Closed",
+          walletState: walletState.Closed,
+        },
+        {
+          testName: "when wallet state is Terminated",
+          walletState: walletState.Terminated,
+        },
+      ]
+
+      testData.forEach((test) => {
+        context(test.testName, () => {
+          before(async () => {
+            await createSnapshot()
+
+            bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
+              ecdsaWalletID,
+              mainUtxoHash: HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: 0,
+              movingFundsRequestedAt: 0,
+              closingStartedAt: 0,
+              pendingMovedFundsSweepRequestsCount: 0,
+              state: test.walletState,
+              movingFundsTargetWalletsCommitmentHash: HashZero,
+            })
+          })
+
+          after(async () => {
+            bridge.wallets.reset()
+
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            await expect(
+              // Only walletPubKeyHash argument is relevant in this scenario.
+              walletCoordinator.validateRedemptionProposal({
+                walletPubKeyHash,
+                redeemersOutputScripts: [],
+                redemptionTxFee: 0,
+              })
+            ).to.be.revertedWith("Wallet is not in Live state")
+          })
+        })
+      })
+    })
+
+    context("when wallet is Live", () => {
+      before(async () => {
+        await createSnapshot()
+
+        bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
+          ecdsaWalletID,
+          mainUtxoHash: HashZero,
+          pendingRedemptionsValue: 0,
+          createdAt: 0,
+          movingFundsRequestedAt: 0,
+          closingStartedAt: 0,
+          pendingMovedFundsSweepRequestsCount: 0,
+          state: walletState.Live,
+          movingFundsTargetWalletsCommitmentHash: HashZero,
+        })
+      })
+
+      after(async () => {
+        bridge.wallets.reset()
+
+        await restoreSnapshot()
+      })
+
+      context("when redemption is below the min size", () => {
+        it("should revert", async () => {
+          await expect(
+            walletCoordinator.validateRedemptionProposal({
+              walletPubKeyHash,
+              redeemersOutputScripts: [], // Set size to 0.
+              redemptionTxFee: 0, // Not relevant in this scenario.
+            })
+          ).to.be.revertedWith("Redemption below the min size")
+        })
+      })
+
+      context("when redemption is above the min size", () => {
+        context("when redemption exceeds the max size", () => {
+          it("should revert", async () => {
+            const maxSize = await walletCoordinator.redemptionMaxSize()
+
+            // Pick more redemption requests than allowed.
+            const redeemersOutputScripts = new Array(maxSize + 1).fill(
+              createTestRedemptionRequest(walletPubKeyHash).key
+                .redeemerOutputScript
+            )
+
+            await expect(
+              walletCoordinator.validateRedemptionProposal({
+                walletPubKeyHash,
+                redeemersOutputScripts,
+                redemptionTxFee: 0, // Not relevant in this scenario.
+              })
+            ).to.be.revertedWith("Redemption exceeds the max size")
+          })
+        })
+
+        context("when redemption does not exceed the max size", () => {
+          context("when proposed redemption tx fee is invalid", () => {
+            context("when proposed redemption tx fee is zero", () => {
+              it("should revert", async () => {
+                await expect(
+                  walletCoordinator.validateRedemptionProposal({
+                    walletPubKeyHash,
+                    redeemersOutputScripts: [
+                      createTestRedemptionRequest(walletPubKeyHash).key
+                        .redeemerOutputScript,
+                    ],
+                    redemptionTxFee: 0,
+                  })
+                ).to.be.revertedWith("Proposed transaction fee cannot be zero")
+              })
+            })
+
+            context(
+              "when proposed redemption tx fee is greater than the allowed total fee",
+              () => {
+                it("should revert", async () => {
+                  await expect(
+                    walletCoordinator.validateRedemptionProposal({
+                      walletPubKeyHash,
+                      redeemersOutputScripts: [
+                        createTestRedemptionRequest(walletPubKeyHash).key
+                          .redeemerOutputScript,
+                      ],
+                      // Exceed the max per-request fee by one.
+                      redemptionTxFee: bridgeRedemptionTxMaxTotalFee + 1,
+                    })
+                  ).to.be.revertedWith("Proposed transaction fee is too high")
+                })
+              }
+            )
+          })
+
+          context("when proposed redemption tx fee is valid", () => {
+            const redemptionTxFee = 9000
+
+            context("when there is a non-pending request", () => {
+              let requestOne
+              let requestTwo
+
+              before(async () => {
+                await createSnapshot()
+
+                requestOne = createTestRedemptionRequest(
+                  walletPubKeyHash,
+                  5000 // necessary to pass the fee share validation
+                )
+                requestTwo = createTestRedemptionRequest(walletPubKeyHash)
+
+                // Request one is a proper one.
+                bridge.pendingRedemptions
+                  .whenCalledWith(
+                    redemptionKey(
+                      requestOne.key.walletPubKeyHash,
+                      requestOne.key.redeemerOutputScript
+                    )
+                  )
+                  .returns(requestOne.content)
+
+                // Simulate the request two is non-pending.
+                bridge.pendingRedemptions
+                  .whenCalledWith(
+                    redemptionKey(
+                      requestTwo.key.walletPubKeyHash,
+                      requestTwo.key.redeemerOutputScript
+                    )
+                  )
+                  .returns({
+                    ...requestTwo.content,
+                    requestedAt: 0,
+                  })
+              })
+
+              after(async () => {
+                bridge.pendingRedemptions.reset()
+
+                await restoreSnapshot()
+              })
+
+              it("should revert", async () => {
+                const proposal = {
+                  walletPubKeyHash,
+                  redeemersOutputScripts: [
+                    requestOne.key.redeemerOutputScript,
+                    requestTwo.key.redeemerOutputScript,
+                  ],
+                  redemptionTxFee,
+                }
+
+                await expect(
+                  walletCoordinator.validateRedemptionProposal(proposal)
+                ).to.be.revertedWith("Not a pending redemption request")
+              })
+            })
+
+            context("when all requests are pending", () => {
+              context("when there is an immature request", () => {
+                let requestOne
+                let requestTwo
+
+                before(async () => {
+                  await createSnapshot()
+
+                  requestOne = createTestRedemptionRequest(
+                    walletPubKeyHash,
+                    5000 // necessary to pass the fee share validation
+                  )
+                  requestTwo = createTestRedemptionRequest(walletPubKeyHash)
+
+                  // Request one is a proper one.
+                  bridge.pendingRedemptions
+                    .whenCalledWith(
+                      redemptionKey(
+                        requestOne.key.walletPubKeyHash,
+                        requestOne.key.redeemerOutputScript
+                      )
+                    )
+                    .returns(requestOne.content)
+
+                  // Simulate the request two has just been created thus not
+                  // achieved the min age yet.
+                  bridge.pendingRedemptions
+                    .whenCalledWith(
+                      redemptionKey(
+                        requestTwo.key.walletPubKeyHash,
+                        requestTwo.key.redeemerOutputScript
+                      )
+                    )
+                    .returns({
+                      ...requestTwo.content,
+                      requestedAt: await lastBlockTime(),
+                    })
+                })
+
+                after(async () => {
+                  bridge.pendingRedemptions.reset()
+
+                  await restoreSnapshot()
+                })
+
+                it("should revert", async () => {
+                  const proposal = {
+                    walletPubKeyHash,
+                    redeemersOutputScripts: [
+                      requestOne.key.redeemerOutputScript,
+                      requestTwo.key.redeemerOutputScript,
+                    ],
+                    redemptionTxFee,
+                  }
+
+                  await expect(
+                    walletCoordinator.validateRedemptionProposal(proposal)
+                  ).to.be.revertedWith(
+                    "Redemption request min age not achieved yet"
+                  )
+                })
+              })
+
+              context("when all requests achieved the min age", () => {
+                context(
+                  "when there is a request that violates the timeout safety margin",
+                  () => {
+                    let requestOne
+                    let requestTwo
+
+                    before(async () => {
+                      await createSnapshot()
+
+                      // Request one is a proper one.
+                      requestOne = createTestRedemptionRequest(
+                        walletPubKeyHash,
+                        5000 // necessary to pass the fee share validation
+                      )
+
+                      // Simulate that request two violates the timeout safety margin.
+                      // In order to do so, we need to use `createTestRedemptionRequest`
+                      // with a custom request creation time that will produce
+                      // a timeout timestamp being closer to the current
+                      // moment than allowed by the refund safety margin.
+                      const safetyMarginViolatedAt = await lastBlockTime()
+                      const requestTimedOutAt =
+                        safetyMarginViolatedAt +
+                        (await walletCoordinator.redemptionRequestTimeoutSafetyMargin())
+                      const requestCreatedAt =
+                        requestTimedOutAt - bridgeRedemptionTimeout
+
+                      requestTwo = createTestRedemptionRequest(
+                        walletPubKeyHash,
+                        0,
+                        requestCreatedAt
+                      )
+
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestOne.key.walletPubKeyHash,
+                            requestOne.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(requestOne.content)
+
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestTwo.key.walletPubKeyHash,
+                            requestTwo.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(requestTwo.content)
+                    })
+
+                    after(async () => {
+                      bridge.pendingRedemptions.reset()
+
+                      await restoreSnapshot()
+                    })
+
+                    it("should revert", async () => {
+                      const proposal = {
+                        walletPubKeyHash,
+                        redeemersOutputScripts: [
+                          requestOne.key.redeemerOutputScript,
+                          requestTwo.key.redeemerOutputScript,
+                        ],
+                        redemptionTxFee,
+                      }
+
+                      await expect(
+                        walletCoordinator.validateRedemptionProposal(proposal)
+                      ).to.be.revertedWith(
+                        "Redemption request timeout safety margin is not preserved"
+                      )
+                    })
+                  }
+                )
+
+                context(
+                  "when all requests preserve the timeout safety margin",
+                  () => {
+                    context(
+                      "when there is a request that incurs an unacceptable tx fee share",
+                      () => {
+                        context("when there is no fee remainder", () => {
+                          let requestOne
+                          let requestTwo
+
+                          before(async () => {
+                            await createSnapshot()
+
+                            // Request one is a proper one.
+                            requestOne = createTestRedemptionRequest(
+                              walletPubKeyHash,
+                              4500 // necessary to pass the fee share validation
+                            )
+
+                            // Simulate that request two takes an unacceptable
+                            // tx fee share. Because redemptionTxFee used
+                            // in the proposal is 9000, the actual fee share
+                            // per-request is 4500. In order to test this case
+                            // the second request must allow for 4499 as allowed
+                            // fee share at maximum.
+                            requestTwo = createTestRedemptionRequest(
+                              walletPubKeyHash,
+                              4499
+                            )
+
+                            bridge.pendingRedemptions
+                              .whenCalledWith(
+                                redemptionKey(
+                                  requestOne.key.walletPubKeyHash,
+                                  requestOne.key.redeemerOutputScript
+                                )
+                              )
+                              .returns(requestOne.content)
+
+                            bridge.pendingRedemptions
+                              .whenCalledWith(
+                                redemptionKey(
+                                  requestTwo.key.walletPubKeyHash,
+                                  requestTwo.key.redeemerOutputScript
+                                )
+                              )
+                              .returns(requestTwo.content)
+                          })
+
+                          after(async () => {
+                            bridge.pendingRedemptions.reset()
+
+                            await restoreSnapshot()
+                          })
+
+                          it("should revert", async () => {
+                            const proposal = {
+                              walletPubKeyHash,
+                              redeemersOutputScripts: [
+                                requestOne.key.redeemerOutputScript,
+                                requestTwo.key.redeemerOutputScript,
+                              ],
+                              redemptionTxFee,
+                            }
+
+                            await expect(
+                              walletCoordinator.validateRedemptionProposal(
+                                proposal
+                              )
+                            ).to.be.revertedWith(
+                              "Proposed transaction per-request fee share is too high"
+                            )
+                          })
+                        })
+
+                        context("when there is a fee remainder", () => {
+                          let requestOne
+                          let requestTwo
+
+                          before(async () => {
+                            await createSnapshot()
+
+                            // Request one is a proper one.
+                            requestOne = createTestRedemptionRequest(
+                              walletPubKeyHash,
+                              4500 // necessary to pass the fee share validation
+                            )
+
+                            // Simulate that request two takes an unacceptable
+                            // tx fee share. Because redemptionTxFee used
+                            // in the proposal is 9001, the actual fee share
+                            // per-request is 4500 and 4501 for the last request
+                            // which takes the remainder. In order to test this
+                            // case the second (last) request must allow for
+                            // 4500 as allowed fee share at maximum.
+                            requestTwo = createTestRedemptionRequest(
+                              walletPubKeyHash,
+                              4500
+                            )
+
+                            bridge.pendingRedemptions
+                              .whenCalledWith(
+                                redemptionKey(
+                                  requestOne.key.walletPubKeyHash,
+                                  requestOne.key.redeemerOutputScript
+                                )
+                              )
+                              .returns(requestOne.content)
+
+                            bridge.pendingRedemptions
+                              .whenCalledWith(
+                                redemptionKey(
+                                  requestTwo.key.walletPubKeyHash,
+                                  requestTwo.key.redeemerOutputScript
+                                )
+                              )
+                              .returns(requestTwo.content)
+                          })
+
+                          after(async () => {
+                            bridge.pendingRedemptions.reset()
+
+                            await restoreSnapshot()
+                          })
+
+                          it("should revert", async () => {
+                            const proposal = {
+                              walletPubKeyHash,
+                              redeemersOutputScripts: [
+                                requestOne.key.redeemerOutputScript,
+                                requestTwo.key.redeemerOutputScript,
+                              ],
+                              redemptionTxFee: 9001,
+                            }
+
+                            await expect(
+                              walletCoordinator.validateRedemptionProposal(
+                                proposal
+                              )
+                            ).to.be.revertedWith(
+                              "Proposed transaction per-request fee share is too high"
+                            )
+                          })
+                        })
+                      }
+                    )
+
+                    context(
+                      "when all requests incur an acceptable tx fee share",
+                      () => {
+                        let requestOne
+                        let requestTwo
+
+                        before(async () => {
+                          await createSnapshot()
+
+                          requestOne = createTestRedemptionRequest(
+                            walletPubKeyHash,
+                            5000 // necessary to pass the fee share validation
+                          )
+
+                          requestTwo = createTestRedemptionRequest(
+                            walletPubKeyHash,
+                            5000 // necessary to pass the fee share validation
+                          )
+
+                          bridge.pendingRedemptions
+                            .whenCalledWith(
+                              redemptionKey(
+                                requestOne.key.walletPubKeyHash,
+                                requestOne.key.redeemerOutputScript
+                              )
+                            )
+                            .returns(requestOne.content)
+
+                          bridge.pendingRedemptions
+                            .whenCalledWith(
+                              redemptionKey(
+                                requestTwo.key.walletPubKeyHash,
+                                requestTwo.key.redeemerOutputScript
+                              )
+                            )
+                            .returns(requestTwo.content)
+                        })
+
+                        after(async () => {
+                          bridge.pendingRedemptions.reset()
+
+                          await restoreSnapshot()
+                        })
+
+                        it("should succeed", async () => {
+                          const proposal = {
+                            walletPubKeyHash,
+                            redeemersOutputScripts: [
+                              requestOne.key.redeemerOutputScript,
+                              requestTwo.key.redeemerOutputScript,
+                            ],
+                            redemptionTxFee,
+                          }
+
+                          const result =
+                            await walletCoordinator.validateRedemptionProposal(
+                              proposal
+                            )
+
+                          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                          expect(result).to.be.true
+                        })
+                      }
+                    )
+                  }
+                )
+              })
+            })
+          })
+        })
+      })
+    })
+  })
 })
 
 const depositKey = (
@@ -2461,6 +3068,54 @@ const createTestDeposit = (
       walletPubKeyHash,
       refundPubKeyHash,
       refundLocktime,
+    },
+  }
+}
+
+const redemptionKey = (
+  walletPubKeyHash: BytesLike,
+  redeemerOutputScript: BytesLike
+) => {
+  const scriptHash = ethers.utils.solidityKeccak256(
+    ["bytes"],
+    [redeemerOutputScript]
+  )
+
+  return ethers.utils.solidityKeccak256(
+    ["bytes32", "bytes20"],
+    [scriptHash, walletPubKeyHash]
+  )
+}
+
+const createTestRedemptionRequest = (
+  walletPubKeyHash: string,
+  txMaxFee?: BigNumberish,
+  requestedAt?: number
+) => {
+  let resolvedRequestedAt = requestedAt
+
+  if (!resolvedRequestedAt) {
+    // If the request creation time is not explicitly set, use `now - 1 day` to
+    // ensure request minimum age is achieved by default.
+    const now = Math.floor(Date.now() / 1000)
+    resolvedRequestedAt = now - day
+  }
+
+  const redeemer = `0x${crypto.randomBytes(20).toString("hex")}`
+
+  const redeemerOutputScript = `0x${crypto.randomBytes(32).toString("hex")}`
+
+  return {
+    key: {
+      walletPubKeyHash,
+      redeemerOutputScript,
+    },
+    content: {
+      redeemer,
+      requestedAmount: 0, // not relevant
+      treasuryFee: 0, // not relevant
+      txMaxFee: txMaxFee ?? 0,
+      requestedAt: resolvedRequestedAt,
     },
   }
 }

--- a/solidity/test/bridge/WalletCoordinator.test.ts
+++ b/solidity/test/bridge/WalletCoordinator.test.ts
@@ -2040,6 +2040,64 @@ describe("WalletCoordinator", () => {
       })
     })
   })
+
+  describe("updateRedemptionProposalParameters", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when called by a third party", () => {
+      it("should revert", async () => {
+        await expect(
+          walletCoordinator
+            .connect(thirdParty)
+            .updateRedemptionProposalParameters(101, 102, 103, 104, 105)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await walletCoordinator
+          .connect(owner)
+          .updateRedemptionProposalParameters(101, 102, 103, 104, 105)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should update redemption proposal parameters", async () => {
+        expect(
+          await walletCoordinator.redemptionProposalValidity()
+        ).to.be.equal(101)
+        expect(await walletCoordinator.redemptionRequestMinAge()).to.be.equal(
+          102
+        )
+        expect(
+          await walletCoordinator.redemptionRequestTimeoutSafetyMargin()
+        ).to.be.equal(103)
+        expect(await walletCoordinator.redemptionMaxSize()).to.be.equal(104)
+        expect(
+          await walletCoordinator.redemptionProposalSubmissionGasOffset()
+        ).to.be.equal(105)
+      })
+
+      it("should emit the RedemptionProposalParametersUpdated event", async () => {
+        await expect(tx)
+          .to.emit(walletCoordinator, "RedemptionProposalParametersUpdated")
+          .withArgs(101, 102, 103, 104, 105)
+      })
+    })
+  })
 })
 
 const depositKey = (


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3609

Here we add the on-chain coordination for redemptions. This changeset enhances the `WalletCoordinator` contract with three methods:
- `submitRedemptionProposal` that can be used to submit redemption proposals for wallets
- `submitRedemptionProposalWithReimbursement` which is the reimbursable version of `submitRedemptionProposal`
- `validateRedemptionProposal` which can be used by off-chain wallet operators to validate proposals using static calls

Moreover, during the work on `validateRedemptionProposal` we noticed the need to harden the validation rules of `validateDepositSweepProposal` function. We added a rule which enforces that each deposit in the proposal is used exactly once.
