### PR TITLE
Lock pragma version for `L*BitcoinDepositor` contracts

### DIFF
--- a/solidity/contracts/l2/L1BitcoinDepositor.sol
+++ b/solidity/contracts/l2/L1BitcoinDepositor.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity ^0.8.17;
+pragma solidity 0.8.17;
 
 import "@keep-network/random-beacon/contracts/Reimbursable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/solidity/contracts/l2/L2BitcoinDepositor.sol
+++ b/solidity/contracts/l2/L2BitcoinDepositor.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity ^0.8.17;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 


### PR DESCRIPTION
Depends on: https://github.com/keep-network/tbtc-v2/pull/805

Here we fix the Solidity version to be `0.8.17` which is used across all tBTC contracts.