### PR TITLE
Signer recognition issue

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@keep-network/tbtc-v2.ts",
+  "name": "tbtc-sdk-v2",
   "version": "2.2.0-dev",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/typescript/src/lib/ethereum/index.ts
+++ b/typescript/src/lib/ethereum/index.ts
@@ -33,7 +33,7 @@ export async function ethereumNetworkFromSigner(
   signer: EthereumSigner
 ): Promise<EthereumNetwork> {
   let chainId: number
-  if (signer instanceof Signer) {
+  if (Signer.isSigner(signer)) {
     chainId = await signer.getChainId()
   } else {
     const network = await signer.getNetwork()
@@ -61,7 +61,7 @@ export async function ethereumNetworkFromSigner(
 export async function ethereumAddressFromSigner(
   signer: EthereumSigner
 ): Promise<EthereumAddress | undefined> {
-  if (signer instanceof Signer) {
+  if (Signer.isSigner(signer)) {
     return EthereumAddress.from(await signer.getAddress())
   } else {
     return undefined

--- a/typescript/test/lib/ethereum.test.ts
+++ b/typescript/test/lib/ethereum.test.ts
@@ -4,6 +4,8 @@ import {
   EthereumAddress,
   EthereumBridge,
   EthereumTBTCToken,
+  ethereumAddressFromSigner, 
+  ethereumNetworkFromSigner,
   Hex,
 } from "../../src"
 import {
@@ -11,7 +13,7 @@ import {
   MockContract,
 } from "@ethereum-waffle/mock-contract"
 import chai, { assert, expect } from "chai"
-import { BigNumber, Wallet, constants, utils } from "ethers"
+import { BigNumber, Wallet, constants, getDefaultProvider, utils } from "ethers"
 import { abi as BridgeABI } from "@keep-network/tbtc-v2/artifacts/Bridge.json"
 import { abi as TBTCTokenABI } from "@keep-network/tbtc-v2/artifacts/TBTC.json"
 import { abi as WalletRegistryABI } from "@keep-network/ecdsa/artifacts/WalletRegistry.json"
@@ -588,6 +590,40 @@ describe("Ethereum", () => {
           amount,
           expectedExtraData,
         ])
+      })
+    })
+  })
+
+  describe("ethereumAddressFromSigner", () => {
+    context("when the signer is a wallet", () => {
+      const [mockSigner] = new MockProvider().getWallets()
+      it("should return the signer's address", async () => {
+        expect(await ethereumAddressFromSigner(mockSigner)).to.be.eql(
+          EthereumAddress.from(mockSigner.address)
+          )
+        })
+      })
+      
+      context("when the signer is a provider", () => {
+      const mockProvider = getDefaultProvider()
+      it("should return undefined", async () => {
+        expect(await ethereumAddressFromSigner(mockProvider)).to.be.undefined
+      })
+    })
+  })
+
+  describe("ethereumNetworkFromSigner", () => {
+    context("when the signer is a wallet", () => {
+      const [mockSigner] = new MockProvider().getWallets()
+      it("should return the signer's network", async () => {
+        expect(await ethereumNetworkFromSigner(mockSigner)).to.be.eql("local")
+      })
+    })
+    
+    context("when the signer is a provider", () => {
+      const mockProvider = getDefaultProvider()
+      it("should return the signer's network", async () => {
+        expect(await ethereumNetworkFromSigner(mockProvider)).to.be.eql("mainnet")
       })
     })
   })


### PR DESCRIPTION
The use of `instanceof` operator leads to unexpected behaviors. The
issue has been solved with the use of built-in native check method.

What's more, implemented unit tests for functions that propagated the issue described above.