### PR TITLE
Add `pull_request` CI trigger

### DIFF
--- a/.github/workflows/cross-chain-arbitrum.yml
+++ b/.github/workflows/cross-chain-arbitrum.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "cross-chain/arbitrum/**"
       - ".github/workflows/cross-chain-arbitrum.yml"
+  pull_request:
 
 jobs:
   contracts-detect-changes:

--- a/.github/workflows/cross-chain-optimism.yml
+++ b/.github/workflows/cross-chain-optimism.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "cross-chain/optimism/**"
       - ".github/workflows/cross-chain-optimism.yml"
+  pull_request:
 
 jobs:
   contracts-detect-changes:

--- a/.github/workflows/cross-chain-polygon.yml
+++ b/.github/workflows/cross-chain-polygon.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "cross-chain/polygon/**"
       - ".github/workflows/cross-chain-polygon.yml"
+  pull_request:
 
 jobs:
   contracts-detect-changes:


### PR DESCRIPTION
We want the workflows building the cross chain projects to execute when changes are commited to the feature branches of PRs modifying files of those projects. We had all the config required to do that, except the most important part - the `pull_request` trigger, which we somehow missed.