### PR TITLE
Get rid of `bcrypto` dependency

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -28,7 +28,6 @@
     "@keep-network/ecdsa": "development",
     "@keep-network/tbtc-v2": "development",
     "bcoin": "git+https://github.com/keep-network/bcoin.git#5accd32c63e6025a0d35d67739c4a6e84095a1f8",
-    "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0",
     "bufio": "^1.0.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
     "ethers": "^5.5.2",

--- a/typescript/src/bitcoin.ts
+++ b/typescript/src/bitcoin.ts
@@ -1,9 +1,7 @@
 import bcoin, { TX, Script } from "bcoin"
 import wif from "wif"
 import bufio from "bufio"
-import hash160 from "bcrypto/lib/hash160"
-import sha256 from "bcrypto/lib/sha256-browser.js"
-import { BigNumber } from "ethers"
+import { BigNumber, utils } from "ethers"
 import { Hex } from "./hex"
 import { BitcoinNetwork, toBcoinNetwork } from "./bitcoin-network"
 
@@ -525,7 +523,12 @@ export function createKeyRing(
  * @returns Hash as a 20-byte un-prefixed hex string.
  */
 export function computeHash160(text: string): string {
-  return hash160.digest(Buffer.from(text, "hex")).toString("hex")
+  const sha256Hash = utils.sha256(
+    Hex.from(Buffer.from(text, "hex")).toPrefixedString()
+  )
+  const hash160 = utils.ripemd160(sha256Hash)
+
+  return Hex.from(hash160).toString()
 }
 
 /**
@@ -534,8 +537,9 @@ export function computeHash160(text: string): string {
  * @returns Hash as a 32-byte un-prefixed hex string.
  */
 export function computeHash256(text: Hex): Hex {
-  const firstHash: Buffer = sha256.digest(text.toBuffer())
-  const secondHash: Buffer = sha256.digest(firstHash)
+  const firstHash = utils.sha256(text.toPrefixedString())
+  const secondHash = utils.sha256(firstHash)
+
   return Hex.from(secondHash)
 }
 

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -13,8 +13,7 @@ import {
 } from "./bitcoin"
 import { BitcoinNetwork } from "./bitcoin-network"
 import Electrum from "electrum-client-js"
-import sha256 from "bcrypto/lib/sha256-browser.js"
-import { BigNumber } from "ethers"
+import { BigNumber, utils } from "ethers"
 import { URL } from "url"
 import { Hex } from "./hex"
 import { backoffRetrier, RetrierFn } from "./backoff"
@@ -557,5 +556,8 @@ export class Client implements BitcoinClient {
  * @returns Electrum script hash as a hex string.
  */
 function computeScriptHash(script: string): string {
-  return sha256.digest(Buffer.from(script, "hex")).reverse().toString("hex")
+  const _script = Hex.from(Buffer.from(script, "hex")).toPrefixedString()
+  const hash256 = utils.sha256(_script)
+
+  return Hex.from(hash256).reverse().toString()
 }

--- a/typescript/src/electrum.ts
+++ b/typescript/src/electrum.ts
@@ -555,7 +555,7 @@ export class Client implements BitcoinClient {
  * @param script - Bitcoin script as hex string
  * @returns Electrum script hash as a hex string.
  */
-function computeScriptHash(script: string): string {
+export function computeScriptHash(script: string): string {
   const _script = Hex.from(Buffer.from(script, "hex")).toPrefixedString()
   const hash256 = utils.sha256(_script)
 

--- a/typescript/test/bitcoin.test.ts
+++ b/typescript/test/bitcoin.test.ts
@@ -14,6 +14,8 @@ import {
   createOutputScriptFromAddress,
   createAddressFromOutputScript,
   readCompactSizeUint,
+  computeHash160,
+  computeHash256,
 } from "../src/bitcoin"
 import { calculateDepositRefundLocktime } from "../src/deposit"
 import { BitcoinNetwork } from "../src/bitcoin-network"
@@ -63,6 +65,31 @@ describe("Bitcoin", () => {
           "The public key parameter must be 64-byte. Neither 0x nor 04 prefix is allowed"
         )
       })
+    })
+  })
+
+  describe("computeHash160", () => {
+    it("should compute hash160 correctly", () => {
+      const compressedPublicKey =
+        "03474444cca71c678f5019d16782b6522735717a94602085b4adf707b465c36ca8"
+      const expectedHash160 = "3e1dfbd72483fb3964ca828ee71cf3270cafdc65"
+
+      expect(computeHash160(compressedPublicKey)).to.be.equal(expectedHash160)
+    })
+  })
+
+  describe("computeHash256", () => {
+    it("should compute hash256 correctly", () => {
+      const hexValue = Hex.from(
+        "03474444cca71c678f5019d16782b6522735717a94602085b4adf707b465c36ca8"
+      )
+      const expectedHash256 = Hex.from(
+        "9f0b7447ca6ea11b8badd8a60a4dec1b846451551ef455975b1720f52bc90546"
+      )
+
+      expect(computeHash256(hexValue).toString()).to.be.equal(
+        expectedHash256.toString()
+      )
     })
   })
 

--- a/typescript/test/electrum.test.ts
+++ b/typescript/test/electrum.test.ts
@@ -1,6 +1,7 @@
 import {
   Credentials as ElectrumCredentials,
   Client as ElectrumClient,
+  computeScriptHash,
 } from "../src/electrum"
 import { BitcoinNetwork } from "../src/bitcoin-network"
 import {
@@ -215,6 +216,16 @@ describe("Electrum", () => {
             testnetTransactionMerkleBranch.blockHeight
           )
           expect(result).to.be.eql(testnetTransactionMerkleBranch)
+        })
+      })
+
+      describe("computeScriptHash", () => {
+        it("should convert Bitcoin script to an Electrum script hash correctly", () => {
+          const script = "00144b47c798d12edd17dfb4ea98e5447926f664731c"
+          const expectedScriptHash =
+            "cabdea0bfc10fb3521721dde503487dd1f0e41dd6609da228066757563f292ab"
+
+          expect(computeScriptHash(script)).to.be.equal(expectedScriptHash)
         })
       })
     })

--- a/typescript/typings.d.ts
+++ b/typescript/typings.d.ts
@@ -3,8 +3,6 @@
  * don't provide their own typings.
  */
 declare module "bcoin"
-declare module "bcrypto/lib/hash160"
-declare module "bcrypto/lib/sha256-browser.js"
 declare module "bufio"
 declare module "electrum-client-js"
 declare module "wif"

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -1522,7 +1522,7 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/keep-ecdsa@1.9.0-dev.1", "@keep-network/keep-ecdsa@>1.9.0-dev <1.9.0-ropsten":
+"@keep-network/keep-ecdsa@>1.9.0-dev <1.9.0-ropsten":
   version "1.9.0-dev.1"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-ecdsa/-/keep-ecdsa-1.9.0-dev.1.tgz#7522b47dd639ddd7479a0e71dc328a9e0bba7cae"
   integrity sha512-FRIDejTUiQO7c9gBXgjtTp2sXkEQKFBBqVjYoZE20OCGRxbgum9FbgD/B5RWIctBy4GGr5wJHnA1789iaK3X6A==


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/695

We use `bcrypto` to compute hashes, but since this library is a bit problematic, here we replace it with hashing algorithms from the `ethers` library. `ethers` has no `hash160` algorithm but under the hood `HASH160 = RIPEMD160(SHA256(X))` so it's possible to compute `hash160` using `ethers`.