### PR TITLE
Decrease frequency of `yarn install` failures in `monitoring`

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -60,7 +60,10 @@ jobs:
         run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Run monitoring post-install scripts
+        run: yarn run postinstall
 
       - name: Build
         run: yarn build
@@ -141,7 +144,10 @@ jobs:
         run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Run monitoring post-install scripts
+        run: yarn run postinstall
 
       - name: Check formatting
         run: yarn format

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -24,6 +24,8 @@ COPY package.json yarn.lock ./
 COPY tsconfig.json ./
 COPY src ./src
 
+# Run install and postinstall separatelly to avoid problems with `bcrypto` and
+# `install-dependencies.sh`.
 RUN yarn install --frozen-lockfile --ignore-scripts
 RUN yarn run postinstall
 

--- a/monitoring/yarn.lock
+++ b/monitoring/yarn.lock
@@ -558,27 +558,27 @@
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" "1.2.1"
 
-"@keep-network/ecdsa@2.1.0-dev.6":
-  version "2.1.0-dev.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.6.tgz#ccc690f784b6e802a5b80b2dfb7127d96e548a25"
-  integrity sha512-1D74OPVzzxxVcG8za/niuxmwEdDc5R6KNuHsUvsFkcHNJE1UgQNw+QdrI+k3M2so6YrO4L5lP7vTvIvBDbEMNQ==
+"@keep-network/ecdsa@2.1.0-dev.14":
+  version "2.1.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.14.tgz#1391174fddb6d13bab8309b482b6cdea0cd1ef84"
+  integrity sha512-kvUIws/XPr1MHTEXByR+lfqPfj8Mg0V9dEnsm/cMO7N7UaB55eBF+LDEVTDgDlmaYFJfr/iC3v6EkPyz9BLNtQ==
   dependencies:
-    "@keep-network/random-beacon" "2.1.0-dev.5"
+    "@keep-network/random-beacon" "2.1.0-dev.14"
     "@keep-network/sortition-pools" "^2.0.0-pre.16"
     "@openzeppelin/contracts" "^4.6.0"
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
-    "@threshold-network/solidity-contracts" "1.3.0-dev.3"
+    "@threshold-network/solidity-contracts" "1.3.0-dev.5"
 
-"@keep-network/ecdsa@2.1.0-goerli.4":
-  version "2.1.0-goerli.4"
-  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-goerli.4.tgz#9ff035b2a1dd000dfdab8617ab3da5c41e7ec6da"
-  integrity sha512-JsBrLeJyC8Lob6MYDsqG5hyYTXWYYARGmiP0kFRT+9B/tDr3HeWGOkCU0uAdMn4dlmu1IPyR5nBbl+9Atyoa1w==
+"@keep-network/ecdsa@development":
+  version "2.1.0-dev.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.15.tgz#ee631a42e165f30c75aae8c54aace765b77e272a"
+  integrity sha512-iUE3SwDSNc/k1oui7Z+fDGhhGyOzpe4/f/oKvDUMHqXx0BQG3QCrOz9KqWuPFXTXMav4LxLbt12WyDITAl/hjw==
   dependencies:
-    "@keep-network/random-beacon" "2.1.0-goerli.6"
-    "@keep-network/sortition-pools" "github:keep-network/sortition-pools#test-fork"
+    "@keep-network/random-beacon" "2.1.0-dev.15"
+    "@keep-network/sortition-pools" "^2.0.0-pre.16"
     "@openzeppelin/contracts" "^4.6.0"
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
-    "@threshold-network/solidity-contracts" "1.3.0-goerli.0"
+    "@threshold-network/solidity-contracts" "1.3.0-dev.6"
 
 "@keep-network/keep-core@1.3.0":
   version "1.3.0"
