### PR TITLE
Tinysecp replacement

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -32,7 +32,6 @@
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
     "ethers": "^5.5.2",
     "p-timeout": "^4.1.0",
-    "tiny-secp256k1": "^2.2.3",
     "wif": "2.0.6"
   },
   "devDependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,6 +24,7 @@
     "contracts": "./node_modules/@keep-network/ecdsa/artifacts/WalletRegistry.json ./node_modules/@keep-network/tbtc-v2/artifacts/{Bridge,TBTCVault,TBTC}.json"
   },
   "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.5",
     "@keep-network/ecdsa": "development",
     "@keep-network/tbtc-v2": "development",
     "bitcoinjs-lib": "^6.1.5",

--- a/typescript/src/lib/bitcoin/ecdsa-key.ts
+++ b/typescript/src/lib/bitcoin/ecdsa-key.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers"
 import { Hex } from "../utils"
 import { ECPairFactory, ECPairInterface } from "ecpair"
-import * as tinysecp from "tiny-secp256k1"
+import * as tinysecp from "@bitcoinerlab/secp256k1"
 import { BitcoinNetwork, toBitcoinJsLibNetwork } from "./network"
 
 /**

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -23,6 +23,14 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@bitcoinerlab/secp256k1@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@bitcoinerlab/secp256k1/-/secp256k1-1.0.5.tgz#4643ba73619c24c7c455cc63c6338c69c2cf187c"
+  integrity sha512-8gT+ukTCFN2rTxn4hD9Jq3k+UJwcprgYjfK/SQUSLgznXoIgsBnlPuARMkyyuEjycQK9VvnPiejKdszVTflh+w==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
+    "@noble/secp256k1" "^1.7.1"
+
 "@celo/base@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.5.2.tgz#168ab5e4e30b374079d8d139fafc52ca6bfd4100"
@@ -1643,10 +1651,15 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@noble/hashes@^1.2.0":
+"@noble/hashes@^1.1.5", "@noble/hashes@^1.2.0":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+
+"@noble/secp256k1@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -7409,13 +7409,6 @@ tiny-secp256k1@^1.1.3:
     elliptic "^6.4.0"
     nan "^2.13.2"
 
-tiny-secp256k1@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-2.2.3.tgz#fe1dde11a64fcee2091157d4b78bcb300feb9b65"
-  integrity sha512-SGcL07SxcPN2nGKHTCvRMkQLYPSoeFcvArUSCYtjVARiFAWU44cCIqYS0mYAU6nY7XfvwURuTIGo2Omt3ZQr0Q==
-  dependencies:
-    uint8array-tools "0.0.7"
-
 tmp@0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -7640,11 +7633,6 @@ typical@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
-
-uint8array-tools@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/uint8array-tools/-/uint8array-tools-0.0.7.tgz#a7a2bb5d8836eae2fade68c771454e6a438b390d"
-  integrity sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==
 
 ultron@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
The currently used implementation of _Secp256k1_ curve turned out to be faulty in Browser environments since it uses Node specific APIs under the hood.

The solution was to replace the `tiny-secp256k1` library with `@bitcoinerlab/secp256k1` which is universal in use (both Node and Browser compliant).

<details><summary>
🛠️ The build process completes successfully:
</summary>

```sh
❯ yarn build
yarn run v1.22.19
$ npm run typechain && tsc --project tsconfig.build.json

> @keep-network/tbtc-v2.ts@2.2.0-dev typechain
> rm -rf ./typechain && for i in $npm_package_config_contracts; do typechain --target ethers-v5 --out-dir ./typechain $i; done && rm ./typechain/index.ts

Successfully generated 5 typings!
Successfully generated 9 typings!
✨  Done in 4.10s.
```

</details>

<details><summary>
🧪 Test runner completes successfully as well:
</summary>

```sh
❯ yarn test
yarn run v1.22.19
$ mocha --exit --recursive 'test/**/*.test.ts'
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
This version of µWS is not compatible with your Node.js build:

