### PR TITLE
feat: replace ethers v5 with @ethersproject modules

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -27,6 +27,16 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.0.5",
     "@coral-xyz/anchor": "0.28.0",
+    "@ethersproject/abi": "^5.5.2",
+    "@ethersproject/abstract-signer": "^5.5.2",
+    "@ethersproject/bignumber": "^5.5.2",
+    "@ethersproject/bytes": "^5.5.2",
+    "@ethersproject/constants": "^5.5.2",
+    "@ethersproject/contracts": "^5.5.2",
+    "@ethersproject/keccak256": "^5.5.2",
+    "@ethersproject/providers": "^5.5.2",
+    "@ethersproject/solidity": "^5.5.2",
+    "@ethersproject/wallet": "^5.5.2",
     "@keep-network/ecdsa": "development",
     "@keep-network/tbtc-v2": "development",
     "@solana/spl-token": "0.3.9",
@@ -38,14 +48,13 @@
     "bufio": "^1.0.6",
     "ecpair": "^2.1.0",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1",
-    "ethers": "^5.5.2",
     "p-timeout": "^4.1.0",
     "starknet": "^6.24.1",
     "url-parse": "^1.5.10",
     "wif": "2.0.6"
   },
   "devDependencies": {
-    "@ethersproject/providers": "^5.7.2",
+    "ethers": "^5.5.2",
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep",
     "@typechain/ethers-v5": "^10.2.0",
     "@types/chai": "^4.2.21",
@@ -70,6 +79,9 @@
     "typedoc": "^0.25.3",
     "typedoc-plugin-markdown": "^3.17.0",
     "typescript": "^5.0.0"
+  },
+  "resolutions": {
+    "@umpirsky/country-list": "https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7"
   },
   "engines": {
     "node": ">=16"

--- a/typescript/scripts/refund.ts
+++ b/typescript/scripts/refund.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { program } from "commander"
 import * as fs from "fs"
 import {

--- a/typescript/src/lib/arbitrum/l2-bitcoin-redeemer.ts
+++ b/typescript/src/lib/arbitrum/l2-bitcoin-redeemer.ts
@@ -7,7 +7,8 @@ import { ArbitrumL2BitcoinRedeemer as L2BitcoinRedeemerTypechain } from "../../.
 import { ChainIdentifier, Chains, L2BitcoinRedeemer } from "../contracts"
 import { EthereumAddress } from "../ethereum"
 import { Hex } from "../utils"
-import { BigNumber, Contract } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { Contract } from "@ethersproject/contracts"
 
 import ArbitrumSepoliaL2BitcoinRedeemerDeployment from "./artifacts/arbitrumSepolia/ArbitrumL2BitcoinRedeemer.json"
 import ArbitrumSepoliaWormholeCoreDeployment from "./artifacts/arbitrumSepolia/WormholeCore.json"

--- a/typescript/src/lib/arbitrum/l2-tbtc-token.ts
+++ b/typescript/src/lib/arbitrum/l2-tbtc-token.ts
@@ -9,7 +9,7 @@ import {
   Chains,
   DestinationChainTBTCToken,
 } from "../contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { EthereumAddress } from "../ethereum"
 
 import ArbitrumL2TBTCTokenDeployment from "./artifacts/arbitrumOne/ArbitrumTBTC.json"

--- a/typescript/src/lib/base/l2-bitcoin-redeemer.ts
+++ b/typescript/src/lib/base/l2-bitcoin-redeemer.ts
@@ -7,7 +7,8 @@ import { BaseL2BitcoinRedeemer as L2BitcoinRedeemerTypechain } from "../../../ty
 import { ChainIdentifier, Chains, L2BitcoinRedeemer } from "../contracts"
 import { EthereumAddress } from "../ethereum"
 import { Hex } from "../utils"
-import { BigNumber, Contract } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { Contract } from "@ethersproject/contracts"
 
 import BaseSepoliaL2BitcoinRedeemerDeployment from "./artifacts/baseSepolia/BaseL2BitcoinRedeemer.json"
 import BaseSepoliaWormholeCoreDeployment from "./artifacts/baseSepolia/WormholeCore.json"

--- a/typescript/src/lib/base/l2-tbtc-token.ts
+++ b/typescript/src/lib/base/l2-tbtc-token.ts
@@ -9,7 +9,7 @@ import {
   Chains,
   DestinationChainTBTCToken,
 } from "../contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { EthereumAddress } from "../ethereum"
 
 import BaseL2TBTCTokenDeployment from "./artifacts/base/BaseTBTC.json"

--- a/typescript/src/lib/bitcoin/ecdsa-key.ts
+++ b/typescript/src/lib/bitcoin/ecdsa-key.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Hex } from "../utils"
 import { ECPairFactory, ECPairInterface } from "ecpair"
 import * as tinysecp from "@bitcoinerlab/secp256k1"

--- a/typescript/src/lib/bitcoin/hash.ts
+++ b/typescript/src/lib/bitcoin/hash.ts
@@ -1,4 +1,5 @@
-import { BigNumber, utils } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { sha256, ripemd160 } from "@ethersproject/sha2"
 import { Hex } from "../utils"
 
 /**
@@ -7,8 +8,8 @@ import { Hex } from "../utils"
  * @returns 20-byte-long hash.
  */
 function computeHash160(text: Hex): Hex {
-  const sha256Hash = utils.sha256(text.toPrefixedString())
-  const hash160 = utils.ripemd160(sha256Hash)
+  const sha256Hash = sha256(text.toPrefixedString())
+  const hash160 = ripemd160(sha256Hash)
 
   return Hex.from(hash160)
 }
@@ -20,8 +21,8 @@ function computeHash160(text: Hex): Hex {
  * @dev Do not confuse it with computeSha256 which computes single SHA256.
  */
 function computeHash256(text: Hex): Hex {
-  const firstHash = utils.sha256(text.toPrefixedString())
-  const secondHash = utils.sha256(firstHash)
+  const firstHash = sha256(text.toPrefixedString())
+  const secondHash = sha256(firstHash)
 
   return Hex.from(secondHash)
 }
@@ -42,7 +43,7 @@ function hashLEToBigNumber(hash: Hex): BigNumber {
  * @dev Do not confuse it with computeHash256 which computes double SHA256.
  */
 function computeSha256(text: Hex): Hex {
-  const hash = utils.sha256(text.toPrefixedString())
+  const hash = sha256(text.toPrefixedString())
   return Hex.from(hash)
 }
 

--- a/typescript/src/lib/bitcoin/header.ts
+++ b/typescript/src/lib/bitcoin/header.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Hex } from "../utils"
 import { BitcoinHashUtils } from "./hash"
 

--- a/typescript/src/lib/bitcoin/spv.ts
+++ b/typescript/src/lib/bitcoin/spv.ts
@@ -1,6 +1,6 @@
 import { BitcoinTx, BitcoinTxHash, extractBitcoinRawTxVectors } from "./tx"
 import { BitcoinClient } from "./client"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   BitcoinHeader,
   BitcoinHeaderSerializer,

--- a/typescript/src/lib/bitcoin/tx.ts
+++ b/typescript/src/lib/bitcoin/tx.ts
@@ -1,6 +1,6 @@
 import { Transaction as Tx } from "bitcoinjs-lib"
 import bufio from "bufio"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Hex } from "../utils"
 
 /**

--- a/typescript/src/lib/contracts/bridge.ts
+++ b/typescript/src/lib/contracts/bridge.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   BitcoinSpvProof,
   BitcoinUtxo,

--- a/typescript/src/lib/contracts/cross-chain.ts
+++ b/typescript/src/lib/contracts/cross-chain.ts
@@ -1,5 +1,6 @@
 import { ChainIdentifier } from "./chain-identifier"
-import { BigNumber, BytesLike } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { BytesLike } from "@ethersproject/bytes"
 import { TransactionReceipt } from "@ethersproject/providers"
 import { ChainMapping, DestinationChainName } from "./chain"
 import { BitcoinRawTxVectors, BitcoinUtxo } from "../bitcoin"

--- a/typescript/src/lib/contracts/tbtc-token.ts
+++ b/typescript/src/lib/contracts/tbtc-token.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { BitcoinUtxo } from "../bitcoin"
 import { Hex } from "../utils"
 import { ChainIdentifier } from "./chain-identifier"

--- a/typescript/src/lib/contracts/tbtc-vault.ts
+++ b/typescript/src/lib/contracts/tbtc-vault.ts
@@ -2,7 +2,7 @@ import { BitcoinTxHash } from "../bitcoin"
 import { Hex } from "../utils"
 import { ChainIdentifier } from "./chain-identifier"
 import { ChainEvent, GetChainEvents } from "./chain-event"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 /**
  * Interface for communication with the TBTCVault on-chain contract.

--- a/typescript/src/lib/contracts/wallet-registry.ts
+++ b/typescript/src/lib/contracts/wallet-registry.ts
@@ -1,6 +1,6 @@
 import { Hex } from "../utils"
 import { ChainEvent, GetChainEvents } from "./chain-event"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { ChainIdentifier } from "./chain-identifier"
 
 /**

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -14,7 +14,7 @@ import {
   BitcoinHashUtils,
 } from "../bitcoin"
 import Electrum from "electrum-client-js"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { URL as nodeURL } from "url"
 import URLParse from "url-parse"
 import { backoffRetrier, Hex, RetrierFn } from "../utils"

--- a/typescript/src/lib/ethereum/adapter.ts
+++ b/typescript/src/lib/ethereum/adapter.ts
@@ -1,14 +1,12 @@
 import {
-  ContractTransaction as EthersContractTransaction,
-  providers,
-  Signer,
-  utils,
-} from "ethers"
-import {
   Contract as EthersContract,
+  ContractTransaction as EthersContractTransaction,
   Event as EthersEvent,
   EventFilter as EthersEventFilter,
 } from "@ethersproject/contracts"
+import { Signer } from "@ethersproject/abstract-signer"
+import type { Provider } from "@ethersproject/providers"
+import { getAddress } from "@ethersproject/address"
 import { GetChainEvents } from "../contracts"
 import {
   backoffRetrier,
@@ -55,7 +53,7 @@ export interface EthersContractConfig {
    * Signer - will return a Contract which will act on behalf of that signer. The signer will sign all contract transactions.
    * Provider - will return a downgraded Contract which only has read-only access (i.e. constant calls)
    */
-  signerOrProvider: Signer | providers.Provider
+  signerOrProvider: Signer | Provider
   /**
    * Number of a block in which the contract was deployed.
    * Optional parameter, if not provided the value will be resolved from the
@@ -94,7 +92,7 @@ export class EthersContractHandle<T extends EthersContract> {
     totalRetryAttempts = 3
   ) {
     this._instance = new EthersContract(
-      config.address ?? utils.getAddress(deployment.address),
+      config.address ?? getAddress(deployment.address),
       `${JSON.stringify(deployment.abi)}`,
       config.signerOrProvider
     ) as T

--- a/typescript/src/lib/ethereum/address.ts
+++ b/typescript/src/lib/ethereum/address.ts
@@ -1,5 +1,5 @@
 import { ChainIdentifier } from "../contracts"
-import { utils } from "ethers"
+import { getAddress } from "@ethersproject/address"
 
 /**
  * Represents an Ethereum address.
@@ -13,7 +13,7 @@ export class EthereumAddress implements ChainIdentifier {
     let validAddress: string
 
     try {
-      validAddress = utils.getAddress(address)
+      validAddress = getAddress(address)
     } catch (e) {
       throw new Error(`Invalid Ethereum address`)
     }

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -20,7 +20,10 @@ import {
   Chains,
 } from "../contracts"
 import { Event as EthersEvent } from "@ethersproject/contracts"
-import { BigNumber, constants, ContractTransaction, utils } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { AddressZero } from "@ethersproject/constants"
+import { ContractTransaction } from "@ethersproject/contracts"
+import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity"
 import { backoffRetrier, Hex } from "../utils"
 import {
   BitcoinPublicKeyUtils,
@@ -118,7 +121,7 @@ export class EthereumBridge
         refundPublicKeyHash: Hex.from(event.args!.refundPubKeyHash),
         refundLocktime: Hex.from(event.args!.refundLocktime),
         vault:
-          event.args!.vault === constants.AddressZero
+          event.args!.vault === AddressZero
             ? undefined
             : EthereumAddress.from(event.args!.vault),
       }
@@ -208,10 +211,10 @@ export class EthereumBridge
     ]).toString("hex")}`
     // Build the redemption key by using the 0x-prefixed wallet PKH and
     // prefixed output script.
-    return utils.solidityKeccak256(
+    return solidityKeccak256(
       ["bytes32", "bytes20"],
       [
-        utils.solidityKeccak256(["bytes"], [prefixedRawRedeemerOutputScript]),
+        solidityKeccak256(["bytes"], [prefixedRawRedeemerOutputScript]),
         `0x${walletPublicKeyHash.toString()}`,
       ]
     )
@@ -311,7 +314,7 @@ export class EthereumBridge
 
     const vaultParam = vault
       ? `0x${vault.identifierHex}`
-      : constants.AddressZero
+      : AddressZero
 
     const tx = await EthersTransactionUtils.sendWithRetry<ContractTransaction>(
       async () => {
@@ -475,7 +478,7 @@ export class EthereumBridge
       .reverse()
       .toPrefixedString()
 
-    return utils.solidityKeccak256(
+    return solidityKeccak256(
       ["bytes32", "uint32"],
       [prefixedReversedDepositTxHash, depositOutputIndex]
     )
@@ -493,7 +496,7 @@ export class EthereumBridge
       depositor: EthereumAddress.from(deposit.depositor),
       amount: BigNumber.from(deposit.amount),
       vault:
-        deposit.vault === constants.AddressZero
+        deposit.vault === AddressZero
           ? undefined
           : EthereumAddress.from(deposit.vault),
       revealedAt: BigNumber.from(deposit.revealedAt).toNumber(),
@@ -643,7 +646,7 @@ export class EthereumBridge
    */
   buildUtxoHash(utxo: BitcoinUtxo): Hex {
     return Hex.from(
-      utils.solidityKeccak256(
+      solidityKeccak256(
         ["bytes32", "uint32", "uint64"],
         [
           utxo.transactionHash.reverse().toPrefixedString(),
@@ -730,7 +733,7 @@ export function packRevealDepositParameters(
     walletPubKeyHash: deposit.walletPublicKeyHash.toPrefixedString(),
     refundPubKeyHash: deposit.refundPublicKeyHash.toPrefixedString(),
     refundLocktime: deposit.refundLocktime.toPrefixedString(),
-    vault: vault ? `0x${vault.identifierHex}` : constants.AddressZero,
+    vault: vault ? `0x${vault.identifierHex}` : AddressZero,
   }
 
   const extraData: string | undefined = deposit.extraData?.toPrefixedString()

--- a/typescript/src/lib/ethereum/index.ts
+++ b/typescript/src/lib/ethereum/index.ts
@@ -5,7 +5,8 @@ import {
   DestinationChainName,
   TBTCContracts,
 } from "../contracts"
-import { providers, Signer } from "ethers"
+import type { Provider } from "@ethersproject/providers"
+import { Signer } from "@ethersproject/abstract-signer"
 import { EthereumBridge } from "./bridge"
 import { EthereumWalletRegistry } from "./wallet-registry"
 import { EthereumTBTCToken } from "./tbtc-token"
@@ -32,7 +33,7 @@ export { EthersContractConfig as EthereumContractConfig } from "./adapter"
  * types and can be either a Signer that can make write transactions
  * or a Provider that works only in the read-only mode.
  */
-export type EthereumSigner = Signer | providers.Provider
+export type EthereumSigner = Signer | Provider
 
 /**
  * Resolves the chain ID from the given signer.
@@ -40,7 +41,7 @@ export type EthereumSigner = Signer | providers.Provider
  * @returns Chain ID as a string.
  */
 export async function chainIdFromSigner(
-  signer: EthereumSigner | providers.Provider
+  signer: EthereumSigner | Provider
 ): Promise<string> {
   let chainId: number
   if (Signer.isSigner(signer)) {

--- a/typescript/src/lib/ethereum/l1-bitcoin-redeemer.ts
+++ b/typescript/src/lib/ethereum/l1-bitcoin-redeemer.ts
@@ -17,7 +17,7 @@ import SepoliaL1BitcoinRedeemerDeployment from "./artifacts/sepolia/L1BitcoinRed
 import MainnetBaseL1BitcoinRedeemerDeployment from "./artifacts/mainnet/L1BitcoinRedeemer.json"
 import MainnetArbitrumL1BitcoinRedeemerDeployment from "./artifacts/mainnet/L1BitcoinRedeemer.json"
 import { BitcoinHashUtils, BitcoinUtxo } from "../bitcoin"
-import { BytesLike } from "ethers"
+import { BytesLike } from "@ethersproject/bytes"
 
 const artifactLoader = {
   getMainnet: (l2ChainName: DestinationChainName) => {

--- a/typescript/src/lib/ethereum/tbtc-token.ts
+++ b/typescript/src/lib/ethereum/tbtc-token.ts
@@ -1,6 +1,8 @@
 import { TBTC as TBTCTypechain } from "../../../typechain/TBTC"
 import { ChainIdentifier, Chains, TBTCToken } from "../contracts"
-import { BigNumber, ContractTransaction, utils } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { ContractTransaction } from "@ethersproject/contracts"
+import { defaultAbiCoder } from "@ethersproject/abi"
 import { BitcoinHashUtils, BitcoinUtxo } from "../bitcoin"
 import { Hex } from "../utils"
 import {
@@ -122,7 +124,7 @@ export class EthereumTBTCToken
     )
 
     return Hex.from(
-      utils.defaultAbiCoder.encode(
+      defaultAbiCoder.encode(
         ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
         [
           redeemer.identifierHex,

--- a/typescript/src/lib/ethereum/tbtc-vault.ts
+++ b/typescript/src/lib/ethereum/tbtc-vault.ts
@@ -9,7 +9,8 @@ import {
   ChainIdentifier,
   Chains,
 } from "../contracts"
-import { BigNumber, ContractTransaction } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { ContractTransaction } from "@ethersproject/contracts"
 import { BitcoinTxHash } from "../bitcoin"
 import { backoffRetrier, Hex } from "../utils"
 import {

--- a/typescript/src/lib/ethereum/wallet-registry.ts
+++ b/typescript/src/lib/ethereum/wallet-registry.ts
@@ -10,7 +10,7 @@ import {
 } from "../contracts"
 import { backoffRetrier, Hex } from "../utils"
 import { Event as EthersEvent } from "@ethersproject/contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   EthersContractConfig,
   EthersContractDeployment,

--- a/typescript/src/lib/sei/l2-tbtc-token.ts
+++ b/typescript/src/lib/sei/l2-tbtc-token.ts
@@ -9,7 +9,7 @@ import {
   Chains,
   DestinationChainTBTCToken,
 } from "../contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { EthereumAddress } from "../ethereum"
 
 import SeiL2TBTCTokenDeployment from "./artifacts/seiMainnet/SeiTBTC.json"

--- a/typescript/src/lib/sei/sei-depositor.ts
+++ b/typescript/src/lib/sei/sei-depositor.ts
@@ -12,7 +12,9 @@ import { SeiProvider } from "./types"
 import { Hex } from "../utils"
 import { packRevealDepositParameters } from "../ethereum"
 import axios from "axios"
-import { ethers } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { keccak256 } from "@ethersproject/keccak256"
+import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**
@@ -295,16 +297,16 @@ export class SeiBitcoinDepositor implements BitcoinDepositor {
             depositTx.locktime.toString()
 
           // Apply double SHA-256 (Bitcoin standard)
-          const fundingTxHash = ethers.utils.keccak256(
-            ethers.utils.keccak256("0x" + fundingTxComponents)
+          const fundingTxHash = keccak256(
+            keccak256("0x" + fundingTxComponents)
           )
 
           // Calculate deposit ID
-          const depositIdHash = ethers.utils.solidityKeccak256(
+          const depositIdHash = solidityKeccak256(
             ["bytes32", "uint256"],
             [fundingTxHash, depositOutputIndex]
           )
-          depositId = ethers.BigNumber.from(depositIdHash).toString()
+          depositId = BigNumber.from(depositIdHash).toString()
         } catch (e) {
           console.warn("Failed to calculate deposit ID:", e)
         }

--- a/typescript/src/lib/sei/types.ts
+++ b/typescript/src/lib/sei/types.ts
@@ -1,11 +1,12 @@
-import { ethers } from "ethers"
+import type { Provider } from "@ethersproject/providers"
+import type { Signer } from "@ethersproject/abstract-signer"
 
 /**
  * Sei provider type - uses standard Ethereum provider since Sei is EVM-compatible
  */
-export type SeiProvider = ethers.providers.Provider
+export type SeiProvider = Provider
 
 /**
  * Sei signer type - uses standard Ethereum signer
  */
-export type SeiSigner = ethers.Signer
+export type SeiSigner = Signer

--- a/typescript/src/lib/solana/solana-tbtc-token.ts
+++ b/typescript/src/lib/solana/solana-tbtc-token.ts
@@ -1,6 +1,6 @@
 import { Program, AnchorProvider, Idl } from "@coral-xyz/anchor"
 import { PublicKey, Transaction } from "@solana/web3.js"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   getMint,
   getAssociatedTokenAddressSync,

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -11,7 +11,9 @@ import { StarkNetProvider } from "./types"
 import { Hex } from "../utils"
 import { packRevealDepositParameters } from "../ethereum"
 import axios from "axios"
-import { ethers } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { keccak256 } from "@ethersproject/keccak256"
+import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**
@@ -298,16 +300,16 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
             depositTx.locktime.toString()
 
           // Apply double SHA-256 (Bitcoin standard)
-          const fundingTxHash = ethers.utils.keccak256(
-            ethers.utils.keccak256("0x" + fundingTxComponents)
+          const fundingTxHash = keccak256(
+            keccak256("0x" + fundingTxComponents)
           )
 
           // Calculate deposit ID
-          const depositIdHash = ethers.utils.solidityKeccak256(
+          const depositIdHash = solidityKeccak256(
             ["bytes32", "uint256"],
             [fundingTxHash, depositOutputIndex]
           )
-          depositId = ethers.BigNumber.from(depositIdHash).toString()
+          depositId = BigNumber.from(depositIdHash).toString()
         } catch (e) {
           console.warn("Failed to calculate deposit ID:", e)
         }

--- a/typescript/src/lib/starknet/starknet-tbtc-token.ts
+++ b/typescript/src/lib/starknet/starknet-tbtc-token.ts
@@ -1,5 +1,5 @@
 import { DestinationChainTBTCToken, ChainIdentifier } from "../contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { StarkNetAddress } from "./address"
 import { Contract } from "starknet"
 import { tbtcABI } from "./abi"

--- a/typescript/src/lib/sui/tbtc-token.ts
+++ b/typescript/src/lib/sui/tbtc-token.ts
@@ -3,7 +3,7 @@ import {
   ChainIdentifier,
   Chains,
 } from "../contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { SuiAddress } from "./chain-identifier"
 import { SuiClient, SuiCoinBalance, SuiError } from "./types"
 

--- a/typescript/src/lib/utils/bitcoin.ts
+++ b/typescript/src/lib/utils/bitcoin.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 /**
  * Converts the amount to Satoshi precision.

--- a/typescript/src/lib/utils/types.ts
+++ b/typescript/src/lib/utils/types.ts
@@ -1,5 +1,5 @@
 import { BitcoinUtxo } from "../../lib/bitcoin"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Hex } from "./hex"
 
 export interface RedemptionWallet {

--- a/typescript/src/services/deposits/funding.ts
+++ b/typescript/src/services/deposits/funding.ts
@@ -10,7 +10,7 @@ import {
   BitcoinUtxo,
   toBitcoinJsLibNetwork,
 } from "../../lib/bitcoin"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Psbt, Transaction } from "bitcoinjs-lib"
 import { Hex } from "../../lib/utils"
 

--- a/typescript/src/services/deposits/refund.ts
+++ b/typescript/src/services/deposits/refund.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   BitcoinAddressConverter,
   BitcoinClient,

--- a/typescript/src/services/maintenance/wallet-tx.ts
+++ b/typescript/src/services/maintenance/wallet-tx.ts
@@ -11,7 +11,7 @@ import {
   BitcoinUtxo,
   toBitcoinJsLibNetwork,
 } from "../../lib/bitcoin"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   DepositReceipt,
   RedemptionRequest,

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -15,7 +15,8 @@ import {
   BitcoinTxOutput,
   BitcoinUtxo,
 } from "../../lib/bitcoin"
-import { BigNumber, BigNumberish, BytesLike } from "ethers"
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber"
+import { BytesLike } from "@ethersproject/bytes"
 import { amountToSatoshi, ApiUrl, endpointUrl, Hex } from "../../lib/utils"
 import { RedeemerProxy } from "./redeemer-proxy"
 import {

--- a/typescript/src/services/tbtc.ts
+++ b/typescript/src/services/tbtc.ts
@@ -18,7 +18,7 @@ import {
   loadEthereumCoreContracts,
 } from "../lib/ethereum"
 import { ElectrumClient } from "../lib/electrum"
-import { providers } from "ethers"
+import type { Provider } from "@ethersproject/providers"
 import { AnchorProvider } from "@coral-xyz/anchor"
 import { loadSolanaCrossChainInterfaces } from "../lib/solana"
 import { loadBaseCrossChainInterfaces } from "../lib/base"
@@ -101,7 +101,7 @@ export class TBTC {
    *         Ethereum mainnet.
    */
   static async initializeMainnet(
-    ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    ethereumSignerOrProvider: EthereumSigner | Provider,
     crossChainSupport: boolean = false
   ): Promise<TBTC> {
     return TBTC.initializeEthereum(
@@ -123,7 +123,7 @@ export class TBTC {
    *         Ethereum mainnet.
    */
   static async initializeSepolia(
-    ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    ethereumSignerOrProvider: EthereumSigner | Provider,
     crossChainSupport: boolean = false
   ): Promise<TBTC> {
     return TBTC.initializeEthereum(
@@ -147,7 +147,7 @@ export class TBTC {
    *         other than the given Ethereum network.
    */
   private static async initializeEthereum(
-    ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    ethereumSignerOrProvider: EthereumSigner | Provider,
     ethereumChainId: Chains.Ethereum,
     bitcoinNetwork: BitcoinNetwork,
     crossChainSupport = false

--- a/typescript/test/data/deposit-refund.ts
+++ b/typescript/test/data/deposit-refund.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Hex } from "../../src/lib/utils"
 import {
   BitcoinRawTx,

--- a/typescript/test/data/deposit-sweep.ts
+++ b/typescript/test/data/deposit-sweep.ts
@@ -11,7 +11,7 @@ import {
   EthereumAddress,
   Hex,
 } from "../../src"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 export const NO_MAIN_UTXO = {
   transactionHash: BitcoinTxHash.from(""),

--- a/typescript/test/data/deposit.ts
+++ b/typescript/test/data/deposit.ts
@@ -1,5 +1,5 @@
 import { BitcoinRawTx, BitcoinTxHash, BitcoinUtxo } from "../../src"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 /**
  * An example address taken from the BTC testnet and having a non-zero balance.

--- a/typescript/test/data/electrum.ts
+++ b/typescript/test/data/electrum.ts
@@ -6,7 +6,7 @@ import {
   BitcoinTxHash,
   Hex,
 } from "../../src"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 /**
  * Bitcoin testnet address used for Electrum client tests.

--- a/typescript/test/data/proof.ts
+++ b/typescript/test/data/proof.ts
@@ -6,7 +6,7 @@ import {
   BitcoinTxMerkleBranch,
   Hex,
 } from "../../src"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 /**
  * Represents a set of data used for given proof scenario.

--- a/typescript/test/data/redemption.ts
+++ b/typescript/test/data/redemption.ts
@@ -1,4 +1,5 @@
-import { BigNumber, BytesLike } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { BytesLike } from "@ethersproject/bytes"
 import {
   BitcoinAddressConverter,
   BitcoinNetwork,

--- a/typescript/test/lib/arbitrum.test.ts
+++ b/typescript/test/lib/arbitrum.test.ts
@@ -15,7 +15,7 @@ import {
 import { MockProvider } from "@ethereum-waffle/provider"
 import { assertContractCalledWith } from "../utils/helpers"
 import { expect } from "chai"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 // ABI imports.
 import { abi as ArbitrumBitcoinDepositorABI } from "../../src/lib/arbitrum/artifacts/arbitrumSepolia/ArbitrumL2BitcoinDepositor.json"

--- a/typescript/test/lib/base.test.ts
+++ b/typescript/test/lib/base.test.ts
@@ -15,7 +15,7 @@ import {
 import { MockProvider } from "@ethereum-waffle/provider"
 import { assertContractCalledWith } from "../utils/helpers"
 import { expect } from "chai"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 // ABI imports.
 import { abi as BaseBitcoinDepositorABI } from "../../src/lib/base/artifacts/baseSepolia/BaseL2BitcoinDepositor.json"

--- a/typescript/test/lib/bitcoin.test.ts
+++ b/typescript/test/lib/bitcoin.test.ts
@@ -21,7 +21,7 @@ import {
   BitcoinRawTx,
   BitcoinTxMerkleBranch,
 } from "../../src"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { btcAddresses, btcAddressFromPublicKey } from "../data/bitcoin"
 import { depositSweepWithNoMainUtxoAndWitnessOutput } from "../data/deposit-sweep"
 import { networks } from "bitcoinjs-lib"

--- a/typescript/test/lib/ethereum.test.ts
+++ b/typescript/test/lib/ethereum.test.ts
@@ -19,7 +19,11 @@ import {
   MockContract,
 } from "@ethereum-waffle/mock-contract"
 import chai, { expect } from "chai"
-import { BigNumber, Wallet, constants, getDefaultProvider, utils } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { Wallet } from "@ethersproject/wallet"
+import { AddressZero, HashZero } from "@ethersproject/constants"
+import { getDefaultProvider } from "@ethersproject/providers"
+import { defaultAbiCoder } from "@ethersproject/abi"
 import { MockProvider } from "@ethereum-waffle/provider"
 import { waffleChai } from "@ethereum-waffle/chai"
 import { assertContractCalledWith } from "../utils/helpers"
@@ -53,10 +57,10 @@ describe("Ethereum", () => {
       )
 
       await bridgeContract.mock.contractReferences.returns(
-        constants.AddressZero,
-        constants.AddressZero,
+        AddressZero,
+        AddressZero,
         walletRegistry.address,
-        constants.AddressZero
+        AddressZero
       )
 
       bridgeHandle = new EthereumBridge({
@@ -485,7 +489,7 @@ describe("Ethereum", () => {
             .returns({
               depositor: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
               amount: BigNumber.from(10000),
-              vault: constants.AddressZero,
+              vault: AddressZero,
               revealedAt: 1654774330,
               sweptAt: 1655033516,
               treasuryFee: BigNumber.from(200),
@@ -528,14 +532,14 @@ describe("Ethereum", () => {
             .returns({
               ecdsaWalletID:
                 "0x9ff37567d973e4d884bc42d2d1a6cb1ff22676ab64f82c62b58e2b0ffd3fff71",
-              mainUtxoHash: constants.HashZero,
+              mainUtxoHash: HashZero,
               pendingRedemptionsValue: BigNumber.from(0),
               createdAt: 1654846075,
               movingFundsRequestedAt: 0,
               closingStartedAt: 0,
               pendingMovedFundsSweepRequestsCount: 0,
               state: 1,
-              movingFundsTargetWalletsCommitmentHash: constants.HashZero,
+              movingFundsTargetWalletsCommitmentHash: HashZero,
             } as any)
 
           await walletRegistry.mock.getWalletPublicKey
@@ -635,7 +639,7 @@ describe("Ethereum", () => {
           vault,
           amount,
         } = data
-        const expectedExtraData = utils.defaultAbiCoder.encode(
+        const expectedExtraData = defaultAbiCoder.encode(
           ["address", "bytes20", "bytes32", "uint32", "uint64", "bytes"],
           [
             redeemer.identifierHex,

--- a/typescript/test/lib/ethereum/l1-bitcoin-depositor-starknet.test.ts
+++ b/typescript/test/lib/ethereum/l1-bitcoin-depositor-starknet.test.ts
@@ -5,7 +5,7 @@ import { StarkNetAddress } from "../../../src/lib/starknet"
 import { StarkNetExtraDataEncoder } from "../../../src/lib/starknet"
 import { Hex } from "../../../src/lib/utils"
 import { MockProvider } from "@ethereum-waffle/provider"
-import { Wallet } from "ethers"
+import { Wallet } from "@ethersproject/wallet"
 
 describe("EthereumL1BitcoinDepositor - StarkNet Support", () => {
   let provider: MockProvider

--- a/typescript/test/lib/sei/l2-tbtc-token.test.ts
+++ b/typescript/test/lib/sei/l2-tbtc-token.test.ts
@@ -11,7 +11,7 @@ import {
 import { MockProvider } from "@ethereum-waffle/provider"
 import { assertContractCalledWith } from "../../utils/helpers"
 import { expect } from "chai"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 // ABI imports - using L2TBTC ABI since Sei uses the same contract
 import { abi as L2TBTCABI } from "../../../src/lib/sei/artifacts/seiTestnet/SeiTBTC.json"

--- a/typescript/test/lib/starknet/provider-integration.test.ts
+++ b/typescript/test/lib/starknet/provider-integration.test.ts
@@ -9,7 +9,7 @@ import {
 import { MockBitcoinClient } from "../../utils/mock-bitcoin-client"
 import { MockTBTCContracts } from "../../utils/mock-tbtc-contracts"
 import { MockCrossChainContractsLoader } from "../../utils/mock-cross-chain-contracts-loader"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 describe("StarkNet Provider Integration", () => {
   let tbtc: TBTC

--- a/typescript/test/lib/starknet/starknet-tbtc-token.test.ts
+++ b/typescript/test/lib/starknet/starknet-tbtc-token.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { StarkNetTBTCToken } from "../../../src/lib/starknet/starknet-tbtc-token"
 import { StarkNetAddress } from "../../../src/lib/starknet/address"
 import { EthereumAddress } from "../../../src/lib/ethereum"

--- a/typescript/test/lib/sui/tbtc-token.test.ts
+++ b/typescript/test/lib/sui/tbtc-token.test.ts
@@ -6,7 +6,7 @@ import sinon from "sinon"
 chai.use(chaiAsPromised)
 import { SuiTBTCToken, SuiAddress, SuiError } from "../../../src/lib/sui"
 import { Chains } from "../../../src/lib/contracts"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 
 describe("SUI tBTC Token", () => {
   let token: SuiTBTCToken

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import {
   testnetAddress,
   testnetPrivateKey,

--- a/typescript/test/services/maintenance.test.ts
+++ b/typescript/test/services/maintenance.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish } from "ethers"
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import {

--- a/typescript/test/services/redemptions.test.ts
+++ b/typescript/test/services/redemptions.test.ts
@@ -28,7 +28,7 @@ import { MockBridge } from "../utils/mock-bridge"
 import * as chai from "chai"
 import { expect } from "chai"
 import chaiAsPromised from "chai-as-promised"
-import { BigNumber, BigNumberish } from "ethers"
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockRedeemerProxy } from "../utils/mock-redeemer-proxy"
 

--- a/typescript/test/services/tbtc-starknet.test.ts
+++ b/typescript/test/services/tbtc-starknet.test.ts
@@ -56,7 +56,7 @@ describe("TBTC - StarkNet Provider Support", () => {
 
     it("should maintain backward compatibility with Ethereum signer", async () => {
       // Arrange - create a mock Ethereum signer
-      const { Wallet } = await import("ethers")
+      const { Wallet } = await import("@ethersproject/wallet")
       const mockEthereumSigner = Wallet.createRandom()
 
       // Act & Assert - should not throw and extract address

--- a/typescript/test/services/tbtc-t003-l2signer.test.ts
+++ b/typescript/test/services/tbtc-t003-l2signer.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { RpcProvider, Account } from "starknet"
-import { Wallet } from "ethers"
+import { Wallet } from "@ethersproject/wallet"
 import { TBTC } from "../../src/services/tbtc"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"

--- a/typescript/test/services/threshold-context-provider-compatibility.test.ts
+++ b/typescript/test/services/threshold-context-provider-compatibility.test.ts
@@ -61,7 +61,7 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
 
     it("should maintain backward compatibility with EthereumSigner", async () => {
       // Import ethers dynamically to avoid dependency issues
-      const { Wallet } = await import("ethers")
+      const { Wallet } = await import("@ethersproject/wallet")
       const ethereumSigner: EthereumSigner = Wallet.createRandom()
 
       // This should still work for backward compatibility
@@ -161,7 +161,7 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
     })
 
     it("should extract address from Ethereum signer for backward compatibility", async () => {
-      const { Wallet } = await import("ethers")
+      const { Wallet } = await import("@ethersproject/wallet")
       const ethereumSigner = Wallet.createRandom()
 
       await expect(tbtc.initializeCrossChain("StarkNet", ethereumSigner)).not.to

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -18,7 +18,9 @@ import {
   BitcoinHashUtils,
   BitcoinTxHash,
 } from "../../src/lib/bitcoin"
-import { BigNumberish, BigNumber, utils, constants } from "ethers"
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber"
+import { AddressZero } from "@ethersproject/constants"
+import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity"
 import { depositSweepWithNoMainUtxoAndWitnessOutput } from "../data/deposit-sweep"
 import { EthereumAddress } from "../../src/lib/ethereum"
 import { Hex } from "../../src/lib/utils"
@@ -148,7 +150,7 @@ export class MockBridge implements Bridge {
           walletPublicKeyHash: deposit.data.walletPublicKeyHash,
           refundPublicKeyHash: deposit.data.refundPublicKeyHash,
           refundLocktime: deposit.data.refundLocktime,
-          vault: EthereumAddress.from(constants.AddressZero),
+          vault: EthereumAddress.from(AddressZero),
         },
       ])
     })
@@ -200,9 +202,9 @@ export class MockBridge implements Bridge {
         this._deposits.has(depositKey)
           ? (this._deposits.get(depositKey) as DepositRequest)
           : {
-              depositor: EthereumAddress.from(constants.AddressZero),
+              depositor: EthereumAddress.from(AddressZero),
               amount: BigNumber.from(0),
-              vault: EthereumAddress.from(constants.AddressZero),
+              vault: EthereumAddress.from(AddressZero),
               revealedAt: 0,
               sweptAt: 0,
               treasuryFee: BigNumber.from(0),
@@ -219,7 +221,7 @@ export class MockBridge implements Bridge {
       .reverse()
       .toPrefixedString()
 
-    return utils.solidityKeccak256(
+    return solidityKeccak256(
       ["bytes32", "uint32"],
       [prefixedReversedDepositTxHash, depositOutputIndex]
     )
@@ -330,7 +332,7 @@ export class MockBridge implements Bridge {
     return redemptionsMap.has(redemptionKey)
       ? (redemptionsMap.get(redemptionKey) as RedemptionRequest)
       : {
-          redeemer: EthereumAddress.from(constants.AddressZero),
+          redeemer: EthereumAddress.from(AddressZero),
           redeemerOutputScript: Hex.from(""),
           requestedAmount: BigNumber.from(0),
           treasuryFee: BigNumber.from(0),
@@ -352,10 +354,10 @@ export class MockBridge implements Bridge {
       rawOutputScript,
     ]).toString("hex")}`
 
-    return utils.solidityKeccak256(
+    return solidityKeccak256(
       ["bytes32", "bytes20"],
       [
-        utils.solidityKeccak256(["bytes"], [prefixedOutputScript]),
+        solidityKeccak256(["bytes"], [prefixedOutputScript]),
         prefixedWalletPublicKeyHash,
       ]
     )
@@ -387,7 +389,7 @@ export class MockBridge implements Bridge {
 
   buildUtxoHash(utxo: BitcoinUtxo): Hex {
     return Hex.from(
-      utils.solidityKeccak256(
+      solidityKeccak256(
         ["bytes32", "uint32", "uint64"],
         [
           utxo.transactionHash.reverse().toPrefixedString(),

--- a/typescript/test/utils/mock-cross-chain.ts
+++ b/typescript/test/utils/mock-cross-chain.ts
@@ -12,7 +12,8 @@ import {
   BitcoinUtxo,
   L2BitcoinRedeemer,
 } from "../../src"
-import { BigNumber, BytesLike } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
+import { BytesLike } from "@ethersproject/bytes"
 
 export class MockDestinationChainTBTCToken
   implements DestinationChainTBTCToken

--- a/typescript/test/utils/mock-tbtc-token.ts
+++ b/typescript/test/utils/mock-tbtc-token.ts
@@ -1,6 +1,6 @@
 import { ChainIdentifier, TBTCToken } from "../../src/lib/contracts"
 import { Hex } from "../../src/lib/utils"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { BitcoinUtxo } from "../../src/lib/bitcoin"
 import { EthereumAddress } from "../../src"
 

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -454,7 +454,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.6.0", "@ethersproject/abi@^5.6.1", "@ethersproject/abi@^5.8.0":
+"@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.5.2", "@ethersproject/abi@^5.6.0", "@ethersproject/abi@^5.6.1", "@ethersproject/abi@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
   integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
@@ -506,7 +506,7 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
 
-"@ethersproject/abstract-signer@5.8.0", "@ethersproject/abstract-signer@^5.6.0", "@ethersproject/abstract-signer@^5.8.0":
+"@ethersproject/abstract-signer@5.8.0", "@ethersproject/abstract-signer@^5.5.2", "@ethersproject/abstract-signer@^5.6.0", "@ethersproject/abstract-signer@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
   integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
@@ -578,7 +578,7 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bignumber@5.8.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.6.0", "@ethersproject/bignumber@^5.8.0":
+"@ethersproject/bignumber@5.8.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.5.2", "@ethersproject/bignumber@^5.6.0", "@ethersproject/bignumber@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
   integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
@@ -594,7 +594,7 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/bytes@5.8.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.6.0", "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.8.0":
+"@ethersproject/bytes@5.8.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.5.2", "@ethersproject/bytes@^5.6.0", "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
   integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
@@ -608,7 +608,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
 
-"@ethersproject/constants@5.8.0", "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.6.0", "@ethersproject/constants@^5.8.0":
+"@ethersproject/constants@5.8.0", "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.5.2", "@ethersproject/constants@^5.6.0", "@ethersproject/constants@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
   integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
@@ -631,7 +631,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
-"@ethersproject/contracts@5.8.0":
+"@ethersproject/contracts@5.8.0", "@ethersproject/contracts@^5.5.2":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.8.0.tgz#243a38a2e4aa3e757215ea64e276f8a8c9d8ed73"
   integrity sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==
@@ -758,7 +758,7 @@
     "@ethersproject/bytes" "^5.6.0"
     js-sha3 "0.8.0"
 
-"@ethersproject/keccak256@5.8.0", "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.6.0", "@ethersproject/keccak256@^5.8.0":
+"@ethersproject/keccak256@5.8.0", "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.5.2", "@ethersproject/keccak256@^5.6.0", "@ethersproject/keccak256@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
   integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
@@ -845,7 +845,7 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/providers@5.8.0", "@ethersproject/providers@^5.6.2", "@ethersproject/providers@^5.7.2":
+"@ethersproject/providers@5.8.0", "@ethersproject/providers@^5.5.2", "@ethersproject/providers@^5.6.2":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.8.0.tgz#6c2ae354f7f96ee150439f7de06236928bc04cb4"
   integrity sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==
@@ -957,7 +957,7 @@
     "@ethersproject/sha2" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/solidity@5.8.0":
+"@ethersproject/solidity@5.8.0", "@ethersproject/solidity@^5.5.2":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.8.0.tgz#429bb9fcf5521307a9448d7358c26b93695379b9"
   integrity sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==
@@ -1056,7 +1056,7 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/wordlists" "^5.6.0"
 
-"@ethersproject/wallet@5.8.0":
+"@ethersproject/wallet@5.8.0", "@ethersproject/wallet@^5.5.2":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.8.0.tgz#49c300d10872e6986d953e8310dc33d440da8127"
   integrity sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==
@@ -2260,9 +2260,9 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@umpirsky/country-list@git://github.com/umpirsky/country-list#05fda51":
+"@umpirsky/country-list@git://github.com/umpirsky/country-list#05fda51", "@umpirsky/country-list@https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7":
   version "1.0.0"
-  resolved "git://github.com/umpirsky/country-list#05fda51cd97b3294e8175ffed06104c44b3c71d7"
+  resolved "https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This increases compatibility of the npm package with other projects that might be using different ethers versions. 

The monolithic `ethers` v5 package should be used in final projects; for libraries and SDKs, it is ill advised because it will cause problems during dependency resolution.

As a note, I had to also add a git resolution in the typescript `package.json` because my yarn setup would fail when fetching it. Feel free to fork this branch and remove that change if it is not suitable for your needs.