### PR TITLE
Bring back 2.5.0-dev version

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -146,7 +146,7 @@ Data about a Bitcoin transaction input.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:63](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L63)
+[lib/bitcoin/tx.ts:63](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L63)
 
 ___
 
@@ -158,7 +158,7 @@ Data about a Bitcoin unspent transaction output.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:93](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L93)
+[lib/bitcoin/tx.ts:93](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L93)
 
 ___
 
@@ -178,7 +178,7 @@ Type representing a mapping between specific L1 and L2 chains.
 
 #### Defined in
 
-[lib/contracts/chain.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L31)
+[lib/contracts/chain.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L31)
 
 ___
 
@@ -191,7 +191,7 @@ between TBTC L1 ledger chain and a specific supported L2/side-chain.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:12](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L12)
+[lib/contracts/cross-chain.ts:12](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L12)
 
 ___
 
@@ -208,7 +208,7 @@ Mode of operation for the cross-chain depositor proxy:
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L19)
+[services/deposits/cross-chain.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L19)
 
 ___
 
@@ -220,7 +220,7 @@ Represents an event emitted on deposit reveal to the on-chain bridge.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:307](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L307)
+[lib/contracts/bridge.ts:307](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L307)
 
 ___
 
@@ -233,7 +233,7 @@ wallet registry.
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:64](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L64)
+[lib/contracts/wallet-registry.ts:64](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L64)
 
 ___
 
@@ -246,7 +246,7 @@ wallet registry.
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:79](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L79)
+[lib/contracts/wallet-registry.ts:79](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L79)
 
 ___
 
@@ -259,7 +259,7 @@ wallet registry.
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:45](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L45)
+[lib/contracts/wallet-registry.ts:45](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L45)
 
 ___
 
@@ -271,7 +271,7 @@ Additional options used by the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:49](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L49)
+[lib/electrum/client.ts:49](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L49)
 
 ___
 
@@ -297,7 +297,7 @@ True if the error matches, false otherwise.
 
 #### Defined in
 
-[lib/utils/backoff.ts:42](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L42)
+[lib/utils/backoff.ts:42](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L42)
 
 ___
 
@@ -311,7 +311,7 @@ or a Provider that works only in the read-only mode.
 
 #### Defined in
 
-[lib/ethereum/index.ts:34](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/index.ts#L34)
+[lib/ethereum/index.ts:34](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L34)
 
 ___
 
@@ -337,7 +337,7 @@ A function that is called with execution status messages.
 
 #### Defined in
 
-[lib/utils/backoff.ts:56](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L56)
+[lib/utils/backoff.ts:56](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L56)
 
 ___
 
@@ -355,7 +355,7 @@ Aggregates L1-specific TBTC cross-chain contracts.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L25)
+[lib/contracts/cross-chain.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L25)
 
 ___
 
@@ -367,7 +367,7 @@ Layer 2 chains supported by tBTC v2 contracts.
 
 #### Defined in
 
-[lib/contracts/chain.ts:26](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L26)
+[lib/contracts/chain.ts:26](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L26)
 
 ___
 
@@ -386,7 +386,7 @@ Aggregates L2-specific TBTC cross-chain contracts.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:17](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L17)
+[lib/contracts/cross-chain.ts:17](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L17)
 
 ___
 
@@ -398,7 +398,7 @@ Represents an event emitted when new wallet is registered on the on-chain bridge
 
 #### Defined in
 
-[lib/contracts/bridge.ts:471](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L471)
+[lib/contracts/bridge.ts:471](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L471)
 
 ___
 
@@ -411,7 +411,7 @@ is cancelled on chain.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:170](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L170)
+[lib/contracts/tbtc-vault.ts:170](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L170)
 
 ___
 
@@ -424,7 +424,7 @@ is finalized on chain.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:186](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L186)
+[lib/contracts/tbtc-vault.ts:186](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L186)
 
 ___
 
@@ -444,7 +444,7 @@ Bridge.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:120](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L120)
+[lib/contracts/tbtc-vault.ts:120](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L120)
 
 ___
 
@@ -457,7 +457,7 @@ on chain.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:136](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L136)
+[lib/contracts/tbtc-vault.ts:136](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L136)
 
 ___
 
@@ -469,7 +469,7 @@ Represents an event emitted on redemption request.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:358](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L358)
+[lib/contracts/bridge.ts:358](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L358)
 
 ___
 
@@ -499,7 +499,7 @@ ___
 
 #### Defined in
 
-[lib/utils/backoff.ts:51](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L51)
+[lib/utils/backoff.ts:51](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L51)
 
 ___
 
@@ -520,7 +520,7 @@ Convenience type aggregating all TBTC core contracts.
 
 #### Defined in
 
-[lib/contracts/index.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/index.ts#L19)
+[lib/contracts/index.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/index.ts#L19)
 
 ## Variables
 
@@ -542,7 +542,7 @@ Utility functions allowing to perform Bitcoin address conversions.
 
 #### Defined in
 
-[lib/bitcoin/address.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/address.ts#L112)
+[lib/bitcoin/address.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/address.ts#L112)
 
 ___
 
@@ -560,7 +560,7 @@ Utility functions allowing to deal with Bitcoin compact size uints.
 
 #### Defined in
 
-[lib/bitcoin/csuint.ts:50](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/csuint.ts#L50)
+[lib/bitcoin/csuint.ts:50](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/csuint.ts#L50)
 
 ___
 
@@ -581,7 +581,7 @@ Utility functions allowing to deal with Bitcoin hashes.
 
 #### Defined in
 
-[lib/bitcoin/hash.ts:52](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/hash.ts#L52)
+[lib/bitcoin/hash.ts:52](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/hash.ts#L52)
 
 ___
 
@@ -601,7 +601,7 @@ Utility functions allowing to serialize and deserialize Bitcoin block headers.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:109](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L109)
+[lib/bitcoin/header.ts:109](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L109)
 
 ___
 
@@ -620,7 +620,7 @@ Utility functions allowing to deal with Bitcoin locktime.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:234](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L234)
+[lib/bitcoin/tx.ts:234](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L234)
 
 ___
 
@@ -638,7 +638,7 @@ Utility functions allowing to perform operations on Bitcoin ECDSA private keys.
 
 #### Defined in
 
-[lib/bitcoin/ecdsa-key.ts:77](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L77)
+[lib/bitcoin/ecdsa-key.ts:77](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L77)
 
 ___
 
@@ -657,7 +657,7 @@ Utility functions allowing to perform operations on Bitcoin ECDSA public keys.
 
 #### Defined in
 
-[lib/bitcoin/ecdsa-key.ts:51](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L51)
+[lib/bitcoin/ecdsa-key.ts:51](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L51)
 
 ___
 
@@ -678,7 +678,7 @@ Utility functions allowing to deal with Bitcoin scripts.
 
 #### Defined in
 
-[lib/bitcoin/script.ts:63](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/script.ts#L63)
+[lib/bitcoin/script.ts:63](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/script.ts#L63)
 
 ___
 
@@ -697,7 +697,7 @@ Utility functions allowing to perform Bitcoin target conversions.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:268](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L268)
+[lib/bitcoin/header.ts:268](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L268)
 
 ___
 
@@ -709,7 +709,7 @@ List of chain mappings supported by tBTC v2 contracts.
 
 #### Defined in
 
-[lib/contracts/chain.ts:50](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L50)
+[lib/contracts/chain.ts:50](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L50)
 
 ## Functions
 
@@ -736,7 +736,7 @@ Bitcoin transaction along with the inclusion proof.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:75](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L75)
+[lib/bitcoin/spv.ts:75](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L75)
 
 ___
 
@@ -786,7 +786,7 @@ A function that can retry any function.
 
 #### Defined in
 
-[lib/utils/backoff.ts:89](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L89)
+[lib/utils/backoff.ts:89](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L89)
 
 ___
 
@@ -810,7 +810,7 @@ Chain ID as a string.
 
 #### Defined in
 
-[lib/ethereum/index.ts:41](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/index.ts#L41)
+[lib/ethereum/index.ts:41](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L41)
 
 ___
 
@@ -835,7 +835,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[lib/electrum/client.ts:668](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L668)
+[lib/electrum/client.ts:668](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L668)
 
 ___
 
@@ -865,7 +865,7 @@ Throws an error if the address of the signer is not a proper
 
 #### Defined in
 
-[lib/ethereum/index.ts:63](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/index.ts#L63)
+[lib/ethereum/index.ts:63](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L63)
 
 ___
 
@@ -898,7 +898,7 @@ Throws an error if the signer's Ethereum chain ID is other than
 
 #### Defined in
 
-[lib/ethereum/index.ts:118](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/index.ts#L118)
+[lib/ethereum/index.ts:118](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L118)
 
 ___
 
@@ -923,7 +923,7 @@ Transaction data with fields represented as un-prefixed hex strings.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:133](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L133)
+[lib/bitcoin/tx.ts:133](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L133)
 
 ___
 
@@ -954,7 +954,7 @@ Throws an error if the signer's Arbitrum chain ID is other than
 
 #### Defined in
 
-[lib/arbitrum/index.ts:22](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/index.ts#L22)
+[lib/arbitrum/index.ts:22](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/index.ts#L22)
 
 ___
 
@@ -985,7 +985,7 @@ Throws an error if the signer's Base chain ID is other than
 
 #### Defined in
 
-[lib/base/index.ts:22](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/index.ts#L22)
+[lib/base/index.ts:22](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/index.ts#L22)
 
 ___
 
@@ -1016,7 +1016,7 @@ Throws an error if the signer's Ethereum chain ID is other than
 
 #### Defined in
 
-[lib/ethereum/index.ts:82](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/index.ts#L82)
+[lib/ethereum/index.ts:82](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L82)
 
 ___
 
@@ -1060,7 +1060,7 @@ Packed parameters.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:714](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L714)
+[lib/ethereum/bridge.ts:714](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L714)
 
 ___
 
@@ -1085,7 +1085,7 @@ Always returns true.
 
 #### Defined in
 
-[lib/utils/backoff.ts:9](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L9)
+[lib/utils/backoff.ts:9](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L9)
 
 ___
 
@@ -1111,7 +1111,7 @@ Matcher function that returns false if error matches one of the patterns.
 
 #### Defined in
 
-[lib/utils/backoff.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/backoff.ts#L20)
+[lib/utils/backoff.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/backoff.ts#L20)
 
 ___
 
@@ -1140,7 +1140,7 @@ An error if the network is not supported by `bitcoinjs-lib`.
 
 #### Defined in
 
-[lib/bitcoin/network.ts:55](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/network.ts#L55)
+[lib/bitcoin/network.ts:55](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/network.ts#L55)
 
 ___
 
@@ -1181,7 +1181,7 @@ If any of the block headers are invalid, or if the block
 
 #### Defined in
 
-[lib/bitcoin/header.ts:132](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L132)
+[lib/bitcoin/header.ts:132](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L132)
 
 ___
 
@@ -1221,7 +1221,7 @@ The function should be used within a try-catch block.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:180](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L180)
+[lib/bitcoin/spv.ts:180](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L180)
 
 ___
 
@@ -1248,4 +1248,4 @@ This function does not validate the depositor's identifier as its
 
 #### Defined in
 
-[lib/contracts/bridge.ts:247](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L247)
+[lib/contracts/bridge.ts:247](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L247)

--- a/typescript/api-reference/classes/ArbitrumL2BitcoinDepositor.md
+++ b/typescript/api-reference/classes/ArbitrumL2BitcoinDepositor.md
@@ -63,7 +63,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:36](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L36)
+[lib/arbitrum/l2-bitcoin-depositor.ts:36](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L36)
 
 ## Properties
 
@@ -73,7 +73,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:34](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L34)
+[lib/arbitrum/l2-bitcoin-depositor.ts:34](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L34)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:33](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L33)
+[lib/arbitrum/l2-bitcoin-depositor.ts:33](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L33)
 
 ___
 
@@ -101,7 +101,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -117,7 +117,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -133,7 +133,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -153,7 +153,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:83](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L83)
+[lib/arbitrum/l2-bitcoin-depositor.ts:83](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L83)
 
 ___
 
@@ -175,7 +175,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:59](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L59)
+[lib/arbitrum/l2-bitcoin-depositor.ts:59](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L59)
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:67](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L67)
+[lib/arbitrum/l2-bitcoin-depositor.ts:67](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L67)
 
 ___
 
@@ -249,7 +249,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:91](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L91)
+[lib/arbitrum/l2-bitcoin-depositor.ts:91](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L91)
 
 ___
 
@@ -304,4 +304,4 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-bitcoin-depositor.ts:75](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L75)
+[lib/arbitrum/l2-bitcoin-depositor.ts:75](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L75)

--- a/typescript/api-reference/classes/ArbitrumL2TBTCToken.md
+++ b/typescript/api-reference/classes/ArbitrumL2TBTCToken.md
@@ -58,7 +58,7 @@ EthersContractHandle\&lt;L2TBTCTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/arbitrum/l2-tbtc-token.ts:22](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L22)
+[lib/arbitrum/l2-tbtc-token.ts:22](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L22)
 
 ## Properties
 
@@ -76,7 +76,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -92,7 +92,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -108,7 +108,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -134,7 +134,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/arbitrum/l2-tbtc-token.ts:51](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L51)
+[lib/arbitrum/l2-tbtc-token.ts:51](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L51)
 
 ___
 
@@ -156,7 +156,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[lib/arbitrum/l2-tbtc-token.ts:43](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L43)
+[lib/arbitrum/l2-tbtc-token.ts:43](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-tbtc-token.ts#L43)
 
 ___
 
@@ -210,4 +210,4 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)

--- a/typescript/api-reference/classes/BaseL2BitcoinDepositor.md
+++ b/typescript/api-reference/classes/BaseL2BitcoinDepositor.md
@@ -63,7 +63,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L37)
+[lib/base/l2-bitcoin-depositor.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L37)
 
 ## Properties
 
@@ -73,7 +73,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:35](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L35)
+[lib/base/l2-bitcoin-depositor.ts:35](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L35)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:34](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L34)
+[lib/base/l2-bitcoin-depositor.ts:34](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L34)
 
 ___
 
@@ -101,7 +101,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -117,7 +117,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -133,7 +133,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -153,7 +153,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:85](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L85)
+[lib/base/l2-bitcoin-depositor.ts:85](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L85)
 
 ___
 
@@ -175,7 +175,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L61)
+[lib/base/l2-bitcoin-depositor.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L61)
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:69](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L69)
+[lib/base/l2-bitcoin-depositor.ts:69](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L69)
 
 ___
 
