### PR TITLE
Upgrade of cross-chain Wormhole gateway contract artifacts

### DIFF
--- a/cross-chain/arbitrum/.openzeppelin/unknown-42161.json
+++ b/cross-chain/arbitrum/.openzeppelin/unknown-42161.json
@@ -617,6 +617,170 @@
           }
         }
       }
+    },
+    "4eab818d90a79d503842492e9ce92e35a3b96c1835245a0d54c5b023197ec36a": {
+      "address": "0xaaC423eDC4E3ee9ef81517e8093d52737165b71F",
+      "txHash": "0x86dee88c640d1cd36f7e5b6c9535062bc323be6b3f94f72989d713bf373cf9e7",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_contract(IWormholeTokenBridge)518",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:122"
+          },
+          {
+            "label": "bridgeToken",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(IERC20Upgradeable)2208",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:123"
+          },
+          {
+            "label": "tbtc",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_contract(L2TBTC)443",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:124"
+          },
+          {
+            "label": "gateways",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_uint16,t_bytes32)",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:136"
+          },
+          {
+            "label": "mintingLimit",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:147"
+          },
+          {
+            "label": "mintedAmount",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:151"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)2208": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)518": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(L2TBTC)443": {
+            "label": "contract L2TBTC",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_uint16,t_bytes32)": {
+            "label": "mapping(uint16 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/cross-chain/arbitrum/deployments/arbitrumOne/ArbitrumWormholeGateway.json
+++ b/cross-chain/arbitrum/deployments/arbitrumOne/ArbitrumWormholeGateway.json
@@ -175,19 +175,6 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "depositWormholeTbtc",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "bytes32",
           "name": "_address",
           "type": "bytes32"
@@ -451,7 +438,7 @@
     "status": 1,
     "byzantium": true
   },
-  "numDeployments": 2,
-  "implementation": "0xa10aD2570ea7b93d19fDae6Bd7189fF4929Bc747",
+  "numDeployments": 3,
+  "implementation": "0xaaC423eDC4E3ee9ef81517e8093d52737165b71F",
   "devdoc": "Contract deployed as upgradable proxy"
 }

--- a/cross-chain/base/.openzeppelin/unknown-8453.json
+++ b/cross-chain/base/.openzeppelin/unknown-8453.json
@@ -453,6 +453,170 @@
           }
         }
       }
+    },
+    "4eab818d90a79d503842492e9ce92e35a3b96c1835245a0d54c5b023197ec36a": {
+      "address": "0x00A5504eFB14373FAF38cB6AB4fc03fDb7762ebE",
+      "txHash": "0x8be13304406c358de242e2c81348338aede32e2ec5ba70c8c05d9da680df07e1",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_contract(IWormholeTokenBridge)518",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:122"
+          },
+          {
+            "label": "bridgeToken",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(IERC20Upgradeable)2208",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:123"
+          },
+          {
+            "label": "tbtc",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_contract(L2TBTC)443",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:124"
+          },
+          {
+            "label": "gateways",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_uint16,t_bytes32)",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:136"
+          },
+          {
+            "label": "mintingLimit",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:147"
+          },
+          {
+            "label": "mintedAmount",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:151"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)2208": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)518": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(L2TBTC)443": {
+            "label": "contract L2TBTC",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_uint16,t_bytes32)": {
+            "label": "mapping(uint16 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/cross-chain/base/deployments/base/BaseWormholeGateway.json
+++ b/cross-chain/base/deployments/base/BaseWormholeGateway.json
@@ -175,19 +175,6 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "depositWormholeTbtc",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "bytes32",
           "name": "_address",
           "type": "bytes32"
@@ -489,7 +476,7 @@
     "status": 1,
     "byzantium": true
   },
-  "numDeployments": 1,
-  "implementation": "0x292C9fdf2e2475599cBe350cc473c221Bd67AE28",
+  "numDeployments": 2,
+  "implementation": "0x00A5504eFB14373FAF38cB6AB4fc03fDb7762ebE",
   "devdoc": "Contract deployed as upgradable proxy"
 }

--- a/cross-chain/optimism/.openzeppelin/optimism.json
+++ b/cross-chain/optimism/.openzeppelin/optimism.json
@@ -617,6 +617,170 @@
           }
         }
       }
