### PR TITLE
Bumping up solidity module version to v1.8.0-dev

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc-v2",
-  "version": "1.7.0-dev",
+  "version": "1.8.0-dev",
   "license": "GPL-3.0-only",
   "files": [
     "artifacts/",


### PR DESCRIPTION
See https://github.com/keep-network/tbtc-v2/issues/830

The v1.7.0 version has just been tagged with `solidity/v1.7.0` and pushed to NPM package repository. v1.7.0 includes the `Timelock` contract that will take over the ownership of `Bridge`, `WalletRegistry` and `RedemptionWatchtower` `ProxyAdmin` contracts.