Error: Cannot find module './uws_darwin_arm64_108.node'
Falling back to a NodeJS implementation; performance may be degraded.




  Bitcoin
    BitcoinNetwork
      unknown
        toString
          ✔ should return correct value
        fromGenesisHash
          ✔ should resolve correct enum key
        toBitcoinJsLibNetwork
          ✔ should throw an error
      testnet
        toString
          ✔ should return correct value
        fromGenesisHash
          ✔ should resolve correct enum key
        toBitcoinJsLibNetwork
          ✔ should return [object Object]
      mainnet
        toString
          ✔ should return correct value
        fromGenesisHash
          ✔ should resolve correct enum key
        toBitcoinJsLibNetwork
          ✔ should return [object Object]
    BitcoinPublicKeyUtils
      compressPublicKey
        when public key parameter has a correct length
          when the Y coordinate is divisible by 2
            ✔ should compress the public key correctly
          when the Y coordinate is not divisible by 2
            ✔ should compress the public key correctly
        when public key parameter has an incorrect length
          ✔ should throw
    BitcoinHashUtils
      computeHash160
        ✔ should compute hash160 correctly
      computeHash256
        ✔ should compute hash256 correctly
      hashLEToBigNumber
        ✔ calculates correct value
      computeSha256
        ✔ should compute hash256 correctly
    BitcoinAddressConverter
      publicKeyToAddress
        with testnet addresses
          ✔ should return correct P2PKH address for testnet
          ✔ should return correct P2WPKH address for testnet
        with mainnet addresses
          ✔ should return correct P2PKH address for mainnet
          ✔ should return correct P2WPKH address for mainnet
      publicKeyHashToAddress
        when network is mainnet
          when witness option is true
            when proper public key hash is provided
              ✔ should encode public key hash into bitcoin address properly
            when wrong public key hash is provided
              ✔ should throw
          when witness option is false
            when proper public key hash is provided
              ✔ should encode public key hash into bitcoin address properly
            when wrong public key hash is provided
              ✔ should throw
        when network is testnet
          when witness option is true
            when proper public key hash is provided
              ✔ should encode public key hash into bitcoin address properly
            when wrong public key hash is provided
              ✔ should throw
          when witness option is false
            when proper public key hash is provided
              ✔ should encode public key hash into bitcoin address properly
            when wrong public key hash is provided
              ✔ should throw
        when network is unknown
          ✔ should throw
      addressToPublicKeyHash
        when network is mainnet
          when proper P2WPKH address is provided
            ✔ should decode P2WPKH adress correctly
          when proper P2PKH address is provided
            ✔ should decode P2PKH address correctly
          when wrong address is provided
            ✔ should throw
          when unsupported P2SH address is provided
            ✔ should throw
          when unsupported P2WSH address is provided
            ✔ should throw
          when address from testnet network is provided
            ✔ should throw
        when network is testnet
          when proper P2WPKH address is provided
            ✔ should decode P2WPKH adress correctly
          when proper P2PKH address is provided
            ✔ should decode P2PKH address correctly
          when wrong address is provided
            ✔ should throw
          when unsupported P2SH address is provided
            ✔ should throw
          when unsupported P2WSH address is provided
            ✔ should throw
          when address from mainnet network is provided
            ✔ should throw
      addressToOutputScript
        with testnet addresses
          ✔ should create correct output script for P2PKH address type
          ✔ should create correct output script for P2WPKH address type
          ✔ should create correct output script for P2SH address type
          ✔ should create correct output script for P2WSH address type
        with mainnet addresses
          ✔ should create correct output script for P2PKH address type
          ✔ should create correct output script for P2WPKH address type
          ✔ should create correct output script for P2SH address type
          ✔ should create correct output script for P2WSH address type
      outputScriptToAddress
        with testnet addresses
          ✔ should return correct P2PKH address
          ✔ should return correct P2WPKH address
          ✔ should return correct P2SH address
          ✔ should return correct P2WSH address
        with mainnet addresses
          ✔ should return correct P2PKH address
          ✔ should return correct P2WPKH address
          ✔ should return correct P2SH address
          ✔ should return correct P2WSH address
    BitcoinLocktimeUtils
      locktimeToNumber
        when locktime is a block height
          when input is non-prefixed hex string
            ✔ should return the locktime in seconds
          when input is 0x prefixed hex string
            ✔ should return the locktime in seconds
          when input is Buffer object
            ✔ should return the locktime in seconds
        when locktime is a timestamp
          when input is non-prefixed hex string
            ✔ should return the locktime in seconds
          when input is 0x prefixed hex string
            ✔ should return the locktime in seconds
          when input is Buffer object
            ✔ should return the locktime in seconds
        for locktime
          when input is non-prefixed hex string
            ✔ should return the locktime in seconds
          when input is 0x prefixed hex string
            ✔ should return the locktime in seconds
          when input is Buffer object
            ✔ should return the locktime in seconds
      calculateLocktime
        when the resulting locktime is lesser than 4 bytes
          ✔ should throw
        when the resulting locktime is greater than 4 bytes
          ✔ should throw
        when the resulting locktime is a 4-byte number
          ✔ should compute a proper 4-byte little-endian locktime as un-prefixed hex string
    BitcoinHeaderSerializer
      serializeHeader
        ✔ calculates correct value
      deserializeHeader
        ✔ calculates correct value
    BitcoinTargetConverter
      bitsToTarget
        ✔ calculates correct value for random block header bits
        ✔ calculates correct value for block header with difficulty of 1
      targetToDifficulty
        ✔ calculates correct value for random block header bits
        ✔ calculates correct value for block header with difficulty of 1
    BitcoinCompactSizeUint
      read
        when the compact size uint is empty
          ✔ should throw
        when the compact size uint is 1-byte
          ✔ should return the uint value and byte length
        when the compact size uint is 3-byte
          ✔ should throw
        when the compact size uint is 5-byte
          ✔ should throw
        when the compact size uint is 9-byte
          ✔ should throw
    BitcoinScriptUtils
      isScript
        isP2PKHScript
          ✔ should return true for a valid P2PKH script
          ✔ should return false for other scripts
        isP2WPKHScript
          ✔ should return true for a valid P2WPKH script
          ✔ should return false for other scripts
        isP2SHScript
          ✔ should return true for a valid P2SH script
          ✔ should return false for other scripts
        isP2WSHScript
          ✔ should return true for a valid P2WSH script
          ✔ should return false for other scripts
    extractBitcoinRawTxVectors
      ✔ should return correct transaction vectors
    assembleBitcoinSpvProof
      when the transaction has one input
        ✔ should return the correct value of the proof
      when the transaction has multiple inputs
        ✔ should return the correct value of the proof
      when the transaction does not have enough confirmations
        ✔ should revert
    validateTransactionProof
      when the transaction proof is correct
        when the transaction is from Bitcoin Mainnet
          when the transaction confirmations span only one epoch
            ✔ should not throw
          when the transaction confirmations span two epochs
            ✔ should not throw
        when the transaction is from Bitcoin Testnet
          ✔ should not throw
      when the transaction proof is incorrect
        when the length of headers chain is incorrect
          ✔ should throw
        when the headers chain contains an incorrect number of headers
          ✔ should throw
        when the merkle proof is of incorrect length
          ✔ should throw
        when the merkle proof is empty
          ✔ should throw
        when the merkle proof contains incorrect hash
          ✔ should throw
        when the block headers do not form a chain
          ✔ should throw
        when one of the block headers has insufficient work
          ✔ should throw
        when some of the block headers are not at current or previous difficulty
          ✔ should throw

  Electrum
    ElectrumClient
      wss://electrumx-server.test.tbtc.network:8443
        getNetwork
          - should return proper network
        findAllUnspentTransactionOutputs
          - should return proper UTXOs for the given address
        getTransactionHistory
          - should return proper transaction history for the given address
        getTransaction
          - should return proper transaction for the given hash
        getRawTransaction
          - should return proper raw transaction for the given hash
        getTransactionConfirmations
          - should return value greater than 6
          - should return proper confirmations number for the given hash
        latestBlockHeight
          - should return value greater than 6
          - should return proper latest block height
        getHeadersChain
          - should return proper headers chain
        getTransactionMerkle
          - should return proper transaction merkle
        computeElectrumScriptHash
          - should convert Bitcoin script to an Electrum script hash correctly
      tcp://electrum.blockstream.info:60001
        getNetwork
          - should return proper network
        findAllUnspentTransactionOutputs
          - should return proper UTXOs for the given address
        getTransactionHistory
          - should return proper transaction history for the given address
        getTransaction
          - should return proper transaction for the given hash
        getRawTransaction
          - should return proper raw transaction for the given hash
        getTransactionConfirmations
          - should return value greater than 6
          - should return proper confirmations number for the given hash
        latestBlockHeight
          - should return value greater than 6
          - should return proper latest block height
        getHeadersChain
          - should return proper headers chain
        getTransactionMerkle
          - should return proper transaction merkle
        computeElectrumScriptHash
          - should convert Bitcoin script to an Electrum script hash correctly
      tcp://testnet.aranguren.org:51001
        getNetwork
          - should return proper network
        findAllUnspentTransactionOutputs
          - should return proper UTXOs for the given address
        getTransactionHistory
          - should return proper transaction history for the given address
        getTransaction
          - should return proper transaction for the given hash
        getRawTransaction
          - should return proper raw transaction for the given hash
        getTransactionConfirmations
          - should return value greater than 6
          - should return proper confirmations number for the given hash
        latestBlockHeight
          - should return value greater than 6
          - should return proper latest block height
        getHeadersChain
          - should return proper headers chain
        getTransactionMerkle
          - should return proper transaction merkle
        computeElectrumScriptHash
          - should convert Bitcoin script to an Electrum script hash correctly
      fallback connection
        - should establish connection with a fallback server

  Ethereum
    EthereumBridge
      pendingRedemptions
