### PR TITLE
Expose `revealDepositWithExtraData` in the `Bridge` contract

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -376,7 +376,27 @@ contract Bridge is
         self.revealDeposit(fundingTx, reveal);
     }
 
-    // TODO: Documentation and tests.
+    /// @notice Sibling of the `revealDeposit` function. This function allows
+    ///         to reveal a P2(W)SH Bitcoin deposit with 32-byte extra data
+    ///         embedded in the deposit script. The extra data allows to
+    ///         attach additional context to the deposit. For example,
+    ///         it allows a third-party smart contract to reveal the
+    ///         deposit on behalf of the original depositor and provide
+    ///         additional services once the deposit is handled. In this
+    ///         case, the address of the original depositor can be encoded
+    ///         as extra data.
+    /// @param fundingTx Bitcoin funding transaction data, see `BitcoinTx.Info`.
+    /// @param reveal Deposit reveal data, see `RevealInfo struct.
+    /// @param extraData 32-byte deposit extra data.
+    /// @dev Requirements:
+    ///      - All requirements from `revealDeposit` function must be met,
+    ///      - `extraData` must not be bytes32(0),
+    ///      - `extraData` must be the actual extra data used in the P2(W)SH
+    ///        BTC deposit transaction.
+    ///
+    ///      If any of these requirements is not met, the wallet _must_ refuse
+    ///      to sweep the deposit and the depositor has to wait until the
+    ///      deposit script unlocks to receive their BTC back.
     function revealDepositWithExtraData(
         BitcoinTx.Info calldata fundingTx,
         Deposit.DepositRevealInfo calldata reveal,

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -82,8 +82,7 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash,
         bytes20 refundPubKeyHash,
         bytes4 refundLocktime,
-        address vault,
-        bytes32 extraData
+        address vault
     );
 
     event DepositsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -82,7 +82,8 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash,
         bytes20 refundPubKeyHash,
         bytes4 refundLocktime,
-        address vault
+        address vault,
+        bytes32 extraData
     );
 
     event DepositsSwept(bytes20 walletPubKeyHash, bytes32 sweepTxHash);
