### PR TITLE
Delaying reveal process in the "make and reveal a deposit" test.

### DIFF
--- a/system-tests/test/minting-unminting.test.ts
+++ b/system-tests/test/minting-unminting.test.ts
@@ -153,6 +153,12 @@ describe("System Test - Minting and unminting", () => {
         - Output index: ${depositUtxo.outputIndex}
       `)
 
+        // It happens from time to time that a deposit reveal process starts when
+        // a deposit is not captured by the Bitcoin chain yet and a deposit is
+        // revealed with a non-existing Bitcoin tx. We should wait some time so
+        // the Bitcoin chain is in sync and then start the revealing process.
+        await new Promise((r) => setTimeout(r, 3000))
+
         // Since the reveal deposit logic does not perform SPV proof, we
         // can reveal the deposit transaction immediately without waiting
         // for confirmations.


### PR DESCRIPTION
It happens that a reveal process starts when a deposit is not captured by the Bitcoin chain because it's out of sync. A delay is added to wait a bit for a chain to sync. This should fix:

```
1) System Test - Minting and unminting
       when minting is initiated by making and revealing a deposit to the TBTCVault
         "before all" hook: make and reveal deposit for "should broadcast the deposit transaction on the Bitcoin network":
     Error: Electrum action failure: [daemon error: DaemonError({'code': -5, 'message': 'No such mempool or blockchain transaction. Use gettransaction for wallet transactions.'})]
      at Client.withElectrum (node_modules/@keep-network/tbtc-v2.ts/src/electrum.ts:190:13)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async Object.revealDeposit (node_modules/@keep-network/tbtc-v2.ts/src/deposit.ts:393:5)
      at async Context.<anonymous> (test/minting-unminting.test.ts:159:9)
```

which was observed here: https://github.com/keep-network/tbtc-v2/actions/runs/6061282789/job/16446311652