### PR TITLE
Tweaks to `AbstractTBTCDepositor` contract

### DIFF
--- a/solidity/.nvmrc
+++ b/solidity/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/solidity/contracts/integrator/TBTCDepositorProxy.sol
+++ b/solidity/contracts/integrator/TBTCDepositorProxy.sol
@@ -167,7 +167,10 @@ abstract contract TBTCDepositorProxy {
     ///         for the deposit and calling the `onDepositFinalized` callback
     ///         function.
     /// @param depositKey Deposit key identifying the deposit.
-    /// @return tbtcAmount Approximate amount of TBTC minted for the deposit.
+    /// @return initialDepositAmount Amount of funding transaction deposit. In
+    ///         TBTC token decimals precision.
+    /// @return tbtcAmount Approximate amount of TBTC minted for the deposit. In
+    ///         TBTC token decimals precision.
     /// @return extraData 32-byte deposit extra data.
     /// @dev Requirements:
     ///      - The deposit must be initialized but not finalized
@@ -178,9 +181,15 @@ abstract contract TBTCDepositorProxy {
     ///      approximation. See documentation of the `calculateTbtcAmount`
     ///      responsible for calculating this value for more details.
     // slither-disable-next-line dead-code
-    function _finalizeDeposit(uint256 depositKey)
+    function _finalizeDeposit(
+        uint256 depositKey
+    )
         internal
-        returns (uint256 tbtcAmount, bytes32 extraData)
+        returns (
+            uint256 initialDepositAmount,
+            uint256 tbtcAmount,
+            bytes32 extraData
+        )
     {
         require(pendingDeposits[depositKey], "Deposit not initialized");
 
@@ -203,6 +212,8 @@ abstract contract TBTCDepositorProxy {
         // being called again for the same deposit.
         // slither-disable-next-line reentrancy-no-eth
         delete pendingDeposits[depositKey];
+
+        initialDepositAmount = deposit.amount * SATOSHI_MULTIPLIER;
 
         tbtcAmount = _calculateTbtcAmount(deposit.amount, deposit.treasuryFee);
 

--- a/solidity/contracts/integrator/TBTCDepositorProxy.sol
+++ b/solidity/contracts/integrator/TBTCDepositorProxy.sol
@@ -64,7 +64,11 @@ import "./ITBTCVault.sol";
 ///          }
 ///
 ///          function finalizeProcess(uint256 depositKey) external {
-///              (uint256 tbtcAmount, bytes32 extraData) = _finalizeDeposit(depositKey);
+///              (
+///                  uint256 initialDepositAmount,
+///                  uint256 tbtcAmount,
+///                  bytes32 extraData
+///              ) = _finalizeDeposit(depositKey);
 ///
 ///              // Do something with the minted TBTC using context
 ///              // embedded in the extraData.

--- a/solidity/contracts/integrator/TBTCDepositorProxy.sol
+++ b/solidity/contracts/integrator/TBTCDepositorProxy.sol
@@ -181,9 +181,7 @@ abstract contract TBTCDepositorProxy {
     ///      approximation. See documentation of the `calculateTbtcAmount`
     ///      responsible for calculating this value for more details.
     // slither-disable-next-line dead-code
-    function _finalizeDeposit(
-        uint256 depositKey
-    )
+    function _finalizeDeposit(uint256 depositKey)
         internal
         returns (
             uint256 initialDepositAmount,

--- a/solidity/contracts/test/TestTBTCDepositorProxy.sol
+++ b/solidity/contracts/test/TestTBTCDepositorProxy.sol
@@ -56,8 +56,8 @@ contract MockBridge is IBridge {
 
     mapping(uint256 => IBridgeTypes.DepositRequest) internal _deposits;
 
-    uint64 internal _depositTreasuryFeeDivisor = 100; // 1/100 == 100 bps == 1% == 0.01
-    uint64 internal _depositTxMaxFee = 1 * 1e7; // 0.1 BTC
+    uint64 internal _depositTreasuryFeeDivisor = 50; // 1/50 == 100 bps == 2% == 0.02
+    uint64 internal _depositTxMaxFee = 1000; // 1000 satoshi = 0.00001 BTC
 
     event DepositRevealed(uint256 depositKey);
 

--- a/solidity/contracts/test/TestTBTCDepositorProxy.sol
+++ b/solidity/contracts/test/TestTBTCDepositorProxy.sol
@@ -44,6 +44,7 @@ contract MockBridge is IBridge {
 
     mapping(uint256 => IBridgeTypes.DepositRequest) internal _deposits;
 
+    uint64 internal _depositTreasuryFeeDivisor = 100; // 1/100 == 100 bps == 1% == 0.01
     uint64 internal _depositTxMaxFee = 1 * 1e7; // 0.1 BTC
 
     event DepositRevealed(uint256 depositKey);
@@ -80,7 +81,9 @@ contract MockBridge is IBridge {
         /* solhint-disable-next-line not-rely-on-time */
         request.revealedAt = uint32(block.timestamp);
         request.vault = reveal.vault;
-        request.treasuryFee = uint64(1 * 1e8); // 1 BTC
+        request.treasuryFee = _depositTreasuryFeeDivisor > 0
+            ? fundingOutputAmount / _depositTreasuryFeeDivisor
+            : 0;
         request.sweptAt = 0;
         request.extraData = extraData;
 
@@ -118,6 +121,10 @@ contract MockBridge is IBridge {
         depositTreasuryFeeDivisor = 0;
         depositTxMaxFee = _depositTxMaxFee;
         depositRevealAheadPeriod = 0;
+    }
+
+    function setDepositTreasuryFeeDivisor(uint64 value) external {
+        _depositTreasuryFeeDivisor = value;
     }
 
     function setDepositTxMaxFee(uint64 value) external {

--- a/solidity/contracts/test/TestTBTCDepositorProxy.sol
+++ b/solidity/contracts/test/TestTBTCDepositorProxy.sol
@@ -89,7 +89,7 @@ contract MockBridge is IBridge {
         emit DepositRevealed(depositKey);
     }
 
-    function sweepDeposit(uint256 depositKey) external {
+    function sweepDeposit(uint256 depositKey) public {
         require(_deposits[depositKey].revealedAt != 0, "Deposit not revealed");
         require(_deposits[depositKey].sweptAt == 0, "Deposit already swept");
         /* solhint-disable-next-line not-rely-on-time */
@@ -152,7 +152,7 @@ contract MockTBTCVault is ITBTCVault {
         _requests[depositKey].requestedAt = uint64(block.timestamp);
     }
 
-    function finalizeOptimisticMintingRequest(uint256 depositKey) external {
+    function finalizeOptimisticMintingRequest(uint256 depositKey) public {
         require(
             _requests[depositKey].requestedAt != 0,
             "Request does not exist"

--- a/solidity/contracts/test/TestTBTCDepositorProxy.sol
+++ b/solidity/contracts/test/TestTBTCDepositorProxy.sol
@@ -11,7 +11,11 @@ import "../integrator/ITBTCVault.sol";
 contract TestTBTCDepositorProxy is TBTCDepositorProxy {
     event InitializeDepositReturned(uint256 depositKey);
 
-    event FinalizeDepositReturned(uint256 tbtcAmount, bytes32 extraData);
+    event FinalizeDepositReturned(
+        uint256 initialDepositAmount,
+        uint256 tbtcAmount,
+        bytes32 extraData
+    );
 
     function initialize(address _bridge, address _tbtcVault) external {
         __TBTCDepositorProxy_initialize(_bridge, _tbtcVault);
@@ -27,8 +31,16 @@ contract TestTBTCDepositorProxy is TBTCDepositorProxy {
     }
 
     function finalizeDepositPublic(uint256 depositKey) external {
-        (uint256 tbtcAmount, bytes32 extraData) = _finalizeDeposit(depositKey);
-        emit FinalizeDepositReturned(tbtcAmount, extraData);
+        (
+            uint256 initialDepositAmount,
+            uint256 tbtcAmount,
+            bytes32 extraData
+        ) = _finalizeDeposit(depositKey);
+        emit FinalizeDepositReturned(
+            initialDepositAmount,
+            tbtcAmount,
+            extraData
+        );
     }
 
     function calculateTbtcAmountPublic(

--- a/solidity/contracts/test/TestTBTCDepositorProxy.sol
+++ b/solidity/contracts/test/TestTBTCDepositorProxy.sol
@@ -74,10 +74,16 @@ contract MockBridge is IBridge {
             "Deposit already revealed"
         );
 
+        bytes memory fundingOutput = fundingTx
+            .outputVector
+            .extractOutputAtIndex(reveal.fundingOutputIndex);
+
+        uint64 fundingOutputAmount = fundingOutput.extractValue();
+
         IBridgeTypes.DepositRequest memory request;
 
         request.depositor = msg.sender;
-        request.amount = uint64(10 * 1e8); // 10 BTC
+        request.amount = fundingOutputAmount;
         /* solhint-disable-next-line not-rely-on-time */
         request.revealedAt = uint32(block.timestamp);
         request.vault = reveal.vault;

--- a/solidity/test/integrator/TBTCDepositorProxy.test.ts
+++ b/solidity/test/integrator/TBTCDepositorProxy.test.ts
@@ -323,17 +323,17 @@ describe("TBTCDepositorProxy", () => {
   })
 
   describe("_calculateTbtcAmount", () => {
-      before(async () => {
-        await createSnapshot()
-            
-        // Set the transaction max fee to 0.1 BTC.
-        await bridge.setDepositTxMaxFee(10000000)
-      })
+    before(async () => {
+      await createSnapshot()
 
-      after(async () => {
-        await restoreSnapshot()
-      })
-    
+      // Set the transaction max fee to 0.1 BTC.
+      await bridge.setDepositTxMaxFee(10000000)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
     context("when all fees are non-zero", () => {
       it("should return the correct amount", async () => {
         const depositAmount = to1ePrecision(10, 8) // 10 BTC

--- a/solidity/test/integrator/TBTCDepositorProxy.test.ts
+++ b/solidity/test/integrator/TBTCDepositorProxy.test.ts
@@ -214,13 +214,14 @@ describe("TBTCDepositorProxy", () => {
       context("when deposit is finalized by the Bridge", () => {
         // The expected tbtcAmount is calculated as follows:
         //
-        // - Deposit amount = 10 BTC (hardcoded in MockBridge)
-        // - Treasury fee = 1 BTC (hardcoded in MockBridge)
-        // - Optimistic minting fee = 1%  (default value used in MockTBTCVault)
-        // - Transaction max fee = 0.1 BTC (default value used in MockBridge)
+        // - Deposit amount = 10000 satoshi (hardcoded in funding transaction fixture)
+        // - Treasury fee = 2% (default value used in MockBridge)
+        // - Optimistic minting fee = 1% (default value used in MockTBTCVault)
+        // - Transaction max fee = 1000 satoshi (default value used in MockBridge)
         //
-        // ((10 BTC - 1 BTC) * 0.99) - 0.1 BTC = 8.81 BTC = 8.81 * 1e8 sat = 8.81 * 1e18 TBTC
-        const expectedTbtcAmount = to1ePrecision(881, 16).toString()
+        // ((10000 sat - 200 sat) * 0.99) - 2000 sat = 8702 sat = 8702 * 1e10 TBTC
+        const expectedInitialDepositAmount = to1ePrecision(10000, 10)
+        const expectedTbtcAmount = to1ePrecision(8702, 10).toString()
 
         context("when the deposit is swept", () => {
           let tx: ContractTransaction
@@ -259,7 +260,11 @@ describe("TBTCDepositorProxy", () => {
           it("should return proper values", async () => {
             await expect(tx)
               .to.emit(depositorProxy, "FinalizeDepositReturned")
-              .withArgs(expectedTbtcAmount, fixture.extraData)
+              .withArgs(
+                expectedInitialDepositAmount,
+                expectedTbtcAmount,
+                fixture.extraData
+              )
           })
         })
 
@@ -306,7 +311,11 @@ describe("TBTCDepositorProxy", () => {
           it("should return proper values", async () => {
             await expect(tx)
               .to.emit(depositorProxy, "FinalizeDepositReturned")
-              .withArgs(expectedTbtcAmount, fixture.extraData)
+              .withArgs(
+                expectedInitialDepositAmount,
+                expectedTbtcAmount,
+                fixture.extraData
+              )
           })
         })
       })
@@ -314,6 +323,17 @@ describe("TBTCDepositorProxy", () => {
   })
 
   describe("_calculateTbtcAmount", () => {
+      before(async () => {
+        await createSnapshot()
+            
+        // Set the transaction max fee to 0.1 BTC.
+        await bridge.setDepositTxMaxFee(10000000)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+    
     context("when all fees are non-zero", () => {
       it("should return the correct amount", async () => {
         const depositAmount = to1ePrecision(10, 8) // 10 BTC
@@ -324,7 +344,7 @@ describe("TBTCDepositorProxy", () => {
         // - Deposit amount = 10 BTC
         // - Treasury fee = 1 BTC
         // - Optimistic minting fee = 1%  (default value used in MockTBTCVault)
-        // - Transaction max fee = 0.1 BTC (default value used in MockBridge)
+        // - Transaction max fee = 0.1 BTC (set in MockBridge)
         //
         // ((10 BTC - 1 BTC) * 0.99) - 0.1 BTC = 8.81 BTC = 8.81 * 1e8 sat = 8.81 * 1e18 TBTC
         const expectedTbtcAmount = to1ePrecision(881, 16)
@@ -386,7 +406,7 @@ describe("TBTCDepositorProxy", () => {
           // - Deposit amount = 10 BTC
           // - Treasury fee = 0 BTC
           // - Optimistic minting fee = 1%  (default value used in MockTBTCVault)
-          // - Transaction max fee = 0.1 BTC (default value used in MockBridge)
+          // - Transaction max fee = 0.1 BTC (set in MockBridge)
           //
           // ((10 BTC - 0 BTC) * 0.99) - 0.1 BTC = 9.8 BTC = 9.8 * 1e8 sat = 9.8 * 1e18 TBTC
           const expectedTbtcAmount = to1ePrecision(98, 17)
@@ -421,7 +441,7 @@ describe("TBTCDepositorProxy", () => {
           // - Deposit amount = 10 BTC
           // - Treasury fee = 1 BTC
           // - Optimistic minting fee = 0%  (set in MockTBTCVault)
-          // - Transaction max fee = 0.1 BTC (default value used in MockBridge)
+          // - Transaction max fee = 0.1 BTC (set in MockBridge)
           //
           // ((10 BTC - 1 BTC) * 1) - 0.1 BTC = 8.9 BTC = 8.9 * 1e8 sat = 8.9 * 1e18 TBTC
           const expectedTbtcAmount = to1ePrecision(89, 17)


### PR DESCRIPTION
In this PR I propose some modifications to the initial implementation of `AbstractTBTCDepositor` contract (https://github.com/keep-network/tbtc-v2/pull/778).

### Return initial deposit amount from _initializeDeposit function

Integrators may be interested in adding more fees to the deposit amount. For this reason, it may be cleanest to calculate it based on the initial deposit amount. By returning the value here they will avoid the need to read the funding deposit amount from the storage again.

### Mock contracts tweaks

I added modifications to the MockBridge and MockTBTCVault contracts, that were useful in tests of the integrator's implementation (https://github.com/thesis/acre/pull/91).  