### PR TITLE
Improve errors in `findWalletForRedemption` function

### DIFF
--- a/typescript/src/redemption.ts
+++ b/typescript/src/redemption.ts
@@ -412,11 +412,12 @@ export async function getRedemptionRequest(
 }
 
 /**
- * Finds the oldest active wallet that has enough BTC to handle a redemption request.
+ * Finds the oldest live wallet that has enough BTC to handle a redemption
+ * request.
  * @param amount The amount to be redeemed in satoshis.
- * @param redeemerOutputScript The redeemer output script the redeemed funds
- *        are supposed to be locked on. Must be un-prefixed and not prepended
- *        with length.
+ * @param redeemerOutputScript The redeemer output script the redeemed funds are
+ *        supposed to be locked on. Must be un-prefixed and not prepended with
+ *        length.
  * @param bitcoinNetwork Bitcoin network.
  * @param bridge The handle to the Bridge on-chain contract.
  * @param bitcoinClient Bitcoin client used to interact with the network.
@@ -441,7 +442,7 @@ export async function findWalletForRedemption(
       }
     | undefined = undefined
   let maxAmount = BigNumber.from(0)
-  let activeWalletsCounter = 0
+  let liveWalletsCounter = 0
 
   for (const wallet of wallets) {
     const { walletPublicKeyHash } = wallet
@@ -457,7 +458,7 @@ export async function findWalletForRedemption(
       )
       continue
     }
-    activeWalletsCounter++
+    liveWalletsCounter++
 
     // Wallet must have a main UTXO that can be determined.
     const mainUtxo = await determineWalletMainUtxo(
@@ -513,15 +514,15 @@ export async function findWalletForRedemption(
     )
   }
 
-  if (activeWalletsCounter === 0) {
-    throw new Error("Currently, there are no active wallets in the network.")
+  if (liveWalletsCounter === 0) {
+    throw new Error("Currently, there are no live wallets in the network.")
   }
 
-  // Cover a corner case when the user requested redemption for all active
-  // wallets in the network using the same Bitcoin address.
-  if (!walletData && activeWalletsCounter > 0 && maxAmount.eq(0)) {
+  // Cover a corner case when the user requested redemption for all live wallets
+  // in the network using the same Bitcoin address.
+  if (!walletData && liveWalletsCounter > 0 && maxAmount.eq(0)) {
     throw new Error(
-      "All active wallets in the network have the pending redemption for a given Bitcoin address. Please use another Bitcoin address."
+      "All live wallets in the network have the pending redemption for a given Bitcoin address. Please use another Bitcoin address."
     )
   }
 

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -1468,7 +1468,7 @@ describe("Redemption", () => {
               bitcoinClient
             )
           ).to.be.rejectedWith(
-            "Currently, there are no active wallets in the network."
+            "Currently, there are no live wallets in the network."
           )
         })
       }
@@ -1726,7 +1726,7 @@ describe("Redemption", () => {
                 bitcoinClient
               )
             ).to.be.rejectedWith(
-              "All active wallets in the network have the pending redemption for a given Bitcoin address. Please use another Bitcoin address."
+              "All live wallets in the network have the pending redemption for a given Bitcoin address. Please use another Bitcoin address."
             )
           })
         }

--- a/typescript/test/redemption.test.ts
+++ b/typescript/test/redemption.test.ts
@@ -1468,7 +1468,7 @@ describe("Redemption", () => {
               bitcoinClient
             )
           ).to.be.rejectedWith(
-            "Could not find a wallet with enough funds. Maximum redemption amount is 0 Satoshi."
+            "Currently, there are no active wallets in the network."
           )
         })
       }
@@ -1673,6 +1673,61 @@ describe("Redemption", () => {
               walletPublicKey: expectedWalletData.walletPublicKey.toString(),
               mainUtxo: expectedWalletData.mainUtxo,
             })
+          })
+        }
+      )
+
+      context(
+        "when all active wallets has pending redemption for a given Bitcoin address",
+        () => {
+          const amount: BigNumber = BigNumber.from("1000000") // 0.01 BTC
+          const redeemerOutputScript =
+            findWalletForRedemptionData.pendingRedemption.redeemerOutputScript
+
+          beforeEach(async () => {
+            const walletPublicKeyHash =
+              findWalletForRedemptionData.walletWithPendingRedemption.event
+                .walletPublicKeyHash
+
+            const pendingRedemptions = new Map<
+              BigNumberish,
+              RedemptionRequest
+            >()
+
+            const pendingRedemption1 = MockBridge.buildRedemptionKey(
+              walletPublicKeyHash.toString(),
+              redeemerOutputScript
+            )
+
+            const pendingRedemption2 = MockBridge.buildRedemptionKey(
+              findWalletForRedemptionData.liveWallet.event.walletPublicKeyHash.toString(),
+              redeemerOutputScript
+            )
+
+            pendingRedemptions.set(
+              pendingRedemption1,
+              findWalletForRedemptionData.pendingRedemption
+            )
+
+            pendingRedemptions.set(
+              pendingRedemption2,
+              findWalletForRedemptionData.pendingRedemption
+            )
+            bridge.setPendingRedemptions(pendingRedemptions)
+          })
+
+          it("should throw an error", async () => {
+            await expect(
+              findWalletForRedemption(
+                amount,
+                redeemerOutputScript,
+                BitcoinNetwork.Testnet,
+                bridge,
+                bitcoinClient
+              )
+            ).to.be.rejectedWith(
+              "All active wallets in the network have the pending redemption for a given Bitcoin address. Please use another Bitcoin address."
+            )
           })
         }
       )


### PR DESCRIPTION
Throw error when currently, there are no live wallets in the network and when the user requested redemption for all live wallets in the network using the same Bitcoin address - in that case, a user should use another Bitcoin address.