### PR TITLE
ci: update Node version to 18.x in GitHub Actions workflow

### DIFF
--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
           cache-dependency-path: solidity/yarn.lock

--- a/solidity/README.adoc
+++ b/solidity/README.adoc
@@ -18,7 +18,7 @@ below.
 
 Please make sure you have the following prerequisites installed on your machine:
 
-- https://nodejs.org[Node.js] >14.17.4
+- https://nodejs.org[Node.js] >=18.0.0
 - https://yarnpkg.com[Yarn] >1.22.10
 
 === Build contracts

--- a/solidity/README.adoc
+++ b/solidity/README.adoc
@@ -18,7 +18,7 @@ below.
 
 Please make sure you have the following prerequisites installed on your machine:
 
-- https://nodejs.org[Node.js] >=18.0.0
+- https://nodejs.org[Node.js] >14.17.4
 - https://yarnpkg.com[Yarn] >1.22.10
 
 === Build contracts


### PR DESCRIPTION
Update the GitHub Actions CI configuration to use Node 18.x instead of 14.x.

This change addresses build failures caused by a transitive dependency (secp256k1@4.0.4) requiring Node >=18.0.0. Previously, our CI was running Node 14.x, which was incompatible with the latest dependency updates coming through packages such as ethereum-cryptography and ganache.

No changes to the application code are included; this update only affects the CI configuration.