making attempt number 0
        ✔ should return the pending redemption
      timedOutRedemptions
making attempt number 0
        ✔ should return the timed-out redemption
      revealDeposit
making attempt number 0
        ✔ should reveal the deposit
      submitDepositSweepProof
making attempt number 0
        ✔ should submit the deposit sweep proof
      txProofDifficultyFactor
making attempt number 0
        ✔ should return the tx proof difficulty factor
      requestRedemption
making attempt number 0
        ✔ should request the redemption
      submitRedemptionProof
making attempt number 0
        ✔ should submit the redemption proof
      deposits
        when the revealed deposit has a vault set
making attempt number 0
          ✔ should return the revealed deposit
        when the revealed deposit has no vault set
making attempt number 0
          ✔ should return the revealed deposit
      activeWalletPublicKey
        when there is an active wallet
making attempt number 0
making attempt number 0
making attempt number 0
making attempt number 0
          ✔ should return the active wallet's public key
        when there is no active wallet
making attempt number 0
          ✔ should return undefined
    EthereumTBTCToken
      requestRedemption
making attempt number 0
        ✔ should request the redemption

  Utils
    Hex
      with input as unprefixed string
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as prefixed string
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as prefixed uppercase string
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as string with leading and trailing zeros
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as empty string
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as unprefixed buffer
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as unprefixed uppercase buffer
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as empty buffer
        `${hex}`
          ✔ should output expected string
        toString
          ✔ should output expected string
        toPrefixedString
          ✔ should output expected string
      with input as string with a character out of 0-9,a-z,A-Z
        ✔ should throw error with message: invalid format of hex string
      with input as string of odd length
        ✔ should throw error with message: invalid length of hex string: 7
      reverse
        ✔ should not modify source hex
        ✔ should reverse target hex
      toBuffer
        ✔ should output a buffer
        ✔ should not modify source hex when target buffer is changed
      equals
        for the same values with matching cases
          ✔ should return true
        for the same values but not matching cases
          ✔ should return true
        for the same value but prefixed and unprefixed
          ✔ should return true
        for different values
          ✔ should return false

  Deposits
    DepositFunding
      submitTransaction
        when witness option is true
          ✔ should broadcast P2WSH transaction with proper structure
          ✔ should return the proper transaction hash
          ✔ should return the proper deposit UTXO
        when witness option is false
          ✔ should broadcast P2SH transaction with proper structure
          ✔ should return the proper transaction hash
          ✔ should return the proper deposit UTXO
      assembleTransaction
        when witness option is true
          ✔ should return P2WSH transaction with proper structure
          ✔ should return the proper transaction hash
          ✔ should return the proper deposit UTXO
        when witness option is false
          ✔ should return P2SH transaction with proper structure
          ✔ should return the proper transaction hash
          ✔ should return the proper deposit UTXO
    DepositScript
      getPlainText
        ✔ should return script with proper structure
      getHash
        when witness option is true
          ✔ should return proper witness script hash
        when witness option is false
          ✔ should return proper non-witness script hash
      deriveAddress
        when network is mainnet
          when witness option is true
            ✔ should return proper address with prefix bc1
          when witness option is false
            ✔ should return proper address with prefix 3
        when network is testnet
          when witness option is true
            ✔ should return proper address with prefix tb1
          when witness option is false
            ✔ should return proper address with prefix 2
    Deposit
      initiateMinting
        manual funding outpoint provision mode
          ✔ should reveal the deposit to the Bridge
    DepositRefund
      DepositRefund
        submitTransaction
          when the refund transaction is requested to be witness
            when the refunded deposit was witness
              ✔ should broadcast refund transaction with proper structure
              ✔ should return the proper transaction hash
            when the refunded deposit was non-witness
              ✔ should broadcast refund transaction with proper structure
              ✔ should return the proper transaction hash
          when the refund transaction is requested to be non-witness
            ✔ should broadcast refund transaction with proper structure
            ✔ should return the proper transaction hash

  Redemptions
    RedemptionsService
      requestRedemption
        ✔ should submit redemption request with correct arguments
      getRedemptionRequest
        when asked for a pending request
          ✔ should return the expected redemption request
        when asked for a timed-out request
          ✔ should return the expected redemption request
      findWalletForRedemption
        when there are no wallets in the network that can handle redemption
          ✔ should throw an error
        when there are registered wallets in the network
          when there is a wallet that can handle the redemption request
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
            ✔ should get all registered wallets
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
            ✔ should return the wallet data that can handle redemption request
          when the redemption request amount is too large and no wallet can handle the request
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
The wallet (328d992e5f5b71de51a1b40fcc4056b99a88a647)cannot handle the redemption request. Continue the loop execution to the next wallet...
The wallet (03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e)cannot handle the redemption request. Continue the loop execution to the next wallet...
            ✔ should throw an error
          when there is pending redemption request from a given wallet to the same address
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
There is a pending redemption request from this wallet to the same Bitcoin address. Given wallet public key hash(328d992e5f5b71de51a1b40fcc4056b99a88a647) and redeemer output script (76a9142cd680318747b720d67bf4246eb7403b476adb3488ac) pair can be used for only one pending request at the same time. Continue the loop execution to the next wallet...
            ✔ should get all registered wallets
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
There is a pending redemption request from this wallet to the same Bitcoin address. Given wallet public key hash(328d992e5f5b71de51a1b40fcc4056b99a88a647) and redeemer output script (76a9142cd680318747b720d67bf4246eb7403b476adb3488ac) pair can be used for only one pending request at the same time. Continue the loop execution to the next wallet...
            ✔ should skip the wallet for which there is a pending redemption request to the same redeemer output script and return the wallet data that can handle redemption request
          when wallet has pending redemptions and the requested amount is greater than possible