@@ -374,6 +375,15 @@ contract Bridge is
         Deposit.DepositRevealInfo calldata reveal
     ) external {
         self.revealDeposit(fundingTx, reveal);
+    }
+
+    // TODO: Documentation and tests.
+    function revealDepositWithExtraData(
+        BitcoinTx.Info calldata fundingTx,
+        Deposit.DepositRevealInfo calldata reveal,
+        bytes32 extraData
+    ) external {
+        self.revealDepositWithExtraData(fundingTx, reveal, extraData);
     }
 
     /// @notice Used by the wallet to prove the BTC deposit sweep transaction

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -96,6 +96,8 @@ library Deposit {
         // the time when the sweep proof was delivered to the Ethereum chain.
         // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 sweptAt;
+        // The 32-byte deposit extra data. Optional, can be bytes32(0).
+        bytes32 extraData;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are
         // not contiguous with other values.
@@ -110,8 +112,7 @@ library Deposit {
         bytes20 indexed walletPubKeyHash,
         bytes20 refundPubKeyHash,
         bytes4 refundLocktime,
-        address vault,
-        bytes32 extraData
+        address vault
     );
 
     /// @notice Used by the depositor to reveal information about their P2(W)SH
@@ -306,26 +307,20 @@ library Deposit {
         deposit.treasuryFee = self.depositTreasuryFeeDivisor > 0
             ? fundingOutputAmount / self.depositTreasuryFeeDivisor
             : 0;
+        deposit.extraData = extraData;
 
-        _emitDepositRevealedEvent(
-            fundingTxHash,
-            fundingOutputAmount,
-            reveal,
-            extraData
-        );
+        _emitDepositRevealedEvent(fundingTxHash, fundingOutputAmount, reveal);
     }
 
     /// @notice Emits the `DepositRevealed` event.
     /// @param fundingTxHash The funding transaction hash.
     /// @param fundingOutputAmount The funding output amount in satoshi.
     /// @param reveal Deposit reveal data, see `RevealInfo struct.
-    /// @param extraData The 32-byte deposit extra data.
     /// @dev This function is extracted to overcome the stack too deep error.
     function _emitDepositRevealedEvent(
         bytes32 fundingTxHash,
         uint64 fundingOutputAmount,
-        DepositRevealInfo calldata reveal,
-        bytes32 extraData
+        DepositRevealInfo calldata reveal
     ) internal {
         // slither-disable-next-line reentrancy-events
         emit DepositRevealed(
@@ -337,8 +332,7 @@ library Deposit {
             reveal.walletPubKeyHash,
             reveal.refundPubKeyHash,
             reveal.refundLocktime,
-            reveal.vault,
-            extraData
+            reveal.vault
         );
     }
 

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -65,7 +65,7 @@ contract WalletProposalValidator {
         uint32 fundingOutputIndex;
     }
 
-    /// @notice Helper structure holding deposit extra data required during
+    /// @notice Helper structure holding deposit extra info required during
     ///         deposit sweep proposal validation. Basically, this structure
     ///         is a combination of BitcoinTx.Info and relevant parts of
     ///         Deposit.DepositRevealInfo.
@@ -188,7 +188,7 @@ contract WalletProposalValidator {
     ///         complexity. Instead of that, each off-chain wallet member is
     ///         supposed to do that check on their own.
     /// @param proposal The sweeping proposal to validate.
-    /// @param depositsExtraInfo Deposits extra data required to perform the validation.
+    /// @param depositsExtraInfo Deposits extra info required to perform the validation.
     /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
     ///      - The target wallet must be in the Live state,
@@ -196,7 +196,7 @@ contract WalletProposalValidator {
     ///        the range [1, `DEPOSIT_SWEEP_MAX_SIZE`],
     ///      - The length of `depositsExtraInfo` array must be equal to the
     ///        length of `proposal.depositsKeys`, i.e. each deposit must
-    ///        have exactly one set of corresponding extra data,
+    ///        have exactly one set of corresponding extra info,
     ///      - The proposed sweep tx fee must be grater than zero,
     ///      - The proposed maximum per-deposit sweep tx fee must be lesser than
     ///        or equal the maximum fee allowed by the Bridge (`Bridge.depositTxMaxFee`),
@@ -204,7 +204,7 @@ contract WalletProposalValidator {
     ///      - Each deposit must be old enough, i.e. at least `DEPOSIT_MIN_AGE
     ///        elapsed since their reveal time,
     ///      - Each deposit must not be swept yet,
-    ///      - Each deposit must have valid extra data (see `validateDepositExtraInfo`),
+    ///      - Each deposit must have valid extra info (see `validateDepositExtraInfo`),
     ///      - Each deposit must have the refund safety margin preserved,
     ///      - Each deposit must be controlled by the same wallet,
     ///      - Each deposit must target the same vault,
@@ -232,7 +232,7 @@ contract WalletProposalValidator {
 
         require(
             proposal.depositsKeys.length == depositsExtraInfo.length,
-            "Each deposit key must have matching extra data"
+            "Each deposit key must have matching extra info"
         );
 
         validateSweepTxFee(proposal.sweepTxFee, proposal.depositsKeys.length);
@@ -354,12 +354,12 @@ contract WalletProposalValidator {
         );
     }
 
-    /// @notice Validates the extra data for the given deposit. This function
+    /// @notice Validates the extra info for the given deposit. This function
     ///         is heavily based on `Deposit.revealDeposit` function.
     /// @param depositKey Key of the given deposit.
     /// @param depositor Depositor that revealed the deposit.
     /// @param extraData 32-byte deposit extra data. Optional, can be bytes32(0).
-    /// @param depositExtraInfo Extra data being subject of the validation.
+    /// @param depositExtraInfo Extra info being subject of the validation.
     /// @dev Requirements:
     ///      - The transaction hash computed using `depositExtraInfo.fundingTx`
     ///        must match the `depositKey.fundingTxHash`. This requirement
@@ -369,7 +369,7 @@ contract WalletProposalValidator {
     ///      - The P2(W)SH script inferred from `depositExtraInfo` is actually
     ///        used to lock funds by the `depositKey.fundingOutputIndex` output
     ///        of the `depositExtraInfo.fundingTx` transaction. This requirement
-    ///        ensures the reveal data provided in the extra data container
+    ///        ensures the reveal data provided in the extra info container
     ///        actually matches the given deposit.
     function validateDepositExtraInfo(
         DepositKey memory depositKey,
@@ -386,7 +386,7 @@ contract WalletProposalValidator {
             )
             .hash256View();
 
-        // Make sure the funding tx provided as part of deposit extra data
+        // Make sure the funding tx provided as part of deposit extra info
         // actually matches the deposit referred by the given deposit key.
         if (depositKey.fundingTxHash != depositExtraFundingTxHash) {
             revert("Extra info funding tx hash does not match");
@@ -463,7 +463,7 @@ contract WalletProposalValidator {
             .extractOutputAtIndex(depositKey.fundingOutputIndex);
         bytes memory fundingOutputHash = fundingOutput.extractHash();
 
-        // Path that checks the deposit extra data validity in case the
+        // Path that checks the deposit extra info validity in case the
         // referred deposit is a P2SH.
         if (
             // slither-disable-next-line calls-loop
@@ -473,7 +473,7 @@ contract WalletProposalValidator {
             return;
         }
 
-        // Path that checks the deposit extra data validity in case the
+        // Path that checks the deposit extra info validity in case the
         // referred deposit is a P2WSH.
         if (
             fundingOutputHash.length == 32 &&

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -196,7 +196,7 @@ describe("WalletProposalValidator", () => {
         })
 
         context("when sweep does not exceed the max size", () => {
-          context("when deposit extra data length does not match", () => {
+          context("when deposit extra info length does not match", () => {
             it("should revert", async () => {
               // The proposal contains one deposit.
               const proposal = {
@@ -206,7 +206,7 @@ describe("WalletProposalValidator", () => {
                 depositsRevealBlocks: [], // Not relevant in this scenario.
               }
 
-              // The extra data array contains two items.
+              // The extra info array contains two items.
               const depositsExtraInfo = [
                 emptyDepositExtraInfo,
                 emptyDepositExtraInfo,
@@ -218,12 +218,12 @@ describe("WalletProposalValidator", () => {
                   depositsExtraInfo
                 )
               ).to.be.revertedWith(
-                "Each deposit key must have matching extra data"
+                "Each deposit key must have matching extra info"
               )
             })
           })
 
-          context("when deposit extra data length matches", () => {
+          context("when deposit extra info length matches", () => {
             context("when proposed sweep tx fee is invalid", () => {
               context("when proposed sweep tx fee is zero", () => {
                 let depositOne
@@ -564,7 +564,7 @@ describe("WalletProposalValidator", () => {
 
                   context("when all deposits are not swept yet", () => {
                     context(
-                      "when there is a deposit with invalid extra data",
+                      "when there is a deposit with invalid extra info",
                       () => {
                         context("when funding tx hashes don't match", () => {
                           let deposit
@@ -602,7 +602,7 @@ describe("WalletProposalValidator", () => {
                               depositsRevealBlocks: [], // Not relevant in this scenario.
                             }
 
-                            // Corrupt the extra data by setting a different
+                            // Corrupt the extra info by setting a different
                             // version than 0x01000000 used to produce the hash.
                             const depositsExtraInfo = [
                               {
@@ -663,7 +663,7 @@ describe("WalletProposalValidator", () => {
                                 depositsRevealBlocks: [], // Not relevant in this scenario.
                               }
 
-                              // Corrupt the extra data by reversing the proper
+                              // Corrupt the extra info by reversing the proper
                               // blinding factor used to produce the script.
                               const depositsExtraInfo = [
                                 {
@@ -729,7 +729,7 @@ describe("WalletProposalValidator", () => {
                                 depositsRevealBlocks: [], // Not relevant in this scenario.
                               }
 
-                              // Corrupt the extra data by reversing the proper
+                              // Corrupt the extra info by reversing the proper
                               // blinding factor used to produce the script.
                               const depositsExtraInfo = [
                                 {
@@ -759,7 +759,7 @@ describe("WalletProposalValidator", () => {
                       }
                     )
 
-                    context("when all deposits extra data are valid", () => {
+                    context("when all deposits extra info are valid", () => {
                       context(
                         "when there is a deposit that violates the refund safety margin",
                         () => {

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -2010,6 +2010,7 @@ const createTestDeposit = (
       vault,
       treasuryFee: 0, // not relevant
       sweptAt: 0, // important to pass the validation
+      extraData: ethers.constants.HashZero, // not relevant
     },
     extraInfo: {
       fundingTx,

--- a/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
+++ b/solidity/test/vault/TBTCVault.OptimisticMinting.test.ts
@@ -1789,6 +1789,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             vault: f.tbtcVault.address,
             treasuryFee: 10,
             sweptAt: 0,
+            extraData: ethers.constants.HashZero,
           })
           f.mockBridge.deposits.whenCalledWith(secondDepositID).returns({
             depositor: depositorAddress,
@@ -1797,6 +1798,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             vault: f.tbtcVault.address,
             treasuryFee: 15,
             sweptAt: 0,
+            extraData: ethers.constants.HashZero,
           })
 
           await f.tbtcVault
@@ -1895,6 +1897,7 @@ describe("TBTCVault - OptimisticMinting", () => {
             vault: f.tbtcVault.address,
             treasuryFee: 10,
             sweptAt: 0,
+            extraData: ethers.constants.HashZero,
           })
 
           await f.tbtcVault


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc-v2/issues/749

Here we expose the `revealDepositWithExtraData` function in the `Bridge` contract. This function allows revealing a deposit whose funding transaction embeds arbitrary 32-byte extra data. 

The new function opens a variety of use cases. An EOA depositor can craft a Bitcoin deposit transaction that allows a third-party smart contract to manage the deposit and provide additional services on top. In this case, 32-byte extra data can be used to securely attribute the deposit to the original EOA depositor.  

### The `revealDepositWithExtraData` function

The `revealDepositWithExtraData` was added next to the existing `revealDeposit` function to provide backward compatibility of the `Bridge` contract API. The `Deposit` library that does the heavy lifting was refactored to handle both regular deposits without extra data and the new deposits with extra data. The common logic was extracted to the `_revealDeposit` internal function to avoid duplication. 

Worth noting, the extra data passed in the new flow has to be externalized so tBTC wallets can reconstruct the deposit script and sweep those deposits, just as the regular ones. To do so, we decided to store the extra data in the `Bridge` storage (as part of the `DepositRequest` structure). This approach is not ideal but has some advantages:
- Negligible gas overhead for regular deposits without extra data (~2000 of gas) 
- Easier integration as extra data can be easily fetched from storage by tBTC wallets and third-party smart contracts 
- Making the `Bridge` aware of the extra data may open some use cases in the future

Alternative approaches rely on emitting the extra data using contract events. However:
- Extending the existing `DepositReveal` event is not backward compatible. The event signature would change and clients trying to fetch past events that don't contain the extra data field would fail. This is especially problematic for tBTC wallets, SPV maintainers, and block explorers
- Using a new event just for emitting the extra data is clunky and makes the integration experience significantly worse

### Changes in the `WalletProposalValidator` contract

The `WalletProposalValidator` contract is used by tBTC off-chain wallet clients to validate incoming deposit sweep proposals. This contract needs to reconstruct deposit scripts so must be aware of the new alternative format with 32-byte extra data. As part of this pull request, we are adjusting this contract to properly validate deposit sweep proposals that include deposits with extra data.

### Impact on gas costs and contract size

Before the presented change, the gas costs of functions and size of affected contract/libraries was as follows:

```
·------------------------------|---------------------------|--------------|-----------------------------·
|     Solc version: 0.8.17     ·  Optimizer enabled: true  ·  Runs: 1000  ·  Block limit: 30000000 gas  │
·······························|···························|··············|······························
|  Methods                                                                                              │
·············|·················|·············|·············|··············|···············|··············
|  Contract  ·  Method         ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
·············|·················|·············|·············|··············|···············|··············
|  Bridge    ·  revealDeposit  ·  82767      ·  105463     ·  102057      ·  170          ·  -          │
·············|·················|·············|·············|··············|···············|··············
```
```
·-------------------------------|-------------|---------------·
|  Contract Name                ·  Size (KB)  ·  Change (KB)  │
································|·············|················
|  Bridge                       ·     21.264  ·               │
································|·············|················
|  Deposit                      ·      6.327  ·               │
································|·············|················
|  WalletProposalValidator      ·     11.266  ·               │
································|·············|················
```

After introducing `revealDepositWithExtraData`, those are as follows:

```
·------------------------------·············|---------------------------|--------------|-----------------------------·
|           Solc version: 0.8.17            ·  Optimizer enabled: true  ·  Runs: 1000  ·  Block limit: 30000000 gas  │
············································|···························|··············|······························
|  Methods                                                                                                           │
·············|······························|·············|·············|··············|···············|··············
|  Contract  ·  Method                      ·  Min        ·  Max        ·  Avg         ·  # calls      ·  eur (avg)  │
·············|······························|·············|·············|··············|···············|··············
|  Bridge    ·  revealDeposit               ·  85270      ·  107966     ·  104562      ·  170          ·  -          │
·············|······························|·············|·············|··············|···············|··············
|  Bridge    ·  revealDepositWithExtraData  ·  124176     ·  126773     ·  125872      ·  12           ·  -          │
·············|······························|·············|·············|··············|···············|··············
```
```
·-------------------------------|-------------|---------------·
|  Contract Name                ·  Size (KB)  ·  Change (KB)  │
································|·············|················
|  Bridge                       ·     21.563  ·               │
································|·············|················
|  Deposit                      ·      6.894  ·               │
································|·············|················
|  WalletProposalValidator      ·     11.520  ·               │
································|·············|················
```

### Next steps

This change is the most important one towards full support of deposits with extra data. However, comprehensive support requires some additional steps:
- Add support in the tBTC off-chain client
- Add support in the tBTC SDK