@@ -249,7 +249,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:93](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L93)
+[lib/base/l2-bitcoin-depositor.ts:93](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L93)
 
 ___
 
@@ -304,4 +304,4 @@ ___
 
 #### Defined in
 
-[lib/base/l2-bitcoin-depositor.ts:77](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L77)
+[lib/base/l2-bitcoin-depositor.ts:77](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L77)

--- a/typescript/api-reference/classes/BaseL2TBTCToken.md
+++ b/typescript/api-reference/classes/BaseL2TBTCToken.md
@@ -58,7 +58,7 @@ EthersContractHandle\&lt;L2TBTCTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/base/l2-tbtc-token.ts:23](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L23)
+[lib/base/l2-tbtc-token.ts:23](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L23)
 
 ## Properties
 
@@ -76,7 +76,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -92,7 +92,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -108,7 +108,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -134,7 +134,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/base/l2-tbtc-token.ts:53](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L53)
+[lib/base/l2-tbtc-token.ts:53](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L53)
 
 ___
 
@@ -156,7 +156,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[lib/base/l2-tbtc-token.ts:45](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L45)
+[lib/base/l2-tbtc-token.ts:45](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-tbtc-token.ts#L45)
 
 ___
 
@@ -210,4 +210,4 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)

--- a/typescript/api-reference/classes/BitcoinTxHash.md
+++ b/typescript/api-reference/classes/BitcoinTxHash.md
@@ -53,7 +53,7 @@ the use cases that expect the Bitcoin internal byte order.
 
 #### Defined in
 
-[lib/utils/hex.ts:7](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L7)
+[lib/utils/hex.ts:7](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L7)
 
 ## Properties
 
@@ -67,7 +67,7 @@ the use cases that expect the Bitcoin internal byte order.
 
 #### Defined in
 
-[lib/utils/hex.ts:5](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L5)
+[lib/utils/hex.ts:5](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L5)
 
 ## Methods
 
@@ -95,7 +95,7 @@ True if both values are equal, false otherwise.
 
 #### Defined in
 
-[lib/utils/hex.ts:57](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L57)
+[lib/utils/hex.ts:57](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L57)
 
 ___
 
@@ -115,7 +115,7 @@ Reversed hexadecimal value.
 
 #### Defined in
 
-[lib/utils/hex.ts:64](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L64)
+[lib/utils/hex.ts:64](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L64)
 
 ___
 
@@ -135,7 +135,7 @@ Hexadecimal value as a Buffer.
 
 #### Defined in
 
-[lib/utils/hex.ts:32](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L32)
+[lib/utils/hex.ts:32](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L32)
 
 ___
 
@@ -155,7 +155,7 @@ Hexadecimal string prefixed with '0x'.
 
 #### Defined in
 
-[lib/utils/hex.ts:46](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L46)
+[lib/utils/hex.ts:46](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L46)
 
 ___
 
@@ -175,7 +175,7 @@ Unprefixed hexadecimal string.
 
 #### Defined in
 
-[lib/utils/hex.ts:39](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L39)
+[lib/utils/hex.ts:39](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L39)
 
 ___
 
@@ -199,4 +199,4 @@ ___
 
 #### Defined in
 
-[lib/utils/hex.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L25)
+[lib/utils/hex.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L25)

--- a/typescript/api-reference/classes/CrossChainDepositor.md
+++ b/typescript/api-reference/classes/CrossChainDepositor.md
@@ -49,7 +49,7 @@ for reference.
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L31)
+[services/deposits/cross-chain.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L31)
 
 ## Properties
 
@@ -59,7 +59,7 @@ for reference.
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:28](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L28)
+[services/deposits/cross-chain.ts:28](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L28)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:29](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L29)
+[services/deposits/cross-chain.ts:29](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L29)
 
 ## Methods
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:72](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L72)
+[services/deposits/cross-chain.ts:72](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L72)
 
 ___
 
@@ -107,7 +107,7 @@ Throws if the L2 deposit owner cannot be resolved. This
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L61)
+[services/deposits/cross-chain.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L61)
 
 ___
 
@@ -135,7 +135,7 @@ The chain-specific identifier of the contract that will be
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:49](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L49)
+[services/deposits/cross-chain.ts:49](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L49)
 
 ___
 
@@ -169,4 +169,4 @@ Reveals the given deposit depending on the reveal mode.
 
 #### Defined in
 
