### PR TITLE
Adding CODEOWNERS for smart contracts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/solidity/ @pdyraga @lukasz-zimnoch @Shadowfiend @nkuba @dimpar @tomaszslabon


### PR DESCRIPTION
Including all original tbtc v2 smart contract developers as code owners.

This change allows to open the repository for more contributors, including DAO developers. 