### PR TITLE
Update Wormhole docs link for Base

### DIFF
--- a/cross-chain/base/deploy_l2/12_update_self_in_wormhole_gateway_mapping.ts
+++ b/cross-chain/base/deploy_l2/12_update_self_in_wormhole_gateway_mapping.ts
@@ -6,7 +6,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { execute } = deployments
   const { deployer } = await getNamedAccounts()
 
-  // See https://docs.wormhole.com/wormhole/reference/environments/evm#base
+  // See https://docs.wormhole.com/wormhole/blockchain-environments/evm#base
   // This ID is valid for both Base Goerli and Base Mainnet
   const wormholeChainID = 30
 


### PR DESCRIPTION
The link has changed for the docs, now it is https://docs.wormhole.com/wormhole/blockchain-environments/evm#base