-[services/deposits/cross-chain.ts:87](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/cross-chain.ts#L87)
+[services/deposits/cross-chain.ts:87](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L87)

--- a/typescript/api-reference/classes/Deposit.md
+++ b/typescript/api-reference/classes/Deposit.md
@@ -48,7 +48,7 @@ This component tries to abstract away that complexity.
 
 #### Defined in
 
-[services/deposits/deposit.ts:47](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L47)
+[services/deposits/deposit.ts:47](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L47)
 
 ## Properties
 
@@ -60,7 +60,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[services/deposits/deposit.ts:36](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L36)
+[services/deposits/deposit.ts:36](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L36)
 
 ___
 
@@ -73,7 +73,7 @@ generated deposit address.
 
 #### Defined in
 
-[services/deposits/deposit.ts:45](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L45)
+[services/deposits/deposit.ts:45](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L45)
 
 ___
 
@@ -85,7 +85,7 @@ Optional depositor proxy used to initiate minting.
 
 #### Defined in
 
-[services/deposits/deposit.ts:40](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L40)
+[services/deposits/deposit.ts:40](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L40)
 
 ___
 
@@ -97,7 +97,7 @@ Bitcoin script corresponding to this deposit.
 
 #### Defined in
 
-[services/deposits/deposit.ts:28](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L28)
+[services/deposits/deposit.ts:28](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L28)
 
 ___
 
@@ -109,7 +109,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[services/deposits/deposit.ts:32](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L32)
+[services/deposits/deposit.ts:32](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L32)
 
 ## Methods
 
@@ -130,7 +130,7 @@ Specific UTXOs targeting this deposit. Empty array in case
 
 #### Defined in
 
-[services/deposits/deposit.ts:99](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L99)
+[services/deposits/deposit.ts:99](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L99)
 
 ___
 
@@ -146,7 +146,7 @@ Bitcoin address corresponding to this deposit.
 
 #### Defined in
 
-[services/deposits/deposit.ts:88](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L88)
+[services/deposits/deposit.ts:88](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L88)
 
 ___
 
@@ -162,7 +162,7 @@ Receipt corresponding to this deposit.
 
 #### Defined in
 
-[services/deposits/deposit.ts:81](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L81)
+[services/deposits/deposit.ts:81](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L81)
 
 ___
 
@@ -206,7 +206,7 @@ Throws an error if the funding outpoint was already used to
 
 #### Defined in
 
-[services/deposits/deposit.ts:128](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L128)
+[services/deposits/deposit.ts:128](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L128)
 
 ___
 
@@ -229,4 +229,4 @@ ___
 
 #### Defined in
 
-[services/deposits/deposit.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L61)
+[services/deposits/deposit.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L61)

--- a/typescript/api-reference/classes/DepositFunding.md
+++ b/typescript/api-reference/classes/DepositFunding.md
@@ -41,7 +41,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[services/deposits/funding.ts:30](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/funding.ts#L30)
+[services/deposits/funding.ts:30](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L30)
 
 ## Properties
 
@@ -51,7 +51,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[services/deposits/funding.ts:28](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/funding.ts#L28)
+[services/deposits/funding.ts:28](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L28)
 
 ## Methods
 
@@ -101,7 +101,7 @@ When the sum of the selected UTXOs is insufficient to cover
 
 #### Defined in
 
-[services/deposits/funding.ts:62](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/funding.ts#L62)
+[services/deposits/funding.ts:62](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L62)
 
 ___
 
@@ -151,7 +151,7 @@ When the sum of the selected UTXOs is insufficient to cover
 
 #### Defined in
 
-[services/deposits/funding.ts:181](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/funding.ts#L181)
+[services/deposits/funding.ts:181](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L181)
 
 ___
 
@@ -171,4 +171,4 @@ ___
 
 #### Defined in
 
-[services/deposits/funding.ts:34](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/funding.ts#L34)
+[services/deposits/funding.ts:34](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L34)

--- a/typescript/api-reference/classes/DepositRefund.md
+++ b/typescript/api-reference/classes/DepositRefund.md
@@ -44,7 +44,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[services/deposits/refund.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L37)
+[services/deposits/refund.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L37)
 
 ## Properties
 
@@ -54,7 +54,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[services/deposits/refund.ts:35](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L35)
+[services/deposits/refund.ts:35](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L35)
 
 ## Methods
 
@@ -84,7 +84,7 @@ The outcome consisting of:
 
 #### Defined in
 
-[services/deposits/refund.ts:111](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L111)
+[services/deposits/refund.ts:111](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L111)
 
 ___
 
@@ -113,7 +113,7 @@ Error if there are discrepancies in values or key formats.
 
 #### Defined in
 
-[services/deposits/refund.ts:191](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L191)
+[services/deposits/refund.ts:191](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L191)
 
 ___
 
@@ -139,7 +139,7 @@ An empty promise upon successful signing.
 
 #### Defined in
 
-[services/deposits/refund.ts:219](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L219)
+[services/deposits/refund.ts:219](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L219)
 
 ___
 
@@ -166,7 +166,7 @@ An empty promise upon successful signing.
 
 #### Defined in
 
-[services/deposits/refund.ts:256](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L256)
+[services/deposits/refund.ts:256](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L256)
 
 ___
 
@@ -203,7 +203,7 @@ This function should be called by the refunder after `refundLocktime`
 
 #### Defined in
 
-[services/deposits/refund.ts:63](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L63)
+[services/deposits/refund.ts:63](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L63)
 
 ___
 
@@ -223,4 +223,4 @@ ___
 
 #### Defined in
 
-[services/deposits/refund.ts:41](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/refund.ts#L41)
+[services/deposits/refund.ts:41](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L41)

--- a/typescript/api-reference/classes/DepositScript.md
+++ b/typescript/api-reference/classes/DepositScript.md
@@ -43,7 +43,7 @@ by the target wallet during the deposit sweep process.
 
 #### Defined in
 
-[services/deposits/deposit.ts:189](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L189)
+[services/deposits/deposit.ts:189](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L189)
 
 ## Properties
 
@@ -56,7 +56,7 @@ and allowing to build a unique deposit script (and address) on Bitcoin chain.
 
 #### Defined in
 
-[services/deposits/deposit.ts:182](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L182)
+[services/deposits/deposit.ts:182](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L182)
 
 ___
 
@@ -69,7 +69,7 @@ should be a witness P2WSH one. If false, legacy P2SH will be used instead.
 
 #### Defined in
 
-[services/deposits/deposit.ts:187](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L187)
+[services/deposits/deposit.ts:187](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L187)
 
 ## Methods
 
@@ -93,7 +93,7 @@ Bitcoin address corresponding to this deposit script.
 
 #### Defined in
 
-[services/deposits/deposit.ts:258](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L258)
+[services/deposits/deposit.ts:258](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L258)
 
 ___
 
@@ -109,7 +109,7 @@ Hashed deposit script as Buffer.
 
 #### Defined in
 
-[services/deposits/deposit.ts:206](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L206)
+[services/deposits/deposit.ts:206](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L206)
 
 ___
 
@@ -125,7 +125,7 @@ Plain-text deposit script as a hex string.
 
 #### Defined in
 
-[services/deposits/deposit.ts:218](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L218)
+[services/deposits/deposit.ts:218](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L218)
 
 ___
 
@@ -146,4 +146,4 @@ ___
 
 #### Defined in
 
-[services/deposits/deposit.ts:196](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposit.ts#L196)
+[services/deposits/deposit.ts:196](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L196)

--- a/typescript/api-reference/classes/DepositsService.md
+++ b/typescript/api-reference/classes/DepositsService.md
@@ -44,7 +44,7 @@ Service exposing features related to tBTC v2 deposits.
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:51](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L51)
+[services/deposits/deposits-service.ts:51](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L51)
 
 ## Properties
 
@@ -73,7 +73,7 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:49](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L49)
+[services/deposits/deposits-service.ts:49](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L49)
 
 ___
 
@@ -86,7 +86,7 @@ initiated by this service.
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:42](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L42)
+[services/deposits/deposits-service.ts:42](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L42)
 
 ___
 
@@ -98,7 +98,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L37)
+[services/deposits/deposits-service.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L37)
 
 ___
 
@@ -111,7 +111,7 @@ This is 9 month in seconds assuming 1 month = 30 days
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:29](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L29)
+[services/deposits/deposits-service.ts:29](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L29)
 
 ___
 
@@ -123,7 +123,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:33](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L33)
+[services/deposits/deposits-service.ts:33](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L33)
 
 ## Methods
 
@@ -145,7 +145,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:183](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L183)
+[services/deposits/deposits-service.ts:183](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L183)
 
 ___
 
@@ -199,7 +199,7 @@ This is actually a call to initiateDepositWithProxy with a built-in
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:163](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L163)
+[services/deposits/deposits-service.ts:163](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L163)
 
 ___
 
@@ -233,7 +233,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:76](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L76)
+[services/deposits/deposits-service.ts:76](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L76)
 
 ___
 
@@ -275,7 +275,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:115](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L115)
+[services/deposits/deposits-service.ts:115](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L115)
 
 ___
 
@@ -304,4 +304,4 @@ Typically, there is no need to use this method when DepositsService
 
 #### Defined in
 
-[services/deposits/deposits-service.ts:261](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/deposits/deposits-service.ts#L261)
+[services/deposits/deposits-service.ts:261](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L261)

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -62,7 +62,7 @@ Electrum-based implementation of the Bitcoin client.
 
 #### Defined in
 
-[lib/electrum/client.ts:73](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L73)
+[lib/electrum/client.ts:73](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L73)
 
 ## Properties
 
@@ -72,7 +72,7 @@ Electrum-based implementation of the Bitcoin client.
 
 #### Defined in
 
-[lib/electrum/client.ts:71](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L71)
+[lib/electrum/client.ts:71](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L71)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:67](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L67)
+[lib/electrum/client.ts:67](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L67)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:68](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L68)
+[lib/electrum/client.ts:68](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L68)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:70](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L70)
+[lib/electrum/client.ts:70](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L70)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:69](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L69)
+[lib/electrum/client.ts:69](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L69)
 
 ## Methods
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:633](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L633)
+[lib/electrum/client.ts:633](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L633)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:261](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L261)
+[lib/electrum/client.ts:261](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L261)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:647](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L647)
+[lib/electrum/client.ts:647](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L647)
 
 ___
 
@@ -217,7 +217,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:583](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L583)
+[lib/electrum/client.ts:583](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L583)
 
 ___
 
@@ -237,7 +237,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:239](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L239)
+[lib/electrum/client.ts:239](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L239)
 
 ___
 
@@ -263,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:396](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L396)
+[lib/electrum/client.ts:396](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L396)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:346](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L346)
+[lib/electrum/client.ts:346](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L346)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:417](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L417)
+[lib/electrum/client.ts:417](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L417)
 
 ___
 
@@ -342,7 +342,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:292](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L292)
+[lib/electrum/client.ts:292](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L292)
 
 ___
 
@@ -369,7 +369,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:602](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L602)
+[lib/electrum/client.ts:602](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L602)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:509](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L509)
+[lib/electrum/client.ts:509](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L509)
 
 ___
 
@@ -415,7 +415,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:567](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L567)
+[lib/electrum/client.ts:567](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L567)
 
 ___
 
@@ -439,7 +439,7 @@ A function that can retry any function.
 
 #### Defined in
 
-[lib/electrum/client.ts:231](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L231)
+[lib/electrum/client.ts:231](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L231)
 
 ___
 
@@ -470,7 +470,7 @@ Promise holding the outcome.
 
 #### Defined in
 
-[lib/electrum/client.ts:169](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L169)
+[lib/electrum/client.ts:169](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L169)
 
 ___
 
@@ -495,7 +495,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L127)
+[lib/electrum/client.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L127)
 
 ___
 
@@ -523,7 +523,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:98](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L98)
+[lib/electrum/client.ts:98](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L98)
 
 ___
 
@@ -547,4 +547,4 @@ Electrum credentials object.
 
 #### Defined in
 
-[lib/electrum/client.ts:148](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L148)
+[lib/electrum/client.ts:148](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L148)

--- a/typescript/api-reference/classes/EthereumAddress.md
+++ b/typescript/api-reference/classes/EthereumAddress.md
@@ -39,7 +39,7 @@ Represents an Ethereum address.
 
 #### Defined in
 
-[lib/ethereum/address.ts:12](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/address.ts#L12)
+[lib/ethereum/address.ts:12](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/address.ts#L12)
 
 ## Properties
 
@@ -55,7 +55,7 @@ Identifier as an un-prefixed hex string.
 
 #### Defined in
 
-[lib/ethereum/address.ts:10](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/address.ts#L10)
+[lib/ethereum/address.ts:10](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/address.ts#L10)
 
 ## Methods
 
@@ -81,7 +81,7 @@ Checks if two identifiers are equal.
 
 #### Defined in
 
-[lib/ethereum/address.ts:28](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/address.ts#L28)
+[lib/ethereum/address.ts:28](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/address.ts#L28)
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/address.ts:24](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/address.ts#L24)
+[lib/ethereum/address.ts:24](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/address.ts#L24)

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -79,7 +79,7 @@ EthersContractHandle\&lt;BridgeTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:60](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L60)
+[lib/ethereum/bridge.ts:60](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L60)
 
 ## Properties
 
@@ -97,7 +97,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -113,7 +113,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -129,7 +129,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -149,7 +149,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:509](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L509)
+[lib/ethereum/bridge.ts:509](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L509)
 
 ___
 
@@ -178,7 +178,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:644](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L644)
+[lib/ethereum/bridge.ts:644](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L644)
 
 ___
 
@@ -205,7 +205,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:444](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L444)
+[lib/ethereum/bridge.ts:444](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L444)
 
 ___
 
@@ -227,7 +227,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -247,7 +247,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:87](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L87)
+[lib/ethereum/bridge.ts:87](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L87)
 
 ___
 
@@ -274,7 +274,7 @@ Bridge.getDepositRevealedEvents
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:95](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L95)
+[lib/ethereum/bridge.ts:95](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L95)
 
 ___
 
@@ -308,7 +308,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -335,7 +335,7 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:556](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L556)
+[lib/ethereum/bridge.ts:556](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L556)
 
 ___
 
@@ -362,7 +362,7 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:661](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L661)
+[lib/ethereum/bridge.ts:661](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L661)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:530](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L530)
+[lib/ethereum/bridge.ts:530](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L530)
 
 ___
 
@@ -406,7 +406,7 @@ Parsed deposit request.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:489](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L489)
+[lib/ethereum/bridge.ts:489](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L489)
 
 ___
 
@@ -431,7 +431,7 @@ Parsed redemption request.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:228](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L228)
+[lib/ethereum/bridge.ts:228](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L228)
 
 ___
 
@@ -455,7 +455,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:615](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L615)
+[lib/ethereum/bridge.ts:615](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L615)
 
 ___
 
@@ -482,7 +482,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:132](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L132)
+[lib/ethereum/bridge.ts:132](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L132)
 
 ___
 
