### PR TITLE
Fix the `npm-compile-publish` job

### DIFF
--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
           cache-dependency-path: typescript/yarn.lock


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/697

The typescript library has been migrated from Node 14 to Node LTS (18) recently. We need to reflect that change in all CI jobs.