### PR TITLE
Added validation of moved funds sweep proposal

### DIFF
--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -731,6 +731,25 @@ contract WalletProposalValidator {
         return walletBtcBalance;
     }
 
+    /// @notice View function encapsulating the main rules of a valid moved
+    ///         funds sweep proposal. This function is meant to facilitate the
+    ///         off-chain validation of the incoming proposals. Thanks to it,
+    ///         most of the work can be done using a single readonly contract
+    ///         call.
+    /// @param proposal The moved funds sweep proposal to validate.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///      - The source wallet must be in the Live or MovingFunds state,
+    ///      - The moved funds sweep request identified by the proposed
+    ///        transaction hash and output index must be in the Pending state,
+    ///      - The transaction hash and output index from the proposal must
+    ///        identify a moved funds sweep request in the Pending state,
+    ///      - The transaction hash and output index from the proposal must
+    ///        identify a moved funds sweep request that belongs to the wallet,
+    ///      - The proposed moved funds sweep transaction fee must be greater
+    ///        than zero,
+    ///      - The proposed moved funds sweep transaction fee must not exceed
+    ///        the maximum total fee allowed for moved funds sweep.
     function validateMovedFundsSweepProposal(
         MovedFundsSweepProposal calldata proposal
     ) external view returns (bool) {

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -22,6 +22,7 @@ import "./BitcoinTx.sol";
 import "./Bridge.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./MovingFunds.sol";
 import "./Wallets.sol";
 
 /// @title Wallet proposal validator.
@@ -102,6 +103,20 @@ contract WalletProposalValidator {
         bytes20[] targetWallets;
         // Proposed BTC fee for the entire transaction.
         uint256 movingFundsTxFee;
+    }
+
+    /// @notice Helper structure representing a moved funds sweep proposal.
+    struct MovedFundsSweepProposal {
+        // 20-byte public key hash of the wallet.
+        bytes20 walletPubKeyHash;
+        // 32-byte hash of the moving funds transaction that caused the sweep
+        // request to be created.
+        bytes32 movingFundsTxHash;
+        // Index of the moving funds transaction output that is subject of the
+        // sweep request.
+        uint32 movingFundsTxOutputIndex;
+        // Proposed BTC fee for the entire transaction.
+        uint256 movedFundsSweepTxFee;
     }
 
     /// @notice Helper structure representing a heartbeat proposal.
@@ -656,6 +671,61 @@ contract WalletProposalValidator {
 
         require(
             proposal.movingFundsTxFee <= movingFundsTxMaxTotalFee,
+            "Proposed transaction fee is too high"
+        );
+
+        return true;
+    }
+
+    function validateMovedFundsSweepProposal(
+        MovedFundsSweepProposal calldata proposal
+    ) external view returns (bool) {
+        Wallets.Wallet memory wallet = bridge.wallets(
+            proposal.walletPubKeyHash
+        );
+
+        // Make sure the wallet is in Live or MovingFunds state.
+        require(
+            wallet.state == Wallets.WalletState.Live ||
+                wallet.state == Wallets.WalletState.MovingFunds,
+            "Source wallet is not in Live or MovingFunds state"
+        );
+
+        // Make sure the moved funds sweep request is valid.
+        uint256 sweepRequestKeyUint = uint256(
+            keccak256(
+                abi.encodePacked(
+                    proposal.movingFundsTxHash,
+                    proposal.movingFundsTxOutputIndex
+                )
+            )
+        );
+
+        MovingFunds.MovedFundsSweepRequest memory sweepRequest = bridge
+            .movedFundsSweepRequests(sweepRequestKeyUint);
+
+        require(
+            sweepRequest.state ==
+                MovingFunds.MovedFundsSweepRequestState.Pending,
+            "Sweep request is not in Pending state"
+        );
+
+        require(
+            sweepRequest.walletPubKeyHash == proposal.walletPubKeyHash,
+            "Sweep request does not belong to the wallet"
+        );
+
+        // Make sure the proposed fee is valid.
+        (, , , , , , , uint64 movedFundsSweepTxMaxTotalFee, , , ) = bridge
+            .movingFundsParameters();
+
+        require(
+            proposal.movedFundsSweepTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+
+        require(
+            proposal.movedFundsSweepTxFee <= movedFundsSweepTxMaxTotalFee,
             "Proposed transaction fee is too high"
         );
 


### PR DESCRIPTION
#Refs: https://github.com/keep-network/keep-core/issues/3733.
#Depends on: https://github.com/keep-network/tbtc-v2/pull/757.

This PR adds moved funds sweep proposal validation to the wallet proposal validator smart contract.