@@ -509,7 +509,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:147](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L147)
+[lib/ethereum/bridge.ts:147](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L147)
 
 ___
 
@@ -538,7 +538,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:349](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L349)
+[lib/ethereum/bridge.ts:349](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L349)
 
 ___
 
@@ -567,7 +567,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:246](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L246)
+[lib/ethereum/bridge.ts:246](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L246)
 
 ___
 
@@ -596,7 +596,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:283](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L283)
+[lib/ethereum/bridge.ts:283](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L283)
 
 ___
 
@@ -625,7 +625,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:393](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L393)
+[lib/ethereum/bridge.ts:393](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L393)
 
 ___
 
@@ -652,7 +652,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:170](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L170)
+[lib/ethereum/bridge.ts:170](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L170)
 
 ___
 
@@ -672,7 +672,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:335](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L335)
+[lib/ethereum/bridge.ts:335](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L335)
 
 ___
 
@@ -692,7 +692,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:581](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L581)
+[lib/ethereum/bridge.ts:581](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L581)
 
 ___
 
@@ -718,7 +718,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:598](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L598)
+[lib/ethereum/bridge.ts:598](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L598)
 
 ___
 
@@ -743,7 +743,7 @@ Deposit key.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:470](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L470)
+[lib/ethereum/bridge.ts:470](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L470)
 
 ___
 
@@ -768,4 +768,4 @@ The redemption key.
 
 #### Defined in
 
-[lib/ethereum/bridge.ts:198](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/bridge.ts#L198)
+[lib/ethereum/bridge.ts:198](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L198)

--- a/typescript/api-reference/classes/EthereumCrossChainExtraDataEncoder.md
+++ b/typescript/api-reference/classes/EthereumCrossChainExtraDataEncoder.md
@@ -55,7 +55,7 @@ for reference.
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:172](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L172)
+[lib/ethereum/l1-bitcoin-depositor.ts:172](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L172)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:158](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L158)
+[lib/ethereum/l1-bitcoin-depositor.ts:158](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L158)

--- a/typescript/api-reference/classes/EthereumDepositorProxy.md
+++ b/typescript/api-reference/classes/EthereumDepositorProxy.md
@@ -46,7 +46,7 @@ for reference.
 
 #### Defined in
 
-[lib/ethereum/depositor-proxy.ts:16](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L16)
+[lib/ethereum/depositor-proxy.ts:16](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L16)
 
 ## Properties
 
@@ -56,7 +56,7 @@ for reference.
 
 #### Defined in
 
-[lib/ethereum/depositor-proxy.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L14)
+[lib/ethereum/depositor-proxy.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L14)
 
 ## Methods
 
@@ -76,7 +76,7 @@ for reference.
 
 #### Defined in
 
-[lib/ethereum/depositor-proxy.ts:28](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L28)
+[lib/ethereum/depositor-proxy.ts:28](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L28)
 
 ___
 
@@ -120,7 +120,7 @@ Packed parameters.
 
 #### Defined in
 
-[lib/ethereum/depositor-proxy.ts:44](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L44)
+[lib/ethereum/depositor-proxy.ts:44](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L44)
 
 ___
 
@@ -149,4 +149,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/depositor-proxy.ts:62](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L62)
+[lib/ethereum/depositor-proxy.ts:62](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L62)

--- a/typescript/api-reference/classes/EthereumL1BitcoinDepositor.md
+++ b/typescript/api-reference/classes/EthereumL1BitcoinDepositor.md
@@ -35,7 +35,7 @@ for reference.
 - [extraDataEncoder](EthereumL1BitcoinDepositor.md#extradataencoder)
 - [getAddress](EthereumL1BitcoinDepositor.md#getaddress)
 - [getChainIdentifier](EthereumL1BitcoinDepositor.md#getchainidentifier)
-- [getDepositState](EthereumL1BitcoinDepositor.md#getDepositState)
+- [getDepositState](EthereumL1BitcoinDepositor.md#getdepositstate)
 - [getEvents](EthereumL1BitcoinDepositor.md#getevents)
 - [initializeDeposit](EthereumL1BitcoinDepositor.md#initializedeposit)
 
@@ -63,7 +63,7 @@ EthersContractHandle\&lt;L1BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:65](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L65)
+[lib/ethereum/l1-bitcoin-depositor.ts:65](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L65)
 
 ## Properties
 
@@ -73,7 +73,7 @@ EthersContractHandle\&lt;L1BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:63](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L63)
+[lib/ethereum/l1-bitcoin-depositor.ts:63](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L63)
 
 ___
 
@@ -91,7 +91,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -107,7 +107,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -123,7 +123,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -143,7 +143,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:108](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L108)
+[lib/ethereum/l1-bitcoin-depositor.ts:108](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L108)
 
 ___
 
@@ -165,7 +165,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:100](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L100)
+[lib/ethereum/l1-bitcoin-depositor.ts:100](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L100)
 
 ___
 
@@ -207,11 +207,11 @@ ___
 
 #### Implementation of
 
-[L1BitcoinDepositor](../interfaces/L1BitcoinDepositor.md).[getDepositState](../interfaces/L1BitcoinDepositor.md#getDepositState)
+[L1BitcoinDepositor](../interfaces/L1BitcoinDepositor.md).[getDepositState](../interfaces/L1BitcoinDepositor.md#getdepositstate)
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:92](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L92)
+[lib/ethereum/l1-bitcoin-depositor.ts:92](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L92)
 
 ___
 
@@ -245,7 +245,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -274,4 +274,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/l1-bitcoin-depositor.ts:116](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L116)
+[lib/ethereum/l1-bitcoin-depositor.ts:116](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L116)

--- a/typescript/api-reference/classes/EthereumTBTCToken.md
+++ b/typescript/api-reference/classes/EthereumTBTCToken.md
@@ -61,7 +61,7 @@ EthersContractHandle\&lt;TBTCTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:26](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L26)
+[lib/ethereum/tbtc-token.ts:26](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L26)
 
 ## Properties
 
@@ -79,7 +79,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -95,7 +95,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -111,7 +111,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -142,7 +142,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:139](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L139)
+[lib/ethereum/tbtc-token.ts:139](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L139)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:108](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L108)
+[lib/ethereum/tbtc-token.ts:108](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L108)
 
 ___
 
@@ -193,7 +193,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:53](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L53)
+[lib/ethereum/tbtc-token.ts:53](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L53)
 
 ___
 
@@ -247,7 +247,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -276,7 +276,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:71](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L71)
+[lib/ethereum/tbtc-token.ts:71](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L71)
 
 ___
 
@@ -302,4 +302,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-token.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L61)
+[lib/ethereum/tbtc-token.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-token.ts#L61)

--- a/typescript/api-reference/classes/EthereumTBTCVault.md
+++ b/typescript/api-reference/classes/EthereumTBTCVault.md
@@ -69,7 +69,7 @@ EthersContractHandle\&lt;TBTCVaultTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:41](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L41)
+[lib/ethereum/tbtc-vault.ts:41](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L41)
 
 ## Properties
 
@@ -87,7 +87,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -103,7 +103,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -119,7 +119,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -146,7 +146,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:150](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L150)
+[lib/ethereum/tbtc-vault.ts:150](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L150)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:173](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L173)
+[lib/ethereum/tbtc-vault.ts:173](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L173)
 
 ___
 
@@ -195,7 +195,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:68](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L68)
+[lib/ethereum/tbtc-vault.ts:68](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L68)
 
 ___
 
@@ -249,7 +249,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -269,7 +269,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:90](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L90)
+[lib/ethereum/tbtc-vault.ts:90](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L90)
 
 ___
 
@@ -296,7 +296,7 @@ TBTCVault.getOptimisticMintingCancelledEvents
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:268](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L268)
+[lib/ethereum/tbtc-vault.ts:268](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L268)
 
 ___
 
@@ -323,7 +323,7 @@ TBTCVault.getOptimisticMintingFinalizedEvents
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:295](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L295)
+[lib/ethereum/tbtc-vault.ts:295](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L295)
 
 ___
 
@@ -350,7 +350,7 @@ TBTCVault.getOptimisticMintingRequestedEvents
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:235](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L235)
+[lib/ethereum/tbtc-vault.ts:235](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L235)
 
 ___
 
@@ -376,7 +376,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:114](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L114)
+[lib/ethereum/tbtc-vault.ts:114](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L114)
 
 ___
 
@@ -402,7 +402,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:104](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L104)
+[lib/ethereum/tbtc-vault.ts:104](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L104)
 
 ___
 
@@ -422,7 +422,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:76](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L76)
+[lib/ethereum/tbtc-vault.ts:76](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L76)
 
 ___
 
@@ -449,7 +449,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:199](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L199)
+[lib/ethereum/tbtc-vault.ts:199](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L199)
 
 ___
 
@@ -473,7 +473,7 @@ Parsed optimistic minting request.
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:222](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L222)
+[lib/ethereum/tbtc-vault.ts:222](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L222)
 
 ___
 
@@ -500,4 +500,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/tbtc-vault.ts:124](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L124)
+[lib/ethereum/tbtc-vault.ts:124](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/tbtc-vault.ts#L124)

--- a/typescript/api-reference/classes/EthereumWalletRegistry.md
+++ b/typescript/api-reference/classes/EthereumWalletRegistry.md
@@ -61,7 +61,7 @@ EthersContractHandle\&lt;WalletRegistryTypechain\&gt;.constructor
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:33](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L33)
+[lib/ethereum/wallet-registry.ts:33](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L33)
 
 ## Properties
 
@@ -79,7 +79,7 @@ EthersContractHandle.\_deployedAtBlockNumber
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
+[lib/ethereum/adapter.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L80)
 
 ___
 
@@ -95,7 +95,7 @@ EthersContractHandle.\_instance
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:74](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
+[lib/ethereum/adapter.ts:74](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L74)
 
 ___
 
@@ -111,7 +111,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
+[lib/ethereum/adapter.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
 ## Methods
 
@@ -133,7 +133,7 @@ EthersContractHandle.getAddress
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:112](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
+[lib/ethereum/adapter.ts:112](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L112)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:60](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L60)
+[lib/ethereum/wallet-registry.ts:60](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L60)
 
 ___
 
@@ -180,7 +180,7 @@ WalletRegistry.getDkgResultApprovedEvents
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:126](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L126)
+[lib/ethereum/wallet-registry.ts:126](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L126)
 
 ___
 
@@ -207,7 +207,7 @@ WalletRegistry.getDkgResultChallengedEvents
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:151](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L151)
+[lib/ethereum/wallet-registry.ts:151](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L151)
 
 ___
 
@@ -234,7 +234,7 @@ WalletRegistry.getDkgResultSubmittedEvents
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:83](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L83)
+[lib/ethereum/wallet-registry.ts:83](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L83)
 
 ___
 
