### PR TITLE
Make `buildRedemptionKey` function static

### DIFF
--- a/typescript/src/ethereum.ts
+++ b/typescript/src/ethereum.ts
@@ -289,7 +289,7 @@ export class Bridge
     walletPublicKey: string,
     redeemerOutputScript: string
   ): Promise<RedemptionRequest> {
-    const redemptionKey = this.buildRedemptionKey(
+    const redemptionKey = Bridge.buildRedemptionKey(
       computeHash160(walletPublicKey),
       redeemerOutputScript
     )
@@ -312,7 +312,7 @@ export class Bridge
     walletPublicKey: string,
     redeemerOutputScript: string
   ): Promise<RedemptionRequest> {
-    const redemptionKey = this.buildRedemptionKey(
+    const redemptionKey = Bridge.buildRedemptionKey(
       computeHash160(walletPublicKey),
       redeemerOutputScript
     )
@@ -337,7 +337,7 @@ export class Bridge
    *        un-prefixed and not prepended with length.
    * @returns The redemption key.
    */
-  private buildRedemptionKey(
+  static buildRedemptionKey(
     walletPublicKeyHash: string,
     redeemerOutputScript: string
   ): string {


### PR DESCRIPTION
To be able to use it outside of the `Bridge` contract handle.