### PR TITLE
Redemptions veto mechanism

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1957,6 +1957,7 @@ contract Bridge is
         external
         onlyGovernance
     {
+        // The internal function is defined in the `BridgeState` library.
         self.setRedemptionWatchtower(redemptionWatchtower);
     }
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1961,7 +1961,7 @@ contract Bridge is
     }
 
     /// @return Address of the redemption watchtower.
-    function redemptionWatchtower() external view returns (address) {
+    function getRedemptionWatchtower() external view returns (address) {
         return self.redemptionWatchtower;
     }
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1964,4 +1964,29 @@ contract Bridge is
     function redemptionWatchtower() external view returns (address) {
         return self.redemptionWatchtower;
     }
+
+    /// @notice Notifies that a redemption request was vetoed in the watchtower.
+    ///         This function is responsible for adjusting the Bridge's state
+    ///         accordingly.
+    ///         The results of calling this function:
+    ///         - the pending redemptions value for the wallet is decreased
+    ///           by the requested amount (minus treasury fee),
+    ///         - the request is removed from pending redemptions mapping,
+    ///         - the tokens taken from the redeemer on redemption request are
+    ///           detained and passed to the redemption watchtower
+    ///           (as Bank's balance) for further processing.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet.
+    /// @param redeemerOutputScript  The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @dev Requirements:
+    ///      - The caller must be the redemption watchtower,
+    ///      - The redemption request identified by `walletPubKeyHash` and
+    ///        `redeemerOutputScript` must exist.
+    function notifyRedemptionVeto(
+        bytes20 walletPubKeyHash,
+        bytes calldata redeemerOutputScript
+    ) external {
+        // The caller is checked in the internal function.
+        self.notifyRedemptionVeto(walletPubKeyHash, redeemerOutputScript);
+    }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -236,6 +236,8 @@ contract Bridge is
 
     event TreasuryUpdated(address treasury);
 
+    event RedemptionWatchtowerSet(address redemptionWatchtower);
+
     modifier onlySpvMaintainer() {
         require(
             self.isSpvMaintainer[msg.sender],
@@ -1943,5 +1945,23 @@ contract Bridge is
     ///         successfully evaluate an SPV proof.
     function txProofDifficultyFactor() external view returns (uint256) {
         return self.txProofDifficultyFactor;
+    }
+
+    /// @notice Sets the redemption watchtower address.
+    /// @param redemptionWatchtower Address of the redemption watchtower.
+    /// @dev Requirements:
+    ///      - The caller must be the governance,
+    ///      - Redemption watchtower address must not be already set,
+    ///      - Redemption watchtower address must not be 0x0.
+    function setRedemptionWatchtower(address redemptionWatchtower)
+        external
+        onlyGovernance
+    {
+        self.setRedemptionWatchtower(redemptionWatchtower);
+    }
+
+    /// @return Address of the redemption watchtower.
+    function redemptionWatchtower() external view returns (address) {
+        return self.redemptionWatchtower;
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1766,4 +1766,20 @@ contract BridgeGovernance is Ownable {
     function governanceDelay() internal view returns (uint256) {
         return governanceDelays[0];
     }
+
+    /// @notice Sets the redemption watchtower address. This function does not
+    ///         have a governance delay as setting the redemption watchtower is
+    ///         a one-off action performed during initialization of the
+    ///         redemption veto mechanism.
+    /// @param redemptionWatchtower Address of the redemption watchtower.
+    /// @dev Requirements:
+    ///      - The caller must be the owner,
+    ///      - Redemption watchtower address must not be already set,
+    ///      - Redemption watchtower address must not be 0x0.
+    function setRedemptionWatchtower(address redemptionWatchtower)
+        external
+        onlyOwner
+    {
+        bridge.setRedemptionWatchtower(redemptionWatchtower);
+    }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -314,6 +314,9 @@ library BridgeState {
         // HASH160 over the compressed ECDSA public key) to the basic wallet
         // information like state and pending redemptions value.
         mapping(bytes20 => Wallets.Wallet) registeredWallets;
+        // Address of the redemption watchtower. The redemption watchtower
+        // is responsible for vetoing redemption requests.
+        address redemptionWatchtower;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -321,7 +324,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[50] __gap;
+        uint256[49] __gap;
     }
 
     event DepositParametersUpdated(
@@ -373,6 +376,8 @@ library BridgeState {
     );
 
     event TreasuryUpdated(address treasury);
+
+    event RedemptionWatchtowerSet(address redemptionWatchtower);
 
     /// @notice Updates parameters of deposits.
     /// @param _depositDustThreshold New value of the deposit dust threshold in
@@ -825,5 +830,28 @@ library BridgeState {
 
         self.treasury = _treasury;
         emit TreasuryUpdated(_treasury);
+    }
+
+    /// @notice Sets the redemption watchtower address.
+    /// @param _redemptionWatchtower Address of the redemption watchtower.
+    /// @dev Requirements:
+    ///      - Redemption watchtower address must not be already set,
+    ///      - Redemption watchtower address must not be 0x0.
+    function setRedemptionWatchtower(
+        Storage storage self,
+        address _redemptionWatchtower
+    ) internal {
+        require(
+            self.redemptionWatchtower == address(0),
+            "Redemption watchtower already set"
+        );
+
+        require(
+            _redemptionWatchtower != address(0),
+            "Redemption watchtower address must not be 0x0"
+        );
+
+        self.redemptionWatchtower = _redemptionWatchtower;
+        emit RedemptionWatchtowerSet(_redemptionWatchtower);
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -181,7 +181,10 @@ library BridgeState {
         // timed out. It is counted from the moment when the redemption
         // request was created via `requestRedemption` call. Reported
         // timed out requests are cancelled and locked TBTC is returned
-        // to the redeemer in full amount.
+        // to the redeemer in full amount. If a redemption watchtower
+        // is set, the redemption timeout should be greater than the maximum
+        // value of the redemption delay that can be enforced by the watchtower.
+        // Consult `IRedemptionWatchtower.getRedemptionDelay` for more details.
         uint32 redemptionTimeout;
         // The amount of stake slashed from each member of a wallet for a
         // redemption timeout.

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -402,6 +402,8 @@ library Redemption {
         bytes memory redeemerOutputScript,
         uint64 amount
     ) internal {
+        // TODO: Validate the request against the RedemptionWatchtower.
+
         Wallets.Wallet storage wallet = self.registeredWallets[
             walletPubKeyHash
         ];
@@ -1074,5 +1076,65 @@ library Redemption {
             key := keccak256(0, 52)
         }
         return key;
+    }
+
+    /// @notice Notifies that a redemption request was vetoed in the watchtower.
+    ///         This function is responsible for adjusting the Bridge's state
+    ///         accordingly.
+    ///         The results of calling this function:
+    ///         - the pending redemptions value for the wallet is decreased
+    ///           by the requested amount (minus treasury fee),
+    ///         - the request is removed from pending redemptions mapping,
+    ///         - the tokens taken from the redeemer on redemption request are
+    ///           detained and passed to the redemption watchtower
+    ///           (as Bank's balance) for further processing.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet.
+    /// @param redeemerOutputScript  The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @dev Requirements:
+    ///      - The caller must be the redemption watchtower,
+    ///      - The redemption request identified by `walletPubKeyHash` and
+    ///        `redeemerOutputScript` must exist.
+    function notifyRedemptionVeto(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash,
+        bytes calldata redeemerOutputScript
+    ) external {
+        require(
+            msg.sender == self.redemptionWatchtower,
+            "Caller is not the redemption watchtower"
+        );
+
+        uint256 redemptionKey = getRedemptionKey(
+            walletPubKeyHash,
+            redeemerOutputScript
+        );
+        Redemption.RedemptionRequest storage redemption = self
+            .pendingRedemptions[redemptionKey];
+
+        // Should never happen, but just in case.
+        require(
+            redemption.requestedAt != 0,
+            "Redemption request does not exist"
+        );
+
+        // Update the wallet's pending redemptions value. This is the
+        // same logic as performed upon redemption request timeout.
+        // If we don't do this, the wallet will hold the reserve
+        // for a redemption request that will never be processed.
+        self.registeredWallets[walletPubKeyHash].pendingRedemptionsValue -=
+            redemption.requestedAmount -
+            redemption.treasuryFee;
+
+        // Capture the amount that should be transferred to the
+        // redemption watchtower.
+        uint64 detainedAmount = redemption.requestedAmount;
+
+        // Delete the redemption request from the pending redemptions
+        // mapping. This is important to avoid this redemption request
+        // to be processed by the wallet or reported as timed out.
+        delete self.pendingRedemptions[redemptionKey];
+
+        self.bank.transferBalance(self.redemptionWatchtower, detainedAmount);
     }
 }

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -43,6 +43,16 @@ interface IRedemptionWatchtower {
         address balanceOwner,
         address redeemer
     ) external view returns (bool);
+
+    /// @notice Returns the applicable redemption delay for a redemption
+    ///         request identified by the given redemption key.
+    /// @param redemptionKey Redemption key built as
+    ///        `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`.
+    /// @return Redemption delay.
+    function getRedemptionDelay(uint256 redemptionKey)
+        external
+        view
+        returns (uint32);
 }
 
 /// @notice Aggregates functions common to the redemption transaction proof

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -152,6 +152,10 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         uint64 waivedAmountLimit
     );
 
+    event Banned(address indexed redeemer);
+
+    event Unbanned(address indexed redeemer);
+
     modifier onlyManager() {
         require(msg.sender == manager, "Caller is not watchtower manager");
         _;
@@ -372,6 +376,8 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             // requests from that address.
             isBanned[redemption.redeemer] = true;
 
+            emit Banned(redemption.redeemer);
+
             emit VetoFinalized(redemptionKey);
 
             // Notify the Bridge about the veto. As result of this call,
@@ -559,5 +565,16 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         }
 
         return true;
+    }
+
+    /// @notice Unbans a redeemer.
+    /// @param redeemer Address of the redeemer to unban.
+    /// @dev Requirements:
+    ///      - The caller must be the watchtower manager,
+    ///      - The redeemer must be banned.
+    function unban(address redeemer) external onlyManager {
+        require(isBanned[redeemer], "Redeemer is not banned");
+        isBanned[redeemer] = false;
+        emit Unbanned(redeemer);
     }
 }

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -157,7 +157,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     event Unbanned(address indexed redeemer);
 
     event VetoedFundsWithdrawn(
-        uint256 indexed redemptionkey,
+        uint256 indexed redemptionKey,
         address indexed redeemer,
         uint64 amount
     );

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -21,17 +21,37 @@ import "./Bridge.sol";
 
 /// @title Redemption watchtower
 /// @notice This contract encapsulates the logic behind the redemption veto
-/// mechanism of the Bridge. The redemption veto mechanism is a safeguard
-/// in the event of malicious redemption requests such as those sourced from a
-/// Bridge hack. The mechanism involves a permissioned set of Guardians
-/// that can object to a redemption request. If a redemption is objected to by
-/// an optimistic redemption guardian, it is delayed. Two subsequent objections
-/// from redemption guardians results in a veto of the redemption request.
-/// A veto returns redeemed amount to the requester while inflicting a freeze
-/// penalty on the amount and a financial penalty. The goal of this penalty is
-/// to introduce a cost that guards against repeated malicious redemption requests.
+///         mechanism of the Bridge. The redemption veto mechanism is a safeguard
+///         in the event of malicious redemption requests such as those sourced
+///         from a Bridge hack. The mechanism involves a permissioned set of
+///         Guardians that can object to a redemption request. If a redemption
+///         is objected to by a redemption guardian, it is delayed. Two
+///         subsequent objections from redemption guardians results in a veto
+///         of the redemption request. A veto returns redeemed amount to the
+///         requester while inflicting a freeze and financial penalty on the
+///         amount. The goal of this penalty is to introduce a cost that guards
+///         against repeated malicious redemption requests.
 contract RedemptionWatchtower is OwnableUpgradeable {
+    /// @notice Set of redemption guardians.
+    mapping(address => bool) public isGuardian;
+    /// @notice The Bridge contract.
     Bridge public bridge;
+    // UNIX timestamp the redemption watchtower (and veto mechanism) was enabled at.
+    // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+    uint32 public watchtowerEnabledAt;
+    /// @notice Address of the manager responsible for parameters management.
+    address public manager;
+
+    event WatchtowerEnabled(uint32 enabledAt, address manager);
+
+    event GuardianAdded(address indexed guardian);
+
+    event GuardianRemoved(address indexed guardian);
+
+    modifier onlyManager() {
+        require(msg.sender == manager, "Caller is not watchtower manager");
+        _;
+    }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -42,5 +62,62 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         __Ownable_init();
 
         bridge = _bridge;
+    }
+
+    /// @notice Enables the redemption watchtower and veto mechanism.
+    /// @param _manager Address of the watchtower manager.
+    /// @param _guardians List of initial guardian addresses.
+    /// @dev Requirements:
+    ///      - The caller must be the owner,
+    ///      - Watchtower must not be enabled already,
+    ///      - Manager address must not be zero.
+    function enableWatchtower(address _manager, address[] calldata _guardians)
+        external
+        onlyOwner
+    {
+        require(watchtowerEnabledAt == 0, "Already enabled");
+
+        require(_manager != address(0), "Manager address must not be 0x0");
+        manager = _manager;
+
+        for (uint256 i = 0; i < _guardians.length; i++) {
+            _addGuardian(_guardians[i]);
+        }
+
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 enabledAt = uint32(block.timestamp);
+        watchtowerEnabledAt = enabledAt;
+
+        emit WatchtowerEnabled(enabledAt, _manager);
+    }
+
+    /// @notice Adds a redemption guardian
+    /// @param guardian Address of the guardian to add.
+    /// @dev Requirements:
+    ///      - The caller must be the watchtower manager,
+    ///      - The guardian must not already exist.
+    function addGuardian(address guardian) external onlyManager {
+        _addGuardian(guardian);
+    }
+
+    /// @notice Adds a redemption guardian
+    /// @param guardian Address of the guardian to add.
+    /// @dev Requirements:
+    ///      - The guardian must not already exist.
+    function _addGuardian(address guardian) internal {
+        require(!isGuardian[guardian], "Guardian already exists");
+        isGuardian[guardian] = true;
+        emit GuardianAdded(guardian);
+    }
+
+    /// @notice Removes a redemption guardian
+    /// @param guardian Address of the guardian to remove.
+    /// @dev Requirements:
+    ///      - The caller must be the owner,
+    ///      - The guardian must exist.
+    function removeGuardian(address guardian) external onlyOwner {
+        require(isGuardian[guardian], "Guardian does not exist");
+        delete isGuardian[guardian];
+        emit GuardianRemoved(guardian);
     }
 }

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -130,6 +130,8 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         address indexed guardian
     );
 
+    event VetoPeriodCheckOmitted(uint256 indexed redemptionKey);
+
     event VetoFinalized(uint256 indexed redemptionKey);
 
     modifier onlyManager() {
@@ -283,13 +285,16 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         // - Objections against a redemption request created BEFORE the
         //   `watchtowerEnabledAt` timestamp can be raised without
         //   any time restrictions.
-        uint32 delay = _redemptionDelay(veto.objectionsCount);
         if (redemption.requestedAt >= watchtowerEnabledAt) {
             require(
                 /* solhint-disable-next-line not-rely-on-time */
-                block.timestamp < redemption.requestedAt + delay,
+                block.timestamp <
+                    redemption.requestedAt +
+                        _redemptionDelay(veto.objectionsCount),
                 "Redemption veto delay period expired"
             );
+        } else {
+            emit VetoPeriodCheckOmitted(redemptionKey);
         }
 
         objections[objectionKey] = true;

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -32,6 +32,7 @@ import "./Redemption.sol";
 ///         requester while inflicting a freeze and financial penalty on the
 ///         amount. The goal of this penalty is to introduce a cost that guards
 ///         against repeated malicious redemption requests.
+// slither-disable-next-line missing-inheritance
 contract RedemptionWatchtower is OwnableUpgradeable {
     struct VetoProposal {
         // Address of the redeemer that requested the redemption.
@@ -217,6 +218,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     function disableWatchtower() external {
         require(watchtowerEnabledAt != 0, "Not enabled");
 
+        // slither-disable-next-line incorrect-equality
         require(watchtowerDisabledAt == 0, "Already disabled");
 
         require(
@@ -403,11 +405,20 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             return 0;
         }
 
-        if (objectionsCount == 0) {
+        if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 0
+        ) {
             return defaultDelay;
-        } else if (objectionsCount == 1) {
+        } else if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 1
+        ) {
             return levelOneDelay;
-        } else if (objectionsCount == 2) {
+        } else if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 2
+        ) {
             return levelTwoDelay;
         } else {
             revert("No delay for given objections count");

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -48,6 +48,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         uint8 objectionsCount;
     }
 
+    /// @notice Number of guardian objections required to veto a redemption request.
+    uint8 public constant REQUIRED_OBJECTIONS_COUNT = 3;
+
     /// @notice Set of redemption guardians.
     mapping(address => bool) public isGuardian;
     /// @notice Set of banned redeemer addresses. Banned redeemers cannot
@@ -312,10 +315,8 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
         VetoProposal storage veto = vetoProposals[redemptionKey];
 
-        uint8 requiredObjectionsCount = 3;
-
         require(
-            veto.objectionsCount < requiredObjectionsCount,
+            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
             "Redemption request already vetoed"
         );
 
@@ -367,7 +368,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         emit ObjectionRaised(redemptionKey, msg.sender);
 
         // If there are enough objections, finalize the veto.
-        if (veto.objectionsCount == requiredObjectionsCount) {
+        if (veto.objectionsCount == REQUIRED_OBJECTIONS_COUNT) {
             // Calculate the veto penalty fee that will be deducted from the
             // final amount that the redeemer can claim after the freeze period.
             uint64 penaltyFee = vetoPenaltyFeeDivisor > 0

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -32,15 +32,89 @@ import "./Bridge.sol";
 ///         amount. The goal of this penalty is to introduce a cost that guards
 ///         against repeated malicious redemption requests.
 contract RedemptionWatchtower is OwnableUpgradeable {
+    struct VetoProposal {
+        // Address of the redeemer that requested the redemption.
+        address redeemer;
+        // Amount that the redeemer can claim after the freeze period.
+        // Value is 0 if the veto is not finalized or the amount was
+        // already claimed.
+        uint64 claimableAmount;
+        // Timestamp when the veto was finalized. Value is 0 if the veto is
+        // not finalized.
+        uint32 finalizedAt;
+        // Number of objections raised against the redemption request.
+        uint8 objectionsCount;
+    }
+
     /// @notice Set of redemption guardians.
     mapping(address => bool) public isGuardian;
+    /// @notice Set of banned redeemer addresses. Banned redeemers cannot
+    ///         request redemptions. A redeemer is banned if one of their
+    ///         redemption requests is vetoed due to an enough number of
+    ///         guardian objections.
+    mapping(address => bool) public isBanned;
+    /// @notice Set of veto proposals indexed by the redemption key built as
+    ///         `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`.
+    ///         The `walletPubKeyHash` is the 20-byte wallet's public key hash
+    ///         (computed using Bitcoin HASH160 over the compressed ECDSA
+    ///         public key) and `redeemerOutputScript` is the Bitcoin script
+    ///         (P2PKH, P2WPKH, P2SH or P2WSH) that is involved in the
+    ///         redemption request.
+    mapping(uint256 => VetoProposal) public vetoProposals;
+    /// @notice Set of individual guardian objections indexed by the objection
+    ///         key built as `keccak256(redemptionKey | guardian)`.
+    ///         The `redemptionKey` is the redemption key built in the same way
+    ///         as in the `vetoProposals` mapping. The `guardian` is the
+    ///         address of the  guardian who raised the objection.
+    mapping(uint256 => bool) public objections;
     /// @notice The Bridge contract.
     Bridge public bridge;
-    // UNIX timestamp the redemption watchtower (and veto mechanism) was enabled at.
-    // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+    /// @notice UNIX timestamp the redemption watchtower (and veto mechanism)
+    ///         was enabled at.
     uint32 public watchtowerEnabledAt;
+    /// @notice Duration of the watchtower lifetime in seconds. Once this
+    ///         period elapses (since the `watchtowerEnabledAt` timestamp),
+    ///         the watchtower can be permanently disabled by anyone.
+    uint32 public watchtowerLifetime;
+    /// @notice UNIX timestamp the redemption watchtower (and veto mechanism)
+    ///         was permanently disabled at.
+    uint32 public watchtowerDisabledAt;
     /// @notice Address of the manager responsible for parameters management.
     address public manager;
+    /// @notice Divisor used to compute the redemption veto penalty fee deducted
+    ///         upon veto finalization. This fee diminishes the amount that the
+    ///         redeemer can claim after the freeze period and is computed as follows:
+    ///         `penaltyFee = requestedAmount / redemptionVetoPenaltyFeeDivisor`
+    ///         For example, if the penalty fee needs to be 2% of each vetoed
+    ///         redemption request, the `redemptionVetoPenaltyFeeDivisor` should
+    ///         be set to `50` because `1/50 = 0.02 = 2%`.
+    uint64 public vetoPenaltyFeeDivisor;
+    /// @notice Time of the redemption veto freeze period. It is the time after
+    ///         which the redeemer can claim the amount of the vetoed redemption
+    ///         request. The freeze period is counted from the moment when the
+    ///         veto request was finalized (i.e. moment of the last guardian
+    ///         objection that caused finalization). Value in seconds.
+    uint32 public vetoFreezePeriod;
+    /// @notice Default delay applied to each redemption request. It is the time
+    ///         during which redemption guardians can raise the first objection.
+    ///         Wallets are not allowed to finalize the redemption request before
+    ///         the delay is over. The delay is counted from the moment when the
+    ///         redemption request was created. Value in seconds.
+    uint32 public defaultDelay;
+    /// @notice Delay applied to redemption requests a single guardian raised an
+    ///         objection to. It is the time during which the remaining guardians
+    ///         can raise their objections. Wallets are not allowed to finalize the
+    ///         redemption request before the delay is over. The delay is counted
+    ///         from the moment when the redemption request was created.
+    ///         Value in seconds.
+    uint32 public levelOneDelay;
+    /// @notice Delay applied to redemption requests two guardians raised an
+    ///         objection to. It is the time during which the last guardian
+    ///         can raise its objection. Wallets are not allowed to finalize the
+    ///         redemption request before the delay is over. The delay is counted
+    ///         from the moment when the redemption request was created.
+    ///         Value in seconds.
+    uint32 public levelTwoDelay;
 
     event WatchtowerEnabled(uint32 enabledAt, address manager);
 
@@ -62,6 +136,13 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         __Ownable_init();
 
         bridge = _bridge;
+
+        watchtowerLifetime = 18 * 30 days; // 18 months
+        vetoPenaltyFeeDivisor = 1; // 100% as initial penalty fee
+        vetoFreezePeriod = 30 days; // 1 month
+        defaultDelay = 2 hours;
+        levelOneDelay = 8 hours;
+        levelTwoDelay = 24 hours;
     }
 
     /// @notice Enables the redemption watchtower and veto mechanism.

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import "./Bridge.sol";
+
+/// @title Redemption watchtower
+/// @notice This contract encapsulates the logic behind the redemption veto
+/// mechanism of the Bridge. The redemption veto mechanism is a safeguard
+/// in the event of malicious redemption requests such as those sourced from a
+/// Bridge hack. The mechanism involves a permissioned set of Guardians
+/// that can object to a redemption request. If a redemption is objected to by
+/// an optimistic redemption guardian, it is delayed. Two subsequent objections
+/// from redemption guardians results in a veto of the redemption request.
+/// A veto returns redeemed amount to the requester while inflicting a freeze
+/// penalty on the amount and a financial penalty. The goal of this penalty is
+/// to introduce a cost that guards against repeated malicious redemption requests.
+contract RedemptionWatchtower is OwnableUpgradeable {
+    Bridge public bridge;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(Bridge _bridge) external initializer {
+        __Ownable_init();
+
+        bridge = _bridge;
+    }
+}

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -248,9 +248,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
     /// @dev Requirements:
     ///      - The caller must be a redemption guardian,
-    ///      - The redemption request must exist (i.e. must be pending),
     ///      - The redemption request must not have been vetoed already,
     ///      - The guardian must not have already objected to the redemption request,
+    ///      - The redemption request must exist (i.e. must be pending),
     ///      - The redemption request must be within the optimistic redemption
     ///        delay period. The only exception is when the redemption request
     ///        was created before the optimistic redemption mechanism
@@ -263,14 +263,6 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         uint256 redemptionKey = Redemption.getRedemptionKey(
             walletPubKeyHash,
             redeemerOutputScript
-        );
-
-        Redemption.RedemptionRequest memory redemption = bridge
-            .pendingRedemptions(redemptionKey);
-
-        require(
-            redemption.requestedAt != 0,
-            "Redemption request does not exist"
         );
 
         VetoProposal storage veto = vetoProposals[redemptionKey];
@@ -286,6 +278,14 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             keccak256(abi.encodePacked(redemptionKey, msg.sender))
         );
         require(!objections[objectionKey], "Guardian already objected");
+
+        Redemption.RedemptionRequest memory redemption = bridge
+            .pendingRedemptions(redemptionKey);
+
+        require(
+            redemption.requestedAt != 0,
+            "Redemption request does not exist"
+        );
 
         // Check if the given redemption request can be objected to:
         // - Objections against a redemption request created AFTER the

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -328,6 +328,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         Redemption.RedemptionRequest memory redemption = bridge
             .pendingRedemptions(redemptionKey);
 
+        // This also handles the case when the redemption was already processed
+        // given we delete successful ones from the `pendingRedemptions` mapping
+        // of the `Bridge` state.
         require(
             redemption.requestedAt != 0,
             "Redemption request does not exist"
@@ -343,8 +346,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         if (redemption.requestedAt >= watchtowerEnabledAt) {
             require(
                 // Use < instead of <= to avoid a theoretical edge case
-                // where the delay is 0 (veto disabled) but three objections
-                // are raised in the same block as the redemption request.
+                // where the delay is 0 (watchtower disabled OR amount below
+                // the veto threshold) but three objections are raised in the
+                // same block as the redemption request.
                 /* solhint-disable-next-line not-rely-on-time */
                 block.timestamp <
                     redemption.requestedAt +

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -615,6 +615,7 @@ contract WalletProposalValidator {
             uint32 minAge = REDEMPTION_REQUEST_MIN_AGE;
             if (redemptionWatchtower != address(0)) {
                 // Check the redemption delay enforced by the watchtower.
+                // slither-disable-next-line calls-loop
                 uint32 delay = IRedemptionWatchtower(redemptionWatchtower)
                     .getRedemptionDelay(redemptionKey);
                 // If the delay is greater than the usual minimum age, use it.

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -608,6 +608,8 @@ contract WalletProposalValidator {
                 "Not a pending redemption request"
             );
 
+            // TODO: Validate the request against the RedemptionWatchtower.
+
             require(
                 /* solhint-disable-next-line not-rely-on-time */
                 block.timestamp >

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -620,6 +620,14 @@ contract WalletProposalValidator {
                     .getRedemptionDelay(redemptionKey);
                 // If the delay is greater than the usual minimum age, use it.
                 // This way both the min age and the watchtower delay are preserved.
+                //
+                // We do not need to bother about last-minute objections issued
+                // by the watchtower. Objections can be issued up to one second
+                // before the min age is achieved while this validation will
+                // pass only one second after the min age is achieved. Even if
+                // a single objection stays longer in the mempool, this won't
+                // be a problem for `Bridge.submitRedemptionProof` which ignores
+                // single objections as long as the veto threshold is not reached.
                 if (delay > minAge) {
                     minAge = delay;
                 }

--- a/solidity/deploy/40_deploy_redemption_watchtower.ts
+++ b/solidity/deploy/40_deploy_redemption_watchtower.ts
@@ -1,0 +1,43 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, ethers, helpers, getNamedAccounts } = hre
+  const { deployer } = await getNamedAccounts()
+
+  const Bridge = await deployments.get("Bridge")
+
+  const [redemptionWatchtower, proxyDeployment] =
+    await helpers.upgrades.deployProxy("RedemptionWatchtower", {
+      contractName: "RedemptionWatchtower",
+      initializerArgs: [Bridge.address],
+      factoryOpts: {
+        signer: await ethers.getSigner(deployer),
+      },
+      proxyOpts: {
+        kind: "transparent",
+      },
+    })
+
+  if (hre.network.tags.etherscan) {
+    // We use `verify` instead of `verify:verify` as the `verify` task is defined
+    // in "@openzeppelin/hardhat-upgrades" to perform Etherscan verification
+    // of Proxy and Implementation contracts.
+    await hre.run("verify", {
+      address: proxyDeployment.address,
+      constructorArgsParams: proxyDeployment.args,
+    })
+  }
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "RedemptionWatchtower",
+      address: redemptionWatchtower.address,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["RedemptionWatchtower"]
+func.dependencies = ["Bridge"]

--- a/solidity/deploy/41_transfer_redemption_watchtower_ownership.ts
+++ b/solidity/deploy/41_transfer_redemption_watchtower_ownership.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, governance } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership(
+    "RedemptionWatchtower",
+    governance,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["RedemptionWatchtowerOwnership"]
+func.dependencies = ["RedemptionWatchtower"]
+func.runAtTheEnd = true

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -224,6 +224,11 @@ const config: HardhatUserConfig = {
       sepolia: 0,
       mainnet: "0x8Bac178fA95Cb56D11A94d4f1b2B1F5Fc48A30eA",
     },
+    redemptionWatchtowerManager: {
+      default: 11,
+      sepolia: 0,
+      mainnet: "0x87F005317692D05BAA4193AB0c961c69e175f45f", // Token Holder DAO
+    },
   },
   dependencyCompiler: {
     paths: [

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -4425,4 +4425,41 @@ describe("Bridge - Governance", () => {
       })
     })
   })
+
+  describe("setRedemptionWatchtower", () => {
+    const watchtower = "0xE8ebaEc51bAeeaBff71707dE2AD028C7fB642A3F"
+
+    context("when caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(thirdParty)
+            .setRedemptionWatchtower(watchtower)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when caller is the owner", () => {
+      let tx: Promise<ContractTransaction>
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = bridgeGovernance
+          .connect(governance)
+          .setRedemptionWatchtower(watchtower)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      // Detailed tests covering the `bridge.setRedemptionWatchtower` call
+      // can be found in the `Bridge.Parameters.test.ts` file. Here we just
+      // ensure correctness of the BridgeGovernance's ACL.
+      it("should not revert", async () => {
+        await expect(tx).to.not.be.reverted
+      })
+    })
+  })
 })

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -1899,7 +1899,7 @@ describe("Bridge - Parameters", () => {
           })
 
           it("should set the watchtower address", async () => {
-            expect(await bridge.redemptionWatchtower()).to.equal(watchtower)
+            expect(await bridge.getRedemptionWatchtower()).to.equal(watchtower)
           })
 
           it("should emit RedemptionWatchtowerSet event", async () => {

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -1759,11 +1759,12 @@ describe("Bridge - Parameters", () => {
 
     context("when caller is the contract guvnor", () => {
       before(async () => {
-        // TODO: We transfer the ownership of the Bridge governance from the
+        await createSnapshot()
+
+        // We transfer the ownership of the Bridge governance from the
         // BridgeGovernance contract to a simple address. This allows testing
         // the Bridge contract directly, without going through the
-        // BridgeGovernance contract. This should be the preferred approach for
-        // all other tests in this file.
+        // BridgeGovernance contract.
         await bridgeGovernance
           .connect(governance)
           .beginBridgeGovernanceTransfer(governance.address)
@@ -1771,6 +1772,10 @@ describe("Bridge - Parameters", () => {
         await bridgeGovernance
           .connect(governance)
           .finalizeBridgeGovernanceTransfer()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
       })
 
       context("when the new treasury address is non-zero", () => {
@@ -1811,6 +1816,98 @@ describe("Bridge - Parameters", () => {
         await expect(
           bridge.connect(thirdParty).updateTreasury(newTreasury)
         ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+  })
+
+  describe("setRedemptionWatchtower", () => {
+    const watchtower = "0xE8ebaEc51bAeeaBff71707dE2AD028C7fB642A3F"
+
+    context("when caller is not the contract guvnor", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge.connect(thirdParty).setRedemptionWatchtower(watchtower)
+        ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+
+    context("when caller is the contract guvnor", () => {
+      before(async () => {
+        await createSnapshot()
+
+        // We transfer the ownership of the Bridge governance from the
+        // BridgeGovernance contract to a simple address. This allows testing
+        // the Bridge contract directly, without going through the
+        // BridgeGovernance contract.
+        await bridgeGovernance
+          .connect(governance)
+          .beginBridgeGovernanceTransfer(governance.address)
+        await helpers.time.increaseTime(constants.governanceDelay)
+        await bridgeGovernance
+          .connect(governance)
+          .finalizeBridgeGovernanceTransfer()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      context("when the watchtower address is already set", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await bridge.connect(governance).setRedemptionWatchtower(watchtower)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            bridge
+              .connect(governance)
+              .setRedemptionWatchtower(thirdParty.address)
+          ).to.be.revertedWith("Redemption watchtower already set")
+        })
+      })
+
+      context("when the watchtower address is not set yet", () => {
+        context("when the watchtower address is zero", () => {
+          it("should revert", async () => {
+            await expect(
+              bridge.connect(governance).setRedemptionWatchtower(ZERO_ADDRESS)
+            ).to.be.revertedWith(
+              "Redemption watchtower address must not be 0x0"
+            )
+          })
+        })
+
+        context("when the watchtower address is non-zero", () => {
+          let tx: ContractTransaction
+
+          before(async () => {
+            await createSnapshot()
+
+            tx = await bridge
+              .connect(governance)
+              .setRedemptionWatchtower(watchtower)
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should set the watchtower address", async () => {
+            expect(await bridge.redemptionWatchtower()).to.equal(watchtower)
+          })
+
+          it("should emit RedemptionWatchtowerSet event", async () => {
+            await expect(tx)
+              .to.emit(bridge, "RedemptionWatchtowerSet")
+              .withArgs(watchtower)
+          })
+        })
       })
     })
   })

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -6,37 +6,38 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import chai, { expect } from "chai"
 import { BigNumber, BigNumberish, Contract, ContractTransaction } from "ethers"
 import { BytesLike } from "@ethersproject/bytes"
-import { smock } from "@defi-wonderland/smock"
 import type { FakeContract } from "@defi-wonderland/smock"
+import { smock } from "@defi-wonderland/smock"
 import { Deployment } from "hardhat-deploy/types"
 import type {
   Bank,
   BankStub,
   Bridge,
-  BridgeStub,
-  IWalletRegistry,
-  IRelay,
   BridgeGovernance,
+  BridgeStub,
+  IRedemptionWatchtower,
+  IRelay,
+  IWalletRegistry,
 } from "../../typechain"
 import { NO_MAIN_UTXO } from "../data/deposit-sweep"
 import {
   MultiplePendingRequestedRedemptions,
+  MultiplePendingRequestedRedemptionsWithMultipleInputs,
+  MultiplePendingRequestedRedemptionsWithMultipleP2WPKHChanges,
+  MultiplePendingRequestedRedemptionsWithNonRequestedRedemption,
+  MultiplePendingRequestedRedemptionsWithP2SHChange,
   MultiplePendingRequestedRedemptionsWithP2WPKHChange,
+  MultiplePendingRequestedRedemptionsWithP2WPKHChangeZeroValue,
+  MultiplePendingRequestedRedemptionsWithProvablyUnspendable,
   RedemptionBalanceChange,
   RedemptionTestData,
+  SingleNonRequestedRedemption,
   SingleP2PKHChange,
   SingleP2SHChange,
   SingleP2WPKHChange,
   SingleP2WPKHChangeZeroValue,
-  SingleNonRequestedRedemption,
   SinglePendingRequestedRedemption,
   SingleProvablyUnspendable,
-  MultiplePendingRequestedRedemptionsWithP2SHChange,
-  MultiplePendingRequestedRedemptionsWithMultipleP2WPKHChanges,
-  MultiplePendingRequestedRedemptionsWithP2WPKHChangeZeroValue,
-  MultiplePendingRequestedRedemptionsWithNonRequestedRedemption,
-  MultiplePendingRequestedRedemptionsWithProvablyUnspendable,
-  MultiplePendingRequestedRedemptionsWithMultipleInputs,
 } from "../data/redemption"
 import { constants, walletState } from "../fixtures"
 import bridgeFixture from "../fixtures/bridge"
@@ -124,401 +125,447 @@ describe("Bridge - Redemption", () => {
   describe("requestRedemption", () => {
     const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
 
-    context("when wallet state is Live", () => {
-      before(async () => {
-        await createSnapshot()
-
-        // Simulate the wallet is an Live one and is known to the system.
-        await bridge.setWallet(walletPubKeyHash, {
-          ecdsaWalletID: ethers.constants.HashZero,
-          mainUtxoHash: ethers.constants.HashZero,
-          pendingRedemptionsValue: 0,
-          createdAt: await lastBlockTime(),
-          movingFundsRequestedAt: 0,
-          closingStartedAt: 0,
-          pendingMovedFundsSweepRequestsCount: 0,
-          state: walletState.Live,
-          movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
-        })
-      })
-
-      after(async () => {
-        await restoreSnapshot()
-      })
-
-      context("when there is a main UTXO for the given wallet", () => {
-        // Prepare a dumb main UTXO with 10M satoshi as value. This will
-        // be the wallet BTC balance.
-        const mainUtxo = {
-          txHash:
-            "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
-          txOutputIndex: 0,
-          txOutputValue: 10000000,
-        }
-
+    context("when redemption watchtower is not set", () => {
+      context("when wallet state is Live", () => {
         before(async () => {
           await createSnapshot()
 
-          // Simulate the prepared main UTXO belongs to the wallet.
-          await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+          // Simulate the wallet is an Live one and is known to the system.
+          await bridge.setWallet(walletPubKeyHash, {
+            ecdsaWalletID: ethers.constants.HashZero,
+            mainUtxoHash: ethers.constants.HashZero,
+            pendingRedemptionsValue: 0,
+            createdAt: await lastBlockTime(),
+            movingFundsRequestedAt: 0,
+            closingStartedAt: 0,
+            pendingMovedFundsSweepRequestsCount: 0,
+            state: walletState.Live,
+            movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+          })
         })
 
         after(async () => {
           await restoreSnapshot()
         })
 
-        context("when main UTXO data are valid", () => {
-          context("when redeemer output script is standard type", () => {
-            // Arbitrary standard output scripts.
-            const redeemerOutputScriptP2WPKH =
-              "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
-            const redeemerOutputScriptP2WSH =
-              "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
-            const redeemerOutputScriptP2PKH =
-              "0x1976a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
-            const redeemerOutputScriptP2SH =
-              "0x17a914f4eedc8f40d4b8e30771f792b065ebec0abaddef87"
+        context("when there is a main UTXO for the given wallet", () => {
+          // Prepare a dumb main UTXO with 10M satoshi as value. This will
+          // be the wallet BTC balance.
+          const mainUtxo = {
+            txHash:
+              "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
+            txOutputIndex: 0,
+            txOutputValue: 10000000,
+          }
 
-            context(
-              "when redeemer output script does not point to the wallet public key hash",
-              () => {
-                context("when amount is not below the dust threshold", () => {
-                  // Requested amount is 1901000 satoshi.
-                  const requestedAmount = BigNumber.from(1901000)
-                  // Treasury fee is `requestedAmount / redemptionTreasuryFeeDivisor`
-                  // where the divisor is `2000` initially. So, we
-                  // have 1901000 / 2000 = 950.5 though Solidity
-                  // loses the decimal part.
-                  const treasuryFee = 950
+          before(async () => {
+            await createSnapshot()
 
-                  context(
-                    "when there is no pending request for the given redemption key",
-                    () => {
-                      context("when wallet has sufficient funds", () => {
-                        context(
-                          "when redeemer made a sufficient allowance in Bank",
-                          () => {
-                            let redeemer: SignerWithAddress
+            // Simulate the prepared main UTXO belongs to the wallet.
+            await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+          })
 
-                            before(async () => {
-                              await createSnapshot()
+          after(async () => {
+            await restoreSnapshot()
+          })
 
-                              // Use an arbitrary ETH account as redeemer.
-                              redeemer = thirdParty
+          context("when main UTXO data are valid", () => {
+            context("when redeemer output script is standard type", () => {
+              // Arbitrary standard output scripts.
+              const redeemerOutputScriptP2WPKH =
+                "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+              const redeemerOutputScriptP2WSH =
+                "0x220020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"
+              const redeemerOutputScriptP2PKH =
+                "0x1976a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
+              const redeemerOutputScriptP2SH =
+                "0x17a914f4eedc8f40d4b8e30771f792b065ebec0abaddef87"
 
-                              await makeRedemptionAllowance(
-                                redeemer,
-                                requestedAmount
+              context(
+                "when redeemer output script does not point to the wallet public key hash",
+                () => {
+                  context("when amount is not below the dust threshold", () => {
+                    // Requested amount is 1901000 satoshi.
+                    const requestedAmount = BigNumber.from(1901000)
+                    // Treasury fee is `requestedAmount / redemptionTreasuryFeeDivisor`
+                    // where the divisor is `2000` initially. So, we
+                    // have 1901000 / 2000 = 950.5 though Solidity
+                    // loses the decimal part.
+                    const treasuryFee = 950
+
+                    context(
+                      "when there is no pending request for the given redemption key",
+                      () => {
+                        context("when wallet has sufficient funds", () => {
+                          context(
+                            "when redeemer made a sufficient allowance in Bank",
+                            () => {
+                              let redeemer: SignerWithAddress
+
+                              before(async () => {
+                                await createSnapshot()
+
+                                // Use an arbitrary ETH account as redeemer.
+                                redeemer = thirdParty
+
+                                await makeRedemptionAllowance(
+                                  redeemer,
+                                  requestedAmount
+                                )
+                              })
+
+                              after(async () => {
+                                await restoreSnapshot()
+                              })
+
+                              context(
+                                "when redeemer output script is P2WPKH",
+                                () => {
+                                  const redeemerOutputScript =
+                                    redeemerOutputScriptP2WPKH
+
+                                  let initialBridgeBalance: BigNumber
+                                  let initialRedeemerBalance: BigNumber
+                                  let initialWalletPendingRedemptionValue: BigNumber
+                                  let tx: ContractTransaction
+
+                                  let redemptionTxMaxFee: BigNumber
+
+                                  before(async () => {
+                                    await createSnapshot()
+
+                                    redemptionTxMaxFee = (
+                                      await bridge.redemptionParameters()
+                                    ).redemptionTxMaxFee
+
+                                    // Capture initial balance of Bridge and
+                                    // redeemer.
+                                    initialBridgeBalance = await bank.balanceOf(
+                                      bridge.address
+                                    )
+                                    initialRedeemerBalance =
+                                      await bank.balanceOf(redeemer.address)
+
+                                    // Capture the initial pending redemptions value
+                                    // for the given wallet.
+                                    initialWalletPendingRedemptionValue = (
+                                      await bridge.wallets(walletPubKeyHash)
+                                    ).pendingRedemptionsValue
+
+                                    // Perform the redemption request.
+                                    tx = await bridge
+                                      .connect(redeemer)
+                                      .requestRedemption(
+                                        walletPubKeyHash,
+                                        mainUtxo,
+                                        redeemerOutputScript,
+                                        requestedAmount
+                                      )
+                                  })
+
+                                  after(async () => {
+                                    await restoreSnapshot()
+                                  })
+
+                                  it("should increase the wallet's pending redemptions value", async () => {
+                                    const walletPendingRedemptionValue = (
+                                      await bridge.wallets(walletPubKeyHash)
+                                    ).pendingRedemptionsValue
+
+                                    expect(
+                                      walletPendingRedemptionValue.sub(
+                                        initialWalletPendingRedemptionValue
+                                      )
+                                    ).to.be.equal(
+                                      requestedAmount.sub(treasuryFee)
+                                    )
+                                  })
+
+                                  it("should store the redemption request", async () => {
+                                    const redemptionKey = buildRedemptionKey(
+                                      walletPubKeyHash,
+                                      redeemerOutputScript
+                                    )
+
+                                    const redemptionRequest =
+                                      await bridge.pendingRedemptions(
+                                        redemptionKey
+                                      )
+
+                                    expect(
+                                      redemptionRequest.redeemer
+                                    ).to.be.equal(redeemer.address)
+                                    expect(
+                                      redemptionRequest.requestedAmount
+                                    ).to.be.equal(requestedAmount)
+                                    expect(
+                                      redemptionRequest.treasuryFee
+                                    ).to.be.equal(treasuryFee)
+                                    expect(
+                                      redemptionRequest.txMaxFee
+                                    ).to.be.equal(redemptionTxMaxFee)
+                                    expect(
+                                      redemptionRequest.requestedAt
+                                    ).to.be.equal(await lastBlockTime())
+                                  })
+
+                                  it("should emit RedemptionRequested event", async () => {
+                                    await expect(tx)
+                                      .to.emit(bridge, "RedemptionRequested")
+                                      .withArgs(
+                                        walletPubKeyHash,
+                                        redeemerOutputScript,
+                                        redeemer.address,
+                                        requestedAmount,
+                                        treasuryFee,
+                                        redemptionTxMaxFee
+                                      )
+                                  })
+
+                                  it("should take the right balance from Bank", async () => {
+                                    const bridgeBalance = await bank.balanceOf(
+                                      bridge.address
+                                    )
+                                    expect(
+                                      bridgeBalance.sub(initialBridgeBalance)
+                                    ).to.equal(requestedAmount)
+
+                                    const redeemerBalance =
+                                      await bank.balanceOf(redeemer.address)
+                                    expect(
+                                      redeemerBalance.sub(
+                                        initialRedeemerBalance
+                                      )
+                                    ).to.equal(requestedAmount.mul(-1))
+                                  })
+                                }
                               )
-                            })
 
-                            after(async () => {
-                              await restoreSnapshot()
-                            })
+                              context(
+                                "when redeemer output script is P2WSH",
+                                () => {
+                                  before(async () => {
+                                    await createSnapshot()
+                                  })
 
-                            context(
-                              "when redeemer output script is P2WPKH",
-                              () => {
-                                const redeemerOutputScript =
-                                  redeemerOutputScriptP2WPKH
+                                  after(async () => {
+                                    await restoreSnapshot()
+                                  })
 
-                                let initialBridgeBalance: BigNumber
-                                let initialRedeemerBalance: BigNumber
-                                let initialWalletPendingRedemptionValue: BigNumber
-                                let tx: ContractTransaction
+                                  // Do not repeat all checks made in the
+                                  // "when redeemer output script is P2WPKH"
+                                  // scenario but just assert the call succeeds
+                                  // for an P2WSH output script.
+                                  it("should succeed", async () => {
+                                    await expect(
+                                      bridge
+                                        .connect(redeemer)
+                                        .requestRedemption(
+                                          walletPubKeyHash,
+                                          mainUtxo,
+                                          redeemerOutputScriptP2WSH,
+                                          requestedAmount
+                                        )
+                                    ).to.not.be.reverted
+                                  })
+                                }
+                              )
 
-                                let redemptionTxMaxFee: BigNumber
+                              context(
+                                "when redeemer output script is P2PKH",
+                                () => {
+                                  before(async () => {
+                                    await createSnapshot()
+                                  })
 
-                                before(async () => {
-                                  await createSnapshot()
+                                  after(async () => {
+                                    await restoreSnapshot()
+                                  })
 
-                                  redemptionTxMaxFee = (
-                                    await bridge.redemptionParameters()
-                                  ).redemptionTxMaxFee
+                                  // Do not repeat all checks made in the
+                                  // "when redeemer output script is P2WPKH"
+                                  // scenario but just assert the call succeeds
+                                  // for an P2PKH output script.
+                                  it("should succeed", async () => {
+                                    await expect(
+                                      bridge
+                                        .connect(redeemer)
+                                        .requestRedemption(
+                                          walletPubKeyHash,
+                                          mainUtxo,
+                                          redeemerOutputScriptP2PKH,
+                                          requestedAmount
+                                        )
+                                    ).to.not.be.reverted
+                                  })
+                                }
+                              )
 
-                                  // Capture initial balance of Bridge and
-                                  // redeemer.
-                                  initialBridgeBalance = await bank.balanceOf(
-                                    bridge.address
-                                  )
-                                  initialRedeemerBalance = await bank.balanceOf(
-                                    redeemer.address
-                                  )
+                              context(
+                                "when redeemer output script is P2SH",
+                                () => {
+                                  before(async () => {
+                                    await createSnapshot()
+                                  })
 
-                                  // Capture the initial pending redemptions value
-                                  // for the given wallet.
-                                  initialWalletPendingRedemptionValue = (
-                                    await bridge.wallets(walletPubKeyHash)
-                                  ).pendingRedemptionsValue
+                                  after(async () => {
+                                    await restoreSnapshot()
+                                  })
 
-                                  // Perform the redemption request.
-                                  tx = await bridge
-                                    .connect(redeemer)
+                                  // Do not repeat all checks made in the
+                                  // "when redeemer output script is P2WPKH"
+                                  // scenario but just assert the call succeeds
+                                  // for an P2SH output script.
+                                  it("should succeed", async () => {
+                                    await expect(
+                                      bridge
+                                        .connect(redeemer)
+                                        .requestRedemption(
+                                          walletPubKeyHash,
+                                          mainUtxo,
+                                          redeemerOutputScriptP2SH,
+                                          requestedAmount
+                                        )
+                                    ).to.not.be.reverted
+                                  })
+                                }
+                              )
+
+                              context(
+                                "when redemption treasury fee is zero",
+                                () => {
+                                  const redeemerOutputScript =
+                                    redeemerOutputScriptP2WPKH
+
+                                  before(async () => {
+                                    await createSnapshot()
+
+                                    await bridgeGovernance
+                                      .connect(governance)
+                                      .beginRedemptionTreasuryFeeDivisorUpdate(
+                                        0
+                                      )
+                                    await helpers.time.increaseTime(
+                                      constants.governanceDelay
+                                    )
+                                    await bridgeGovernance
+                                      .connect(governance)
+                                      .finalizeRedemptionTreasuryFeeDivisorUpdate()
+
+                                    await bridge
+                                      .connect(redeemer)
+                                      .requestRedemption(
+                                        walletPubKeyHash,
+                                        mainUtxo,
+                                        redeemerOutputScript,
+                                        requestedAmount
+                                      )
+                                  })
+
+                                  after(async () => {
+                                    await restoreSnapshot()
+                                  })
+
+                                  // Do not repeat all checks made in the
+                                  // "when redeemer output script is P2WPKH"
+                                  // scenario but just assert the requested
+                                  // amount and treasury fee
+                                  it("should store the redemption request with zero fee", async () => {
+                                    const redemptionKey = buildRedemptionKey(
+                                      walletPubKeyHash,
+                                      redeemerOutputScript
+                                    )
+
+                                    const redemptionRequest =
+                                      await bridge.pendingRedemptions(
+                                        redemptionKey
+                                      )
+
+                                    expect(
+                                      redemptionRequest.requestedAmount
+                                    ).to.be.equal(requestedAmount)
+                                    expect(
+                                      redemptionRequest.treasuryFee
+                                    ).to.be.equal(0)
+                                  })
+                                }
+                              )
+                            }
+                          )
+
+                          context(
+                            "when redeemer has not made a sufficient allowance in Bank",
+                            () => {
+                              it("should revert", async () => {
+                                await expect(
+                                  bridge
+                                    .connect(thirdParty)
                                     .requestRedemption(
                                       walletPubKeyHash,
                                       mainUtxo,
-                                      redeemerOutputScript,
+                                      redeemerOutputScriptP2WPKH,
                                       requestedAmount
                                     )
-                                })
+                                ).to.be.revertedWith(
+                                  "Transfer amount exceeds allowance"
+                                )
+                              })
+                            }
+                          )
+                        })
 
-                                after(async () => {
-                                  await restoreSnapshot()
-                                })
+                        context("when wallet has insufficient funds", () => {
+                          before(async () => {
+                            await createSnapshot()
 
-                                it("should increase the wallet's pending redemptions value", async () => {
-                                  const walletPendingRedemptionValue = (
-                                    await bridge.wallets(walletPubKeyHash)
-                                  ).pendingRedemptionsValue
-
-                                  expect(
-                                    walletPendingRedemptionValue.sub(
-                                      initialWalletPendingRedemptionValue
-                                    )
-                                  ).to.be.equal(
-                                    requestedAmount.sub(treasuryFee)
-                                  )
-                                })
-
-                                it("should store the redemption request", async () => {
-                                  const redemptionKey = buildRedemptionKey(
-                                    walletPubKeyHash,
-                                    redeemerOutputScript
-                                  )
-
-                                  const redemptionRequest =
-                                    await bridge.pendingRedemptions(
-                                      redemptionKey
-                                    )
-
-                                  expect(
-                                    redemptionRequest.redeemer
-                                  ).to.be.equal(redeemer.address)
-                                  expect(
-                                    redemptionRequest.requestedAmount
-                                  ).to.be.equal(requestedAmount)
-                                  expect(
-                                    redemptionRequest.treasuryFee
-                                  ).to.be.equal(treasuryFee)
-                                  expect(
-                                    redemptionRequest.txMaxFee
-                                  ).to.be.equal(redemptionTxMaxFee)
-                                  expect(
-                                    redemptionRequest.requestedAt
-                                  ).to.be.equal(await lastBlockTime())
-                                })
-
-                                it("should emit RedemptionRequested event", async () => {
-                                  await expect(tx)
-                                    .to.emit(bridge, "RedemptionRequested")
-                                    .withArgs(
-                                      walletPubKeyHash,
-                                      redeemerOutputScript,
-                                      redeemer.address,
-                                      requestedAmount,
-                                      treasuryFee,
-                                      redemptionTxMaxFee
-                                    )
-                                })
-
-                                it("should take the right balance from Bank", async () => {
-                                  const bridgeBalance = await bank.balanceOf(
-                                    bridge.address
-                                  )
-                                  expect(
-                                    bridgeBalance.sub(initialBridgeBalance)
-                                  ).to.equal(requestedAmount)
-
-                                  const redeemerBalance = await bank.balanceOf(
-                                    redeemer.address
-                                  )
-                                  expect(
-                                    redeemerBalance.sub(initialRedeemerBalance)
-                                  ).to.equal(requestedAmount.mul(-1))
-                                })
-                              }
+                            // Simulate a situation when the wallet has so many
+                            // pending redemptions that a new request will
+                            // exceed its Bitcoin balance. This is done by making
+                            // a redemption request that will request the entire
+                            // wallet's balance right before the tested request.
+                            await makeRedemptionAllowance(
+                              thirdParty,
+                              mainUtxo.txOutputValue
                             )
-
-                            context(
-                              "when redeemer output script is P2WSH",
-                              () => {
-                                before(async () => {
-                                  await createSnapshot()
-                                })
-
-                                after(async () => {
-                                  await restoreSnapshot()
-                                })
-
-                                // Do not repeat all checks made in the
-                                // "when redeemer output script is P2WPKH"
-                                // scenario but just assert the call succeeds
-                                // for an P2WSH output script.
-                                it("should succeed", async () => {
-                                  await expect(
-                                    bridge
-                                      .connect(redeemer)
-                                      .requestRedemption(
-                                        walletPubKeyHash,
-                                        mainUtxo,
-                                        redeemerOutputScriptP2WSH,
-                                        requestedAmount
-                                      )
-                                  ).to.not.be.reverted
-                                })
-                              }
-                            )
-
-                            context(
-                              "when redeemer output script is P2PKH",
-                              () => {
-                                before(async () => {
-                                  await createSnapshot()
-                                })
-
-                                after(async () => {
-                                  await restoreSnapshot()
-                                })
-
-                                // Do not repeat all checks made in the
-                                // "when redeemer output script is P2WPKH"
-                                // scenario but just assert the call succeeds
-                                // for an P2PKH output script.
-                                it("should succeed", async () => {
-                                  await expect(
-                                    bridge
-                                      .connect(redeemer)
-                                      .requestRedemption(
-                                        walletPubKeyHash,
-                                        mainUtxo,
-                                        redeemerOutputScriptP2PKH,
-                                        requestedAmount
-                                      )
-                                  ).to.not.be.reverted
-                                })
-                              }
-                            )
-
-                            context(
-                              "when redeemer output script is P2SH",
-                              () => {
-                                before(async () => {
-                                  await createSnapshot()
-                                })
-
-                                after(async () => {
-                                  await restoreSnapshot()
-                                })
-
-                                // Do not repeat all checks made in the
-                                // "when redeemer output script is P2WPKH"
-                                // scenario but just assert the call succeeds
-                                // for an P2SH output script.
-                                it("should succeed", async () => {
-                                  await expect(
-                                    bridge
-                                      .connect(redeemer)
-                                      .requestRedemption(
-                                        walletPubKeyHash,
-                                        mainUtxo,
-                                        redeemerOutputScriptP2SH,
-                                        requestedAmount
-                                      )
-                                  ).to.not.be.reverted
-                                })
-                              }
-                            )
-
-                            context(
-                              "when redemption treasury fee is zero",
-                              () => {
-                                const redeemerOutputScript =
-                                  redeemerOutputScriptP2WPKH
-
-                                before(async () => {
-                                  await createSnapshot()
-
-                                  await bridgeGovernance
-                                    .connect(governance)
-                                    .beginRedemptionTreasuryFeeDivisorUpdate(0)
-                                  await helpers.time.increaseTime(
-                                    constants.governanceDelay
-                                  )
-                                  await bridgeGovernance
-                                    .connect(governance)
-                                    .finalizeRedemptionTreasuryFeeDivisorUpdate()
-
-                                  await bridge
-                                    .connect(redeemer)
-                                    .requestRedemption(
-                                      walletPubKeyHash,
-                                      mainUtxo,
-                                      redeemerOutputScript,
-                                      requestedAmount
-                                    )
-                                })
-
-                                after(async () => {
-                                  await restoreSnapshot()
-                                })
-
-                                // Do not repeat all checks made in the
-                                // "when redeemer output script is P2WPKH"
-                                // scenario but just assert the requested
-                                // amount and treasury fee
-                                it("should store the redemption request with zero fee", async () => {
-                                  const redemptionKey = buildRedemptionKey(
-                                    walletPubKeyHash,
-                                    redeemerOutputScript
-                                  )
-
-                                  const redemptionRequest =
-                                    await bridge.pendingRedemptions(
-                                      redemptionKey
-                                    )
-
-                                  expect(
-                                    redemptionRequest.requestedAmount
-                                  ).to.be.equal(requestedAmount)
-                                  expect(
-                                    redemptionRequest.treasuryFee
-                                  ).to.be.equal(0)
-                                })
-                              }
-                            )
-                          }
-                        )
-
-                        context(
-                          "when redeemer has not made a sufficient allowance in Bank",
-                          () => {
-                            it("should revert", async () => {
-                              await expect(
-                                bridge
-                                  .connect(thirdParty)
-                                  .requestRedemption(
-                                    walletPubKeyHash,
-                                    mainUtxo,
-                                    redeemerOutputScriptP2WPKH,
-                                    requestedAmount
-                                  )
-                              ).to.be.revertedWith(
-                                "Transfer amount exceeds allowance"
+                            await bridge
+                              .connect(thirdParty)
+                              .requestRedemption(
+                                walletPubKeyHash,
+                                mainUtxo,
+                                redeemerOutputScriptP2WPKH,
+                                mainUtxo.txOutputValue
                               )
-                            })
-                          }
-                        )
-                      })
+                          })
 
-                      context("when wallet has insufficient funds", () => {
+                          after(async () => {
+                            await restoreSnapshot()
+                          })
+
+                          it("should revert", async () => {
+                            await expect(
+                              bridge
+                                .connect(thirdParty)
+                                .requestRedemption(
+                                  walletPubKeyHash,
+                                  mainUtxo,
+                                  redeemerOutputScriptP2WSH,
+                                  requestedAmount
+                                )
+                            ).to.be.revertedWith("Insufficient wallet funds")
+                          })
+                        })
+                      }
+                    )
+
+                    context(
+                      "when there is a pending request for the given redemption key",
+                      () => {
                         before(async () => {
                           await createSnapshot()
 
-                          // Simulate a situation when the wallet has so many
-                          // pending redemptions that a new request will
-                          // exceed its Bitcoin balance. This is done by making
-                          // a redemption request that will request the entire
-                          // wallet's balance right before the tested request.
+                          // Make a request targeting the given wallet and
+                          // redeemer output script. Tested request will use
+                          // the same parameters.
                           await makeRedemptionAllowance(
                             thirdParty,
                             mainUtxo.txOutputValue
@@ -544,240 +591,136 @@ describe("Bridge - Redemption", () => {
                               .requestRedemption(
                                 walletPubKeyHash,
                                 mainUtxo,
-                                redeemerOutputScriptP2WSH,
+                                redeemerOutputScriptP2WPKH,
                                 requestedAmount
                               )
-                          ).to.be.revertedWith("Insufficient wallet funds")
+                          ).to.be.revertedWith(
+                            "There is a pending redemption request from this wallet to the same address"
+                          )
                         })
-                      })
-                    }
-                  )
+                      }
+                    )
+                  })
 
-                  context(
-                    "when there is a pending request for the given redemption key",
-                    () => {
-                      before(async () => {
-                        await createSnapshot()
-
-                        // Make a request targeting the given wallet and
-                        // redeemer output script. Tested request will use
-                        // the same parameters.
-                        await makeRedemptionAllowance(
-                          thirdParty,
-                          mainUtxo.txOutputValue
-                        )
-                        await bridge
+                  context("when amount is below the dust threshold", () => {
+                    it("should revert", async () => {
+                      // Initial dust threshold set in the tests `fixture`
+                      // for tests is 100000. A value lower by 1 sat should
+                      // trigger the tested condition.
+                      await expect(
+                        bridge
                           .connect(thirdParty)
                           .requestRedemption(
                             walletPubKeyHash,
                             mainUtxo,
                             redeemerOutputScriptP2WPKH,
-                            mainUtxo.txOutputValue
+                            99999
                           )
-                      })
+                      ).to.be.revertedWith("Redemption amount too small")
+                    })
+                  })
+                }
+              )
 
-                      after(async () => {
-                        await restoreSnapshot()
-                      })
-
-                      it("should revert", async () => {
-                        await expect(
-                          bridge
-                            .connect(thirdParty)
-                            .requestRedemption(
-                              walletPubKeyHash,
-                              mainUtxo,
-                              redeemerOutputScriptP2WPKH,
-                              requestedAmount
-                            )
-                        ).to.be.revertedWith(
-                          "There is a pending redemption request from this wallet to the same address"
-                        )
-                      })
-                    }
-                  )
-                })
-
-                context("when amount is below the dust threshold", () => {
+              context(
+                "when redeemer output script points to the wallet public key hash",
+                () => {
                   it("should revert", async () => {
-                    // Initial dust threshold set in the tests `fixture`
-                    // for tests is 100000. A value lower by 1 sat should
-                    // trigger the tested condition.
+                    // Wallet public key hash hidden under P2WPKH.
                     await expect(
                       bridge
                         .connect(thirdParty)
                         .requestRedemption(
                           walletPubKeyHash,
                           mainUtxo,
-                          redeemerOutputScriptP2WPKH,
-                          99999
+                          `0x160014${walletPubKeyHash.substring(2)}`,
+                          100000
                         )
-                    ).to.be.revertedWith("Redemption amount too small")
+                    ).to.be.revertedWith(
+                      "Redeemer output script must not point to the wallet PKH"
+                    )
+
+                    // Wallet public key hash hidden under P2PKH.
+                    await expect(
+                      bridge
+                        .connect(thirdParty)
+                        .requestRedemption(
+                          walletPubKeyHash,
+                          mainUtxo,
+                          `0x1976a914${walletPubKeyHash.substring(2)}88ac`,
+                          100000
+                        )
+                    ).to.be.revertedWith(
+                      "Redeemer output script must not point to the wallet PKH"
+                    )
+
+                    // Wallet public key hash hidden under P2SH.
+                    await expect(
+                      bridge
+                        .connect(thirdParty)
+                        .requestRedemption(
+                          walletPubKeyHash,
+                          mainUtxo,
+                          `0x17a914${walletPubKeyHash.substring(2)}87`,
+                          100000
+                        )
+                    ).to.be.revertedWith(
+                      "Redeemer output script must not point to the wallet PKH"
+                    )
+
+                    // There is no need to check for P2WSH since that type
+                    // uses 32-byte hashes. Because wallet public key hash is
+                    // always 20-byte, there is no possibility those hashes
+                    // can be confused during change output recognition.
                   })
-                })
-              }
-            )
+                }
+              )
+            })
 
-            context(
-              "when redeemer output script points to the wallet public key hash",
-              () => {
-                it("should revert", async () => {
-                  // Wallet public key hash hidden under P2WPKH.
-                  await expect(
-                    bridge
-                      .connect(thirdParty)
-                      .requestRedemption(
-                        walletPubKeyHash,
-                        mainUtxo,
-                        `0x160014${walletPubKeyHash.substring(2)}`,
-                        100000
-                      )
-                  ).to.be.revertedWith(
-                    "Redeemer output script must not point to the wallet PKH"
-                  )
-
-                  // Wallet public key hash hidden under P2PKH.
-                  await expect(
-                    bridge
-                      .connect(thirdParty)
-                      .requestRedemption(
-                        walletPubKeyHash,
-                        mainUtxo,
-                        `0x1976a914${walletPubKeyHash.substring(2)}88ac`,
-                        100000
-                      )
-                  ).to.be.revertedWith(
-                    "Redeemer output script must not point to the wallet PKH"
-                  )
-
-                  // Wallet public key hash hidden under P2SH.
-                  await expect(
-                    bridge
-                      .connect(thirdParty)
-                      .requestRedemption(
-                        walletPubKeyHash,
-                        mainUtxo,
-                        `0x17a914${walletPubKeyHash.substring(2)}87`,
-                        100000
-                      )
-                  ).to.be.revertedWith(
-                    "Redeemer output script must not point to the wallet PKH"
-                  )
-
-                  // There is no need to check for P2WSH since that type
-                  // uses 32-byte hashes. Because wallet public key hash is
-                  // always 20-byte, there is no possibility those hashes
-                  // can be confused during change output recognition.
-                })
-              }
-            )
+            context("when redeemer output script is not standard type", () => {
+              it("should revert", async () => {
+                // The set of non-standard/malformed scripts is infinite.
+                // A malformed P2PKH redeemer script is used as example.
+                await expect(
+                  bridge
+                    .connect(thirdParty)
+                    .requestRedemption(
+                      walletPubKeyHash,
+                      mainUtxo,
+                      "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac",
+                      100000
+                    )
+                ).to.be.revertedWith(
+                  "Redeemer output script must be a standard type"
+                )
+              })
+            })
           })
 
-          context("when redeemer output script is not standard type", () => {
+          context("when main UTXO data are invalid", () => {
             it("should revert", async () => {
-              // The set of non-standard/malformed scripts is infinite.
-              // A malformed P2PKH redeemer script is used as example.
+              // The proper main UTXO hash `0` as `txOutputIndex`.
               await expect(
-                bridge
-                  .connect(thirdParty)
-                  .requestRedemption(
-                    walletPubKeyHash,
-                    mainUtxo,
-                    "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac",
-                    100000
-                  )
-              ).to.be.revertedWith(
-                "Redeemer output script must be a standard type"
-              )
+                bridge.connect(thirdParty).requestRedemption(
+                  walletPubKeyHash,
+                  {
+                    txHash:
+                      "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
+                    txOutputIndex: 1,
+                    txOutputValue: 10000000,
+                  },
+                  "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
+                  100000
+                )
+              ).to.be.revertedWith("Invalid main UTXO data")
             })
           })
         })
 
-        context("when main UTXO data are invalid", () => {
+        context("when there is no main UTXO for the given wallet", () => {
           it("should revert", async () => {
-            // The proper main UTXO hash `0` as `txOutputIndex`.
-            await expect(
-              bridge.connect(thirdParty).requestRedemption(
-                walletPubKeyHash,
-                {
-                  txHash:
-                    "0x3835ecdee2daa83c9a19b5012104ace55ecab197b5e16489c26d372e475f5d2a",
-                  txOutputIndex: 1,
-                  txOutputValue: 10000000,
-                },
-                "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
-                100000
-              )
-            ).to.be.revertedWith("Invalid main UTXO data")
-          })
-        })
-      })
-
-      context("when there is no main UTXO for the given wallet", () => {
-        it("should revert", async () => {
-          // Since there is no main UTXO for this wallet recorded in the
-          // Bridge, the `mainUtxo` parameter can be anything.
-          await expect(
-            bridge
-              .connect(thirdParty)
-              .requestRedemption(
-                walletPubKeyHash,
-                NO_MAIN_UTXO,
-                "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
-                100000
-              )
-          ).to.be.revertedWith("No main UTXO for the given wallet")
-        })
-      })
-    })
-
-    context("when wallet state is other than Live", () => {
-      const testData: { testName: string; state: number }[] = [
-        {
-          testName: "when wallet state is Unknown",
-          state: walletState.Unknown,
-        },
-        {
-          testName: "when wallet state is MovingFunds",
-          state: walletState.MovingFunds,
-        },
-        {
-          testName: "when wallet state is Closing",
-          state: walletState.Closing,
-        },
-        {
-          testName: "when wallet state is Closed",
-          state: walletState.Closed,
-        },
-        {
-          testName: "when wallet state is Terminated",
-          state: walletState.Terminated,
-        },
-      ]
-
-      testData.forEach((test) => {
-        context(test.testName, () => {
-          before(async () => {
-            await createSnapshot()
-
-            await bridge.setWallet(walletPubKeyHash, {
-              ecdsaWalletID: ethers.constants.HashZero,
-              mainUtxoHash: ethers.constants.HashZero,
-              pendingRedemptionsValue: 0,
-              createdAt: await lastBlockTime(),
-              movingFundsRequestedAt: 0,
-              closingStartedAt: 0,
-              pendingMovedFundsSweepRequestsCount: 0,
-              state: test.state,
-              movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
-            })
-          })
-
-          after(async () => {
-            await restoreSnapshot()
-          })
-
-          it("should revert", async () => {
+            // Since there is no main UTXO for this wallet recorded in the
+            // Bridge, the `mainUtxo` parameter can be anything.
             await expect(
               bridge
                 .connect(thirdParty)
@@ -787,10 +730,195 @@ describe("Bridge - Redemption", () => {
                   "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
                   100000
                 )
-            ).to.be.revertedWith("Wallet must be in Live state")
+            ).to.be.revertedWith("No main UTXO for the given wallet")
           })
         })
       })
+
+      context("when wallet state is other than Live", () => {
+        const testData: { testName: string; state: number }[] = [
+          {
+            testName: "when wallet state is Unknown",
+            state: walletState.Unknown,
+          },
+          {
+            testName: "when wallet state is MovingFunds",
+            state: walletState.MovingFunds,
+          },
+          {
+            testName: "when wallet state is Closing",
+            state: walletState.Closing,
+          },
+          {
+            testName: "when wallet state is Closed",
+            state: walletState.Closed,
+          },
+          {
+            testName: "when wallet state is Terminated",
+            state: walletState.Terminated,
+          },
+        ]
+
+        testData.forEach((test) => {
+          context(test.testName, () => {
+            before(async () => {
+              await createSnapshot()
+
+              await bridge.setWallet(walletPubKeyHash, {
+                ecdsaWalletID: ethers.constants.HashZero,
+                mainUtxoHash: ethers.constants.HashZero,
+                pendingRedemptionsValue: 0,
+                createdAt: await lastBlockTime(),
+                movingFundsRequestedAt: 0,
+                closingStartedAt: 0,
+                pendingMovedFundsSweepRequestsCount: 0,
+                state: test.state,
+                movingFundsTargetWalletsCommitmentHash:
+                  ethers.constants.HashZero,
+              })
+            })
+
+            after(async () => {
+              await restoreSnapshot()
+            })
+
+            it("should revert", async () => {
+              await expect(
+                bridge
+                  .connect(thirdParty)
+                  .requestRedemption(
+                    walletPubKeyHash,
+                    NO_MAIN_UTXO,
+                    "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
+                    100000
+                  )
+              ).to.be.revertedWith("Wallet must be in Live state")
+            })
+          })
+        })
+      })
+    })
+
+    context("when redemption watchtower is set", () => {
+      const data: RedemptionTestData = SinglePendingRequestedRedemption
+      const { redeemerOutputScript, redeemer } = data.redemptionRequests[0]
+
+      let redeemerSigner: SignerWithAddress
+      let watchtower: FakeContract<IRedemptionWatchtower>
+
+      before(async () => {
+        await createSnapshot()
+
+        redeemerSigner = await impersonateAccount(redeemer, {
+          from: governance,
+          value: 10,
+        })
+
+        watchtower = await smock.fake<IRedemptionWatchtower>(
+          "IRedemptionWatchtower"
+        )
+
+        await bridgeGovernance
+          .connect(governance)
+          .setRedemptionWatchtower(watchtower.address)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      context(
+        "when redemption watchtower considers the redemption as unsafe",
+        () => {
+          before(async () => {
+            await createSnapshot()
+
+            watchtower.isSafeRedemption
+              .whenCalledWith(
+                walletPubKeyHash,
+                redeemerOutputScript,
+                redeemer,
+                redeemer
+              )
+              .returns(false)
+          })
+
+          after(async () => {
+            watchtower.isSafeRedemption.reset()
+
+            await restoreSnapshot()
+          })
+
+          it("should revert", async () => {
+            await expect(
+              bridge.connect(redeemerSigner).requestRedemption(
+                walletPubKeyHash,
+                NO_MAIN_UTXO, // not relevant
+                redeemerOutputScript,
+                0 // not relevant
+              )
+            ).to.be.revertedWith(
+              "Redemption request rejected by the watchtower"
+            )
+          })
+        }
+      )
+
+      context(
+        "when redemption watchtower considers the redemption as safe",
+        () => {
+          before(async () => {
+            await createSnapshot()
+
+            await bridge.setWallet(walletPubKeyHash, {
+              ecdsaWalletID: data.wallet.ecdsaWalletID,
+              mainUtxoHash: ethers.constants.HashZero,
+              pendingRedemptionsValue: data.wallet.pendingRedemptionsValue,
+              createdAt: await lastBlockTime(),
+              movingFundsRequestedAt: 0,
+              closingStartedAt: 0,
+              pendingMovedFundsSweepRequestsCount: 0,
+              state: walletState.Live,
+              movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+            })
+            await bridge.setWalletMainUtxo(walletPubKeyHash, data.mainUtxo)
+            await bridge.setActiveWallet(walletPubKeyHash)
+
+            await makeRedemptionAllowance(
+              redeemerSigner,
+              data.redemptionRequests[0].amount
+            )
+
+            watchtower.isSafeRedemption
+              .whenCalledWith(
+                walletPubKeyHash,
+                redeemerOutputScript,
+                redeemer,
+                redeemer
+              )
+              .returns(true)
+          })
+
+          after(async () => {
+            watchtower.isSafeRedemption.reset()
+
+            await restoreSnapshot()
+          })
+
+          it("should not revert", async () => {
+            await expect(
+              bridge
+                .connect(redeemerSigner)
+                .requestRedemption(
+                  walletPubKeyHash,
+                  data.mainUtxo,
+                  redeemerOutputScript,
+                  data.redemptionRequests[0].amount
+                )
+            ).to.not.be.reverted
+          })
+        }
+      )
     })
   })
 
@@ -4622,12 +4750,22 @@ describe("Bridge - Redemption", () => {
     })
 
     context("when the caller is the redemption watchtower", () => {
-      let watchtower: SignerWithAddress
+      let watchtower: FakeContract<IRedemptionWatchtower>
+      let watchtowerSigner: SignerWithAddress
 
       before(async () => {
         await createSnapshot()
 
-        watchtower = thirdParty
+        watchtower = await smock.fake<IRedemptionWatchtower>(
+          "IRedemptionWatchtower"
+        )
+
+        watchtower.isSafeRedemption.returns(true)
+
+        watchtowerSigner = await impersonateAccount(watchtower.address, {
+          from: governance,
+          value: 10,
+        })
 
         await bridgeGovernance
           .connect(governance)
@@ -4635,6 +4773,8 @@ describe("Bridge - Redemption", () => {
       })
 
       after(async () => {
+        watchtower.isSafeRedemption.reset()
+
         await restoreSnapshot()
       })
 
@@ -4642,7 +4782,7 @@ describe("Bridge - Redemption", () => {
         it("should revert", async () => {
           await expect(
             bridge
-              .connect(watchtower)
+              .connect(watchtowerSigner)
               .notifyRedemptionVeto(walletPublicKeyHash, redeemerOutputScript)
           ).to.be.revertedWith("Redemption request does not exist")
         })
@@ -4710,7 +4850,7 @@ describe("Bridge - Redemption", () => {
           initialWatchtowerBalance = await bank.balanceOf(watchtower.address)
 
           tx = await bridge
-            .connect(watchtower)
+            .connect(watchtowerSigner)
             .notifyRedemptionVeto(walletPublicKeyHash, redeemerOutputScript)
         })
 

--- a/solidity/test/bridge/RedemptionWatchtower.test.ts
+++ b/solidity/test/bridge/RedemptionWatchtower.test.ts
@@ -1,0 +1,282 @@
+import { helpers, waffle, ethers } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { expect } from "chai"
+import { ContractTransaction } from "ethers"
+import type { Bridge, BridgeStub, RedemptionWatchtower } from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime } = helpers.time
+
+describe("RedemptionWatchtower", () => {
+  let governance: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let redemptionWatchtowerManager: SignerWithAddress
+  let guardians: SignerWithAddress[]
+
+  let bridge: Bridge & BridgeStub
+  let redemptionWatchtower: RedemptionWatchtower
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      governance,
+      thirdParty,
+      redemptionWatchtowerManager,
+      guardians,
+      bridge,
+      redemptionWatchtower,
+    } = await waffle.loadFixture(bridgeFixture))
+
+    // Make sure test actors are correctly set up.
+    const actors = [
+      governance,
+      thirdParty,
+      redemptionWatchtowerManager,
+      ...guardians,
+    ].map((actor) => actor.address)
+
+    if (actors.length !== new Set(actors).size) {
+      throw new Error("Duplicate actors; please double check the fixture")
+    }
+  })
+
+  describe("enableWatchtower", () => {
+    context("when called not by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          redemptionWatchtower.connect(thirdParty).enableWatchtower(
+            redemptionWatchtowerManager.address,
+            guardians.map((g) => g.address)
+          )
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      context("when already enabled", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await redemptionWatchtower.connect(governance).enableWatchtower(
+            redemptionWatchtowerManager.address,
+            guardians.map((g) => g.address)
+          )
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revert", async () => {
+          await expect(
+            redemptionWatchtower.connect(governance).enableWatchtower(
+              redemptionWatchtowerManager.address,
+              guardians.map((g) => g.address)
+            )
+          ).to.be.revertedWith("Already enabled")
+        })
+      })
+
+      context("when not enabled yet", () => {
+        context("when manager address is zero", () => {
+          it("should revert", async () => {
+            await expect(
+              redemptionWatchtower.connect(governance).enableWatchtower(
+                ethers.constants.AddressZero,
+                guardians.map((g) => g.address)
+              )
+            ).to.be.revertedWith("Manager address must not be 0x0")
+          })
+        })
+
+        context("when manager address is non-zero", () => {
+          let tx: ContractTransaction
+
+          before(async () => {
+            await createSnapshot()
+
+            tx = await redemptionWatchtower
+              .connect(governance)
+              .enableWatchtower(
+                redemptionWatchtowerManager.address,
+                guardians.map((g) => g.address)
+              )
+          })
+
+          after(async () => {
+            await restoreSnapshot()
+          })
+
+          it("should set the watchtower manager properly", async () => {
+            expect(await redemptionWatchtower.manager()).to.equal(
+              redemptionWatchtowerManager.address
+            )
+          })
+
+          it("should set initial guardians properly", async () => {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const guardian of guardians) {
+              // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-unused-expressions
+              expect(await redemptionWatchtower.isGuardian(guardian.address)).to
+                .be.true
+            }
+          })
+
+          it("should emit WatchtowerEnabled event", async () => {
+            await expect(tx)
+              .to.emit(redemptionWatchtower, "WatchtowerEnabled")
+              .withArgs(
+                await lastBlockTime(),
+                redemptionWatchtowerManager.address
+              )
+          })
+
+          it("should emit GuardianAdded events", async () => {
+            await expect(tx)
+              .to.emit(redemptionWatchtower, "GuardianAdded")
+              .withArgs(guardians[0].address)
+
+            await expect(tx)
+              .to.emit(redemptionWatchtower, "GuardianAdded")
+              .withArgs(guardians[1].address)
+
+            await expect(tx)
+              .to.emit(redemptionWatchtower, "GuardianAdded")
+              .withArgs(guardians[2].address)
+          })
+        })
+      })
+    })
+  })
+
+  describe("addGuardian", () => {
+    before(async () => {
+      await createSnapshot()
+
+      await redemptionWatchtower.connect(governance).enableWatchtower(
+        redemptionWatchtowerManager.address,
+        guardians.map((g) => g.address)
+      )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when called not by the watchtower manager", () => {
+      it("should revert", async () => {
+        await expect(
+          redemptionWatchtower
+            .connect(governance) // governance has not such a power
+            .addGuardian(thirdParty.address)
+        ).to.be.revertedWith("Caller is not watchtower manager")
+      })
+    })
+
+    context("when called by the watchtower manager", () => {
+      context("when guardian already exists", () => {
+        it("should revert", async () => {
+          await expect(
+            redemptionWatchtower
+              .connect(redemptionWatchtowerManager)
+              .addGuardian(guardians[0].address)
+          ).to.be.revertedWith("Guardian already exists")
+        })
+      })
+
+      context("when guardian does not exist", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await redemptionWatchtower
+            .connect(redemptionWatchtowerManager)
+            .addGuardian(thirdParty.address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add the guardian properly", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await redemptionWatchtower.isGuardian(thirdParty.address)).to
+            .be.true
+        })
+
+        it("should emit GuardianAdded event", async () => {
+          await expect(tx)
+            .to.emit(redemptionWatchtower, "GuardianAdded")
+            .withArgs(thirdParty.address)
+        })
+      })
+    })
+  })
+
+  describe("removeGuardian", () => {
+    before(async () => {
+      await createSnapshot()
+
+      await redemptionWatchtower.connect(governance).enableWatchtower(
+        redemptionWatchtowerManager.address,
+        guardians.map((g) => g.address)
+      )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          redemptionWatchtower
+            .connect(redemptionWatchtowerManager) // manager has not such a power
+            .removeGuardian(guardians[0].address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the governance", () => {
+      context("when guardian does not exist", () => {
+        it("should revert", async () => {
+          await expect(
+            redemptionWatchtower
+              .connect(governance)
+              .removeGuardian(thirdParty.address)
+          ).to.be.revertedWith("Guardian does not exist")
+        })
+      })
+
+      context("when guardian exists", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await redemptionWatchtower
+            .connect(governance)
+            .removeGuardian(guardians[0].address)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should remove the guardian properly", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await redemptionWatchtower.isGuardian(guardians[0].address)).to
+            .be.false
+        })
+
+        it("should emit GuardianRemoved event", async () => {
+          await expect(tx)
+            .to.emit(redemptionWatchtower, "GuardianRemoved")
+            .withArgs(guardians[0].address)
+        })
+      })
+    })
+  })
+})

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -3,7 +3,6 @@ import { ethers, helpers } from "hardhat"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import { BigNumber, BigNumberish, BytesLike } from "ethers"
-import { arch } from "node:os"
 import type {
   Bridge,
   IRedemptionWatchtower,

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -3,13 +3,18 @@ import { ethers, helpers } from "hardhat"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import { BigNumber, BigNumberish, BytesLike } from "ethers"
-import type { Bridge, WalletProposalValidator } from "../../typechain"
+import { arch } from "node:os"
+import type {
+  Bridge,
+  IRedemptionWatchtower,
+  WalletProposalValidator,
+} from "../../typechain"
 import { walletState, movedFundsSweepRequestState } from "../fixtures"
 import { NO_MAIN_UTXO } from "../data/deposit-sweep"
 
 chai.use(smock.matchers)
 
-const { lastBlockTime } = helpers.time
+const { lastBlockTime, increaseTime } = helpers.time
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 const { AddressZero, HashZero } = ethers.constants
 
@@ -1477,65 +1482,173 @@ describe("WalletProposalValidator", () => {
 
             context("when all requests are pending", () => {
               context("when there is an immature request", () => {
-                let requestOne
-                let requestTwo
+                context(
+                  "when immaturity is caused by REDEMPTION_REQUEST_MIN_AGE violation",
+                  () => {
+                    let requestOne
+                    let requestTwo
 
-                before(async () => {
-                  await createSnapshot()
+                    before(async () => {
+                      await createSnapshot()
 
-                  requestOne = createTestRedemptionRequest(
-                    walletPubKeyHash,
-                    5000 // necessary to pass the fee share validation
-                  )
-                  requestTwo = createTestRedemptionRequest(walletPubKeyHash)
-
-                  // Request one is a proper one.
-                  bridge.pendingRedemptions
-                    .whenCalledWith(
-                      redemptionKey(
-                        requestOne.key.walletPubKeyHash,
-                        requestOne.key.redeemerOutputScript
+                      requestOne = createTestRedemptionRequest(
+                        walletPubKeyHash,
+                        5000 // necessary to pass the fee share validation
                       )
-                    )
-                    .returns(requestOne.content)
+                      requestTwo = createTestRedemptionRequest(walletPubKeyHash)
 
-                  // Simulate the request two has just been created thus not
-                  // achieved the min age yet.
-                  bridge.pendingRedemptions
-                    .whenCalledWith(
-                      redemptionKey(
-                        requestTwo.key.walletPubKeyHash,
-                        requestTwo.key.redeemerOutputScript
-                      )
-                    )
-                    .returns({
-                      ...requestTwo.content,
-                      requestedAt: await lastBlockTime(),
+                      // Request one is a proper one.
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestOne.key.walletPubKeyHash,
+                            requestOne.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(requestOne.content)
+
+                      // Simulate the request two has just been created thus not
+                      // achieved the min age yet.
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestTwo.key.walletPubKeyHash,
+                            requestTwo.key.redeemerOutputScript
+                          )
+                        )
+                        .returns({
+                          ...requestTwo.content,
+                          requestedAt: await lastBlockTime(),
+                        })
                     })
-                })
 
-                after(async () => {
-                  bridge.pendingRedemptions.reset()
+                    after(async () => {
+                      bridge.pendingRedemptions.reset()
 
-                  await restoreSnapshot()
-                })
+                      await restoreSnapshot()
+                    })
 
-                it("should revert", async () => {
-                  const proposal = {
-                    walletPubKeyHash,
-                    redeemersOutputScripts: [
-                      requestOne.key.redeemerOutputScript,
-                      requestTwo.key.redeemerOutputScript,
-                    ],
-                    redemptionTxFee,
+                    it("should revert", async () => {
+                      const proposal = {
+                        walletPubKeyHash,
+                        redeemersOutputScripts: [
+                          requestOne.key.redeemerOutputScript,
+                          requestTwo.key.redeemerOutputScript,
+                        ],
+                        redemptionTxFee,
+                      }
+
+                      await expect(
+                        walletProposalValidator.validateRedemptionProposal(
+                          proposal
+                        )
+                      ).to.be.revertedWith(
+                        "Redemption request min age not achieved yet"
+                      )
+                    })
                   }
+                )
 
-                  await expect(
-                    walletProposalValidator.validateRedemptionProposal(proposal)
-                  ).to.be.revertedWith(
-                    "Redemption request min age not achieved yet"
-                  )
-                })
+                context(
+                  "when immaturity is caused by watchtower's delay violation",
+                  () => {
+                    let watchtower: FakeContract<IRedemptionWatchtower>
+                    let requestOne
+                    let requestTwo
+
+                    before(async () => {
+                      await createSnapshot()
+
+                      requestOne = createTestRedemptionRequest(
+                        walletPubKeyHash,
+                        5000, // necessary to pass the fee share validation
+                        await lastBlockTime()
+                      )
+                      requestTwo = createTestRedemptionRequest(
+                        walletPubKeyHash,
+                        5000, // necessary to pass the fee share validation
+                        await lastBlockTime()
+                      )
+
+                      // Request one is a proper one.
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestOne.key.walletPubKeyHash,
+                            requestOne.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(requestOne.content)
+
+                      // Simulate the request two has just been created thus not
+                      // achieved the min age yet.
+                      bridge.pendingRedemptions
+                        .whenCalledWith(
+                          redemptionKey(
+                            requestTwo.key.walletPubKeyHash,
+                            requestTwo.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(requestTwo.content)
+
+                      watchtower = await smock.fake<IRedemptionWatchtower>(
+                        "IRedemptionWatchtower"
+                      )
+                      bridge.getRedemptionWatchtower.returns(watchtower.address)
+
+                      const redemptionOneDelay = 3600
+                      watchtower.getRedemptionDelay
+                        .whenCalledWith(
+                          buildRedemptionKey(
+                            requestOne.key.walletPubKeyHash,
+                            requestOne.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(redemptionOneDelay)
+
+                      const redemptionTwoDelay = 7200
+                      watchtower.getRedemptionDelay
+                        .whenCalledWith(
+                          buildRedemptionKey(
+                            requestTwo.key.walletPubKeyHash,
+                            requestTwo.key.redeemerOutputScript
+                          )
+                        )
+                        .returns(redemptionTwoDelay)
+
+                      // Increase time to a point when delay for redemption
+                      // one was elapsed but not for redemption two.
+                      await increaseTime(redemptionTwoDelay)
+                    })
+
+                    after(async () => {
+                      bridge.getRedemptionWatchtower.reset()
+                      watchtower.getRedemptionDelay.reset()
+                      bridge.pendingRedemptions.reset()
+
+                      await restoreSnapshot()
+                    })
+
+                    it("should revert", async () => {
+                      const proposal = {
+                        walletPubKeyHash,
+                        redeemersOutputScripts: [
+                          requestOne.key.redeemerOutputScript,
+                          requestTwo.key.redeemerOutputScript,
+                        ],
+                        redemptionTxFee,
+                      }
+
+                      await expect(
+                        walletProposalValidator.validateRedemptionProposal(
+                          proposal
+                        )
+                      ).to.be.revertedWith(
+                        "Redemption request min age not achieved yet"
+                      )
+                    })
+                  }
+                )
               })
 
               context("when all requests achieved the min age", () => {
@@ -1846,64 +1959,111 @@ describe("WalletProposalValidator", () => {
                         })
 
                         context("when all requests are unique", () => {
-                          let requestOne
-                          let requestTwo
+                          const testData: {
+                            testName: string
+                            watchtower: boolean
+                          }[] = [
+                            {
+                              testName: "when watchtower is not set",
+                              watchtower: false,
+                            },
+                            {
+                              testName: "when watchtower is set",
+                              watchtower: true,
+                            },
+                          ]
 
-                          before(async () => {
-                            await createSnapshot()
+                          testData.forEach((test) => {
+                            context(test.testName, () => {
+                              let watchtower: FakeContract<IRedemptionWatchtower>
+                              let requestOne
+                              let requestTwo
 
-                            requestOne = createTestRedemptionRequest(
-                              walletPubKeyHash,
-                              5000 // necessary to pass the fee share validation
-                            )
+                              before(async () => {
+                                await createSnapshot()
 
-                            requestTwo = createTestRedemptionRequest(
-                              walletPubKeyHash,
-                              5000 // necessary to pass the fee share validation
-                            )
-
-                            bridge.pendingRedemptions
-                              .whenCalledWith(
-                                redemptionKey(
-                                  requestOne.key.walletPubKeyHash,
-                                  requestOne.key.redeemerOutputScript
+                                requestOne = createTestRedemptionRequest(
+                                  walletPubKeyHash,
+                                  5000 // necessary to pass the fee share validation
                                 )
-                              )
-                              .returns(requestOne.content)
 
-                            bridge.pendingRedemptions
-                              .whenCalledWith(
-                                redemptionKey(
-                                  requestTwo.key.walletPubKeyHash,
-                                  requestTwo.key.redeemerOutputScript
+                                requestTwo = createTestRedemptionRequest(
+                                  walletPubKeyHash,
+                                  5000 // necessary to pass the fee share validation
                                 )
-                              )
-                              .returns(requestTwo.content)
-                          })
 
-                          after(async () => {
-                            bridge.pendingRedemptions.reset()
+                                bridge.pendingRedemptions
+                                  .whenCalledWith(
+                                    redemptionKey(
+                                      requestOne.key.walletPubKeyHash,
+                                      requestOne.key.redeemerOutputScript
+                                    )
+                                  )
+                                  .returns(requestOne.content)
 
-                            await restoreSnapshot()
-                          })
+                                bridge.pendingRedemptions
+                                  .whenCalledWith(
+                                    redemptionKey(
+                                      requestTwo.key.walletPubKeyHash,
+                                      requestTwo.key.redeemerOutputScript
+                                    )
+                                  )
+                                  .returns(requestTwo.content)
 
-                          it("should succeed", async () => {
-                            const proposal = {
-                              walletPubKeyHash,
-                              redeemersOutputScripts: [
-                                requestOne.key.redeemerOutputScript,
-                                requestTwo.key.redeemerOutputScript,
-                              ],
-                              redemptionTxFee,
-                            }
+                                if (test.watchtower) {
+                                  watchtower =
+                                    await smock.fake<IRedemptionWatchtower>(
+                                      "IRedemptionWatchtower"
+                                    )
 
-                            const result =
-                              await walletProposalValidator.validateRedemptionProposal(
-                                proposal
-                              )
+                                  bridge.getRedemptionWatchtower.returns(
+                                    watchtower.address
+                                  )
 
-                            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                            expect(result).to.be.true
+                                  // All requests created by createTestRedemptionRequest
+                                  // are requested at `now - 1 day` by default.
+                                  // To test the watchtower delay path, we need
+                                  // to use a delay that is greater than
+                                  // `REDEMPTION_REQUEST_MIN_AGE` (10 min) and
+                                  // ensure that the delay is preserved
+                                  // at the moment of the proposal validation.
+                                  // A value of 2 hours will be a good fit.
+                                  watchtower.getRedemptionDelay.returns(
+                                    7200 // 2 hours
+                                  )
+                                }
+                              })
+
+                              after(async () => {
+                                if (test.watchtower) {
+                                  bridge.getRedemptionWatchtower.reset()
+                                  watchtower.getRedemptionDelay.reset()
+                                }
+
+                                bridge.pendingRedemptions.reset()
+
+                                await restoreSnapshot()
+                              })
+
+                              it("should succeed", async () => {
+                                const proposal = {
+                                  walletPubKeyHash,
+                                  redeemersOutputScripts: [
+                                    requestOne.key.redeemerOutputScript,
+                                    requestTwo.key.redeemerOutputScript,
+                                  ],
+                                  redemptionTxFee,
+                                }
+
+                                const result =
+                                  await walletProposalValidator.validateRedemptionProposal(
+                                    proposal
+                                  )
+
+                                // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                                expect(result).to.be.true
+                              })
+                            })
                           })
                         })
                       }
@@ -2795,4 +2955,16 @@ const movedFundsSweepRequestKey = (
   ethers.utils.solidityKeccak256(
     ["bytes32", "uint32"],
     [movingFundsTxHash, movingFundsTxOutputIndex]
+  )
+
+const buildRedemptionKey = (
+  walletPubKeyHash: BytesLike,
+  redeemerOutputScript: BytesLike
+): string =>
+  ethers.utils.solidityKeccak256(
+    ["bytes32", "bytes20"],
+    [
+      ethers.utils.solidityKeccak256(["bytes"], [redeemerOutputScript]),
+      walletPubKeyHash,
+    ]
   )

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -14,6 +14,7 @@ import type {
   VendingMachine,
   BridgeGovernance,
   IRelay,
+  RedemptionWatchtower,
 } from "../../typechain"
 
 /**
@@ -22,9 +23,18 @@ import type {
 export default async function bridgeFixture() {
   await deployments.fixture()
 
-  const { deployer, governance, spvMaintainer, treasury } =
-    await helpers.signers.getNamedSigners()
-  const [thirdParty] = await helpers.signers.getUnnamedSigners()
+  const {
+    deployer,
+    governance,
+    spvMaintainer,
+    treasury,
+    redemptionWatchtowerManager,
+  } = await helpers.signers.getNamedSigners()
+
+  const [thirdParty, guardian1, guardian2, guardian3] =
+    await helpers.signers.getUnnamedSigners()
+
+  const guardians = [guardian1, guardian2, guardian3]
 
   const tbtc: TBTC = await helpers.contracts.getContract("TBTC")
 
@@ -65,6 +75,9 @@ export default async function bridgeFixture() {
   })
 
   await bank.connect(governance).updateBridge(bridge.address)
+
+  const redemptionWatchtower: RedemptionWatchtower =
+    await helpers.contracts.getContract("RedemptionWatchtower")
 
   // Deploys a new instance of Bridge contract behind a proxy. Allows to
   // specify txProofDifficultyFactor. The new instance is deployed with
@@ -111,6 +124,8 @@ export default async function bridgeFixture() {
     spvMaintainer,
     thirdParty,
     treasury,
+    redemptionWatchtowerManager,
+    guardians,
     tbtc,
     vendingMachine,
     tbtcVault,
@@ -121,6 +136,7 @@ export default async function bridgeFixture() {
     reimbursementPool,
     maintainerProxy,
     bridgeGovernance,
+    redemptionWatchtower,
     deployBridge,
   }
 }


### PR DESCRIPTION
Closes: https://github.com/keep-network/tbtc-v2/issues/781

Here we present the implementation of the redemptions veto mechanism, specified in the [TIP-072: Optimistic redemptions](https://forum.threshold.network/t/tip-072-optimistic-redemptions/793). 

### High-level architecture

The current byte size of the `Bridge` contract (~22 kB) is close to the limit. To leave some space for future `Bridge` upgrades, we decided to encapsulate the logic of the redemption veto mechanism in a separate upgradeable contract called `RedemptionWatchtower`, and attach it to the existing `Bridge` instance. Such a design has a positive impact on the `Bridge` size, nicely separates the concerns, and reduces the amount of direct changes in the living `Bridge` instance.
 
The `RedemptionWatchtower` contract acts as a central point for redemption guardians, manages vetoed redemptions, and provides other functionality specified in the TIP. It also serves as a source of information about vetoed redemptions, banned redeemers, and processing delays that should be preserved for specific redemption requests.

The chart below presents how the `RedemptionWatchtower` fits into the existing architecture and provides an overview of interactions between relevant smart contracts and system actors:

```
                                +---------------+
                                |               |
                      +---------+    Wallets    +-------------+
                      |         |               |             |
   pendingRedemptions |         +---------------+             | validateRedemptionProposal
                      |                                       |
                      |                                       |
                      v                                       v
+--------------------------+                          +-----------------------------+
|                          |     pendingRedemptions   |                             |
|          Bridge          |<-------------------------+   WalletProposalValidator   |
|                          |                          |                             |
+----+---------------------+                          +-------+---------------------+
     |                ^                                       |
     |                |                                       |
     |                |                                       |
     |                |                                       | getRedemptionDelay
     |                | notifyRedemptionVeto                  |
     |                +---------+                             |
     |                          |                             |
     |                          |                             |
     | isSafeRedemption    +----+---------------------+       |
     +-------------------->|                          |<------+
                           |   RedemptionWatchtower   |
                  +------->|                          |<------+
                  |        +--------------------------+       |
                  |                     ^                     |
                  |                     |                     |
                  |                     |                     |
   raiseObjection |                     | management          | security
                  |                     | actions             | actions
                  |                     |                     |
                  |                     |                     |
          +-------+-------+     +-------+-------+     +-------+-------+
          |               |     |               |     |               |
          |   Guardians   |     |    Manager    |     |     Owner     |
          |               |     |               |     |               |
          +---------------+     +---------------+     +---------------+
```

### The `RedemptionWatchtower` contract

The `RedemptionWatchtower` contract interacts with several actors of the protocol. Each actor has a different set of capabilities:

**Owner (Threshold Council)**

The owner can call the following functions:
- `enableWatchtower` which enables the veto mechanism for the first time. This function must set the watchtower's manager and can establish an initial set of guardians. This function also captures the timestamp of the call. This information is necessary to ensure the proper lifecycle of the veto mechanism (shut down after 18 months). It is also crucial for determining stalled redemptions that were created in the pre-veto era and can be vetoed indefinitely.
- `removeGuardian` that can be used to remove specific guardians. This function is a safeguard against malicious guardians hence, it must be directly available to the owner. 

**Manager (Token holder DAO)**

As per the TIP, most of the governance should be the authority of the Token holder DAO. To make it possible, we are introducing the role of the watchtower's manager who can use the following functions:
- `addGuardian` which allows adding new redemption guardians
- `updateWatchtowerParameters` that can update all governable parameters that steer the veto mechanism. Those parameters are redemption veto delays, veto time and financial penalties, and the mechanism lifetime.
- `unban` which can be used to unban redeemers who were banned mistakenly. This is a safeguard for guardian mistakes that must be in place to protect honest redeemers.

**Guardians**

Guardians are the executors of the veto process. The only function they can call is `raiseObjection`. That function should be used to raise objections against specific redemption requests. Three subsequent objections lead to a redemption veto. Vetoed redemptions are not processed by the protocol, the requested amount is diminished by a penalty fee, and frozen for a specific time. Once the freeze period ends, the redeemer can claim those funds back. Moreover, redeemers whose redemptions were vetoed become banned and cannot ask for redemptions in the future. Last but not least, even a single objection (not leading to a veto) against a redemption (from a given wallet to a given BTC address) prevents asking the same wallet to redeem to the same BTC address in the future (this is similar to timed out redemptions).

**Others**

The `RedemptionWatchtower` exposes some functions available to the broad public. Those are:
- `isSafeRedemption` which determines whether a redemption involving a specific wallet, BTC address, Bank's balance owner, and redeemer can be considered as safe. This function leverages the objections history and banned redeemers to determine so. A redemption is considered safe if neither the balance owner nor redeemer is banned and past redemptions from the given wallet to the given BTC address were not subject to guardian objections. 
- `getRedemptionDelay` that informs tBTC wallets about processing delays that should be preserved for specific redemption requests. Delays are determined based on raised objections.
- `withdrawVetoedFunds` which can be used by redeemers to withdraw funds from vetoed redemptions once the freeze period ends. 
- `disableWatchtower` that can be used by anyone to disable the veto mechanism once the watchtower's lifetime elapses.

### Changes in the `Bridge` contract

Integration of the `RedemptionWatchtower` contract with the existing `Bridge` incurs several changes in the latter. 

First and foremost, the `Bridge`'s state gains a new address field (`redemptionWatchtower`) that points to the `RedemptionWatchtower` contract. That field can be set using the new `setRedemptionWatchtower` function available for the `Bridge`'s governance. 

Secondly, the `Bridge` exposes a new `notifyRedemptionVeto` callback function. This function can be called only by the `redemptionWatchtower` address. The main responsibility of this function is propagating the consequences of a redemption veto to the `Bridge`'s state, namely:
- Reduce the pending redemptions value of the target wallet (supposed to handle the vetoed redemption). This is the same action as performed upon redemption timeout. This must be done because otherwise, the wallet would hold the reserve for a redemption request that would never be processed
- Delete the redemption request from the pending redemptions mapping. This is important to avoid the vetoed redemption request being processed by the wallet or reported as timed out
- Detain the redemption's request amount and transfer it under the control of the redemption watchtower for further processing (i.e. burn the penalty fee and allow withdrawal of the rest after the freeze period)

Last but not least, the `Bridge` leverages the `redemptionWatchtower` address to determine the safety of upcoming redemption requests. This is achieved using the `isSafeRedemption` call. This way, redemptions from banned redeemers (and balance owners) are blocked. The same applies to redemptions from specific wallets to specific BTC addresses which were subject to guardian objections in the past.

### Changes in the `WalletProposalValidator` contract

The last piece of the puzzle is the integration of the veto mechanism with the off-chain tBTC wallets. Wallets must respect the new veto delay and not process redemptions during the period a redemption veto can still land. According to [RFC-12](https://github.com/keep-network/tbtc-v2/blob/main/docs/rfc/rfc-12.adoc#224-introduce-the-walletproposalvalidator-contract), the tBTC wallets always consult the `WalletProposalValidator` to validate the ongoing redemption proposal before issuing the redemption transaction on the Bitcoin chain. That means it is enough to modify the `WalletProposalValidator.validateRedemptionProposal` function and take the veto delay into account there. The `validateRedemptionProposal` function calls the `RedemptionWatchtower.getRedemptionDelay` function for each redemption in the proposal and considers it valid only if the returned veto delay (counted since the redemption creation timestamp) already elapsed. This logic guarantees that a particular redemption proposal can only be considered valid if all of its redemption requests have surpassed their respective veto delay periods. 

In light of the above, we should also prevent invalid redemption proposals (with redemptions violating the veto delay) from being issued by RFC-12 coordinators. An invalid proposal means a coordination window miss and the optimal strategy here is ensuring proposal validity at generation time. This requires adjustments in the [off-chain redemption proposal generator logic](https://github.com/keep-network/keep-core/blob/2a76f4de820eb13b2d49c67a15a59eac7552fa26/pkg/tbtcpg/redemptions.go#L70). This work is beyond the scope of this pull request and will be addressed in a follow-up PR.

The ultimate protection against wallets not obeying the aforementioned rules is the fact that vetoed redemptions are removed from the `pendingRedemption` set in the `Bridge`. That means the `Bridge` will reject an SPV proof of a redemption transaction that handles at least one vetoed redemption request (that happens in the `submitRedemptionProof` function). In such a case, the given wallet will be deemed as fraudulent and punished according to the protocol rules.



