### PR TITLE
Rename `threshold` repo to `docs`, `token-dashboard` to` dapp` 

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -55,10 +55,10 @@ jobs:
 
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
-  # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
-  # a PR updating the docs will be created in the destination repository. The
-  # commit pushing the changes will be verified using GPG key.
+  # Markdown and sync it with a specific path of the `threshold-network/docs`
+  # repository. If changes will be detected, a PR updating the docs will be
+  # created in the destination repository. The commit pushing the changes will
+  # be verified using GPG key.
   contracts-docs-publish:
     name: Publish contracts documentation
     needs: docs-detect-changes
@@ -75,7 +75,7 @@ jobs:
       preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: true
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/tbtc-v2/tbtc-v2-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com

--- a/monitoring/docs/monitoring-and-telemetry.adoc
+++ b/monitoring/docs/monitoring-and-telemetry.adoc
@@ -23,7 +23,7 @@ flowchart TD
 
 There are several sources of monitoring and telemetry data:
 
-* https://github.com/threshold-network/token-dashboard[Threshold dashboard] + https://github.com/keep-network/v2-end-to-end[second track deposit verifier]
+* https://github.com/threshold-network/dapp[Threshold dashboard] + https://github.com/keep-network/v2-end-to-end[second track deposit verifier]
 * https://github.com/keep-network/optimistic-minting[TBTCv2 minters and guardians]
 * https://github.com/keep-network/tbtc-v2/tree/main/monitoring[TBTCv2 monitoring]
 


### PR DESCRIPTION
We're renaming some of the repositories in the `threshold-network` organization. One of them is `threshold` repo, which will be renamed to `docs`. The other is `token-dashboard` that will be renamed to `dapp`. We need to update the references of the old names.

⚠️ We should merge this PR roughly at the same time when we'll actually change the repo names in GitHub.