@@ -597,15 +597,7 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/keep-core@1.8.0-ropsten.16":
-  version "1.8.0-ropsten.16"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-ropsten.16.tgz#56a1c66124e30a31f2db45869462bffee2c571df"
-  integrity sha512-6AGSb95sTGB/qwbxgko1+IzK+gbh6u0+IbynikZ1MFm3zQ6XNAe8oZiojP/O5Kxu5+tbw68a77rKB5aLnmJMYQ==
-  dependencies:
-    "@openzeppelin/upgrades" "^2.7.2"
-    openzeppelin-solidity "2.4.0"
-
-"@keep-network/keep-core@1.8.1-goerli.0", "@keep-network/keep-core@^1.8.1-goerli.0":
+"@keep-network/keep-core@1.8.1-goerli.0":
   version "1.8.1-goerli.0"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-goerli.0.tgz#238485aab51902021d42357bf59695225002f0ab"
   integrity sha512-h3La/RqbyEZjBBPg8V+pcRFo3UpWZUF4CxWfXHZnUR4PnkZKnIDrTNFQPhpV2uYFZwrbJxTR9mzOq/DOAiXPwA==
@@ -628,16 +620,6 @@
   dependencies:
     "@keep-network/keep-core" "1.3.0"
     "@keep-network/sortition-pools" "1.1.2"
-    "@openzeppelin/upgrades" "^2.7.2"
-    openzeppelin-solidity "2.3.0"
-
-"@keep-network/keep-ecdsa@1.8.0-ropsten.1":
-  version "1.8.0-ropsten.1"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-ecdsa/-/keep-ecdsa-1.8.0-ropsten.1.tgz#e8b0232a3383ede5f1789f8bd14fd5ce682bfdf1"
-  integrity sha512-KXItqehvCV5waZ6TZ1lvBoWWwFBgNTSnoC2/w0sXmn0RE8gPHr6qCKiL20MJtDUw7ys3gW0rHvd+POd8T/f9Sw==
-  dependencies:
-    "@keep-network/keep-core" "1.8.0-ropsten.16"
-    "@keep-network/sortition-pools" "1.2.0-dev.1"
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
@@ -665,25 +647,35 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
     "@threshold-network/solidity-contracts" "1.2.1"
 
-"@keep-network/random-beacon@2.1.0-dev.5":
-  version "2.1.0-dev.5"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-dev.5.tgz#5ea1a76f57c8171fe3b12ecf4cfcefee38f954ac"
-  integrity sha512-v3Mqzwx69WqG5bi8qEO4b72PpDMbwl69f5PYHZ0vO3g2pzU1PpVq2nq/vzgdqW2xgztvnHFwOq+lOyN8hx0K3A==
+"@keep-network/random-beacon@2.1.0-dev.14":
+  version "2.1.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-dev.14.tgz#d9fac9fa8a5a06ea0985114c4ca79e4805c16d55"
+  integrity sha512-FdVSW2VtUIcwPCrnrWUudbXOFi+SKZ6cEz7P3+gO+49DFas4ApH6lkRILD/DUHQDMV7D56TxAdw/DHt0dbA+wg==
   dependencies:
     "@keep-network/sortition-pools" "^2.0.0-pre.16"
-    "@openzeppelin/contracts" "^4.6.0"
+    "@openzeppelin/contracts" "4.7.3"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" "1.3.0-dev.3"
+    "@threshold-network/solidity-contracts" "1.3.0-dev.5"
 
-"@keep-network/random-beacon@2.1.0-goerli.6":
-  version "2.1.0-goerli.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-goerli.6.tgz#dd6dcf4f5101b35a603a819f30fc884ecfeb0b85"
-  integrity sha512-A+rnK0NkP4Q+EHzbbW9iuSUEjUgCAJdhdh14WY9zMpIreXn4KoT44WmyqcjYbwWe+1DcbsX5SwDK7yjmoeqcFA==
+"@keep-network/random-beacon@2.1.0-dev.15":
+  version "2.1.0-dev.15"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-dev.15.tgz#541620c469e3bc75a5d1f7649889540b0e032e9e"
+  integrity sha512-vxBICRtmqSmJtFU5hZMpwB0alhgKchyMbxk4DtLZ7T2zBjd5tjt3CqeKEk+ON09g7yL1mIxY07InP4okviUK4A==
   dependencies:
-    "@keep-network/sortition-pools" "github:keep-network/sortition-pools#test-fork"
-    "@openzeppelin/contracts" "^4.6.0"
+    "@keep-network/sortition-pools" "^2.0.0-pre.16"
+    "@openzeppelin/contracts" "4.7.3"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-    "@threshold-network/solidity-contracts" "1.3.0-goerli.0"
+    "@threshold-network/solidity-contracts" "1.3.0-dev.5"
+
+"@keep-network/random-beacon@development":
+  version "2.1.0-dev.16"
+  resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-dev.16.tgz#9f2b5c19aa79f6ff1a5498ba7b55eb170463161d"
+  integrity sha512-o+cG/VDkhUc91W+4bMplYCgOu0twSFICqarpv5k2ES8GcaafaeV8stXGhCxjvHYJjU/sfG8mhlQZhWdZixq+JQ==
+  dependencies:
+    "@keep-network/sortition-pools" "^2.0.0-pre.16"
+    "@openzeppelin/contracts" "4.7.3"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+    "@threshold-network/solidity-contracts" "1.3.0-dev.6"
 
 "@keep-network/sortition-pools@1.1.2":
   version "1.1.2"
@@ -707,46 +699,39 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/sortition-pools@github:keep-network/sortition-pools#test-fork":
-  version "2.1.0-pre"
-  resolved "https://codeload.github.com/keep-network/sortition-pools/tar.gz/a41007f4c818864cdca0b6a6446424c071157ced"
-  dependencies:
-    "@openzeppelin/contracts" "^4.3.2"
-    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
-
 "@keep-network/tbtc-v2-mainnet@npm:@keep-network/tbtc-v2@mainnet":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.2.tgz#ae17196470517c9708e2c7bf3368e44be218cd21"
-  integrity sha512-Ly8msd4upIwjXcme4QsStRe0NqUZdSKZt4tANgdLY9YECHk0Uo2AfqLmknJQEictneuV/aId7JWvJph21WgjIA==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.4.0.tgz#5a5ac5ebb20be5b533d74a0682eb2ffa236caa48"
+  integrity sha512-K1F48vzPppQLQW9O5fuHDEyNrOs/Xaiz+lZg4iFLa/qPY3S6qrXFKRnxp1MWJ2aaN9wRgbJFvfxlkIytZmkZcw==
   dependencies:
     "@keep-network/bitcoin-spv-sol" "3.4.0-solc-0.8"
     "@keep-network/ecdsa" "2.0.0"
     "@keep-network/random-beacon" "2.0.0"
     "@keep-network/tbtc" "1.1.0"
-    "@openzeppelin/contracts" "^4.6.0"
-    "@openzeppelin/contracts-upgradeable" "^4.6.0"
+    "@openzeppelin/contracts" "^4.8.1"
+    "@openzeppelin/contracts-upgradeable" "^4.8.1"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2-testnet@npm:@keep-network/tbtc-v2@goerli":
-  version "1.0.3-goerli.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.3-goerli.0.tgz#e21bea562de0a263c0e61aff38dcee0faeeae352"
-  integrity sha512-GnSmZoxXRrWgXT5XyCgIMYN8V7FIObP/txERvfYXTvh5bZs7nH4sci9ELxMx4WxiSDp0qsdsDMwbXCe2ACKtug==
+  version "1.5.0-goerli.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.5.0-goerli.0.tgz#bc578a0c2e505235953bdb17a79eeab46cb0d577"
+  integrity sha512-o1k+/7oiI7xR2fXyv4zYKhIN4fqsEsYBTXkuxNT6C+Br2ohARCucGfTD2HM9bhiNip96TH8VHO2r4u1W+hIH7Q==
   dependencies:
     "@keep-network/bitcoin-spv-sol" "3.4.0-solc-0.8"
