### PR TITLE
Improve public key fetching for closed/terminated wallets

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -393,7 +393,7 @@ Represents an event emitted when new wallet is registered on the on-chain bridge
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:455](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L455)
+[src/lib/contracts/bridge.ts:457](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L457)
 
 ___
 
@@ -1024,7 +1024,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:688](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L688)
+[src/lib/ethereum/bridge.ts:699](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L699)
 
 ___
 

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -177,7 +177,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:618](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L618)
+[src/lib/ethereum/bridge.ts:629](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L629)
 
 ___
 
@@ -334,7 +334,7 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:530](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L530)
+[src/lib/ethereum/bridge.ts:541](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L541)
 
 ___
 
@@ -361,13 +361,13 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:635](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L635)
+[src/lib/ethereum/bridge.ts:646](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L646)
 
 ___
 
 ### getWalletCompressedPublicKey
 
-▸ **getWalletCompressedPublicKey**(`ecdsaWalletID`): `Promise`\<[`Hex`](Hex.md)\>
+▸ **getWalletCompressedPublicKey**(`ecdsaWalletID`): `Promise`\<`undefined` \| [`Hex`](Hex.md)\>
 
 #### Parameters
 
@@ -377,7 +377,7 @@ ___
 
 #### Returns
 
-`Promise`\<[`Hex`](Hex.md)\>
+`Promise`\<`undefined` \| [`Hex`](Hex.md)\>
 
 #### Defined in
 
@@ -454,7 +454,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:589](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L589)
+[src/lib/ethereum/bridge.ts:600](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L600)
 
 ___
 
@@ -664,7 +664,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:555](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L555)
+[src/lib/ethereum/bridge.ts:566](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L566)
 
 ___
 
@@ -690,7 +690,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:572](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L572)
+[src/lib/ethereum/bridge.ts:583](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L583)
 
 ___
 

--- a/typescript/api-reference/interfaces/Wallet.md
+++ b/typescript/api-reference/interfaces/Wallet.md
@@ -27,7 +27,7 @@ UNIX timestamp indicating the moment the wallet's closing period started.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:437](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L437)
+[src/lib/contracts/bridge.ts:439](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L439)
 
 ___
 
@@ -39,7 +39,7 @@ UNIX timestamp the wallet was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:428](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L428)
+[src/lib/contracts/bridge.ts:430](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L430)
 
 ___
 
@@ -63,7 +63,7 @@ Latest wallet's main UTXO hash.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:420](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L420)
+[src/lib/contracts/bridge.ts:422](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L422)
 
 ___
 
@@ -76,7 +76,7 @@ funds.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:433](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L433)
+[src/lib/contracts/bridge.ts:435](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L435)
 
 ___
 
@@ -88,7 +88,7 @@ Moving funds target wallet commitment submitted by the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:449](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L449)
+[src/lib/contracts/bridge.ts:451](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L451)
 
 ___
 
@@ -100,7 +100,7 @@ Total count of pending moved funds sweep requests targeting this wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:441](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L441)
+[src/lib/contracts/bridge.ts:443](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L443)
 
 ___
 
@@ -112,7 +112,7 @@ The total redeemable value of pending redemption requests targeting that wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:424](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L424)
+[src/lib/contracts/bridge.ts:426](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
 
 ___
 
@@ -124,16 +124,18 @@ Current state of the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:445](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L445)
+[src/lib/contracts/bridge.ts:447](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L447)
 
 ___
 
 ### walletPublicKey
 
-• **walletPublicKey**: [`Hex`](../classes/Hex.md)
+• `Optional` **walletPublicKey**: [`Hex`](../classes/Hex.md)
 
-Compressed public key of the ECDSA Wallet.
+Compressed public key of the ECDSA Wallet. If the wallet is Closed
+or Terminated, this field is empty as the public key is removed from the
+WalletRegistry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:416](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L416)
+[src/lib/contracts/bridge.ts:418](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L418)

--- a/typescript/src/lib/contracts/bridge.ts
+++ b/typescript/src/lib/contracts/bridge.ts
@@ -411,9 +411,11 @@ export interface Wallet {
    */
   ecdsaWalletID: Hex
   /**
-   * Compressed public key of the ECDSA Wallet.
+   * Compressed public key of the ECDSA Wallet. If the wallet is Closed
+   * or Terminated, this field is empty as the public key is removed from the
+   * WalletRegistry.
    */
-  walletPublicKey: Hex
+  walletPublicKey?: Hex
   /**
    * Latest wallet's main UTXO hash.
    */

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -512,15 +512,26 @@ export class EthereumBridge
     return walletPublicKey
   }
 
-  private async getWalletCompressedPublicKey(ecdsaWalletID: Hex): Promise<Hex> {
+  private async getWalletCompressedPublicKey(
+    ecdsaWalletID: Hex
+  ): Promise<Hex | undefined> {
     const walletRegistry = await this.walletRegistry()
-    const uncompressedPublicKey = await walletRegistry.getWalletPublicKey(
-      ecdsaWalletID
-    )
 
-    return Hex.from(
-      BitcoinPublicKeyUtils.compressPublicKey(uncompressedPublicKey)
-    )
+    try {
+      const uncompressedPublicKey = await walletRegistry.getWalletPublicKey(
+        ecdsaWalletID
+      )
+
+      return Hex.from(
+        BitcoinPublicKeyUtils.compressPublicKey(uncompressedPublicKey)
+      )
+    } catch (error) {
+      console.log(
+        `cannot get wallet public key for ${ecdsaWalletID}; error: ${error}`
+      )
+
+      return undefined
+    }
   }
 
   // eslint-disable-next-line valid-jsdoc

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -130,7 +130,7 @@ export class RedemptionsService {
         await this.tbtcContracts.bridge.wallets(walletPublicKeyHash)
 
       // Wallet must be in Live state.
-      if (state !== WalletState.Live) {
+      if (state !== WalletState.Live || !walletPublicKey) {
         console.debug(
           `Wallet is not in Live state ` +
             `(wallet public key hash: ${walletPublicKeyHash.toString()}). ` +


### PR DESCRIPTION
Closes: https://github.com/keep-network/tbtc-v2/issues/812

The current logic used to fetch wallet public keys was throwing errors while used for `Closed` or `Terminated` wallets. This is because the `WalletRegistry` contract does no longer hold the public key for such wallets. In effect, the exception was propagated upstream and caused problems while searching wallets for redemption.

Here we fix that problem by making the public key field optional and keeping it undefined for closed/terminated wallets. That way, the client code can detect this fact and omit closed/terminated wallets during processing.