### PR TITLE
Deploy V2 Wormhole depositor implementations for Arbitrum and Base

### DIFF
--- a/cross-chain/arbitrum/.openzeppelin/mainnet.json
+++ b/cross-chain/arbitrum/.openzeppelin/mainnet.json
@@ -614,6 +614,311 @@
           }
         }
       }
+    },
+    "320c520de2a07433bc54545720051f7a587bc95c24bf989a67b7797f6cf8d3d2": {
+      "address": "0x82FDDF79765Ed75325bCBdf65F67dF0879AAbe8C",
+      "txHash": "0x52ccc4cd3f32e941f85970088f2fcd3cdca462dc2d93a440f413624f2ba7fa89",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "bridge",
+            "offset": 2,
+            "slot": "0",
+            "type": "t_contract(IBridge)6048",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "tbtcVault",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(ITBTCVault)6080",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "49",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "99",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "100",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "reimbursementPool",
+            "offset": 0,
+            "slot": "149",
+            "type": "t_contract(ReimbursementPool)3280",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "150",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "deposits",
+            "offset": 0,
+            "slot": "199",
+            "type": "t_mapping(t_uint256,t_enum(DepositState)4564)",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "tbtcToken",
+            "offset": 0,
+            "slot": "200",
+            "type": "t_contract(IERC20Upgradeable)3659",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "wormhole",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_contract(IWormhole)5372",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "wormholeRelayer",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_contract(IWormholeRelayer)5412",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "wormholeTokenBridge",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_contract(IWormholeTokenBridge)5497",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "l2WormholeGateway",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "l2ChainId",
+            "offset": 20,
+            "slot": "204",
+            "type": "t_uint16",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "l2BitcoinDepositor",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "l2FinalizeDepositGasLimit",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "gasReimbursements",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_uint256,t_struct(GasReimbursement)4571_storage)",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "initializeDepositGasOffset",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "finalizeDepositGasOffset",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "reimbursementAuthorizations",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          },
+          {
+            "label": "reimburseTxMaxFee",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_bool",
+            "contract": "L1BTCDepositorWormholeV2Arbitrum",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IBridge)6048": {
+            "label": "contract IBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC20Upgradeable)3659": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ITBTCVault)6080": {
+            "label": "contract ITBTCVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormhole)5372": {
+            "label": "contract IWormhole",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeRelayer)5412": {
+            "label": "contract IWormholeRelayer",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)5497": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ReimbursementPool)3280": {
+            "label": "contract ReimbursementPool",
+            "numberOfBytes": "20"
+          },
+          "t_enum(DepositState)4564": {
+            "label": "enum L1BTCDepositorWormholeV2Arbitrum.DepositState",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_enum(DepositState)4564)": {
+            "label": "mapping(uint256 => enum L1BTCDepositorWormholeV2Arbitrum.DepositState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(GasReimbursement)4571_storage)": {
+            "label": "mapping(uint256 => struct L1BTCDepositorWormholeV2Arbitrum.GasReimbursement)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(GasReimbursement)4571_storage": {
+            "label": "struct L1BTCDepositorWormholeV2Arbitrum.GasReimbursement",
+            "numberOfBytes": "32",
+            "members": [
+              {
+                "astId": 4567,
+                "contract": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol:L1BTCDepositorWormholeV2Arbitrum",
+                "label": "receiver",
+                "offset": 0,
+                "slot": "0",
+                "type": "t_address"
+              },
+              {
+                "astId": 4570,
+                "contract": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol:L1BTCDepositorWormholeV2Arbitrum",
+                "label": "gasSpent",
+                "offset": 20,
+                "slot": "0",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
     }
   }
 }

--- a/cross-chain/arbitrum/deploy_l1/01_upgrade_arbitrum_l1_bitcoin_depositor_to_v2.ts
+++ b/cross-chain/arbitrum/deploy_l1/01_upgrade_arbitrum_l1_bitcoin_depositor_to_v2.ts
@@ -13,13 +13,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // `prepareUpgrade` fails with "invalid address" after the implementation is
   // already deployed on-chain.
   const originalFormat = providers.Formatter.prototype.transactionResponse
-  providers.Formatter.prototype.transactionResponse = function (
-    transaction: any
-  ): any {
-    if (transaction.to === "") {
-      transaction.to = null
-    }
-    return originalFormat.call(this, transaction)
+  providers.Formatter.prototype.transactionResponse = function (tx: any): any {
+    const patched = tx.to === "" ? { ...tx, to: null } : tx
+    return originalFormat.call(this, patched)
   }
 
   const { deployer } = await helpers.signers.getNamedSigners()

--- a/cross-chain/arbitrum/deploy_l1/01_upgrade_arbitrum_l1_bitcoin_depositor_to_v2.ts
+++ b/cross-chain/arbitrum/deploy_l1/01_upgrade_arbitrum_l1_bitcoin_depositor_to_v2.ts
@@ -1,12 +1,26 @@
 import type { Artifact, HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction, Deployment } from "hardhat-deploy/types"
-import { ContractFactory } from "ethers"
+import { ContractFactory, providers } from "ethers"
 
-const CONTRACT_NAME = "L1BTCDepositorWormholeV2"
+const CONTRACT_NAME = "L1BTCDepositorWormholeV2Arbitrum"
 const DEPLOYMENT_NAME = "ArbitrumOneL1BitcoinDepositor"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, upgrades, artifacts, run } = hre
+
+  // Patch ethers.js v5 Formatter to handle empty-string `to` field returned by
+  // some RPC providers for contract-creation transactions. Without this patch,
+  // `prepareUpgrade` fails with "invalid address" after the implementation is
+  // already deployed on-chain.
+  const originalFormat = providers.Formatter.prototype.transactionResponse
+  providers.Formatter.prototype.transactionResponse = function (
+    transaction: any
+  ): any {
+    if (transaction.to === "") {
+      transaction.to = null
+    }
+    return originalFormat.call(this, transaction)
+  }
 
   const { deployer } = await helpers.signers.getNamedSigners()
 
@@ -65,6 +79,5 @@ export default func
 
 func.tags = ["UpgradeArbitrumL1BitcoinDepositorToV2"]
 
-// Comment this line when running an upgrade.
-// yarn deploy --tags UpgradeArbitrumL1BitcoinDepositorToV2 --network <network>
-func.skip = async () => false
+// Upgrade deployed on 2026-04-02. Implementation: 0x82FDDF79765Ed75325bCBdf65F67dF0879AAbe8C
+func.skip = async () => true

--- a/cross-chain/arbitrum/deployments/mainnet/ArbitrumOneL1BitcoinDepositor.json
+++ b/cross-chain/arbitrum/deployments/mainnet/ArbitrumOneL1BitcoinDepositor.json
@@ -252,7 +252,7 @@
       "name": "deposits",
       "outputs": [
         {
-          "internalType": "enum L1BTCDepositorWormholeV2.DepositState",
+          "internalType": "enum L1BTCDepositorWormholeV2Arbitrum.DepositState",
           "name": "",
           "type": "uint8"
         }
@@ -796,6 +796,6 @@
     "byzantium": true
   },
   "numDeployments": 2,
-  "implementation": "0x3fFeE7D7bE970201a33d17E318E2421a06Ad69f8",
+  "implementation": "0x82FDDF79765Ed75325bCBdf65F67dF0879AAbe8C",
   "devdoc": "Contract deployed as upgradable proxy"
 }

