### PR TITLE
Add README do NPM package

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist/",
     "src/",
-    "typechain/"
+    "typechain/",
+    "README.md"
   ],
   "config": {
     "contracts": "./node_modules/@keep-network/ecdsa/artifacts/WalletRegistry.json ./node_modules/@keep-network/tbtc-v2/artifacts/{Bridge,TBTCVault,TBTC}.json"


### PR DESCRIPTION
In order to display the description of a package in NPM registry, the `README.md` file needs to be part of the project and needs to be placed in root. We have the file, but we were not including it in the project. This commit changes that.