### PR TITLE
Include test contracts in published NPM package

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -6,7 +6,6 @@
     "artifacts/",
     "build/contracts/",
     "contracts/",
-    "!**/test/",
     "deploy/",
     "export/",
     "tasks/",


### PR DESCRIPTION
Here we remove the rule we added to exclude test contracts from published NPM package. In
https://github.com/keep-network/tbtc-v2/pull/779 we prepared a `TestTBTCDepositor` contract to be used by the integrators in tests for mocking the tBTC Bridge contracts. It is useful to include this file in the package, so the integrators can leverage it.