--- a/cross-chain/arbitrum/hardhat.config.ts
+++ b/cross-chain/arbitrum/hardhat.config.ts
@@ -156,8 +156,8 @@ const config: HardhatUserConfig = {
       sepolia: 0,
       arbitrumGoerli: 0,
       arbitrumSepolia: 0,
-      mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
-      arbitrumOne: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+      mainnet: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
+      arbitrumOne: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
     },
     governance: {
       default: 2,

--- a/cross-chain/arbitrum/test/UpgradeArbitrumL1BitcoinDepositorToV2.test.ts
+++ b/cross-chain/arbitrum/test/UpgradeArbitrumL1BitcoinDepositorToV2.test.ts
@@ -69,8 +69,8 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Deploy Script Structure", () =
 
 describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   const artifactRelativePath = path.join(
-    "L1BTCDepositorWormholeV2.sol",
-    "L1BTCDepositorWormholeV2.json"
+    "L1BTCDepositorWormholeV2Arbitrum.sol",
+    "L1BTCDepositorWormholeV2Arbitrum.json"
   )
   const sourceArtifactPath = path.resolve(
     __dirname,
@@ -103,16 +103,16 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
     )
   })
 
-  it("should resolve the L1BTCDepositorWormholeV2 artifact", () => {
-    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2")
+  it("should resolve the L1BTCDepositorWormholeV2Arbitrum artifact", () => {
+    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
 
-    assert.equal(artifact.contractName, "L1BTCDepositorWormholeV2")
+    assert.equal(artifact.contractName, "L1BTCDepositorWormholeV2Arbitrum")
     assert.isArray(artifact.abi)
     assert.isAbove(artifact.abi.length, 0)
   })
 
   it("should resolve V2 via ethers.getContractFactory without HH700", async () => {
-    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2")
+    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2Arbitrum")
     const initializeFragment = factory.interface.getFunction("initialize")
 
     assert.exists(factory)
@@ -122,7 +122,7 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
 
   requiredAbiFunctions.forEach((fnName) => {
     it(`should include ${fnName} in the resolved artifact ABI`, () => {
-      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2")
+      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
       const functionNames = getFunctionNames(artifact.abi as AbiEntry[])
 
       assert.include(functionNames, fnName)
@@ -130,11 +130,11 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should expose source metadata for the copied V2 artifact", () => {
-    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2")
+    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
 
     assert.equal(
       artifact.sourceName,
-      "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2.sol"
+      "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
     )
     assert.notEqual(artifact.bytecode, "0x")
   })

--- a/cross-chain/arbitrum/test/UpgradeArbitrumL1BitcoinDepositorToV2.test.ts
+++ b/cross-chain/arbitrum/test/UpgradeArbitrumL1BitcoinDepositorToV2.test.ts
@@ -60,10 +60,10 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Deploy Script Structure", () =
     assert.isFunction(func.skip)
   })
 
-  it("should have skip return false by default", async () => {
+  it("should have skip return true after deployment", async () => {
     const shouldSkip = await func.skip!({} as any)
 
-    assert.isFalse(shouldSkip)
+    assert.isTrue(shouldSkip)
   })
 })
 
@@ -104,7 +104,9 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should resolve the L1BTCDepositorWormholeV2Arbitrum artifact", () => {
-    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
+    const artifact = artifacts.readArtifactSync(
+      "L1BTCDepositorWormholeV2Arbitrum"
+    )
 
     assert.equal(artifact.contractName, "L1BTCDepositorWormholeV2Arbitrum")
     assert.isArray(artifact.abi)
@@ -112,7 +114,9 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should resolve V2 via ethers.getContractFactory without HH700", async () => {
-    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2Arbitrum")
+    const factory = await ethers.getContractFactory(
+      "L1BTCDepositorWormholeV2Arbitrum"
+    )
     const initializeFragment = factory.interface.getFunction("initialize")
 
     assert.exists(factory)
@@ -122,7 +126,9 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
 
   requiredAbiFunctions.forEach((fnName) => {
     it(`should include ${fnName} in the resolved artifact ABI`, () => {
-      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
+      const artifact = artifacts.readArtifactSync(
+        "L1BTCDepositorWormholeV2Arbitrum"
+      )
       const functionNames = getFunctionNames(artifact.abi as AbiEntry[])
 
       assert.include(functionNames, fnName)
@@ -130,7 +136,9 @@ describe("UpgradeArbitrumL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should expose source metadata for the copied V2 artifact", () => {
-    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Arbitrum")
+    const artifact = artifacts.readArtifactSync(
+      "L1BTCDepositorWormholeV2Arbitrum"
+    )
 
     assert.equal(
       artifact.sourceName,

--- a/cross-chain/base/.openzeppelin/mainnet.json
+++ b/cross-chain/base/.openzeppelin/mainnet.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": "3.2",
   "admin": {
-    "address": "0x5a165919357eB5854287a0BAd49d703f144B187f"
+    "address": "0x5a165919357Eb5854287a0Bad49D703f144B187f"
   },
   "proxies": [
     {
@@ -296,6 +296,311 @@
               }
             ],
             "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "67eea0fa60cf5623e5477197cd91b709d85a0db5164565177efdf6666ee2bb98": {
+      "address": "0x32aAfccfb865060F7F9fB3766c50134F9228B67E",
+      "txHash": "0xf51c877672e90a362dec53e75483dcff4542855d0504063573e012b97b45dd9d",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "bridge",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IBridge)6000",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "tbtcVault",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(ITBTCVault)6032",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "49",
+            "type": "t_uint8",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "49",
+            "type": "t_bool",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "100",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "reimbursementPool",
+            "offset": 0,
+            "slot": "150",
+            "type": "t_contract(ReimbursementPool)3280",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "deposits",
+            "offset": 0,
+            "slot": "200",
+            "type": "t_mapping(t_uint256,t_enum(DepositState)4516)",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "tbtcToken",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_contract(IERC20Upgradeable)3659",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "wormhole",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_contract(IWormhole)5324",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "wormholeRelayer",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_contract(IWormholeRelayer)5364",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "wormholeTokenBridge",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_contract(IWormholeTokenBridge)5449",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "l2WormholeGateway",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "l2ChainId",
+            "offset": 20,
+            "slot": "205",
+            "type": "t_uint16",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "l2BitcoinDepositor",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_address",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "l2FinalizeDepositGasLimit",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "gasReimbursements",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_uint256,t_struct(GasReimbursement)4523_storage)",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "initializeDepositGasOffset",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "finalizeDepositGasOffset",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_uint256",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "reimbursementAuthorizations",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          },
+          {
+            "label": "reimburseTxMaxFee",
+            "offset": 0,
+            "slot": "212",
+            "type": "t_bool",
+            "contract": "L1BTCDepositorWormholeV2Base",
+            "src": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IBridge)6000": {
+            "label": "contract IBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC20Upgradeable)3659": {
+            "label": "contract IERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ITBTCVault)6032": {
+            "label": "contract ITBTCVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormhole)5324": {
+            "label": "contract IWormhole",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeRelayer)5364": {
+            "label": "contract IWormholeRelayer",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWormholeTokenBridge)5449": {
+            "label": "contract IWormholeTokenBridge",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ReimbursementPool)3280": {
+            "label": "contract ReimbursementPool",
+            "numberOfBytes": "20"
+          },
+          "t_enum(DepositState)4516": {
+            "label": "enum L1BTCDepositorWormholeV2Base.DepositState",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_enum(DepositState)4516)": {
+            "label": "mapping(uint256 => enum L1BTCDepositorWormholeV2Base.DepositState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(GasReimbursement)4523_storage)": {
+            "label": "mapping(uint256 => struct L1BTCDepositorWormholeV2Base.GasReimbursement)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(GasReimbursement)4523_storage": {
+            "label": "struct L1BTCDepositorWormholeV2Base.GasReimbursement",
+            "numberOfBytes": "32",
+            "members": [
+              {
+                "astId": 4519,
+                "contract": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol:L1BTCDepositorWormholeV2Base",
+                "label": "receiver",
+                "offset": 0,
+                "slot": "0",
+                "type": "t_address"
+              },
+              {
+                "astId": 4522,
+                "contract": "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol:L1BTCDepositorWormholeV2Base",
+                "label": "gasSpent",
+                "offset": 20,
+                "slot": "0",
+                "type": "t_uint96"
+              }
+            ]
           },
           "t_uint16": {
             "label": "uint16",

--- a/cross-chain/base/deploy_l1/00_deploy_base_l1_bitcoin_depositor.ts
+++ b/cross-chain/base/deploy_l1/00_deploy_base_l1_bitcoin_depositor.ts
@@ -19,7 +19,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const [, proxyDeployment] = await helpers.upgrades.deployProxy(
     "BaseL1BitcoinDepositor",
     {
-      contractName: "L1BTCDepositorWormholeV2",
+      contractName: "L1BTCDepositorWormholeV2Base",
       initializerArgs: [
         tbtcBridge.address,
         tbtcVault.address,

--- a/cross-chain/base/deploy_l1/02_upgrade_base_l1_bitcoin_depositor_to_v2.ts
+++ b/cross-chain/base/deploy_l1/02_upgrade_base_l1_bitcoin_depositor_to_v2.ts
@@ -13,13 +13,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // `prepareUpgrade` fails with "invalid address" after the implementation is
   // already deployed on-chain.
   const originalFormat = providers.Formatter.prototype.transactionResponse
-  providers.Formatter.prototype.transactionResponse = function (
-    transaction: any
-  ): any {
-    if (transaction.to === "") {
-      transaction.to = null
-    }
-    return originalFormat.call(this, transaction)
+  providers.Formatter.prototype.transactionResponse = function (tx: any): any {
+    const patched = tx.to === "" ? { ...tx, to: null } : tx
+    return originalFormat.call(this, patched)
   }
 
   const { deployer } = await helpers.signers.getNamedSigners()

--- a/cross-chain/base/deploy_l1/02_upgrade_base_l1_bitcoin_depositor_to_v2.ts
+++ b/cross-chain/base/deploy_l1/02_upgrade_base_l1_bitcoin_depositor_to_v2.ts
@@ -1,12 +1,26 @@
 import type { Artifact, HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction, Deployment } from "hardhat-deploy/types"
-import { ContractFactory } from "ethers"
+import { ContractFactory, providers } from "ethers"
 
-const CONTRACT_NAME = "L1BTCDepositorWormholeV2"
+const CONTRACT_NAME = "L1BTCDepositorWormholeV2Base"
 const DEPLOYMENT_NAME = "BaseL1BitcoinDepositor"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, upgrades, artifacts, run } = hre
+
+  // Patch ethers.js v5 Formatter to handle empty-string `to` field returned by
+  // some RPC providers for contract-creation transactions. Without this patch,
+  // `prepareUpgrade` fails with "invalid address" after the implementation is
+  // already deployed on-chain.
+  const originalFormat = providers.Formatter.prototype.transactionResponse
+  providers.Formatter.prototype.transactionResponse = function (
+    transaction: any
+  ): any {
+    if (transaction.to === "") {
+      transaction.to = null
+    }
+    return originalFormat.call(this, transaction)
+  }
 
   const { deployer } = await helpers.signers.getNamedSigners()
 
@@ -65,6 +79,5 @@ export default func
 
 func.tags = ["UpgradeBaseL1BitcoinDepositorToV2"]
 
-// Comment this line when running an upgrade.
-// yarn deploy --tags UpgradeBaseL1BitcoinDepositorToV2 --network <network>
-func.skip = async () => false
+// Upgrade deployed on 2026-04-02. Implementation: 0x32aAfccfb865060F7F9fB3766c50134F9228B67E
+func.skip = async () => true

--- a/cross-chain/base/deployments/mainnet/BaseL1BitcoinDepositor.json
+++ b/cross-chain/base/deployments/mainnet/BaseL1BitcoinDepositor.json
@@ -252,7 +252,7 @@
       "name": "deposits",
       "outputs": [
         {
-          "internalType": "enum L1BTCDepositorWormholeV2.DepositState",
+          "internalType": "enum L1BTCDepositorWormholeV2Base.DepositState",
           "name": "",
           "type": "uint8"
         }
@@ -795,7 +795,7 @@
     "status": 1,
     "byzantium": true
   },
-  "numDeployments": 1,
-  "implementation": "0x59FAE614867b66421b44D1Ed3461e6B6a4B50106",
+  "numDeployments": 2,
+  "implementation": "0x32aAfccfb865060F7F9fB3766c50134F9228B67E",
   "devdoc": "Contract deployed as upgradable proxy"
 }

--- a/cross-chain/base/hardhat.config.ts
+++ b/cross-chain/base/hardhat.config.ts
@@ -184,8 +184,8 @@ const config: HardhatUserConfig = {
       sepolia: 0,
       baseGoerli: 0,
       baseSepolia: 0,
-      mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
-      base: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+      mainnet: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
+      base: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
     },
     governance: {
       default: 2,

--- a/cross-chain/base/test/UpgradeBaseL1BitcoinDepositorToV2.test.ts
+++ b/cross-chain/base/test/UpgradeBaseL1BitcoinDepositorToV2.test.ts
@@ -84,7 +84,9 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should resolve V2 via ethers.getContractFactory without HH700", async () => {
-    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2Base")
+    const factory = await ethers.getContractFactory(
+      "L1BTCDepositorWormholeV2Base"
+    )
     expect(factory).to.not.equal(undefined)
     expect(factory.interface).to.not.equal(undefined)
     expect(factory.interface.functions).to.have.property(
@@ -101,7 +103,9 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
 
   requiredAbiFunctions.forEach((fnName) => {
     it(`should include ${fnName} in the resolved artifact ABI`, () => {
-      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Base")
+      const artifact = artifacts.readArtifactSync(
+        "L1BTCDepositorWormholeV2Base"
+      )
       const functionNames = artifact.abi
         .filter((entry: any) => entry.type === "function")
         .map((entry: any) => entry.name)
@@ -111,8 +115,15 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   })
 
   it("should pass OpenZeppelin prepareUpgrade for a legacy proxy", async () => {
-    const [deployer, bridge, vault, wormhole, wormholeRelayer, tokenBridge, l2Gateway] =
-      await ethers.getSigners()
+    const [
+      deployer,
+      bridge,
+      vault,
+      wormhole,
+      wormholeRelayer,
+      tokenBridge,
+      l2Gateway,
+    ] = await ethers.getSigners()
 
     // Deploy a mock vault contract that implements tbtcToken() so that
     // the legacy L1BitcoinDepositor.initialize() can call it successfully.

--- a/cross-chain/base/test/UpgradeBaseL1BitcoinDepositorToV2.test.ts
+++ b/cross-chain/base/test/UpgradeBaseL1BitcoinDepositorToV2.test.ts
@@ -48,8 +48,8 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Deploy Script Structure", () => {
 
 describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
   const artifactRelativePath = path.join(
-    "L1BTCDepositorWormholeV2.sol",
-    "L1BTCDepositorWormholeV2.json"
+    "L1BTCDepositorWormholeV2Base.sol",
+    "L1BTCDepositorWormholeV2Base.json"
   )
   const sourceArtifactPath = path.resolve(
     __dirname,
@@ -75,16 +75,16 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
     )
   })
 
-  it("should resolve the L1BTCDepositorWormholeV2 artifact", () => {
-    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2")
+  it("should resolve the L1BTCDepositorWormholeV2Base artifact", () => {
+    const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Base")
 
-    expect(artifact.contractName).to.equal("L1BTCDepositorWormholeV2")
+    expect(artifact.contractName).to.equal("L1BTCDepositorWormholeV2Base")
     expect(artifact.abi).to.be.an("array")
     expect(artifact.abi.length).to.be.greaterThan(0)
   })
 
   it("should resolve V2 via ethers.getContractFactory without HH700", async () => {
-    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2")
+    const factory = await ethers.getContractFactory("L1BTCDepositorWormholeV2Base")
     expect(factory).to.not.equal(undefined)
     expect(factory.interface).to.not.equal(undefined)
     expect(factory.interface.functions).to.have.property(
@@ -101,7 +101,7 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
 
   requiredAbiFunctions.forEach((fnName) => {
     it(`should include ${fnName} in the resolved artifact ABI`, () => {
-      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2")
+      const artifact = artifacts.readArtifactSync("L1BTCDepositorWormholeV2Base")
       const functionNames = artifact.abi
         .filter((entry: any) => entry.type === "function")
         .map((entry: any) => entry.name)
@@ -145,7 +145,7 @@ describe("UpgradeBaseL1BitcoinDepositorToV2 - Artifact Resolution", () => {
     await legacyProxy.deployed()
 
     const v2Factory = await ethers.getContractFactory(
-      "L1BTCDepositorWormholeV2",
+      "L1BTCDepositorWormholeV2Base",
       deployer
     )
 

--- a/cross-chain/common/copyWormholeV2Artifact.ts
+++ b/cross-chain/common/copyWormholeV2Artifact.ts
@@ -2,11 +2,11 @@ import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import * as fs from "fs"
 import * as path from "path"
 
-export async function copyWormholeV2Artifact(
+async function copySingleArtifact(
   hre: HardhatRuntimeEnvironment,
-  packageDir: string
+  packageDir: string,
+  contractName: string
 ): Promise<void> {
-  const contractName = "L1BTCDepositorWormholeV2"
   const sourceArtifactDir = path.resolve(
     packageDir,
     `../../solidity/build/contracts/cross-chain/wormhole/${contractName}.sol`
@@ -101,4 +101,14 @@ async function mergeV2ValidationData(
     targetCachePath,
     JSON.stringify(targetData, null, 2)
   )
+}
+
+export async function copyWormholeV2Artifact(
+  hre: HardhatRuntimeEnvironment,
+  packageDir: string
+): Promise<void> {
+  // Arbitrum variant (Initializable first in inheritance, tbtcToken at slot 200)
+  await copySingleArtifact(hre, packageDir, "L1BTCDepositorWormholeV2Arbitrum")
+  // Base variant (Initializable implicit via OwnableUpgradeable, tbtcToken at slot 201)
+  await copySingleArtifact(hre, packageDir, "L1BTCDepositorWormholeV2Base")
 }

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
@@ -29,12 +29,16 @@ import "../../integrator/ITBTCVault.sol";
 import "./Wormhole.sol";
 import "../utils/Crosschain.sol";
 
-/// @title L1BTCDepositorWormholeV2
-/// @notice L1 tBTC depositor that bridges minted tBTC to an L2 chain via
-///         Wormhole `transferTokensWithPayload`. An off-chain relayer monitors
-///         the `TokensTransferredWithPayload` event to fetch the signed VAA
-///         and complete delivery on the destination L2.
-contract L1BTCDepositorWormholeV2 is
+/// @title L1BTCDepositorWormholeV2Arbitrum
+/// @notice Arbitrum-specific variant of the L1 tBTC depositor that bridges
+///         minted tBTC to an L2 chain via Wormhole `transferTokensWithPayload`.
+///         An off-chain relayer monitors the `TokensTransferredWithPayload`
+///         event to fetch the signed VAA and complete delivery on the
+///         destination L2. This variant lists `Initializable` explicitly in
+///         the inheritance, matching the Arbitrum proxy's C3 linearization
+///         where `Initializable` storage is packed into slot 0 with `bridge`.
+///         See `L1BTCDepositorWormholeV2Base` for the Base variant.
+contract L1BTCDepositorWormholeV2Arbitrum is
     Initializable,
     AbstractBTCDepositor,
     OwnableUpgradeable,

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import "@keep-network/random-beacon/contracts/Reimbursable.sol";
+
+import "../../integrator/AbstractBTCDepositor.sol";
+import "../../integrator/IBridge.sol";
+import "../../integrator/ITBTCVault.sol";
+
+import "./Wormhole.sol";
+
+/// @title L1BTCDepositorWormholeV2Base
+/// @notice Base-specific variant of L1BTCDepositorWormholeV2. Functionally
+///         identical to the Arbitrum variant but uses a different inheritance
+///         order: `Initializable` is NOT listed explicitly, matching the
+///         original Base proxy deployment where `Initializable` storage was
+///         placed after `AbstractTBTCDepositor`'s gap (slot 49) instead of
+///         being packed into slot 0. This produces a +1 storage slot offset
+///         from slot 200 onward compared to the Arbitrum variant.
+contract L1BTCDepositorWormholeV2Base is
+    AbstractBTCDepositor,
+    OwnableUpgradeable,
+    Reimbursable
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    // -------------------------------------------------------------------
+    // Types
+    // -------------------------------------------------------------------
+
+    /// @notice Reflects the deposit state:
+    ///         - Unknown deposit has not been initialized yet.
+    ///         - Initialized deposit has been initialized with a call to
+    ///           `initializeDeposit` function and is known to this contract.
+    ///         - Finalized deposit led to tBTC ERC20 minting and was finalized
+    ///           with a call to `finalizeDeposit` function that transferred
+    ///           tBTC ERC20 to the destination chain deposit owner.
+    enum DepositState {
+        Unknown,
+        Initialized,
+        Finalized
+    }
+
+    /// @notice Holds information about a deferred gas reimbursement.
+    struct GasReimbursement {
+        /// @notice Receiver that is supposed to receive the reimbursement.
+        address receiver;
+        /// @notice Gas expenditure that is meant to be reimbursed.
+        uint96 gasSpent;
+    }
+
+    // -------------------------------------------------------------------
+    // Storage variables -- MUST match the deployed proxy's storage layout.
+    // Do NOT reorder, insert, or remove any variable.
+    // -------------------------------------------------------------------
+
+    /// @notice Holds the deposit state, keyed by the deposit key calculated for
+    ///         the individual deposit during the call to `initializeDeposit`
+    ///         function.
+    mapping(uint256 => DepositState) public deposits;
+
+    /// @notice ERC20 L1 tBTC token contract.
+    IERC20Upgradeable public tbtcToken;
+
+    /// @notice `Wormhole` core contract on L1.
+    IWormhole public wormhole;
+
+    /// @notice `WormholeRelayer` contract on L1. Preserved for storage layout
+    ///         compatibility; not used by this implementation.
+    IWormholeRelayer public wormholeRelayer;
+
+    /// @notice Wormhole `TokenBridge` contract on L1.
+    IWormholeTokenBridge public wormholeTokenBridge;
+
+    /// @notice tBTC `L2WormholeGateway` contract on the corresponding L2 chain.
+    address public l2WormholeGateway;
+
+    /// @notice Wormhole chain ID of the corresponding L2 chain.
+    uint16 public l2ChainId;
+
+    /// @notice tBTC depositor contract on the corresponding L2 chain.
+    address public l2BitcoinDepositor;
+
+    /// @notice Gas limit field preserved for storage layout compatibility;
+    ///         not used by this implementation.
+    uint256 public l2FinalizeDepositGasLimit;
+
+    /// @notice Holds deferred gas reimbursements for deposit initialization
+    ///         (indexed by deposit key). Reimbursement for deposit
+    ///         initialization is paid out upon deposit finalization.
+    mapping(uint256 => GasReimbursement) public gasReimbursements;
+
+    /// @notice Gas that is meant to balance the overall cost of deposit
+    ///         initialization. Can be updated by the owner based on the
+    ///         current market conditions.
+    uint256 public initializeDepositGasOffset;
+
+    /// @notice Gas that is meant to balance the overall cost of deposit
+    ///         finalization. Can be updated by the owner based on the
+    ///         current market conditions.
+    uint256 public finalizeDepositGasOffset;
+
+    /// @notice Set of addresses that are authorized to receive gas
+    ///         reimbursements for deposit initialization and finalization.
+    mapping(address => bool) public reimbursementAuthorizations;
+
+    /// @notice Feature flag controlling whether the deposit transaction max fee
+    ///         is reimbursed (added to the user's tBTC) or deducted.
+    ///         - `true`  => Add `txMaxFee` to the minted tBTC amount
+    ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount
+    bool public reimburseTxMaxFee;
+
+    // -------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------
+
+    event DepositInitialized(
+        uint256 indexed depositKey,
+        bytes32 indexed destinationChainDepositOwner,
+        address indexed l1Sender
+    );
+
+    event DepositFinalized(
+        uint256 indexed depositKey,
+        bytes32 indexed destinationChainDepositOwner,
+        address indexed l1Sender,
+        uint256 initialAmount,
+        uint256 tbtcAmount
+    );
+
+    event GasOffsetParametersUpdated(
+        uint256 initializeDepositGasOffset,
+        uint256 finalizeDepositGasOffset
+    );
+
+    event ReimbursementAuthorizationUpdated(
+        address indexed _address,
+        bool authorization
+    );
+
+    event ReimburseTxMaxFeeUpdated(bool reimburseTxMaxFee);
+
+    /// @notice Emitted when the gas limit field is updated by the owner.
+    ///         Preserved for backward compatibility.
+    event L2FinalizeDepositGasLimitUpdated(uint256 l2FinalizeDepositGasLimit);
+
+    /// @notice Emitted when tBTC tokens are transferred via Wormhole
+    ///         `transferTokensWithPayload`. Off-chain relayers monitor this
+    ///         event to discover the transfer VAA and complete the bridging
+    ///         on the destination L2 chain.
+    event TokensTransferredWithPayload(
+        uint256 amount,
+        address l2Receiver,
+        uint64 transferSequence
+    );
+
+    // -------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------
+
+    /// @dev Restricts `updateReimbursementPool` in Reimbursable to the owner.
+    modifier onlyReimbursableAdmin() override {
+        require(msg.sender == owner(), "Caller is not the owner");
+        _;
+    }
+
+    // -------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    // -------------------------------------------------------------------
+    // Initializer
+    // -------------------------------------------------------------------
+
+    /// @dev Intended for fresh proxy deployments (e.g. tests). Existing
+    ///      proxies are already initialized; the `initializer` modifier
+    ///      prevents re-initialization.
+    function initialize(
+        address _tbtcBridge,
+        address _tbtcVault,
+        address _wormhole,
+        address _wormholeRelayer,
+        address _wormholeTokenBridge,
+        address _l2WormholeGateway,
+        uint16 _l2ChainId
+    ) external initializer {
+        __AbstractBTCDepositor_initialize(_tbtcBridge, _tbtcVault);
+        __Ownable_init();
+
+        tbtcToken = IERC20Upgradeable(ITBTCVault(_tbtcVault).tbtcToken());
+
+        initializeDepositGasOffset = 60_000;
+        finalizeDepositGasOffset = 20_000;
+        reimburseTxMaxFee = false;
+
+        require(_wormhole != address(0), "Wormhole address cannot be zero");
+        require(
+            _wormholeRelayer != address(0),
+            "WormholeRelayer address cannot be zero"
+        );
+        require(
+            _wormholeTokenBridge != address(0),
+            "WormholeTokenBridge address cannot be zero"
+        );
+        require(
+            _l2WormholeGateway != address(0),
+            "L2WormholeGateway address cannot be zero"
+        );
+
+        wormhole = IWormhole(_wormhole);
+        wormholeRelayer = IWormholeRelayer(_wormholeRelayer);
+        wormholeTokenBridge = IWormholeTokenBridge(_wormholeTokenBridge);
+        // slither-disable-next-line missing-zero-check
+        l2WormholeGateway = _l2WormholeGateway;
+        l2ChainId = _l2ChainId;
+        l2FinalizeDepositGasLimit = 500_000;
+    }
+
+    // -------------------------------------------------------------------
+    // Admin functions
+    // -------------------------------------------------------------------
+
+    /// @notice Updates the values of gas offset parameters.
+    /// @dev Can be called only by the contract owner. The caller is responsible
+    ///      for validating parameters.
+    /// @param _initializeDepositGasOffset New initialize deposit gas offset.
+    /// @param _finalizeDepositGasOffset New finalize deposit gas offset.
+    function updateGasOffsetParameters(
+        uint256 _initializeDepositGasOffset,
+        uint256 _finalizeDepositGasOffset
+    ) external onlyOwner {
+        initializeDepositGasOffset = _initializeDepositGasOffset;
+        finalizeDepositGasOffset = _finalizeDepositGasOffset;
+
+        emit GasOffsetParametersUpdated(
+            _initializeDepositGasOffset,
+            _finalizeDepositGasOffset
+        );
+    }
+
+    /// @notice Updates the reimbursement authorization for the given address.
+    /// @param _address Address to update the authorization for.
+    /// @param authorization New authorization status.
+    /// @dev Requirements:
+    ///      - Can be called only by the contract owner.
+    function updateReimbursementAuthorization(
+        address _address,
+        bool authorization
+    ) external onlyOwner {
+        emit ReimbursementAuthorizationUpdated(_address, authorization);
+        reimbursementAuthorizations[_address] = authorization;
+    }
+
+    /// @notice Toggles whether the deposit transaction max fee is reimbursed
+    ///         or deducted. Only callable by the contract owner.
+    /// @param _reimburseTxMaxFee `true` => reimburse (add) the deposit tx max fee,
+    ///                        `false` => deduct the deposit tx max fee.
+    function setReimburseTxMaxFee(bool _reimburseTxMaxFee) external onlyOwner {
+        reimburseTxMaxFee = _reimburseTxMaxFee;
+        emit ReimburseTxMaxFeeUpdated(_reimburseTxMaxFee);
+    }
+
+    /// @notice Sets the address of the tBTC depositor contract on the
+    ///         corresponding L2 chain. This function solves the chicken-and-egg
+    ///         problem of setting the depositor contract address on both chains.
+    /// @param _l2BitcoinDepositor Address of the L2 depositor contract.
+    /// @dev Requirements:
+    ///      - Can be called only by the contract owner,
+    ///      - The address must not be set yet,
+    ///      - The new address must not be 0x0.
+    function attachL2BitcoinDepositor(address _l2BitcoinDepositor)
+        external
+        onlyOwner
+    {
+        require(
+            l2BitcoinDepositor == address(0),
+            "L2 Bitcoin Depositor already set"
+        );
+        require(
+            _l2BitcoinDepositor != address(0),
+            "L2 Bitcoin Depositor must not be 0x0"
+        );
+        l2BitcoinDepositor = _l2BitcoinDepositor;
+    }
+
+    /// @notice Updates the gas limit field. Preserved for backward
+    ///         compatibility; not used by this implementation.
+    /// @param _l2FinalizeDepositGasLimit New gas limit.
+    /// @dev Requirements:
+    ///      - Can be called only by the contract owner.
+    function updateL2FinalizeDepositGasLimit(uint256 _l2FinalizeDepositGasLimit)
+        external
+        onlyOwner
+    {
+        l2FinalizeDepositGasLimit = _l2FinalizeDepositGasLimit;
+        emit L2FinalizeDepositGasLimitUpdated(_l2FinalizeDepositGasLimit);
+    }
+
+    // -------------------------------------------------------------------
+    // Deposit lifecycle
+    // -------------------------------------------------------------------
+
+    /// @notice Initializes the deposit process on L1 by revealing the deposit
+    ///         data (funding transaction and components of the P2(W)SH deposit
+    ///         address) to the tBTC Bridge.
+    /// @param fundingTx Bitcoin funding transaction data.
+    /// @param reveal Deposit reveal data.
+    /// @param destinationChainDepositOwner Address of the destination chain
+    ///        deposit owner in Bytes32 format.
+    /// @dev Requirements:
+    ///      - The destination chain deposit owner address must not be 0x0,
+    ///      - The function can be called only one time for the given Bitcoin
+    ///        funding transaction,
+    ///      - All the requirements of tBTC Bridge.revealDepositWithExtraData
+    ///        must be met.
+    function initializeDeposit(
+        IBridgeTypes.BitcoinTxInfo calldata fundingTx,
+        IBridgeTypes.DepositRevealInfo calldata reveal,
+        bytes32 destinationChainDepositOwner
+    ) external {
+        uint256 gasStart = gasleft();
+
+        require(
+            destinationChainDepositOwner != bytes32(0),
+            "L2 deposit owner must not be 0x0"
+        );
+
+        (uint256 depositKey, ) = _initializeDeposit(
+            fundingTx,
+            reveal,
+            destinationChainDepositOwner
+        );
+
+        require(
+            deposits[depositKey] == DepositState.Unknown,
+            "Wrong deposit state"
+        );
+
+        // slither-disable-next-line reentrancy-benign
+        deposits[depositKey] = DepositState.Initialized;
+
+        // slither-disable-next-line reentrancy-events
+        emit DepositInitialized(
+            depositKey,
+            destinationChainDepositOwner,
+            msg.sender
+        );
+
+        // Record a deferred gas reimbursement if the reimbursement pool is
+        // attached and the caller is authorized to receive reimbursements.
+        if (
+            address(reimbursementPool) != address(0) &&
+            reimbursementAuthorizations[msg.sender]
+        ) {
+            uint256 gasSpent = (gasStart - gasleft()) +
+                initializeDepositGasOffset;
+
+            // Should not happen as long as initializeDepositGasOffset is
+            // set to a reasonable value. If it happens, it's better to
+            // omit the reimbursement than to revert the transaction.
+            if (gasSpent > type(uint96).max) {
+                return;
+            }
+
+            // slither-disable-next-line reentrancy-benign
+            gasReimbursements[depositKey] = GasReimbursement({
+                receiver: msg.sender,
+                gasSpent: uint96(gasSpent)
+            });
+        }
+    }
+
+    /// @notice Finalizes the deposit process by transferring ERC20 L1 tBTC
+    ///         to the destination chain deposit owner.
+    /// @param depositKey The deposit key, as emitted in the `DepositInitialized`
+    ///        event emitted by the `initializeDeposit` function for the deposit.
+    /// @dev Requirements:
+    ///      - `initializeDeposit` was called for the given deposit before,
+    ///      - ERC20 L1 tBTC was minted by tBTC Bridge to this contract,
+    ///      - The function was not called for the given deposit before,
+    ///      - The call must carry a payment equal to `quoteFinalizeDeposit`.
+    function finalizeDeposit(uint256 depositKey) external payable {
+        uint256 gasStart = gasleft();
+
+        require(
+            deposits[depositKey] == DepositState.Initialized,
+            "Wrong deposit state"
+        );
+
+        deposits[depositKey] = DepositState.Finalized;
+
+        (
+            uint256 initialDepositAmount,
+            uint256 tbtcAmount,
+            bytes32 destinationChainDepositOwner
+        ) = _finalizeDeposit(depositKey);
+
+        // Reimburse or deduct the deposit transaction max fee.
+        if (reimburseTxMaxFee) {
+            (, , uint64 depositTxMaxFee, ) = bridge.depositParameters();
+            uint256 txMaxFee = depositTxMaxFee * SATOSHI_MULTIPLIER;
+            tbtcAmount += txMaxFee;
+        }
+
+        // slither-disable-next-line reentrancy-events
+        emit DepositFinalized(
+            depositKey,
+            destinationChainDepositOwner,
+            msg.sender,
+            initialDepositAmount,
+            tbtcAmount
+        );
+
+        _transferTbtc(tbtcAmount, destinationChainDepositOwner);
+
+        // `ReimbursementPool` calls the untrusted receiver address using a
+        // low-level call. Reentrancy risk is mitigated by making sure that
+        // `ReimbursementPool.refund` is a non-reentrant function and executing
+        // reimbursements as the last step of the deposit finalization.
+        if (address(reimbursementPool) != address(0)) {
+            GasReimbursement memory reimbursement = gasReimbursements[
+                depositKey
+            ];
+            if (reimbursement.receiver != address(0)) {
+                // slither-disable-next-line reentrancy-benign
+                delete gasReimbursements[depositKey];
+
+                reimbursementPool.refund(
+                    reimbursement.gasSpent,
+                    reimbursement.receiver
+                );
+            }
+
+            if (reimbursementAuthorizations[msg.sender]) {
+                uint256 msgValueOffset = _refundToGasSpent(msg.value);
+                reimbursementPool.refund(
+                    (gasStart - gasleft()) +
+                        msgValueOffset +
+                        finalizeDepositGasOffset,
+                    msg.sender
+                );
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // View functions
+    // -------------------------------------------------------------------
+
+    /// @notice Quotes the payment that must be attached to the `finalizeDeposit`
+    ///         function call. Only the Wormhole core message fee is required.
+    /// @return cost The cost of the `finalizeDeposit` function call in WEI.
+    function quoteFinalizeDeposit() external view returns (uint256 cost) {
+        cost = wormhole.messageFee();
+    }
+
+    // -------------------------------------------------------------------
+    // Internal functions
+    // -------------------------------------------------------------------
+
+    /// @notice The `ReimbursementPool` contract issues refunds based on
+    ///         gas spent. If there is a need to get a specific refund based
+    ///         on WEI value, such a value must be first converted to gas spent.
+    /// @param refund Refund value in WEI.
+    /// @return Refund value as gas spent.
+    function _refundToGasSpent(uint256 refund)
+        internal
+        virtual
+        returns (uint256)
+    {
+        uint256 maxGasPrice = reimbursementPool.maxGasPrice();
+        uint256 staticGas = reimbursementPool.staticGas();
+
+        uint256 gasPrice = tx.gasprice < maxGasPrice
+            ? tx.gasprice
+            : maxGasPrice;
+
+        if (gasPrice == 0) {
+            return 0;
+        }
+
+        uint256 gasSpent = (refund / gasPrice);
+
+        if (staticGas > gasSpent) {
+            return 0;
+        }
+
+        return gasSpent - staticGas;
+    }
+
+    /// @notice Transfers ERC20 L1 tBTC to the L2 deposit owner using the
+    ///         Wormhole protocol. The function initiates a Wormhole token
+    ///         transfer that locks the ERC20 L1 tBTC within the Wormhole
+    ///         Token Bridge contract and assigns Wormhole-wrapped L2 tBTC to
+    ///         the corresponding `L2WormholeGateway` contract.
+    /// @param amount Amount of tBTC L1 ERC20 to transfer (1e18 precision).
+    /// @param l2Receiver Address of the L2 deposit owner.
+    function _transferTbtc(uint256 amount, bytes32 l2Receiver) internal {
+        // Wormhole supports the 1e8 precision at most. tBTC is 1e18 so
+        // the amount needs to be normalized.
+        amount = WormholeUtils.normalize(amount);
+
+        require(amount > 0, "Amount too low to bridge");
+
+        uint256 wormholeMessageFee = wormhole.messageFee();
+        require(
+            msg.value == wormholeMessageFee,
+            "msg.value must equal wormhole.messageFee()"
+        );
+
+        // The Wormhole Token Bridge will pull the tBTC amount
+        // from this contract. We need to approve the transfer first.
+        tbtcToken.safeIncreaseAllowance(address(wormholeTokenBridge), amount);
+
+        // Initiate a Wormhole token transfer that will lock L1 tBTC within
+        // the Wormhole Token Bridge contract and assign Wormhole-wrapped
+        // L2 tBTC to the corresponding `L2WormholeGateway` contract.
+        // slither-disable-next-line arbitrary-send-eth
+        uint64 transferSequence = wormholeTokenBridge.transferTokensWithPayload{
+            value: wormholeMessageFee
+        }(
+            address(tbtcToken),
+            amount,
+            l2ChainId,
+            WormholeUtils.toWormholeAddress(l2WormholeGateway),
+            0, // Nonce is a free field that is not relevant in this context.
+            abi.encode(l2Receiver) // Set the L2 receiver address as the transfer payload.
+        );
+
+        // slither-disable-next-line reentrancy-events
+        emit TokensTransferredWithPayload(
+            amount,
+            address(uint160(uint256(l2Receiver))),
+            transferSequence
+        );
+    }
+}

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
@@ -13,7 +13,7 @@ import {
   IWormhole,
   IWormholeRelayer,
   IWormholeTokenBridge,
-  L1BTCDepositorWormholeV2,
+  L1BTCDepositorWormholeV2Arbitrum,
   ReimbursementPool,
   TestERC20,
 } from "../../../typechain"
@@ -88,7 +88,7 @@ async function getV2StorageLayout(): Promise<
   const debugArtifactPath = path.resolve(
     __dirname,
     "../../../build/contracts/cross-chain/wormhole/" +
-      "L1BTCDepositorWormholeV2.sol/L1BTCDepositorWormholeV2.dbg.json"
+      "L1BTCDepositorWormholeV2Arbitrum.sol/L1BTCDepositorWormholeV2Arbitrum.dbg.json"
   )
   const debugArtifact = parseJson<{ buildInfo: string }>(
     await fs.promises.readFile(debugArtifactPath, "utf8"),
@@ -104,12 +104,12 @@ async function getV2StorageLayout(): Promise<
   )
   const layout =
     buildInfo?.output?.contracts?.[
-      "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2.sol"
-    ]?.L1BTCDepositorWormholeV2?.storageLayout
+      "contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol"
+    ]?.L1BTCDepositorWormholeV2Arbitrum?.storageLayout
 
   if (!layout?.storage) {
     throw new Error(
-      "storageLayout not found for L1BTCDepositorWormholeV2. " +
+      "storageLayout not found for L1BTCDepositorWormholeV2Arbitrum. " +
         "Run `yarn build` first."
     )
   }
@@ -117,7 +117,7 @@ async function getV2StorageLayout(): Promise<
   return layout.storage
 }
 
-describe("L1BTCDepositorWormholeV2", () => {
+describe("L1BTCDepositorWormholeV2Arbitrum", () => {
   const contractsFixture = async () => {
     const { deployer, governance } = await helpers.signers.getNamedSigners()
 
@@ -151,9 +151,9 @@ describe("L1BTCDepositorWormholeV2", () => {
     )
 
     const deployment = await helpers.upgrades.deployProxy(
-      `L1BTCDepositorWormholeV2_${randomBytes(8).toString("hex")}`,
+      `L1BTCDepositorWormholeV2Arbitrum_${randomBytes(8).toString("hex")}`,
       {
-        contractName: "L1BTCDepositorWormholeV2",
+        contractName: "L1BTCDepositorWormholeV2Arbitrum",
         initializerArgs: [
           bridge.address,
           tbtcVault.address,
@@ -169,7 +169,7 @@ describe("L1BTCDepositorWormholeV2", () => {
         },
       }
     )
-    const l1BtcDepositor = deployment[0] as L1BTCDepositorWormholeV2
+    const l1BtcDepositor = deployment[0] as L1BTCDepositorWormholeV2Arbitrum
 
     await l1BtcDepositor.connect(deployer).transferOwnership(governance.address)
 
@@ -201,7 +201,7 @@ describe("L1BTCDepositorWormholeV2", () => {
   let l2WormholeGateway: FakeContract<IWormholeGateway>
   let l2BitcoinDepositor: string
   let reimbursementPool: FakeContract<ReimbursementPool>
-  let l1BtcDepositor: L1BTCDepositorWormholeV2
+  let l1BtcDepositor: L1BTCDepositorWormholeV2Arbitrum
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -468,7 +468,7 @@ describe("L1BTCDepositorWormholeV2", () => {
       // should leave it in a state where initialize() cannot be called.
       const { deployer } = await helpers.signers.getNamedSigners()
       const factory = await ethers.getContractFactory(
-        "L1BTCDepositorWormholeV2",
+        "L1BTCDepositorWormholeV2Arbitrum",
         deployer
       )
       const impl = await factory.deploy()
@@ -808,11 +808,11 @@ describe("L1BTCDepositorWormholeV2", () => {
       try {
         const { deployer } = await helpers.signers.getNamedSigners()
 
-        const proxyName = `L1BTCDepositorWormholeV2_prepare_${randomBytes(
+        const proxyName = `L1BTCDepositorWormholeV2Arbitrum_prepare_${randomBytes(
           8
         ).toString("hex")}`
         const v2Deployment = await helpers.upgrades.deployProxy(proxyName, {
-          contractName: "L1BTCDepositorWormholeV2",
+          contractName: "L1BTCDepositorWormholeV2Arbitrum",
           initializerArgs: [
             bridge.address,
             tbtcVault.address,
@@ -828,9 +828,9 @@ describe("L1BTCDepositorWormholeV2", () => {
           },
         })
 
-        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2
+        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2Arbitrum
         const v2Factory = await ethers.getContractFactory(
-          "L1BTCDepositorWormholeV2",
+          "L1BTCDepositorWormholeV2Arbitrum",
           deployer
         )
 
@@ -875,11 +875,11 @@ describe("L1BTCDepositorWormholeV2", () => {
         const { deployer } = await helpers.signers.getNamedSigners()
 
         // Deploy V2 behind a fresh transparent proxy.
-        const proxyName = `L1BTCDepositorWormholeV2_upgrade_${randomBytes(
+        const proxyName = `L1BTCDepositorWormholeV2Arbitrum_upgrade_${randomBytes(
           8
         ).toString("hex")}`
         const v2Deployment = await helpers.upgrades.deployProxy(proxyName, {
-          contractName: "L1BTCDepositorWormholeV2",
+          contractName: "L1BTCDepositorWormholeV2Arbitrum",
           initializerArgs: [
             bridge.address,
             tbtcVault.address,
@@ -894,7 +894,7 @@ describe("L1BTCDepositorWormholeV2", () => {
             kind: "transparent",
           },
         })
-        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2
+        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2Arbitrum
 
         // Verify proxy reads all initialized state correctly.
         expect(await proxy.wormhole()).to.equal(wormhole.address)
@@ -914,7 +914,7 @@ describe("L1BTCDepositorWormholeV2", () => {
         const ownerSigner = await ethers.getSigner(proxyAdminOwner)
 
         const v2Factory = await ethers.getContractFactory(
-          "L1BTCDepositorWormholeV2",
+          "L1BTCDepositorWormholeV2Arbitrum",
           deployer
         )
         const v2Impl = await v2Factory.deploy()
@@ -927,9 +927,9 @@ describe("L1BTCDepositorWormholeV2", () => {
         // After V2-to-V2 upgrade, all state should be preserved since the
         // storage layout is identical.
         const upgraded = (await ethers.getContractAt(
-          "L1BTCDepositorWormholeV2",
+          "L1BTCDepositorWormholeV2Arbitrum",
           proxy.address
-        )) as L1BTCDepositorWormholeV2
+        )) as L1BTCDepositorWormholeV2Arbitrum
 
         expect(await upgraded.wormhole()).to.equal(wormhole.address)
         expect(await upgraded.wormholeRelayer()).to.equal(
@@ -957,11 +957,11 @@ describe("L1BTCDepositorWormholeV2", () => {
         const depositorAddr = "0xeE6F5f69860f310114185677D017576aed0dEC83"
 
         // Deploy V2 behind proxy and populate state.
-        const proxyName = `L1BTCDepositorWormholeV2_state_${randomBytes(
+        const proxyName = `L1BTCDepositorWormholeV2Arbitrum_state_${randomBytes(
           8
         ).toString("hex")}`
         const v2Deployment = await helpers.upgrades.deployProxy(proxyName, {
-          contractName: "L1BTCDepositorWormholeV2",
+          contractName: "L1BTCDepositorWormholeV2Arbitrum",
           initializerArgs: [
             bridge.address,
             tbtcVault.address,
@@ -976,7 +976,7 @@ describe("L1BTCDepositorWormholeV2", () => {
             kind: "transparent",
           },
         })
-        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2
+        const proxy = v2Deployment[0] as L1BTCDepositorWormholeV2Arbitrum
         await proxy.connect(deployer).transferOwnership(gov.address)
 
         // Set additional state on V2.
@@ -991,7 +991,7 @@ describe("L1BTCDepositorWormholeV2", () => {
         const ownerSigner = await ethers.getSigner(proxyAdminOwner)
 
         const v2Factory = await ethers.getContractFactory(
-          "L1BTCDepositorWormholeV2",
+          "L1BTCDepositorWormholeV2Arbitrum",
           deployer
         )
         const v2Impl = await v2Factory.deploy()
@@ -1002,9 +1002,9 @@ describe("L1BTCDepositorWormholeV2", () => {
           .upgrade(proxy.address, v2Impl.address)
 
         const upgraded = (await ethers.getContractAt(
-          "L1BTCDepositorWormholeV2",
+          "L1BTCDepositorWormholeV2Arbitrum",
           proxy.address
-        )) as L1BTCDepositorWormholeV2
+        )) as L1BTCDepositorWormholeV2Arbitrum
 
         // All V2 state (including fields from flattened AbstractL1BTCDepositor
         // logic) should be preserved across the upgrade.


### PR DESCRIPTION
## Context

Wormhole shut down their Standard Relaying service on April 1, 2026. The `L1BitcoinDepositor` contracts on Arbitrum and Base rely on `wormholeRelayer.sendVaasToEvm()` to deliver tBTC to L2 after deposit finalization — this path no longer works.

The fix replaces the on-chain Wormhole Relayer dependency with our off-chain tBTC cross-chain relayer, which already handles VAA delivery for SUI deposits. The new V2 contracts use `wormholeTokenBridge.transferTokensWithPayload()` to lock tBTC and emit a `TokensTransferredWithPayload` event. The relayer monitors this event, fetches the signed VAA from WormholeScan, and calls `receiveTbtc()` on the L2 WormholeGateway to complete delivery.

## Solution

Two chain-specific V2 implementation contracts replace the current `L1BitcoinDepositor`:

- **`L1BTCDepositorWormholeV2Arbitrum`** — for the Arbitrum proxy
- **`L1BTCDepositorWormholeV2Base`** — for the Base proxy

Two variants are required because the Arbitrum and Base proxies were originally deployed with different C3 linearization orders, producing a 1-slot storage offset from slot 200 onward. Both variants are functionally identical — same logic, same function signatures, same events. The only difference is the inheritance declaration that controls storage layout compatibility.

### What changed

- `sendVaasToEvm()` (Wormhole Standard Relaying) → `transferTokensWithPayload()` (Token Bridge direct)
- `initializeDeposit` third parameter: `address` → `bytes32` (matches relayer and SUI contract pattern)
- New `TokensTransferredWithPayload(uint256, address, uint64)` event for relayer to discover VAAs
- `quoteFinalizeDeposit()` returns `wormhole.messageFee()` instead of relayer delivery price
- `wormholeRelayer` and `l2FinalizeDepositGasLimit` storage slots preserved but unused

### What didn't change

- Storage layout (24 slots each, matching their respective proxies)
- All admin functions (`updateGasOffsetParameters`, `setReimburseTxMaxFee`, etc.)
- `finalizeDeposit(uint256)` signature and payability
- Gas reimbursement logic
- `reimburseTxMaxFee` feature flag (already `true` on both chains, persists through upgrade)

## Deployments

All implementations deployed on Ethereum mainnet and verified on Etherscan.

### Implementations

| Chain | Contract | Address | Etherscan | Bytecode |
|---|---|---|---|---|
| Arbitrum | `L1BTCDepositorWormholeV2Arbitrum` | `0x82FDDF79765Ed75325bCBdf65F67dF0879AAbe8C` | [Verified](https://etherscan.io/address/0x82fddf79765ed75325bcbdf65f67df0879aabe8c#code) | 11,734 bytes |
| Base | `L1BTCDepositorWormholeV2Base` | `0x32aAfccfb865060F7F9fB3766c50134F9228B67E` | [Verified](https://etherscan.io/address/0x32aafccfb865060f7f9fb3766c50134f9228b67e#code) | 11,671 bytes |

### Proxies (unchanged)

| Chain | Proxy | Current Impl | ProxyAdmin |
|---|---|---|---|
| Arbitrum | `0x75A6e4A7C8fAa162192FAD6C1F7A6d48992c619A` | `0x3fFeE7D7bE970201a33d17E318E2421a06Ad69f8` | `0x37169570D846Cc05D5848AAA30194d308b355638` |
| Base | `0x186D048097c7406C64EfB0537886E3CaE100a1fe` | `0x59FAE614867b66421b44D1Ed3461e6B6a4B50106` | `0x5a165919357Eb5854287a0Bad49D703f144B187f` |

### Governance

| Item | Value |
|---|---|
| TimelockController | `0x92f2d8b72a7F6a551Be60b9aa4194248E9B4913D` |
| Council Safe (proposer) | `0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f` |
| Timelock delay | 86,400 seconds (24 hours) |
| Deployer | `0x716089154304f22a2F9c8d2f8C45815183BF3532` |

### Storage Layout

| Variable | Arbitrum Slot | Base Slot | Note |
|---|---|---|---|
| `_initialized` | 0 (packed) | 49 | C3 linearization difference |
| `bridge` | 0 (packed) | 0 | |
| `tbtcVault` | 1 | 1 | |
| `_owner` | 99 | 100 | +1 offset |
| `reimbursementPool` | 149 | 150 | +1 offset |
| `deposits` | 199 | 200 | +1 offset |
| `tbtcToken` | 200 | 201 | +1 offset |
| `reimburseTxMaxFee` | 211 | 212 | +1 offset, both `true` |

### Function Selectors

| Function | Selector | Changed? |
|---|---|---|
| `initializeDeposit(…, bytes32)` | `0x6da5658a` | Yes (was `address` → `bytes32`) |
| `finalizeDeposit(uint256)` | `0x46d9d49a` | No |
| `quoteFinalizeDeposit()` | `0x13b38cce` | No |
| All other functions | — | No |

## Companion PR

- tbtc-crosschain-relayer PR #51: Relayer EVM manual VAA pipeline (merged and deployed)

## Test plan

- [x] `yarn build` passes in `solidity/`
- [x] 41 unit tests pass (`yarn test --grep L1BTCDepositorWormholeV2`)
- [x] Storage layout validated slot-by-slot against on-chain state for both chains
- [x] Both upgrade simulations succeed (`cast call ProxyAdmin.upgrade --from timelock` returns `0x`)
- [x] Relayer function signatures verified matching V2 ABI
- [x] `reimburseTxMaxFee` confirmed `true` on both chains, persists through upgrade
- [ ] Council submits timelock `schedule()` for both chains
- [ ] After 24h, `execute()` upgrades both proxies
- [ ] Post-upgrade: verify `initializeDeposit` works via relayer on both chains