### PR TITLE
Add zero address checks for `L*BitcoinDepositor` initializers

### DIFF
--- a/solidity/contracts/l2/L1BitcoinDepositor.sol
+++ b/solidity/contracts/l2/L1BitcoinDepositor.sol
@@ -190,6 +190,20 @@ contract L1BitcoinDepositor is
         __AbstractTBTCDepositor_initialize(_tbtcBridge, _tbtcVault);
         __Ownable_init();
 
+        require(_wormhole != address(0), "Wormhole address cannot be zero");
+        require(
+            _wormholeRelayer != address(0),
+            "WormholeRelayer address cannot be zero"
+        );
+        require(
+            _wormholeTokenBridge != address(0),
+            "WormholeTokenBridge address cannot be zero"
+        );
+        require(
+            _l2WormholeGateway != address(0),
+            "L2WormholeGateway address cannot be zero"
+        );
+
         tbtcToken = IERC20Upgradeable(ITBTCVault(_tbtcVault).tbtcToken());
         wormhole = IWormhole(_wormhole);
         wormholeRelayer = IWormholeRelayer(_wormholeRelayer);

--- a/solidity/contracts/l2/L2BitcoinDepositor.sol
+++ b/solidity/contracts/l2/L2BitcoinDepositor.sol
@@ -69,6 +69,15 @@ contract L2BitcoinDepositor is IWormholeReceiver, OwnableUpgradeable {
     ) external initializer {
         __Ownable_init();
 
+        require(
+            _wormholeRelayer != address(0),
+            "WormholeRelayer address cannot be zero"
+        );
+        require(
+            _l2WormholeGateway != address(0),
+            "L2WormholeGateway address cannot be zero"
+        );
+
         wormholeRelayer = IWormholeRelayer(_wormholeRelayer);
         l2WormholeGateway = IL2WormholeGateway(_l2WormholeGateway);
         l1ChainId = _l1ChainId;


### PR DESCRIPTION
Depends on: https://github.com/keep-network/tbtc-v2/pull/804

Here we add the missing zero-address checks to prevent incorrectly set values.