### PR TITLE
TypeScript: Start version 2.1.0-dev

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2.ts",
-  "version": "2.0.0-dev",
+  "version": "2.1.0-dev",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
We released version 2.0.0, so need to start a next one for development.