amount 1500000
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
The wallet (328d992e5f5b71de51a1b40fcc4056b99a88a647)cannot handle the redemption request. Continue the loop execution to the next wallet...
            ✔ should skip the wallet wallet with pending redemptions and return the wallet data that can handle redemption request 
          when all active wallets has pending redemption for a given Bitcoin address
Wallet is not in Live state (wallet public key hash: 4ea4c237477cf092b563a0a77e941fa4b6e3d7fc). Continue the loop execution to the next wallet...
Could not find matching UTXO on chains for wallet public key hash (b617e1aab6abb8b9c3933d46c0c41022ce448580). Continue the loop execution to the next wallet...
There is a pending redemption request from this wallet to the same Bitcoin address. Given wallet public key hash(328d992e5f5b71de51a1b40fcc4056b99a88a647) and redeemer output script (76a9142cd680318747b720d67bf4246eb7403b476adb3488ac) pair can be used for only one pending request at the same time. Continue the loop execution to the next wallet...
There is a pending redemption request from this wallet to the same Bitcoin address. Given wallet public key hash(03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e) and redeemer output script (76a9142cd680318747b720d67bf4246eb7403b476adb3488ac) pair can be used for only one pending request at the same time. Continue the loop execution to the next wallet...
            ✔ should throw an error
      determineWalletMainUtxo
        when wallet main UTXO is not set in the Bridge
          ✔ should return undefined
        when wallet main UTXO is set in the Bridge
          with main UTXO coming from recent witness transaction
            with bitcoin testnet network
              ✔ should return the expected main UTXO
            with bitcoin mainnet network
              ✔ should return the expected main UTXO
          with main UTXO coming from recent legacy transaction
            with bitcoin testnet network
              ✔ should return the expected main UTXO
            with bitcoin mainnet network
              ✔ should return the expected main UTXO
          with main UTXO coming from old witness transaction
            with bitcoin testnet network
              ✔ should return the expected main UTXO
            with bitcoin mainnet network
              ✔ should return the expected main UTXO
          with main UTXO coming from old legacy transaction
            with bitcoin testnet network
              ✔ should return the expected main UTXO
            with bitcoin mainnet network
              ✔ should return the expected main UTXO

  Maintenance
    WalletTx
      DepositSweep
        submitTransaction
          when the new main UTXO is requested to be witness
            when there is no main UTXO from previous deposit sweep
              ✔ should broadcast sweep transaction with proper structure
              ✔ should return the proper transaction hash
              ✔ should return the proper new main UTXO
            when there is main UTXO from previous deposit sweep
              when main UTXO from previous deposit sweep is witness
                ✔ should broadcast sweep transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should return the proper new main UTXO
              when main UTXO from previous deposit sweep is non-witness
                ✔ should broadcast sweep transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should return the proper new main UTXO
          when the new main UTXO is requested to be non-witness
            ✔ should broadcast sweep transaction with proper structure
            ✔ should return the proper transaction hash
            ✔ should return the proper new main UTXO
        assembleTransaction
          when the new main UTXO is requested to be witness
            when there is no main UTXO from previous deposit sweep
              ✔ should return sweep transaction with proper structure
              ✔ should return the proper transaction hash
              ✔ should return the proper new main UTXO
            when there is main UTXO from previous deposit sweep
              when main UTXO prom previous deposit sweep is witness
                ✔ should return sweep transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should return the proper new main UTXO
              when main UTXO from previous deposit sweep is non-witness
                ✔ should return sweep transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should return the proper new main UTXO
          when the new main UTXO is requested to be non-witness
            ✔ should return sweep transaction with proper structure
            ✔ should return the proper transaction hash
            ✔ should return the proper new main UTXO
          when there are no UTXOs
            ✔ should revert
          when the numbers of UTXOs and deposit elements are not equal
            ✔ should revert
          when the main UTXO does not belong to the wallet
            ✔ should revert
          when the wallet private does not correspond to the wallet public key
            ✔ should revert
          when the type of UTXO is unsupported
            ✔ should revert
      Redemption
        submitTransaction
          when there are redemption requests provided
            when all redeemer output scripts identify pending redemptions
              when there is a change created
                when the change output is P2WPKH
                  when there is a single redeemer
                    when the redeemer output script is derived from a P2PKH address
                      ✔ should broadcast redemption transaction with proper structure
                      ✔ should return the proper transaction hash
                      ✔ should return the proper new main UTXO
                    when the redeemer output script is derived from a P2WPKH address
                      ✔ should broadcast redemption transaction with proper structure
                      ✔ should return the proper transaction hash
                      ✔ should return the proper new main UTXO
                    when the redeemer output script is derived from a P2SH address
                      ✔ should broadcast redemption transaction with proper structure
                      ✔ should return the proper transaction hash
                      ✔ should return the proper new main UTXO
                    when the redeemer output script is derived from a P2WSH address
                      ✔ should broadcast redemption transaction with proper structure
                      ✔ should return the proper transaction hash
                      ✔ should return the proper new main UTXO
                  when there are multiple redeemers
                    ✔ should broadcast redemption transaction with proper structure
                    ✔ should return the proper transaction hash
                    ✔ should return the proper new main UTXO
                when the change output is P2PKH
                  ✔ should broadcast redemption transaction with proper structure
                  ✔ should return the proper transaction hash
                  ✔ should return the proper new main UTXO
              when there is no change UTXO created
                ✔ should broadcast redemption transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should not return the new main UTXO
            when not all redeemer output scripts identify pending redemptions
              ✔ should revert
          when there are no redemption requests provided
            ✔ should revert
        assembleTransaction
          when there are redemption requests provided
            when there is a change UTXO created
              when the change output is P2WPKH
                when there is a single redeemer
                  when the redeemer output script is derived from a P2PKH address
                    ✔ should return transaction with proper structure
                    ✔ should return the proper transaction hash
                    ✔ should return the proper new main UTXO
                  when the redeemer output script is derived from a P2WPKH address
                    ✔ should return transaction with proper structure
                    ✔ should return the proper transaction hash
                    ✔ should return the proper new main UTXO
                  when the redeemer output script is derived from a P2SH address
                    ✔ should return transaction with proper structure
                    ✔ should return the proper transaction hash
                    ✔ should return the proper new main UTXO
                  when the redeemer output script is derived from a P2WSH address
                    ✔ should return transaction with proper structure
                    ✔ should return the proper transaction hash
                    ✔ should return the proper new main UTXO
                when there are multiple redeemers
                  ✔ should return transaction with proper structure
                  ✔ should return the proper transaction hash
                  ✔ should return the proper new main UTXO
              when the change output is P2PKH
                ✔ should return transaction with proper structure
                ✔ should return the proper transaction hash
                ✔ should return the proper new main UTXO
            when there is no change UTXO created
              ✔ should return transaction with proper structure
              ✔ should return the proper transaction hash
              ✔ should not return the new main UTXO
          when there are no redemption requests provided
            ✔ should revert
    Spv
      submitDepositSweepProof
        ✔ should submit deposit sweep proof with correct arguments
      submitRedemptionProof
        ✔ should submit redemption proof with correct arguments


  271 passing (3s)
  37 pending

✨  Done in 5.42s.
```

</details>

<details><summary>🤔</summary>

_I know, there is a typo in the branch name XD_

</details>