### PR TITLE
Revert "Don't run postinstall script separately from yarn install"

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -24,7 +24,8 @@ COPY package.json yarn.lock ./
 COPY tsconfig.json ./
 COPY src ./src
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --ignore-scripts
+RUN yarn run postinstall
 
 RUN yarn build
 


### PR DESCRIPTION
This reverts commit 2c7c63e15e3b7af800710770a458f93ff67eb1cc.

See the following comment for a full description https://github.com/keep-network/tbtc-v2/pull/629#issuecomment-1584316498