### PR TITLE
Start solidity/v1.6.0-dev version

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.5.0-dev",
+  "version": "1.6.0-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
`solidity/v1.5.0` was already published, so we need to start a new version development.