-    "@keep-network/ecdsa" "2.1.0-goerli.4"
-    "@keep-network/random-beacon" "2.1.0-goerli.6"
-    "@keep-network/tbtc" "^1.1.2-goerli.0"
-    "@openzeppelin/contracts" "^4.6.0"
-    "@openzeppelin/contracts-upgradeable" "^4.6.0"
+    "@keep-network/ecdsa" development
+    "@keep-network/random-beacon" development
+    "@keep-network/tbtc" development
+    "@openzeppelin/contracts" "^4.8.1"
+    "@openzeppelin/contracts-upgradeable" "^4.8.1"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.1.0-dev.13"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.13.tgz#713c00c2ed01313d8bd24019e2097ce62e086c24"
-  integrity sha512-iT3q3POIRvNjiu82xmIRcR+dgZbNPPMZWAnXltg89yzruC/O7FFsGjUVUbW+h5nOhb+SUncUX+ag25XOQo+TyA==
+  version "1.3.0-dev.4"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.3.0-dev.4.tgz#7e0c62948b57f9506bf21d5268cd3c0675f4c712"
+  integrity sha512-M/lhApMkRoTZzYP+k02194KEkkN3T+eKQDClbL/+rO+86qBZOmO0y0CgsZyzv1HlUBjUa5X3dnd1zp6qf2qIqg==
   dependencies:
-    "@keep-network/ecdsa" "2.1.0-dev.6"
-    "@keep-network/tbtc-v2" "1.0.3-dev.3"
+    "@keep-network/ecdsa" "2.1.0-dev.14"
+    "@keep-network/tbtc-v2" "1.5.0-dev.5"
     bcoin "git+https://github.com/keep-network/bcoin.git#5accd32c63e6025a0d35d67739c4a6e84095a1f8"
     bcrypto "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0"
     bufio "^1.0.6"
@@ -755,14 +740,14 @@
     p-timeout "^4.1.0"
     wif "2.0.6"
 
-"@keep-network/tbtc-v2@1.0.3-dev.3":
-  version "1.0.3-dev.3"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.3-dev.3.tgz#12e35c34eb8c267fab4824a971691f90eea6ca84"
-  integrity sha512-iy2zsgUSZhq7Y+TNAJ8mxeytP+XdJhu8uBLIzMdkhkLZVQgcAXNZ5C80AnR+42lUeKbTa0f6byA0AN9pGAA35A==
+"@keep-network/tbtc-v2@1.5.0-dev.5":
+  version "1.5.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.5.0-dev.5.tgz#a8391801ca9ea44a5e961002e721158bcdad855c"
+  integrity sha512-l+3vbWE8HdOxH1TwfU/qr1q7F/TmJByDq6INrQx1lca1zvjjOo+4d/qgv8CjcH9UZFg8D2BE56zaqhUl8hARLw==
   dependencies:
     "@keep-network/bitcoin-spv-sol" "3.4.0-solc-0.8"
-    "@keep-network/ecdsa" "2.1.0-dev.6"
-    "@keep-network/random-beacon" "2.1.0-dev.5"
+    "@keep-network/ecdsa" "2.1.0-dev.14"
+    "@keep-network/random-beacon" "2.1.0-dev.15"
     "@keep-network/tbtc" "1.1.2-dev.1"
     "@openzeppelin/contracts" "^4.8.1"
     "@openzeppelin/contracts-upgradeable" "^4.8.1"
@@ -778,24 +763,13 @@
     "@summa-tx/relay-sol" "^2.0.2"
     openzeppelin-solidity "2.3.0"
 
-"@keep-network/tbtc@1.1.2-dev.1":
+"@keep-network/tbtc@1.1.2-dev.1", "@keep-network/tbtc@development":
   version "1.1.2-dev.1"
   resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-dev.1.tgz#dd1e734c0fed50474c74d7170c8749127231d1f9"
   integrity sha512-IRa0j1D7JBG8UpduaFxkaq2Ii6F61HhNMUBmxr7kAIZwj/yx8sYXWi921mn0L2Z+hAYNcwEUVhCM91VKQH29pQ==
   dependencies:
     "@celo/contractkit" "^1.0.2"
     "@keep-network/keep-ecdsa" ">1.9.0-dev <1.9.0-ropsten"
