### PR TITLE
Do not emit events from AbstractTBTCDepositor

### DIFF
--- a/solidity/contracts/integrator/AbstractTBTCDepositor.sol
+++ b/solidity/contracts/integrator/AbstractTBTCDepositor.sol
@@ -96,14 +96,6 @@ abstract contract AbstractTBTCDepositor {
     // slither-disable-next-line unused-state
     uint256[47] private __gap;
 
-    event DepositInitialized(uint256 indexed depositKey, uint32 initializedAt);
-
-    event DepositFinalized(
-        uint256 indexed depositKey,
-        uint256 tbtcAmount,
-        uint32 finalizedAt
-    );
-
     /// @notice Initializes the contract. MUST BE CALLED from the child
     ///         contract initializer.
     // slither-disable-next-line dead-code
@@ -148,12 +140,6 @@ abstract contract AbstractTBTCDepositor {
         uint256 depositKey = _calculateDepositKey(
             _calculateBitcoinTxHash(fundingTx),
             reveal.fundingOutputIndex
-        );
-
-        emit DepositInitialized(
-            depositKey,
-            /* solhint-disable-next-line not-rely-on-time */
-            uint32(block.timestamp)
         );
 
         // The Bridge does not allow to reveal the same deposit twice and
@@ -210,14 +196,6 @@ abstract contract AbstractTBTCDepositor {
         initialDepositAmount = deposit.amount * SATOSHI_MULTIPLIER;
 
         tbtcAmount = _calculateTbtcAmount(deposit.amount, deposit.treasuryFee);
-
-        // slither-disable-next-line reentrancy-events
-        emit DepositFinalized(
-            depositKey,
-            tbtcAmount,
-            /* solhint-disable-next-line not-rely-on-time */
-            uint32(block.timestamp)
-        );
 
         extraData = deposit.extraData;
     }

--- a/solidity/test/integrator/AbstractTBTCDepositor.test.ts
+++ b/solidity/test/integrator/AbstractTBTCDepositor.test.ts
@@ -131,12 +131,6 @@ describe("AbstractTBTCDepositor", () => {
             .withArgs(fixture.expectedDepositKey)
         })
 
-        it("should emit the DepositInitialized event", async () => {
-          await expect(tx)
-            .to.emit(depositor, "DepositInitialized")
-            .withArgs(fixture.expectedDepositKey, await lastBlockTime())
-        })
-
         it("should return proper values", async () => {
           await expect(tx)
             .to.emit(depositor, "InitializeDepositReturned")
@@ -233,16 +227,6 @@ describe("AbstractTBTCDepositor", () => {
             await restoreSnapshot()
           })
 
-          it("should emit the DepositFinalized event", async () => {
-            await expect(tx)
-              .to.emit(depositor, "DepositFinalized")
-              .withArgs(
-                fixture.expectedDepositKey,
-                expectedTbtcAmount,
-                await lastBlockTime()
-              )
-          })
-
           it("should return proper values", async () => {
             await expect(tx)
               .to.emit(depositor, "FinalizeDepositReturned")
@@ -275,16 +259,6 @@ describe("AbstractTBTCDepositor", () => {
 
           after(async () => {
             await restoreSnapshot()
-          })
-
-          it("should emit the DepositFinalized event", async () => {
-            await expect(tx)
-              .to.emit(depositor, "DepositFinalized")
-              .withArgs(
-                fixture.expectedDepositKey,
-                expectedTbtcAmount,
-                await lastBlockTime()
-              )
           })
 
           it("should return proper values", async () => {


### PR DESCRIPTION
In all cases considered so far, the child contract emits its own events in the functions calling `_initializeDeposit` and `_finalizeDeposit`. The events emitted by child contracts have the advantage of emitting decoded extra data in the parameters. We could emit events from the parent contract as well but they cost gas and we are emitting the same data in child contract events. Also, we sometimes need to be creative in child contracts and come up with other names than `DepositInitialized` and `DepositFinalized` even though that is exactly what happens :)

Also, lesson learned today: if there is a contract inheriting from `AbstractTBTCDepositor` and declaring an event with the same name - say `DepositFinalized` - when testing the contract whether the event was emitted, Hardhat will complain this event does not exist in the contract.