@@ -268,7 +268,7 @@ EthersContractHandle.getEvents
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:127](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
+[lib/ethereum/adapter.ts:127](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L127)
 
 ___
 
@@ -294,4 +294,4 @@ ___
 
 #### Defined in
 
-[lib/ethereum/wallet-registry.ts:68](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L68)
+[lib/ethereum/wallet-registry.ts:68](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/wallet-registry.ts#L68)

--- a/typescript/api-reference/classes/Hex.md
+++ b/typescript/api-reference/classes/Hex.md
@@ -45,7 +45,7 @@ Represents a hexadecimal value.
 
 #### Defined in
 
-[lib/utils/hex.ts:7](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L7)
+[lib/utils/hex.ts:7](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L7)
 
 ## Properties
 
@@ -55,7 +55,7 @@ Represents a hexadecimal value.
 
 #### Defined in
 
-[lib/utils/hex.ts:5](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L5)
+[lib/utils/hex.ts:5](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L5)
 
 ## Methods
 
@@ -79,7 +79,7 @@ True if both values are equal, false otherwise.
 
 #### Defined in
 
-[lib/utils/hex.ts:57](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L57)
+[lib/utils/hex.ts:57](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L57)
 
 ___
 
@@ -95,7 +95,7 @@ Reversed hexadecimal value.
 
 #### Defined in
 
-[lib/utils/hex.ts:64](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L64)
+[lib/utils/hex.ts:64](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L64)
 
 ___
 
@@ -111,7 +111,7 @@ Hexadecimal value as a Buffer.
 
 #### Defined in
 
-[lib/utils/hex.ts:32](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L32)
+[lib/utils/hex.ts:32](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L32)
 
 ___
 
@@ -127,7 +127,7 @@ Hexadecimal string prefixed with '0x'.
 
 #### Defined in
 
-[lib/utils/hex.ts:46](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L46)
+[lib/utils/hex.ts:46](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L46)
 
 ___
 
@@ -143,7 +143,7 @@ Unprefixed hexadecimal string.
 
 #### Defined in
 
-[lib/utils/hex.ts:39](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L39)
+[lib/utils/hex.ts:39](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L39)
 
 ___
 
@@ -163,4 +163,4 @@ ___
 
 #### Defined in
 
-[lib/utils/hex.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/utils/hex.ts#L25)
+[lib/utils/hex.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/utils/hex.ts#L25)

--- a/typescript/api-reference/classes/MaintenanceService.md
+++ b/typescript/api-reference/classes/MaintenanceService.md
@@ -33,7 +33,7 @@ operators of the tBTC v2 system.
 
 #### Defined in
 
-[services/maintenance/maintenance-service.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L20)
+[services/maintenance/maintenance-service.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L20)
 
 ## Properties
 
@@ -45,7 +45,7 @@ Features for optimistic minting maintainers.
 
 #### Defined in
 
-[services/maintenance/maintenance-service.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L14)
+[services/maintenance/maintenance-service.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L14)
 
 ___
 
@@ -57,4 +57,4 @@ Features for SPV proof maintainers.
 
 #### Defined in
 
-[services/maintenance/maintenance-service.ts:18](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L18)
+[services/maintenance/maintenance-service.ts:18](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/maintenance-service.ts#L18)

--- a/typescript/api-reference/classes/OptimisticMinting.md
+++ b/typescript/api-reference/classes/OptimisticMinting.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:9](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L9)
+[services/maintenance/optimistic-minting.ts:9](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L9)
 
 ## Properties
 
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:7](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L7)
+[services/maintenance/optimistic-minting.ts:7](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L7)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Transaction hash of the optimistic mint cancel transaction.
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L37)
+[services/maintenance/optimistic-minting.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L37)
 
 ___
 
@@ -95,7 +95,7 @@ Transaction hash of the optimistic mint finalize transaction.
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:54](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L54)
+[services/maintenance/optimistic-minting.ts:54](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L54)
 
 ___
 
@@ -120,7 +120,7 @@ Optimistic minting request.
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:71](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L71)
+[services/maintenance/optimistic-minting.ts:71](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L71)
 
 ___
 
@@ -145,4 +145,4 @@ Transaction hash of the optimistic mint request transaction.
 
 #### Defined in
 
-[services/maintenance/optimistic-minting.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L20)
+[services/maintenance/optimistic-minting.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/optimistic-minting.ts#L20)

--- a/typescript/api-reference/classes/RedemptionsService.md
+++ b/typescript/api-reference/classes/RedemptionsService.md
@@ -41,7 +41,7 @@ Service exposing features related to tBTC v2 redemptions.
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L31)
+[services/redemptions/redemptions-service.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L31)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:29](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L29)
+[services/redemptions/redemptions-service.ts:29](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L29)
 
 ___
 
@@ -65,7 +65,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L25)
+[services/redemptions/redemptions-service.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L25)
 
 ## Methods
 
@@ -92,7 +92,7 @@ Object containing:
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:132](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L132)
+[services/redemptions/redemptions-service.ts:132](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L132)
 
 ___
 
@@ -119,7 +119,7 @@ Promise holding the wallet main UTXO or undefined value.
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:300](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L300)
+[services/redemptions/redemptions-service.ts:302](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L302)
 
 ___
 
@@ -145,7 +145,7 @@ Promise with the wallet details needed to request a redemption.
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:181](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L181)
+[services/redemptions/redemptions-service.ts:181](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L181)
 
 ___
 
@@ -176,7 +176,7 @@ Throws an error if no redemption request exists for the given
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:412](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L412)
+[services/redemptions/redemptions-service.ts:414](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L414)
 
 ___
 
@@ -205,7 +205,7 @@ Object containing:
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:49](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L49)
+[services/redemptions/redemptions-service.ts:49](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L49)
 
 ___
 
@@ -237,4 +237,4 @@ Object containing:
 
 #### Defined in
 
-[services/redemptions/redemptions-service.ts:88](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L88)
+[services/redemptions/redemptions-service.ts:88](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L88)