+    },
+    "4eab818d90a79d503842492e9ce92e35a3b96c1835245a0d54c5b023197ec36a": {
+      "address": "0xC08dcC93130Ab30987dD7fe64e011402BbE5FdA6",
+      "txHash": "0x0668c5ce526563d6ef603b1ea0df1717271a9cac97895817e8893e2fb164be96",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_contract(IWormholeTokenBridge)518",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:122"
+          },
+          {
+            "label": "bridgeToken",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(IERC20Upgradeable)2208",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:123"
+          },
+          {
+            "label": "tbtc",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_contract(L2TBTC)443",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:124"
+          },
+          {
+            "label": "gateways",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_uint16,t_bytes32)",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:136"
+          },
+          {
+            "label": "mintingLimit",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:147"
+          },
+          {
+            "label": "mintedAmount",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:151"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)2208": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)518": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(L2TBTC)443": {
+            "label": "contract L2TBTC",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_uint16,t_bytes32)": {
+            "label": "mapping(uint16 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/cross-chain/optimism/deployments/optimism/OptimismWormholeGateway.json
+++ b/cross-chain/optimism/deployments/optimism/OptimismWormholeGateway.json
@@ -175,19 +175,6 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "depositWormholeTbtc",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "bytes32",
           "name": "_address",
           "type": "bytes32"
@@ -451,7 +438,7 @@
     "status": 1,
     "byzantium": true
   },
-  "numDeployments": 2,
-  "implementation": "0xF94D0d0471Ae14B6310d94fA4F95e5fc9f3ffC17",
+  "numDeployments": 3,
+  "implementation": "0xC08dcC93130Ab30987dD7fe64e011402BbE5FdA6",
   "devdoc": "Contract deployed as upgradable proxy"
 }

--- a/cross-chain/polygon/.openzeppelin/polygon.json
+++ b/cross-chain/polygon/.openzeppelin/polygon.json
@@ -617,6 +617,170 @@
           }
         }
       }
+    },
+    "4eab818d90a79d503842492e9ce92e35a3b96c1835245a0d54c5b023197ec36a": {
+      "address": "0x04671C72Aab5AC02A03c1098314b1BB6B560c197",
+      "txHash": "0xbdc3017d335d0209565f182c4b7d29bd52babf6d67ea94c2f49a0087df7e3e45",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_contract(IWormholeTokenBridge)518",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:122"
+          },
+          {
+            "label": "bridgeToken",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(IERC20Upgradeable)2208",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:123"
+          },
+          {
+            "label": "tbtc",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_contract(L2TBTC)443",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:124"
+          },
+          {
+            "label": "gateways",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_uint16,t_bytes32)",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:136"
+          },
+          {
+            "label": "mintingLimit",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:147"
+          },
+          {
+            "label": "mintedAmount",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "L2WormholeGateway",
+            "src": "@keep-network/tbtc-v2/contracts/l2/L2WormholeGateway.sol:151"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20Upgradeable)2208": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)518": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(L2TBTC)443": {
+            "label": "contract L2TBTC",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_uint16,t_bytes32)": {
+            "label": "mapping(uint16 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/cross-chain/polygon/deployments/polygon/PolygonWormholeGateway.json
+++ b/cross-chain/polygon/deployments/polygon/PolygonWormholeGateway.json
@@ -175,19 +175,6 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "depositWormholeTbtc",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "bytes32",
           "name": "_address",
           "type": "bytes32"
@@ -466,7 +453,7 @@
     "status": 1,
     "byzantium": true
   },
-  "numDeployments": 2,
-  "implementation": "0xdF708431162Ba247dDaE362D2c919e0fbAfcf9DE",
+  "numDeployments": 3,
+  "implementation": "0x04671C72Aab5AC02A03c1098314b1BB6B560c197",
   "devdoc": "Contract deployed as upgradable proxy"
 }


### PR DESCRIPTION
Four implementations of the `L2WormholeGateway` contract have been upgraded recently:
- `ArbitrumWormholeGateway`
- `BaseWormholeGateway`
- `OptimismWormholeGateway`
- `PolygonWormholeGateway`

Here we push new artifacts reflecting that upgrade.