### PR TITLE
Fix: EthereumWalletRegistry initialization typo

### DIFF
--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -15,11 +15,14 @@ import {
 } from "../bitcoin"
 import Electrum from "electrum-client-js"
 import { BigNumber } from "ethers"
-import { URL } from "url"
+import { URL as nodeURL } from "url"
 import { backoffRetrier, Hex, RetrierFn } from "../utils"
 
 import MainnetElectrumUrls from "./urls/mainnet.json"
 import TestnetElectrumUrls from "./urls/testnet.json"
+
+const browserURL = window.URL
+const URL = nodeURL ?? browserURL
 
 /**
  * Represents a set of credentials required to establish an Electrum connection.
@@ -143,6 +146,7 @@ export class ElectrumClient implements BitcoinClient {
    */
   private static parseElectrumCredentials(url: string): ElectrumCredentials {
     const urlObj = new URL(url)
+    console.log({url, urlObj})
 
     return {
       host: urlObj.hostname,

--- a/typescript/src/lib/ethereum/index.ts
+++ b/typescript/src/lib/ethereum/index.ts
@@ -96,7 +96,7 @@ export async function loadEthereumContracts(
   const tbtcVault = new EthereumTBTCVault({ signerOrProvider: signer }, network)
   const walletRegistry = new EthereumWalletRegistry(
     { signerOrProvider: signer },
-    "mainnet"
+    network
   )
 
   const bridgeWalletRegistry = await bridge.walletRegistry()

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["es2020", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixed error while declaring EthereumWalletRegistry instance. Error caused using Mainnet contracts on Goerli chain resulting with error when SDK is consumed with an entrypoint.