--- a/typescript/api-reference/classes/Spv.md
+++ b/typescript/api-reference/classes/Spv.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[services/maintenance/spv.ts:21](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/spv.ts#L21)
+[services/maintenance/spv.ts:21](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/spv.ts#L21)
 
 ## Properties
 
@@ -47,7 +47,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[services/maintenance/spv.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/spv.ts#L19)
+[services/maintenance/spv.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/spv.ts#L19)
 
 ___
 
@@ -59,7 +59,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[services/maintenance/spv.ts:15](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/spv.ts#L15)
+[services/maintenance/spv.ts:15](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/spv.ts#L15)
 
 ## Methods
 
@@ -86,7 +86,7 @@ Empty promise.
 
 #### Defined in
 
-[services/maintenance/spv.ts:34](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/spv.ts#L34)
+[services/maintenance/spv.ts:34](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/spv.ts#L34)
 
 ___
 
@@ -113,4 +113,4 @@ Empty promise.
 
 #### Defined in
 
-[services/maintenance/spv.ts:67](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/spv.ts#L67)
+[services/maintenance/spv.ts:67](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/spv.ts#L67)

--- a/typescript/api-reference/classes/TBTC.md
+++ b/typescript/api-reference/classes/TBTC.md
@@ -47,7 +47,7 @@ Entrypoint component of the tBTC v2 SDK.
 
 #### Defined in
 
-[services/tbtc.ts:60](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L60)
+[services/tbtc.ts:60](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L60)
 
 ## Properties
 
@@ -61,7 +61,7 @@ the `initializeCrossChain` method.
 
 #### Defined in
 
-[services/tbtc.ts:58](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L58)
+[services/tbtc.ts:58](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L58)
 
 ___
 
@@ -73,7 +73,7 @@ Reference to the cross-chain contracts loader.
 
 #### Defined in
 
-[services/tbtc.ts:52](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L52)
+[services/tbtc.ts:52](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L52)
 
 ___
 
@@ -85,7 +85,7 @@ Bitcoin client handle for low-level access.
 
 #### Defined in
 
-[services/tbtc.ts:48](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L48)
+[services/tbtc.ts:48](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L48)
 
 ___
 
@@ -97,7 +97,7 @@ Service supporting the tBTC v2 deposit flow.
 
 #### Defined in
 
-[services/tbtc.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L31)
+[services/tbtc.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L31)
 
 ___
 
@@ -110,7 +110,7 @@ and operators.
 
 #### Defined in
 
-[services/tbtc.ts:36](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L36)
+[services/tbtc.ts:36](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
 
 ___
 
@@ -122,7 +122,7 @@ Service supporting the tBTC v2 redemption flow.
 
 #### Defined in
 
-[services/tbtc.ts:40](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L40)
+[services/tbtc.ts:40](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L40)
 
 ___
 
@@ -134,7 +134,7 @@ Handle to tBTC contracts for low-level access.
 
 #### Defined in
 
-[services/tbtc.ts:44](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L44)
+[services/tbtc.ts:44](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L44)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
-[services/tbtc.ts:273](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L273)
+[services/tbtc.ts:273](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L273)
 
 ___
 
@@ -210,7 +210,7 @@ In case this function needs to support non-EVM L2 chains that can't
 
 #### Defined in
 
-[services/tbtc.ts:209](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L209)
+[services/tbtc.ts:209](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L209)
 
 ___
 
@@ -242,7 +242,7 @@ This function is especially useful for local development as it gives
 
 #### Defined in
 
-[services/tbtc.ts:181](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L181)
+[services/tbtc.ts:181](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L181)
 
 ___
 
@@ -276,7 +276,7 @@ Throws an error if the underlying signer's Ethereum network is
 
 #### Defined in
 
-[services/tbtc.ts:134](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L134)
+[services/tbtc.ts:134](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L134)
 
 ___
 
@@ -308,7 +308,7 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[services/tbtc.ts:88](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L88)
+[services/tbtc.ts:88](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L88)
 
 ___
 
@@ -340,4 +340,4 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[services/tbtc.ts:110](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/tbtc.ts#L110)
+[services/tbtc.ts:110](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L110)

--- a/typescript/api-reference/classes/WalletTx.md
+++ b/typescript/api-reference/classes/WalletTx.md
@@ -40,7 +40,7 @@ using threshold signature schemes.
 
 #### Defined in
 
-[services/maintenance/wallet-tx.ts:48](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L48)
+[services/maintenance/wallet-tx.ts:48](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L48)
 
 ## Properties
 
@@ -50,7 +50,7 @@ using threshold signature schemes.
 
 #### Defined in
 
-[services/maintenance/wallet-tx.ts:45](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L45)
+[services/maintenance/wallet-tx.ts:45](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L45)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[services/maintenance/wallet-tx.ts:46](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L46)
+[services/maintenance/wallet-tx.ts:46](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/maintenance/wallet-tx.ts#L46)

--- a/typescript/api-reference/enums/BitcoinNetwork-1.md
+++ b/typescript/api-reference/enums/BitcoinNetwork-1.md
@@ -20,7 +20,7 @@ Bitcoin Mainnet.
 
 #### Defined in
 
-[lib/bitcoin/network.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/network.ts#L20)
+[lib/bitcoin/network.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/network.ts#L20)
 
 ___
 
@@ -32,7 +32,7 @@ Bitcoin Testnet.
 
 #### Defined in
 
-[lib/bitcoin/network.ts:16](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/network.ts#L16)
+[lib/bitcoin/network.ts:16](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/network.ts#L16)
 
 ___
 
@@ -44,4 +44,4 @@ Unknown network.
 
 #### Defined in
 
-[lib/bitcoin/network.ts:12](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/network.ts#L12)
+[lib/bitcoin/network.ts:12](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/network.ts#L12)

--- a/typescript/api-reference/enums/Chains.Arbitrum.md
+++ b/typescript/api-reference/enums/Chains.Arbitrum.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[lib/contracts/chain.ts:18](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L18)
+[lib/contracts/chain.ts:18](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L18)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[lib/contracts/chain.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L19)
+[lib/contracts/chain.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L19)

--- a/typescript/api-reference/enums/Chains.Base.md
+++ b/typescript/api-reference/enums/Chains.Base.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[lib/contracts/chain.ts:13](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L13)
+[lib/contracts/chain.ts:13](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L13)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[lib/contracts/chain.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L14)
+[lib/contracts/chain.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L14)

--- a/typescript/api-reference/enums/Chains.Ethereum.md
+++ b/typescript/api-reference/enums/Chains.Ethereum.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[lib/contracts/chain.ts:9](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L9)
+[lib/contracts/chain.ts:9](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L9)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[lib/contracts/chain.ts:7](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L7)
+[lib/contracts/chain.ts:7](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L7)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[lib/contracts/chain.ts:8](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain.ts#L8)
+[lib/contracts/chain.ts:8](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain.ts#L8)

--- a/typescript/api-reference/enums/DepositState.md
+++ b/typescript/api-reference/enums/DepositState.md
@@ -18,7 +18,7 @@ Represents the state of the deposit.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:121](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L121)
+[lib/contracts/cross-chain.ts:121](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L121)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:119](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L119)
+[lib/contracts/cross-chain.ts:119](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L119)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:117](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L117)
+[lib/contracts/cross-chain.ts:117](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L117)

--- a/typescript/api-reference/enums/WalletState-1.md
+++ b/typescript/api-reference/enums/WalletState-1.md
@@ -22,7 +22,7 @@ any action in the Bridge.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:395](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L395)
+[lib/contracts/bridge.ts:395](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L395)
 
 ___
 
@@ -36,7 +36,7 @@ and must defend against them.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:390](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L390)
+[lib/contracts/bridge.ts:390](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L390)
 
 ___
 
@@ -48,7 +48,7 @@ The wallet can sweep deposits and accept redemption requests.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:377](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L377)
+[lib/contracts/bridge.ts:377](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L377)
 
 ___
 
@@ -63,7 +63,7 @@ accepted.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:384](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L384)
+[lib/contracts/bridge.ts:384](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L384)
 
 ___
 
@@ -78,7 +78,7 @@ any actions in the Bridge.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:402](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L402)
+[lib/contracts/bridge.ts:402](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L402)
 
 ___
 
@@ -90,4 +90,4 @@ The wallet is unknown to the Bridge.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:373](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L373)
+[lib/contracts/bridge.ts:373](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L373)

--- a/typescript/api-reference/interfaces/BitcoinClient.md
+++ b/typescript/api-reference/interfaces/BitcoinClient.md
@@ -43,7 +43,7 @@ Broadcasts the given transaction over the network.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:103](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L103)
+[lib/bitcoin/client.ts:103](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ List of UTXOs.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:23](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L23)
+[lib/bitcoin/client.ts:23](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L23)
 
 ___
 
@@ -91,7 +91,7 @@ Gets the hash of the coinbase transaction for the given block height.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:109](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L109)
+[lib/bitcoin/client.ts:109](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L109)
 
 ___
 
@@ -116,7 +116,7 @@ Concatenation of block headers in a hexadecimal format.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:86](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L86)
+[lib/bitcoin/client.ts:86](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L86)
 
 ___
 
@@ -134,7 +134,7 @@ Bitcoin network.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L14)
+[lib/bitcoin/client.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L14)
 
 ___
 
@@ -158,7 +158,7 @@ Raw transaction.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:49](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L49)
+[lib/bitcoin/client.ts:49](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L49)
 
 ___
 
@@ -182,7 +182,7 @@ Transaction object.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:42](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L42)
+[lib/bitcoin/client.ts:42](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L42)
 
 ___
 
@@ -207,7 +207,7 @@ The number of confirmations.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:57](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L57)
+[lib/bitcoin/client.ts:57](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L57)
 
 ___
 
@@ -233,7 +233,7 @@ at the moment of request.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:35](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L35)
+[lib/bitcoin/client.ts:35](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L35)
 
 ___
 
@@ -258,7 +258,7 @@ Merkle branch.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:94](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L94)
+[lib/bitcoin/client.ts:94](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L94)
 
 ___
 
@@ -288,7 +288,7 @@ Array of confirmed transaction hashes related to the provided
 
 #### Defined in
 
-[lib/bitcoin/client.ts:71](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L71)
+[lib/bitcoin/client.ts:71](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L71)
 
 ___
 
@@ -306,4 +306,4 @@ Height of the last mined block.
 
 #### Defined in
 
-[lib/bitcoin/client.ts:77](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/client.ts#L77)
+[lib/bitcoin/client.ts:77](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/client.ts#L77)

--- a/typescript/api-reference/interfaces/BitcoinHeader.md
+++ b/typescript/api-reference/interfaces/BitcoinHeader.md
@@ -25,7 +25,7 @@ less than or equal to. The field is 4-byte long.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L37)
+[lib/bitcoin/header.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L37)
 
 ___
 
@@ -38,7 +38,7 @@ The field is 32-byte long.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L25)
+[lib/bitcoin/header.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L25)
 
 ___
 
@@ -52,7 +52,7 @@ produce a hash less than or equal to the target threshold. The field is
 
 #### Defined in
 
-[lib/bitcoin/header.ts:44](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L44)
+[lib/bitcoin/header.ts:44](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L44)
 
 ___
 
@@ -64,7 +64,7 @@ The hash of the previous block's header. The field is 32-byte long.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L19)
+[lib/bitcoin/header.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L19)
 
 ___
 
@@ -77,7 +77,7 @@ The Unix epoch time when the miner started hashing the header. The field is
 
 #### Defined in
 
-[lib/bitcoin/header.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L31)
+[lib/bitcoin/header.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L31)
 
 ___
 
@@ -90,4 +90,4 @@ to follow. The field is 4-byte long.
 
 #### Defined in
 
-[lib/bitcoin/header.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/header.ts#L14)
+[lib/bitcoin/header.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/header.ts#L14)

--- a/typescript/api-reference/interfaces/BitcoinRawTx.md
+++ b/typescript/api-reference/interfaces/BitcoinRawTx.md
@@ -18,4 +18,4 @@ The full transaction payload as an un-prefixed hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:22](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L22)
+[lib/bitcoin/tx.ts:22](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L22)

--- a/typescript/api-reference/interfaces/BitcoinRawTxVectors.md
+++ b/typescript/api-reference/interfaces/BitcoinRawTxVectors.md
@@ -22,7 +22,7 @@ as a hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:113](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L113)
+[lib/bitcoin/tx.ts:113](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L113)
 
 ___
 
@@ -34,7 +34,7 @@ Transaction locktime as a hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:124](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L124)
+[lib/bitcoin/tx.ts:124](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L124)
 
 ___
 
@@ -47,7 +47,7 @@ as a hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:119](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L119)
+[lib/bitcoin/tx.ts:119](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L119)
 
 ___
 
@@ -59,4 +59,4 @@ Transaction version as a hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:107](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L107)
+[lib/bitcoin/tx.ts:107](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L107)

--- a/typescript/api-reference/interfaces/BitcoinSpvProof.md
+++ b/typescript/api-reference/interfaces/BitcoinSpvProof.md
@@ -24,7 +24,7 @@ Concatenated block headers in hexadecimal format. Each block header is
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L31)
+[lib/bitcoin/spv.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L31)
 
 ___
 
@@ -37,7 +37,7 @@ the sha256 hash of the coinbase transaction.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L37)
+[lib/bitcoin/spv.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L37)
 
 ___
 
@@ -49,7 +49,7 @@ Merkle proof of coinbase transaction inclusion in a block.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:42](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L42)
+[lib/bitcoin/spv.ts:42](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L42)
 
 ___
 
@@ -61,7 +61,7 @@ The merkle proof of transaction inclusion in a block.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L20)
+[lib/bitcoin/spv.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L20)
 
 ___
 
@@ -73,4 +73,4 @@ Transaction index in the block (0-indexed).
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:25](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L25)
+[lib/bitcoin/spv.ts:25](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L25)

--- a/typescript/api-reference/interfaces/BitcoinTx.md
+++ b/typescript/api-reference/interfaces/BitcoinTx.md
@@ -20,7 +20,7 @@ The vector of transaction inputs.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L37)
+[lib/bitcoin/tx.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L37)
 
 ___
 
@@ -32,7 +32,7 @@ The vector of transaction outputs.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:42](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L42)
+[lib/bitcoin/tx.ts:42](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L42)
 
 ___
 
@@ -44,4 +44,4 @@ The transaction hash (or transaction ID) as an un-prefixed hex string.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:32](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L32)
+[lib/bitcoin/tx.ts:32](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L32)

--- a/typescript/api-reference/interfaces/BitcoinTxMerkleBranch.md
+++ b/typescript/api-reference/interfaces/BitcoinTxMerkleBranch.md
@@ -20,7 +20,7 @@ The height of the block the transaction was confirmed in.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:52](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L52)
+[lib/bitcoin/spv.ts:52](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L52)
 
 ___
 
@@ -34,7 +34,7 @@ the deepest pairing first. Each hash is an unprefixed hex string.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:59](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L59)
+[lib/bitcoin/spv.ts:59](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L59)
 
 ___
 
@@ -46,4 +46,4 @@ The 0-based index of the transaction's position in the block.
 
 #### Defined in
 
-[lib/bitcoin/spv.ts:64](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/spv.ts#L64)
+[lib/bitcoin/spv.ts:64](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L64)

--- a/typescript/api-reference/interfaces/BitcoinTxOutpoint.md
+++ b/typescript/api-reference/interfaces/BitcoinTxOutpoint.md
@@ -19,7 +19,7 @@ The zero-based index of the output from the specified transaction.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:57](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L57)
+[lib/bitcoin/tx.ts:57](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L57)
 
 ___
 
@@ -31,4 +31,4 @@ The hash of the transaction the outpoint belongs to.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:52](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L52)
+[lib/bitcoin/tx.ts:52](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L52)

--- a/typescript/api-reference/interfaces/BitcoinTxOutput.md
+++ b/typescript/api-reference/interfaces/BitcoinTxOutput.md
@@ -20,7 +20,7 @@ The 0-based index of the output.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:77](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L77)
+[lib/bitcoin/tx.ts:77](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L77)
 
 ___
 
@@ -32,7 +32,7 @@ The receiving scriptPubKey.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:87](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L87)
+[lib/bitcoin/tx.ts:87](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L87)
 
 ___
 
@@ -44,4 +44,4 @@ The value of the output in satoshis.
 
 #### Defined in
 
-[lib/bitcoin/tx.ts:82](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/tx.ts#L82)
+[lib/bitcoin/tx.ts:82](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/tx.ts#L82)

--- a/typescript/api-reference/interfaces/Bridge.md
+++ b/typescript/api-reference/interfaces/Bridge.md
@@ -45,7 +45,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/bridge.ts:26](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L26)
+[lib/contracts/bridge.ts:26](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L26)
 
 ___
 
@@ -61,7 +61,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/bridge.ts:169](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L169)
+[lib/contracts/bridge.ts:169](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L169)
 
 ___
 
@@ -77,7 +77,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/bridge.ts:195](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L195)
+[lib/contracts/bridge.ts:195](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L195)
 
 ## Methods
 
