### PR TITLE
Solidity: Start version 1.7.0-dev

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.6.0-dev",
+  "version": "1.7.0-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
We released version 1.6.0, so need to start a next one for development.