### PR TITLE
Added validation of moving funds proposal

### DIFF
--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -94,6 +94,16 @@ contract WalletProposalValidator {
         uint256 redemptionTxFee;
     }
 
+    /// @notice Helper structure representing a moving funds proposal.
+    struct MovingFundsProposal {
+        // 20-byte public key hash of the source wallet.
+        bytes20 walletPubKeyHash;
+        // List of 20-byte public key hashes of target wallets.
+        bytes20[] targetWallets;
+        // Proposed BTC fee for the entire transaction.
+        uint256 movingFundsTxFee;
+    }
+
     /// @notice Helper structure representing a heartbeat proposal.
     struct HeartbeatProposal {
         // 20-byte public key hash of the target wallet.
@@ -585,6 +595,152 @@ contract WalletProposalValidator {
         }
 
         return true;
+    }
+
+    /// @notice View function encapsulating the main rules of a valid moving
+    ///         funds proposal. This function is meant to facilitate the
+    ///         off-chain validation of the incoming proposals. Thanks to it,
+    ///         most of the work can be done using a single readonly contract
+    ///         call.
+    /// @param proposal The moving funds proposal to validate.
+    /// @param walletMainUtxo The main UTXO of the source wallet.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///     - The source wallet must be in the MovingFunds state,
+    ///     - The source wallet must not have any pending redemptions,
+    ///     - The source wallet must not have any pending moved funds sweep
+    ///       requests,
+    ///     - The source wallet's BTC balance must be greater than zero,
+    ///     - The number of target wallets in the proposal must match the
+    ///       expected count, based on the Live wallets count, source wallet's
+    ///       BTC balance and maximum BTC transfer limit,
+    ///     - All target wallets must be in the Live state and ordered correctly
+    ///       (i.e. no duplicates and in ascending order of wallet addresses),
+    ///     - The proposed moving funds transaction fee must be greater than
+    ///       zero,
+    ///     - The proposed moving funds transaction fee must not exceed the
+    ///       maximum total fee allowed for moving funds.
+    function validateMovingFundsProposal(
+        MovingFundsProposal calldata proposal,
+        BitcoinTx.UTXO calldata walletMainUtxo
+    ) external view returns (bool) {
+        Wallets.Wallet memory sourceWallet = bridge.wallets(
+            proposal.walletPubKeyHash
+        );
+
+        // Make sure the source wallet is eligible for moving funds.
+        require(
+            sourceWallet.state == Wallets.WalletState.MovingFunds,
+            "Source wallet is not in MovingFunds state"
+        );
+
+        require(
+            sourceWallet.pendingRedemptionsValue == 0,
+            "Source wallet has pending redemptions"
+        );
+
+        require(
+            sourceWallet.pendingMovedFundsSweepRequestsCount == 0,
+            "Source wallet has pending moved funds sweep requests"
+        );
+
+        // Make sure the number of target wallets is correct.
+        uint64 sourceWalletBtcBalance = getWalletBtcBalance(
+            sourceWallet.mainUtxoHash,
+            walletMainUtxo
+        );
+
+        require(
+            sourceWalletBtcBalance > 0,
+            "Source wallet BTC balance is zero"
+        );
+
+        uint32 liveWalletsCount = bridge.liveWalletsCount();
+
+        (, , , , , uint64 walletMaxBtcTransfer, ) = bridge.walletParameters();
+
+        uint256 expectedTargetWalletsCount = Math.min(
+            liveWalletsCount,
+            Math.ceilDiv(sourceWalletBtcBalance, walletMaxBtcTransfer)
+        );
+
+        require(expectedTargetWalletsCount > 0, "No target wallets available");
+
+        require(
+            proposal.targetWallets.length == expectedTargetWalletsCount,
+            "Submitted target wallets count is other than expected"
+        );
+
+        // Make sure the target wallets are Live and are ordered correctly.
+        uint160 lastProcessedTargetWallet = 0;
+
+        for (uint256 i = 0; i < proposal.targetWallets.length; i++) {
+            bytes20 targetWallet = proposal.targetWallets[i];
+
+            require(
+                targetWallet != proposal.walletPubKeyHash,
+                "Target wallet is equal to source wallet"
+            );
+
+            require(
+                uint160(targetWallet) > lastProcessedTargetWallet,
+                "Target wallet order is incorrect"
+            );
+
+            // slither-disable-next-line calls-loop
+            require(
+                bridge.wallets(targetWallet).state == Wallets.WalletState.Live,
+                "Target wallet is not in Live state"
+            );
+
+            lastProcessedTargetWallet = uint160(targetWallet);
+        }
+
+        // Make sure the proposed fee does not exceed the total fee limit.
+        (uint64 movingFundsTxMaxTotalFee, , , , , , , , , , ) = bridge
+            .movingFundsParameters();
+
+        require(
+            proposal.movingFundsTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+
+        require(
+            proposal.movingFundsTxFee <= movingFundsTxMaxTotalFee,
+            "Proposed transaction fee is too high"
+        );
+
+        return true;
+    }
+
+    /// @notice Calculates the Bitcoin balance of a wallet based on its main
+    ///         UTXO.
+    /// @param walletMainUtxoHash The hash of the wallet's main UTXO.
+    /// @param walletMainUtxo The detailed data of the wallet's main UTXO.
+    /// @return walletBtcBalance The calculated Bitcoin balance of the wallet.
+    function getWalletBtcBalance(
+        bytes32 walletMainUtxoHash,
+        BitcoinTx.UTXO calldata walletMainUtxo
+    ) internal view returns (uint64 walletBtcBalance) {
+        // If the wallet has a main UTXO hash set, cross-check it with the
+        // provided plain-text parameter and get the transaction output value
+        // as BTC balance. Otherwise, the BTC balance is just zero.
+        if (walletMainUtxoHash != bytes32(0)) {
+            require(
+                keccak256(
+                    abi.encodePacked(
+                        walletMainUtxo.txHash,
+                        walletMainUtxo.txOutputIndex,
+                        walletMainUtxo.txOutputValue
+                    )
+                ) == walletMainUtxoHash,
+                "Invalid wallet main UTXO data"
+            );
+
+            walletBtcBalance = walletMainUtxo.txOutputValue;
+        }
+
+        return walletBtcBalance;
     }
 
     /// @notice View function encapsulating the main rules of a valid heartbeat

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -1897,10 +1897,15 @@ describe("WalletProposalValidator", () => {
 
   describe("validateMovingFundsProposal", () => {
     const walletPubKeyHash = "0x7ac2d9378a1c47e589dfb8095ca95ed2140d2726"
-    const ecdsaWalletID =
-      "0x4ad6b3ccbca81645865d8d0d575797a15528e98ced22f29a6f906d3259569863"
+    const targetWallets = [
+      "0x84a70187011e156686788e0a2bc50944a4721e83",
+      "0xf64a45c07e3778b8ce58cb0058477c821c543aad",
+      "0xcaea95433d9bfa80bb8dc8819a48e2a9aa96147c",
+    ]
+    // Hash calculated from the above target wallets.
+    const targetWalletsHash =
+      "0x16311d424d513a1743fbc9c0e4fea5b70eddefd15f54613503e5cdfab24f8877"
     const movingFundsTxMaxTotalFee = 20000
-    const walletMaxBtcTransfer = 30000000
 
     before(async () => {
       await createSnapshot()
@@ -1918,12 +1923,10 @@ describe("WalletProposalValidator", () => {
         0,
         0,
       ])
-      bridge.walletParameters.returns([0, 0, 0, 0, 0, walletMaxBtcTransfer, 0])
     })
 
     after(async () => {
       bridge.movingFundsParameters.reset()
-      bridge.walletParameters.reset()
 
       await restoreSnapshot()
     })
@@ -1958,7 +1961,7 @@ describe("WalletProposalValidator", () => {
             await createSnapshot()
 
             bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-              ecdsaWalletID,
+              ecdsaWalletID: HashZero,
               mainUtxoHash: HashZero,
               pendingRedemptionsValue: 0,
               createdAt: 0,
@@ -1978,15 +1981,11 @@ describe("WalletProposalValidator", () => {
 
           it("should revert", async () => {
             await expect(
-              // Only walletPubKeyHash argument is relevant in this scenario.
-              walletProposalValidator.validateMovingFundsProposal(
-                {
-                  walletPubKeyHash,
-                  movingFundsTxFee: 0,
-                  targetWallets: [],
-                },
-                NO_MAIN_UTXO
-              )
+              walletProposalValidator.validateMovingFundsProposal({
+                walletPubKeyHash,
+                movingFundsTxFee: 0,
+                targetWallets: [],
+              })
             ).to.be.revertedWith("Source wallet is not in MovingFunds state")
           })
         })
@@ -1994,19 +1993,20 @@ describe("WalletProposalValidator", () => {
     })
 
     context("when wallet's state is MovingFunds", () => {
-      context("when the wallet has pending redemptions", () => {
+      context("when moving funds commitment has not been submitted", () => {
         before(async () => {
           await createSnapshot()
 
           bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-            ecdsaWalletID,
+            ecdsaWalletID: HashZero,
             mainUtxoHash: HashZero,
-            pendingRedemptionsValue: 10000, // Make the value positive.
+            pendingRedemptionsValue: 0,
             createdAt: 0,
             movingFundsRequestedAt: 0,
             closingStartedAt: 0,
             pendingMovedFundsSweepRequestsCount: 0,
             state: walletState.MovingFunds,
+            // Indicate the commitment has not been submitted.
             movingFundsTargetWalletsCommitmentHash: HashZero,
           })
         })
@@ -2019,451 +2019,115 @@ describe("WalletProposalValidator", () => {
 
         it("should revert", async () => {
           await expect(
-            walletProposalValidator.validateMovingFundsProposal(
-              {
-                walletPubKeyHash,
-                movingFundsTxFee: 0,
-                targetWallets: [],
-              },
-              NO_MAIN_UTXO
-            )
-          ).to.be.revertedWith("Source wallet has pending redemptions")
+            walletProposalValidator.validateMovingFundsProposal({
+              walletPubKeyHash,
+              movingFundsTxFee: 0,
+              targetWallets: [],
+            })
+          ).to.be.revertedWith("Target wallets commitment is not submitted")
         })
       })
 
-      context("when the wallet does not have pending redemptions", () => {
-        context(
-          "when the wallet has pending moved funds sweep requests",
-          () => {
-            before(async () => {
-              await createSnapshot()
+      context("when moving funds commitment has been submitted", () => {
+        context("when commitment hash does not match target wallets", () => {
+          before(async () => {
+            await createSnapshot()
 
-              bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-                ecdsaWalletID,
-                mainUtxoHash: HashZero,
-                pendingRedemptionsValue: 0,
-                createdAt: 0,
-                movingFundsRequestedAt: 0,
-                closingStartedAt: 0,
-                pendingMovedFundsSweepRequestsCount: 1, // Make the value positive.
-                state: walletState.MovingFunds,
-                movingFundsTargetWalletsCommitmentHash: HashZero,
+            bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
+              ecdsaWalletID: HashZero,
+              mainUtxoHash: HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: 0,
+              movingFundsRequestedAt: 0,
+              closingStartedAt: 0,
+              pendingMovedFundsSweepRequestsCount: 0,
+              state: walletState.MovingFunds,
+              // Set a hash that does not match the target wallets.
+              movingFundsTargetWalletsCommitmentHash:
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            })
+          })
+
+          after(async () => {
+            bridge.wallets.reset()
+
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            await expect(
+              walletProposalValidator.validateMovingFundsProposal({
+                walletPubKeyHash,
+                movingFundsTxFee: 0,
+                targetWallets,
               })
+            ).to.be.revertedWith(
+              "Target wallets do not match target wallets commitment hash"
+            )
+          })
+        })
+
+        context("when commitment hash matches target wallets", () => {
+          before(async () => {
+            await createSnapshot()
+
+            bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
+              ecdsaWalletID: HashZero,
+              mainUtxoHash: HashZero,
+              pendingRedemptionsValue: 0,
+              createdAt: 0,
+              movingFundsRequestedAt: 0,
+              closingStartedAt: 0,
+              pendingMovedFundsSweepRequestsCount: 0,
+              state: walletState.MovingFunds,
+              // Set the correct hash.
+              movingFundsTargetWalletsCommitmentHash: targetWalletsHash,
             })
+          })
 
-            after(async () => {
-              bridge.wallets.reset()
+          after(async () => {
+            bridge.wallets.reset()
 
-              await restoreSnapshot()
-            })
+            await restoreSnapshot()
+          })
 
+          context("when transaction fee is zero", () => {
             it("should revert", async () => {
               await expect(
-                walletProposalValidator.validateMovingFundsProposal(
-                  {
-                    walletPubKeyHash,
-                    movingFundsTxFee: 0,
-                    targetWallets: [],
-                  },
-                  NO_MAIN_UTXO
-                )
-              ).to.be.revertedWith(
-                "Source wallet has pending moved funds sweep requests"
-              )
+                walletProposalValidator.validateMovingFundsProposal({
+                  walletPubKeyHash,
+                  movingFundsTxFee: 0,
+                  targetWallets,
+                })
+              ).to.be.revertedWith("Proposed transaction fee cannot be zero")
             })
-          }
-        )
+          })
 
-        context(
-          "when the wallet does not have pending moved funds sweep requests",
-          () => {
-            context("when the provided main UTXO is invalid", () => {
-              before(async () => {
-                await createSnapshot()
-
-                bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-                  ecdsaWalletID,
-                  mainUtxoHash:
-                    // Use any non-zero hash to indicate the wallet has a main UTXO.
-                    "0x1111111111111111111111111111111111111111111111111111111111111111",
-                  pendingRedemptionsValue: 0,
-                  createdAt: 0,
-                  movingFundsRequestedAt: 0,
-                  closingStartedAt: 0,
-                  pendingMovedFundsSweepRequestsCount: 0,
-                  state: walletState.MovingFunds,
-                  movingFundsTargetWalletsCommitmentHash: HashZero,
+          context("when transaction fee is too high", () => {
+            it("should revert", async () => {
+              await expect(
+                walletProposalValidator.validateMovingFundsProposal({
+                  walletPubKeyHash,
+                  movingFundsTxFee: movingFundsTxMaxTotalFee + 1,
+                  targetWallets,
                 })
-              })
-
-              after(async () => {
-                bridge.wallets.reset()
-
-                await restoreSnapshot()
-              })
-
-              it("should revert", async () => {
-                await expect(
-                  walletProposalValidator.validateMovingFundsProposal(
-                    {
-                      walletPubKeyHash,
-                      movingFundsTxFee: 0,
-                      targetWallets: [],
-                    },
-                    {
-                      txHash:
-                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                      txOutputIndex: 0,
-                      txOutputValue: 1000,
-                    }
-                  )
-                ).to.be.revertedWith("Invalid wallet main UTXO data")
-              })
+              ).to.be.revertedWith("Proposed transaction fee is too high")
             })
+          })
 
-            context("when the provided main UTXO is valid", () => {
-              context("when the wallet's balance is zero", () => {
-                before(async () => {
-                  await createSnapshot()
-
-                  bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-                    ecdsaWalletID,
-                    // Use zero hash so that the wallet's main is considered not
-                    // set.
-                    mainUtxoHash: HashZero,
-                    pendingRedemptionsValue: 0,
-                    createdAt: 0,
-                    movingFundsRequestedAt: 0,
-                    closingStartedAt: 0,
-                    pendingMovedFundsSweepRequestsCount: 0,
-                    state: walletState.MovingFunds,
-                    movingFundsTargetWalletsCommitmentHash: HashZero,
-                  })
+          context("when transaction fee is valid", () => {
+            it("should pass validation", async () => {
+              const result =
+                await walletProposalValidator.validateMovingFundsProposal({
+                  walletPubKeyHash,
+                  movingFundsTxFee: movingFundsTxMaxTotalFee,
+                  targetWallets,
                 })
-
-                after(async () => {
-                  bridge.wallets.reset()
-
-                  await restoreSnapshot()
-                })
-
-                it("should revert", async () => {
-                  await expect(
-                    walletProposalValidator.validateMovingFundsProposal(
-                      {
-                        walletPubKeyHash,
-                        movingFundsTxFee: 0,
-                        targetWallets: [],
-                      },
-                      NO_MAIN_UTXO
-                    )
-                  ).to.be.revertedWith("Source wallet BTC balance is zero")
-                })
-              })
-
-              context("when the wallet's balance is positive", () => {
-                const targetWallets = [
-                  "0x1111111111111111111111111111111111111111",
-                  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                  "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                ]
-
-                before(async () => {
-                  await createSnapshot()
-
-                  // Set the source wallet.
-                  bridge.wallets.whenCalledWith(walletPubKeyHash).returns({
-                    ecdsaWalletID,
-                    mainUtxoHash:
-                      "0x2cd9812b371968dc7e244c6757778d436cda256db583909a1758cac47c5d3df9",
-                    pendingRedemptionsValue: 0,
-                    createdAt: 0,
-                    movingFundsRequestedAt: 0,
-                    closingStartedAt: 0,
-                    pendingMovedFundsSweepRequestsCount: 0,
-                    state: walletState.MovingFunds,
-                    movingFundsTargetWalletsCommitmentHash: HashZero,
-                  })
-
-                  // Set target wallets.
-                  targetWallets.forEach((targetWallet) => {
-                    bridge.wallets.whenCalledWith(targetWallet).returns({
-                      ecdsaWalletID,
-                      mainUtxoHash: HashZero,
-                      pendingRedemptionsValue: 0,
-                      createdAt: 0,
-                      movingFundsRequestedAt: 0,
-                      closingStartedAt: 0,
-                      pendingMovedFundsSweepRequestsCount: 0,
-                      state: walletState.Live,
-                      movingFundsTargetWalletsCommitmentHash: HashZero,
-                    })
-                  })
-                })
-
-                after(async () => {
-                  bridge.wallets.reset()
-
-                  await restoreSnapshot()
-                })
-
-                context("when there are no target wallets available", () => {
-                  before(async () => {
-                    await createSnapshot()
-
-                    bridge.liveWalletsCount.returns(0)
-                  })
-
-                  after(async () => {
-                    bridge.liveWalletsCount.reset()
-
-                    await restoreSnapshot()
-                  })
-
-                  it("should revert", async () => {
-                    await expect(
-                      walletProposalValidator.validateMovingFundsProposal(
-                        {
-                          walletPubKeyHash,
-                          movingFundsTxFee: 0,
-                          targetWallets: [],
-                        },
-                        {
-                          txHash:
-                            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                          txOutputIndex: 0,
-                          txOutputValue: 100000000,
-                        }
-                      )
-                    ).to.be.revertedWith("No target wallets available")
-                  })
-                })
-
-                context("when there are target wallets available", () => {
-                  before(async () => {
-                    await createSnapshot()
-
-                    bridge.liveWalletsCount.returns(3)
-                  })
-
-                  after(async () => {
-                    bridge.liveWalletsCount.reset()
-
-                    await restoreSnapshot()
-                  })
-
-                  context(
-                    "when the number of target wallets is other than expected",
-                    () => {
-                      it("should revert", async () => {
-                        await expect(
-                          walletProposalValidator.validateMovingFundsProposal(
-                            {
-                              walletPubKeyHash,
-                              movingFundsTxFee: 0,
-                              targetWallets: [
-                                // Provide one target wallet instead of three.
-                                targetWallets[0],
-                              ],
-                            },
-                            {
-                              txHash:
-                                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                              txOutputIndex: 0,
-                              txOutputValue: 100000000,
-                            }
-                          )
-                        ).to.be.revertedWith(
-                          "Submitted target wallets count is other than expected"
-                        )
-                      })
-                    }
-                  )
-
-                  context(
-                    "when the number of target wallets is expected",
-                    () => {
-                      context(
-                        "when the source wallet is used as a target wallet",
-                        () => {
-                          it("should revert", async () => {
-                            await expect(
-                              walletProposalValidator.validateMovingFundsProposal(
-                                {
-                                  walletPubKeyHash,
-                                  movingFundsTxFee: 0,
-                                  targetWallets: [
-                                    "0x1111111111111111111111111111111111111111",
-                                    walletPubKeyHash, // Use source wallet.
-                                    "0x3333333333333333333333333333333333333333",
-                                  ],
-                                },
-                                {
-                                  txHash:
-                                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                  txOutputIndex: 0,
-                                  txOutputValue: 100000000,
-                                }
-                              )
-                            ).to.be.revertedWith(
-                              "Target wallet is equal to source wallet"
-                            )
-                          })
-                        }
-                      )
-
-                      context(
-                        "when the source wallet is not used as a target wallet",
-                        () => {
-                          context(
-                            "when the order of target wallets is incorrect",
-                            () => {
-                              it("should revert", async () => {
-                                await expect(
-                                  walletProposalValidator.validateMovingFundsProposal(
-                                    {
-                                      walletPubKeyHash,
-                                      movingFundsTxFee: 0,
-                                      targetWallets: [
-                                        // Change order.
-                                        targetWallets[0],
-                                        targetWallets[2],
-                                        targetWallets[1],
-                                      ],
-                                    },
-                                    {
-                                      txHash:
-                                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                      txOutputIndex: 0,
-                                      txOutputValue: 100000000,
-                                    }
-                                  )
-                                ).to.be.revertedWith(
-                                  "Target wallet order is incorrect"
-                                )
-                              })
-                            }
-                          )
-
-                          context(
-                            "when the order of target wallets is correct",
-                            () => {
-                              context(
-                                "when one of the target wallets is not Live",
-                                () => {
-                                  it("should revert", async () => {
-                                    await expect(
-                                      walletProposalValidator.validateMovingFundsProposal(
-                                        {
-                                          walletPubKeyHash,
-                                          movingFundsTxFee: 0,
-                                          targetWallets: [
-                                            targetWallets[0],
-                                            targetWallets[1],
-                                            // Use unknown wallet, so that its state is not Unknown.
-                                            "0xcccccccccccccccccccccccccccccccccccccccc",
-                                          ],
-                                        },
-                                        {
-                                          txHash:
-                                            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                          txOutputIndex: 0,
-                                          txOutputValue: 100000000,
-                                        }
-                                      )
-                                    ).to.be.revertedWith(
-                                      "Target wallet is not in Live state"
-                                    )
-                                  })
-                                }
-                              )
-
-                              context(
-                                "when all the target wallets are Live",
-                                () => {
-                                  context(
-                                    "when the provided transaction fee is incorrect",
-                                    () => {
-                                      it("should revert", async () => {
-                                        await expect(
-                                          walletProposalValidator.validateMovingFundsProposal(
-                                            {
-                                              walletPubKeyHash,
-                                              movingFundsTxFee: 0,
-                                              targetWallets,
-                                            },
-                                            {
-                                              txHash:
-                                                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                              txOutputIndex: 0,
-                                              txOutputValue: 100000000,
-                                            }
-                                          )
-                                        ).to.be.revertedWith(
-                                          "Proposed transaction fee cannot be zero"
-                                        )
-                                      })
-
-                                      it("should revert", async () => {
-                                        await expect(
-                                          walletProposalValidator.validateMovingFundsProposal(
-                                            {
-                                              walletPubKeyHash,
-                                              movingFundsTxFee:
-                                                movingFundsTxMaxTotalFee + 1,
-                                              targetWallets,
-                                            },
-                                            {
-                                              txHash:
-                                                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                              txOutputIndex: 0,
-                                              txOutputValue: 100000000,
-                                            }
-                                          )
-                                        ).to.be.revertedWith(
-                                          "Proposed transaction fee is too high"
-                                        )
-                                      })
-                                    }
-                                  )
-
-                                  context(
-                                    "when the provided transaction fee is correct",
-                                    () => {
-                                      it("should pass validation", async () => {
-                                        const result =
-                                          await walletProposalValidator.validateMovingFundsProposal(
-                                            {
-                                              walletPubKeyHash,
-                                              movingFundsTxFee:
-                                                movingFundsTxMaxTotalFee,
-                                              targetWallets,
-                                            },
-                                            {
-                                              txHash:
-                                                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                                              txOutputIndex: 0,
-                                              txOutputValue: 100000000,
-                                            }
-                                          )
-                                        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                                        expect(result).to.be.true
-                                      })
-                                    }
-                                  )
-                                }
-                              )
-                            }
-                          )
-                        }
-                      )
-                    }
-                  )
-                })
-              })
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              expect(result).to.be.true
             })
-          }
-        )
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
#Refs: https://github.com/keep-network/keep-core/issues/3733.

This PR adds moving funds proposal validation to the wallet proposal validator smart contract.
The validation performs several checks:
- the source wallet's state must be MovingFunds,
- the source wallet's commitment hash must be submitted,
- the target wallets from the proposal must match the submitted commitment hash,
- the proposed fee must be greater than zero,
- the transaction proposed fee must not exceed the maximum fee.