@@ -97,7 +97,7 @@ Compressed (33 bytes long with 02 or 03 prefix) active wallet's
 
 #### Defined in
 
-[lib/contracts/bridge.ts:163](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L163)
+[lib/contracts/bridge.ts:163](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L163)
 
 ___
 
@@ -121,7 +121,7 @@ The hash of the UTXO.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:189](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L189)
+[lib/contracts/bridge.ts:189](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L189)
 
 ___
 
@@ -146,7 +146,7 @@ Revealed deposit data.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:68](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L68)
+[lib/contracts/bridge.ts:68](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L68)
 
 ___
 
@@ -162,7 +162,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L20)
+[lib/contracts/bridge.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L20)
 
 ___
 
@@ -187,7 +187,7 @@ Promise with the pending redemption.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:124](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L124)
+[lib/contracts/bridge.ts:124](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L124)
 
 ___
 
@@ -213,7 +213,7 @@ Promise with the pending redemption.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:138](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L138)
+[lib/contracts/bridge.ts:138](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L138)
 
 ___
 
@@ -240,7 +240,7 @@ Transaction hash of the request redemption transaction.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:84](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L84)
+[lib/contracts/bridge.ts:84](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L84)
 
 ___
 
@@ -267,7 +267,7 @@ Transaction hash of the reveal deposit transaction.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:54](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L54)
+[lib/contracts/bridge.ts:54](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L54)
 
 ___
 
@@ -294,7 +294,7 @@ Transaction hash of the submit deposit sweep proof transaction.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L37)
+[lib/contracts/bridge.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L37)
 
 ___
 
@@ -321,7 +321,7 @@ Transaction hash of the submit redemption proof transaction.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:100](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L100)
+[lib/contracts/bridge.ts:100](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L100)
 
 ___
 
@@ -346,7 +346,7 @@ Promise with the pending redemption.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:152](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L152)
+[lib/contracts/bridge.ts:152](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L152)
 
 ___
 
@@ -369,7 +369,7 @@ This number signifies how many confirmations a transaction has to
 
 #### Defined in
 
-[lib/contracts/bridge.ts:113](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L113)
+[lib/contracts/bridge.ts:113](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L113)
 
 ___
 
@@ -385,7 +385,7 @@ Returns the attached WalletRegistry instance.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:174](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L174)
+[lib/contracts/bridge.ts:174](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L174)
 
 ___
 
@@ -409,4 +409,4 @@ Promise with the wallet details.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:182](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L182)
+[lib/contracts/bridge.ts:182](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L182)

--- a/typescript/api-reference/interfaces/ChainEvent.md
+++ b/typescript/api-reference/interfaces/ChainEvent.md
@@ -20,7 +20,7 @@ Block hash of the event emission.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L14)
+[lib/contracts/chain-event.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L14)
 
 ___
 
@@ -32,7 +32,7 @@ Block number of the event emission.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:10](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L10)
+[lib/contracts/chain-event.ts:10](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L10)
 
 ___
 
@@ -44,4 +44,4 @@ Transaction hash within which the event was emitted.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:18](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L18)
+[lib/contracts/chain-event.ts:18](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L18)

--- a/typescript/api-reference/interfaces/ChainIdentifier.md
+++ b/typescript/api-reference/interfaces/ChainIdentifier.md
@@ -26,7 +26,7 @@ Identifier as an un-prefixed hex string.
 
 #### Defined in
 
-[lib/contracts/chain-identifier.ts:8](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-identifier.ts#L8)
+[lib/contracts/chain-identifier.ts:8](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-identifier.ts#L8)
 
 ## Methods
 
@@ -48,4 +48,4 @@ Checks if two identifiers are equal.
 
 #### Defined in
 
-[lib/contracts/chain-identifier.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-identifier.ts#L14)
+[lib/contracts/chain-identifier.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-identifier.ts#L14)

--- a/typescript/api-reference/interfaces/CrossChainContractsLoader.md
+++ b/typescript/api-reference/interfaces/CrossChainContractsLoader.md
@@ -29,7 +29,7 @@ Loads the chain mapping based on underlying L1 chain.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:38](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L38)
+[lib/contracts/cross-chain.ts:38](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L38)
 
 ___
 
@@ -55,4 +55,4 @@ Loads L1-specific TBTC cross-chain contracts for the given L2 chain.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:43](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L43)
+[lib/contracts/cross-chain.ts:43](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L43)

--- a/typescript/api-reference/interfaces/CrossChainExtraDataEncoder.md
+++ b/typescript/api-reference/interfaces/CrossChainExtraDataEncoder.md
@@ -36,7 +36,7 @@ Identifier of the deposit owner.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:184](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L184)
+[lib/contracts/cross-chain.ts:184](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L184)
 
 ___
 
@@ -60,4 +60,4 @@ Encoded extra data.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:177](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L177)
+[lib/contracts/cross-chain.ts:177](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L177)

--- a/typescript/api-reference/interfaces/DepositReceipt.md
+++ b/typescript/api-reference/interfaces/DepositReceipt.md
@@ -25,7 +25,7 @@ public key and refund public key.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:212](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L212)
+[lib/contracts/bridge.ts:212](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L212)
 
 ___
 
@@ -37,7 +37,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:206](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L206)
+[lib/contracts/bridge.ts:206](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L206)
 
 ___
 
@@ -49,7 +49,7 @@ Optional 32-byte extra data.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:237](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L237)
+[lib/contracts/bridge.ts:237](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L237)
 
 ___
 
@@ -61,7 +61,7 @@ A 4-byte little-endian refund locktime.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:232](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L232)
+[lib/contracts/bridge.ts:232](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L232)
 
 ___
 
@@ -76,7 +76,7 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:227](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
+[lib/contracts/bridge.ts:227](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
 
 ___
 
@@ -90,4 +90,4 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:219](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L219)
+[lib/contracts/bridge.ts:219](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L219)

--- a/typescript/api-reference/interfaces/DepositRequest.md
+++ b/typescript/api-reference/interfaces/DepositRequest.md
@@ -23,7 +23,7 @@ Deposit amount in satoshis.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:281](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L281)
+[lib/contracts/bridge.ts:281](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L281)
 
 ___
 
@@ -35,7 +35,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:276](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L276)
+[lib/contracts/bridge.ts:276](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L276)
 
 ___
 
@@ -47,7 +47,7 @@ UNIX timestamp the deposit was revealed at.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:291](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L291)
+[lib/contracts/bridge.ts:291](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L291)
 
 ___
 
@@ -60,7 +60,7 @@ should have zero as value.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:296](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
+[lib/contracts/bridge.ts:296](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
 
 ___
 
@@ -73,7 +73,7 @@ Denominated in satoshi.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:301](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L301)
+[lib/contracts/bridge.ts:301](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L301)
 
 ___
 
@@ -85,4 +85,4 @@ Optional identifier of the vault the deposit should be routed in.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:286](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L286)
+[lib/contracts/bridge.ts:286](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L286)

--- a/typescript/api-reference/interfaces/DepositorProxy.md
+++ b/typescript/api-reference/interfaces/DepositorProxy.md
@@ -34,7 +34,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/depositor-proxy.ts:19](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L19)
+[lib/contracts/depositor-proxy.ts:19](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L19)
 
 ___
 
@@ -61,4 +61,4 @@ Transaction hash of the reveal deposit transaction.
 
 #### Defined in
 
-[lib/contracts/depositor-proxy.ts:31](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L31)
+[lib/contracts/depositor-proxy.ts:31](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L31)

--- a/typescript/api-reference/interfaces/ElectrumCredentials.md
+++ b/typescript/api-reference/interfaces/ElectrumCredentials.md
@@ -20,7 +20,7 @@ Host pointing to the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:35](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L35)
+[lib/electrum/client.ts:35](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L35)
 
 ___
 
@@ -32,7 +32,7 @@ Port the Electrum server listens on.
 
 #### Defined in
 
-[lib/electrum/client.ts:39](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L39)
+[lib/electrum/client.ts:39](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L39)
 
 ___
 
@@ -44,4 +44,4 @@ Protocol used by the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:43](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/electrum/client.ts#L43)
+[lib/electrum/client.ts:43](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L43)

--- a/typescript/api-reference/interfaces/EthereumContractConfig.md
+++ b/typescript/api-reference/interfaces/EthereumContractConfig.md
@@ -22,7 +22,7 @@ contract artifact.
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:53](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L53)
+[lib/ethereum/adapter.ts:53](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L53)
 
 ___
 
@@ -36,7 +36,7 @@ contract artifact.
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:64](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L64)
+[lib/ethereum/adapter.ts:64](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L64)
 
 ___
 
@@ -49,4 +49,4 @@ Provider - will return a downgraded Contract which only has read-only access (i.
 
 #### Defined in
 
-[lib/ethereum/adapter.ts:58](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/ethereum/adapter.ts#L58)
+[lib/ethereum/adapter.ts:58](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L58)

--- a/typescript/api-reference/interfaces/GetChainEvents.Function.md
+++ b/typescript/api-reference/interfaces/GetChainEvents.Function.md
@@ -33,4 +33,4 @@ Array of found events.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:60](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L60)
+[lib/contracts/chain-event.ts:60](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L60)

--- a/typescript/api-reference/interfaces/GetChainEvents.Options.md
+++ b/typescript/api-reference/interfaces/GetChainEvents.Options.md
@@ -24,7 +24,7 @@ Number of blocks for interval length in partial events pulls.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:43](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L43)
+[lib/contracts/chain-event.ts:43](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L43)
 
 ___
 
@@ -37,7 +37,7 @@ If not defined a block number of a contract deployment is used.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:30](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L30)
+[lib/contracts/chain-event.ts:30](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L30)
 
 ___
 
@@ -49,7 +49,7 @@ A logger function to pass execution messages.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:47](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L47)
+[lib/contracts/chain-event.ts:47](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L47)
 
 ___
 
@@ -61,7 +61,7 @@ Number of retries in case of an error getting the events.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:39](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L39)
+[lib/contracts/chain-event.ts:39](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L39)
 
 ___
 
@@ -74,4 +74,4 @@ If not defined the latest block number will be used.
 
 #### Defined in
 
-[lib/contracts/chain-event.ts:35](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/chain-event.ts#L35)
+[lib/contracts/chain-event.ts:35](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/chain-event.ts#L35)

--- a/typescript/api-reference/interfaces/L1BitcoinDepositor.md
+++ b/typescript/api-reference/interfaces/L1BitcoinDepositor.md
@@ -13,7 +13,7 @@ specific to the given L2 chain, deployed on the L1 chain.
 
 - [extraDataEncoder](L1BitcoinDepositor.md#extradataencoder)
 - [getChainIdentifier](L1BitcoinDepositor.md#getchainidentifier)
-- [getDepositState](L1BitcoinDepositor.md#getDepositState)
+- [getDepositState](L1BitcoinDepositor.md#getdepositstate)
 - [initializeDeposit](L1BitcoinDepositor.md#initializedeposit)
 
 ## Methods
@@ -31,7 +31,7 @@ encode and decode the extra data included in the cross-chain deposit script.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:145](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L145)
+[lib/contracts/cross-chain.ts:145](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L145)
 
 ___
 
@@ -47,7 +47,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:139](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L139)
+[lib/contracts/cross-chain.ts:139](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L139)
 
 ___
 
@@ -71,7 +71,7 @@ The state of the deposit.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:134](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L134)
+[lib/contracts/cross-chain.ts:134](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L134)
 
 ___
 
@@ -98,4 +98,4 @@ Transaction hash of the reveal deposit transaction.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:157](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L157)
+[lib/contracts/cross-chain.ts:157](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L157)

--- a/typescript/api-reference/interfaces/L2BitcoinDepositor.md
+++ b/typescript/api-reference/interfaces/L2BitcoinDepositor.md
@@ -33,7 +33,7 @@ encode and decode the extra data included in the cross-chain deposit script.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:92](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L92)
+[lib/contracts/cross-chain.ts:92](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L92)
 
 ___
 
@@ -49,7 +49,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:72](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L72)
+[lib/contracts/cross-chain.ts:72](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L72)
 
 ___
 
@@ -68,7 +68,7 @@ The identifier of the deposit owner or undefined if not set.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:79](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L79)
+[lib/contracts/cross-chain.ts:79](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L79)
 
 ___
 