-    "@summa-tx/bitcoin-spv-sol" "^3.1.0"
-    "@summa-tx/relay-sol" "^2.0.2"
-    openzeppelin-solidity "2.3.0"
-
-"@keep-network/tbtc@^1.1.2-goerli.0":
-  version "1.1.2-ropsten.12"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-ropsten.12.tgz#5a5d9d9424f9d70e05a07e6b62b29e0c8d19742c"
-  integrity sha512-9ICNoPNoE2Trj0B5BGNls36CoDBfHLutxf82kUZuII6X7QHBYFfJ/p/iRLGsIN22RUdnSjoxDXGbxHUvnj+bFw==
-  dependencies:
-    "@celo/contractkit" "^1.0.2"
-    "@keep-network/keep-ecdsa" "1.8.0-ropsten.1"
     "@summa-tx/bitcoin-spv-sol" "^3.1.0"
     "@summa-tx/relay-sol" "^2.0.2"
     openzeppelin-solidity "2.3.0"
@@ -883,6 +857,11 @@
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
+
+"@openzeppelin/contracts@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
 "@openzeppelin/contracts@^2.4.0":
   version "2.5.1"
@@ -1112,22 +1091,22 @@
     "@openzeppelin/contracts-upgradeable" "~4.5.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@threshold-network/solidity-contracts@1.3.0-dev.3":
-  version "1.3.0-dev.3"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-dev.3.tgz#aa896b80a083ca8a7cb5219e3c9d1c47e3d86b03"
-  integrity sha512-BNm5+JKrFvg9hZ02Sp/A+vKs1PQB37rYdcZqLrLhvwDFzHFvL+XA2IXqvN1CznQTeehwnX3DtCcONTVP42i56A==
+"@threshold-network/solidity-contracts@1.3.0-dev.5":
+  version "1.3.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-dev.5.tgz#f7a2727d627a10218f0667bc0d33e19ed8f87fdc"
+  integrity sha512-AInTKQkJ0PKa32q2m8GnZFPYEArsnvOwhIFdBFaHdq9r4EGyqHMf4YY1WjffkheBZ7AQ0DNA8Lst30kBoQd0SA==
   dependencies:
     "@keep-network/keep-core" ">1.8.1-dev <1.8.1-goerli"
     "@openzeppelin/contracts" "~4.5.0"
     "@openzeppelin/contracts-upgradeable" "~4.5.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@threshold-network/solidity-contracts@1.3.0-goerli.0":
-  version "1.3.0-goerli.0"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-goerli.0.tgz#392813309a19b20fda1ef98f94935cd3cdb15d78"
-  integrity sha512-qM5FQIPMxUoztYYTQs5ylESvPuD3j9NHFFRLP1ECPMcBlVRZPP273WqmgGLwU9YdEq+8Fp0T3q7W8IUlvdkE3w==
+"@threshold-network/solidity-contracts@1.3.0-dev.6":
+  version "1.3.0-dev.6"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-dev.6.tgz#41e34a84f409f63635e59f9a6ce170df1472b8a1"
+  integrity sha512-U7nMp+86M5qkjW7YUvT3qWgRiEEUIxqE96vkEiARTOkWX5JdLP2CXehkHCkEzjdgOCczmCp3fFtcgKFnQhhZ8A==
   dependencies:
-    "@keep-network/keep-core" "^1.8.1-goerli.0"
+    "@keep-network/keep-core" ">1.8.1-dev <1.8.1-goerli"
     "@openzeppelin/contracts" "~4.5.0"
     "@openzeppelin/contracts-upgradeable" "~4.5.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"


### PR DESCRIPTION
In this PR we:
* Update dependencies to `tbtc-v2` and `tbtc-v2.ts` packages to decrease frequency of manually run `yarn install`'s failures
* Update CI to run `postinstall` scripts separately from `yarn install` (to eliminate `yarn install` failures in CI)
* Explain the need for running `postinstall` separately in the Dockerfile (as requested in https://github.com/keep-network/tbtc-v2/pull/629#issuecomment-1598546489)