### PR TITLE
Don't add comments about API docs previews to PRs

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -51,7 +51,7 @@ jobs:
       preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: false
       addTOC: false
-      commentPR: true
+      commentPR: false
       exportAsGHArtifacts: true
 
   # This job will be triggered for releases which name starts with


### PR DESCRIPTION
Previously we've been adding comments to PRs modifying Solidity contracts about available previews of the API documentation. As each push to the PR branch results in one such comment, PRs with a lot of pushes get quite busy with a lot of the similar comments. In the future it would be good to modify our commenting mechanism so that it would just leave one comment per PR and update it on each push. Until we do that we're turning off the PR commenting, to increase readability.

Ref:
https://github.com/keep-network/keep-core/pull/3791
https://github.com/threshold-network/solidity-contracts/pull/165