@@ -95,7 +95,7 @@ Transaction hash of the reveal deposit transaction.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:104](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L104)
+[lib/contracts/cross-chain.ts:104](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L104)
 
 ___
 
@@ -118,4 +118,4 @@ issued by this contract.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:86](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L86)
+[lib/contracts/cross-chain.ts:86](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L86)

--- a/typescript/api-reference/interfaces/L2TBTCToken.md
+++ b/typescript/api-reference/interfaces/L2TBTCToken.md
@@ -37,7 +37,7 @@ The balance of the given identifier in 1e18 precision.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L61)
+[lib/contracts/cross-chain.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L61)
 
 ___
 
@@ -53,4 +53,4 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/cross-chain.ts:54](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/cross-chain.ts#L54)
+[lib/contracts/cross-chain.ts:54](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L54)

--- a/typescript/api-reference/interfaces/RedeemerProxy.md
+++ b/typescript/api-reference/interfaces/RedeemerProxy.md
@@ -25,7 +25,7 @@ claim the tBTC tokens if anything goes wrong during the redemption process.
 
 #### Defined in
 
-[services/redemptions/redeemer-proxy.ts:13](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redeemer-proxy.ts#L13)
+[services/redemptions/redeemer-proxy.ts:13](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redeemer-proxy.ts#L13)
 
 ___
 
@@ -50,4 +50,4 @@ Target chain hash of the request redemption transaction
 
 #### Defined in
 
-[services/redemptions/redeemer-proxy.ts:21](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/services/redemptions/redeemer-proxy.ts#L21)
+[services/redemptions/redeemer-proxy.ts:21](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redeemer-proxy.ts#L21)

--- a/typescript/api-reference/interfaces/RedemptionRequest.md
+++ b/typescript/api-reference/interfaces/RedemptionRequest.md
@@ -23,7 +23,7 @@ On-chain identifier of the redeemer.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:320](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L320)
+[lib/contracts/bridge.ts:320](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L320)
 
 ___
 
@@ -36,7 +36,7 @@ prepended with length.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:326](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L326)
+[lib/contracts/bridge.ts:326](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L326)
 
 ___
 
@@ -50,7 +50,7 @@ by the sum of the fee share and the treasury fee for this particular output.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:333](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L333)
+[lib/contracts/bridge.ts:333](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L333)
 
 ___
 
@@ -62,7 +62,7 @@ UNIX timestamp the request was created at.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:352](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L352)
+[lib/contracts/bridge.ts:352](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L352)
 
 ___
 
@@ -77,7 +77,7 @@ on-chain contract at the time the redemption request was made.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:341](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L341)
+[lib/contracts/bridge.ts:341](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L341)
 
 ___
 
@@ -90,4 +90,4 @@ redemption's `requestedAmount` to pay the transaction network fee.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:347](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L347)
+[lib/contracts/bridge.ts:347](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L347)

--- a/typescript/api-reference/interfaces/TBTCToken.md
+++ b/typescript/api-reference/interfaces/TBTCToken.md
@@ -40,7 +40,7 @@ through custom integration with the tBTC Bridge contract.
 
 #### Defined in
 
-[lib/contracts/tbtc-token.ts:61](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L61)
+[lib/contracts/tbtc-token.ts:61](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L61)
 
 ___
 
@@ -56,7 +56,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/tbtc-token.ts:13](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L13)
+[lib/contracts/tbtc-token.ts:13](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L13)
 
 ___
 
@@ -86,7 +86,7 @@ Transaction hash of the approve and call transaction.
 
 #### Defined in
 
-[lib/contracts/tbtc-token.ts:40](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L40)
+[lib/contracts/tbtc-token.ts:40](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L40)
 
 ___
 
@@ -110,4 +110,4 @@ with 1e8 precision in satoshi.
 
 #### Defined in
 
-[lib/contracts/tbtc-token.ts:23](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L23)
+[lib/contracts/tbtc-token.ts:23](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-token.ts#L23)

--- a/typescript/api-reference/interfaces/TBTCVault.md
+++ b/typescript/api-reference/interfaces/TBTCVault.md
@@ -40,7 +40,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:107](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L107)
+[lib/contracts/tbtc-vault.ts:107](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L107)
 
 ___
 
@@ -56,7 +56,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:113](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L113)
+[lib/contracts/tbtc-vault.ts:113](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L113)
 
 ___
 
@@ -72,7 +72,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:101](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L101)
+[lib/contracts/tbtc-vault.ts:101](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L101)
 
 ## Methods
 
@@ -97,7 +97,7 @@ Transaction hash of the optimistic mint cancel transaction.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:67](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L67)
+[lib/contracts/tbtc-vault.ts:67](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L67)
 
 ___
 
@@ -122,7 +122,7 @@ Transaction hash of the optimistic mint finalize transaction.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:80](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L80)
+[lib/contracts/tbtc-vault.ts:80](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L80)
 
 ___
 
@@ -138,7 +138,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:14](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L14)
+[lib/contracts/tbtc-vault.ts:14](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L14)
 
 ___
 
@@ -156,7 +156,7 @@ Array containing identifiers of all currently registered minters.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:30](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L30)
+[lib/contracts/tbtc-vault.ts:30](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L30)
 
 ___
 
@@ -178,7 +178,7 @@ Checks if given identifier is registered as guardian.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:44](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L44)
+[lib/contracts/tbtc-vault.ts:44](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L44)
 
 ___
 
@@ -200,7 +200,7 @@ Checks if given identifier is registered as minter.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:37](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L37)
+[lib/contracts/tbtc-vault.ts:37](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L37)
 
 ___
 
@@ -221,7 +221,7 @@ Optimistic Minting Delay in seconds.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:23](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L23)
+[lib/contracts/tbtc-vault.ts:23](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L23)
 
 ___
 
@@ -246,7 +246,7 @@ Optimistic minting request.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:92](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L92)
+[lib/contracts/tbtc-vault.ts:92](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L92)
 
 ___
 
@@ -271,4 +271,4 @@ Transaction hash of the optimistic mint request transaction.
 
 #### Defined in
 
-[lib/contracts/tbtc-vault.ts:54](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L54)
+[lib/contracts/tbtc-vault.ts:54](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/tbtc-vault.ts#L54)

--- a/typescript/api-reference/interfaces/Wallet.md
+++ b/typescript/api-reference/interfaces/Wallet.md
@@ -27,7 +27,7 @@ UNIX timestamp indicating the moment the wallet's closing period started.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:453](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L453)
+[lib/contracts/bridge.ts:453](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L453)
 
 ___
 
@@ -39,7 +39,7 @@ UNIX timestamp the wallet was created at.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:444](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L444)
+[lib/contracts/bridge.ts:444](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L444)
 
 ___
 
@@ -51,7 +51,7 @@ Identifier of a ECDSA Wallet registered in the ECDSA Wallet Registry.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:426](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
+[lib/contracts/bridge.ts:426](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
 
 ___
 
@@ -63,7 +63,7 @@ Latest wallet's main UTXO hash.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:436](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L436)
+[lib/contracts/bridge.ts:436](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L436)
 
 ___
 
@@ -76,7 +76,7 @@ funds.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:449](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L449)
+[lib/contracts/bridge.ts:449](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L449)
 
 ___
 
@@ -88,7 +88,7 @@ Moving funds target wallet commitment submitted by the wallet.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:465](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L465)
+[lib/contracts/bridge.ts:465](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L465)
 
 ___
 
@@ -100,7 +100,7 @@ Total count of pending moved funds sweep requests targeting this wallet.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:457](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L457)
+[lib/contracts/bridge.ts:457](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L457)
 
 ___
 
@@ -112,7 +112,7 @@ The total redeemable value of pending redemption requests targeting that wallet.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:440](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L440)
+[lib/contracts/bridge.ts:440](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L440)
 
 ___
 
@@ -124,7 +124,7 @@ Current state of the wallet.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:461](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L461)
+[lib/contracts/bridge.ts:461](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L461)
 
 ___
 
@@ -138,4 +138,4 @@ WalletRegistry.
 
 #### Defined in
 
-[lib/contracts/bridge.ts:432](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L432)
+[lib/contracts/bridge.ts:432](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L432)

--- a/typescript/api-reference/interfaces/WalletRegistry.md
+++ b/typescript/api-reference/interfaces/WalletRegistry.md
@@ -33,7 +33,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:32](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L32)
+[lib/contracts/wallet-registry.ts:32](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L32)
 
 ___
 
@@ -49,7 +49,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:38](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L38)
+[lib/contracts/wallet-registry.ts:38](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L38)
 
 ___
 
@@ -65,7 +65,7 @@ GetEventsFunction
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:26](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L26)
+[lib/contracts/wallet-registry.ts:26](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L26)
 
 ## Methods
 
@@ -81,7 +81,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:13](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L13)
+[lib/contracts/wallet-registry.ts:13](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L13)
 
 ___
 
@@ -105,4 +105,4 @@ Uncompressed public key without the 04 prefix.
 
 #### Defined in
 
-[lib/contracts/wallet-registry.ts:20](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L20)
+[lib/contracts/wallet-registry.ts:20](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/wallet-registry.ts#L20)

--- a/typescript/api-reference/modules/BitcoinNetwork.md
+++ b/typescript/api-reference/modules/BitcoinNetwork.md
@@ -30,4 +30,4 @@ Bitcoin Network.
 
 #### Defined in
 
-[lib/bitcoin/network.ts:33](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/bitcoin/network.ts#L33)
+[lib/bitcoin/network.ts:33](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/network.ts#L33)

--- a/typescript/api-reference/modules/WalletState.md
+++ b/typescript/api-reference/modules/WalletState.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[lib/contracts/bridge.ts:408](https://github.com/Unknown-Gravity/tbtc-v2-sdk/blob/main/typescript/src/lib/contracts/bridge.ts#L408)
+[lib/contracts/bridge.ts:408](https://github.com/keep-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L408)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2.ts",
-  "version": "2.5.1-dev",
+  "version": "2.5.0-dev",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
This is something I missed during the review of PR #825 adding the getDepositStatus function. The version should stay on 2.5.0-dev as this is the -dev version automatically pushed to the NPM registry and the last published non-dev version was 2.4.1. The next published non-dev release should be 2.5.0.

I have also sneaked in docs regenerate change to fix the problem with a link that got updated in a fork with changes merged to this repository in #825 and #822. 