### PR TITLE
Split contracts API doc into multiple files

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -50,6 +50,7 @@ jobs:
       # newline and does this in a loop.
       preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: false
+      addTOC: false
       commentPR: true
       exportAsGHArtifacts: true
 
@@ -74,12 +75,14 @@ jobs:
       # newline and does this in a loop.
       preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: true
+      addTOC: false
       verifyCommits: true
       destinationRepo: threshold-network/threshold
       destinationFolder: ./docs/app-development/tbtc-v2/tbtc-v2-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com
       userName: Valkyrie
+      rsyncDelete: true
     secrets:
       githubToken: ${{ secrets.THRESHOLD_DOCS_GITHUB_TOKEN }}
       gpgPrivateKey: ${{ secrets.THRESHOLD_DOCS_GPG_PRIVATE_KEY_BASE64 }}

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -261,7 +261,7 @@ const config: HardhatUserConfig = {
   docgen: {
     outputDir: "generated-docs",
     templates: "docgen-templates",
-    pages: "single", // `single`, `items` or `files`
+    pages: "files", // `single`, `items` or `files`
     exclude: ["./test"],
   },
 }


### PR DESCRIPTION
Having all the contracts documented in one common file turned out to be hard to render by the GitBook. We're switching to documenting each contract file in a separate Markdown file.
As the generated files will be much smaller now and GitBook has its own file `ON THIS PAGE` section, we don't need to generate Table of Contents. The one thing that we also change as part of this PR is `rsyncDelete` setting - we'll have it set to `true`, in order to delete documentation of contracts which get removed from the repo. As we're not working directly on a `main` branch, this isn't dangerous (we'll see all the deletions in the PR diff).

Refs:
https://github.com/threshold-network/solidity-contracts/pull/149
https://github.com/keep-network/keep-core/pull/3657
https://github.com/threshold-network/threshold/pull/36