### PR TITLE
fix(deploy): TOB-TBTCAC-45: enforce strict library bytecode verification

### DIFF
--- a/solidity/deploy/80_upgrade_bridge_v2.ts
+++ b/solidity/deploy/80_upgrade_bridge_v2.ts
@@ -100,7 +100,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   // Verify on-chain library bytecodes match compiled artifacts.
-  await verifyLibraryBytecodes(hre, libraryAddresses)
+  // strict=true: abort the upgrade if any library has a bytecode mismatch
+  // or missing on-chain code (TOB-TBTCAC-45).
+  await verifyLibraryBytecodes(hre, libraryAddresses, /* strict */ true)
 
   const [bridge, proxyDeployment] = await helpers.upgrades.upgradeProxy(
     "Bridge",

--- a/solidity/deploy/utils/library-resolution.ts
+++ b/solidity/deploy/utils/library-resolution.ts
@@ -37,7 +37,7 @@ export async function resolveLibrary(
 export async function verifyLibraryBytecodes(
   hre: HardhatRuntimeEnvironment,
   libs: Record<string, string>,
-  strict = false
+  strict = true
 ): Promise<void> {
   const { deployments, ethers } = hre
   for (const [name, address] of Object.entries(libs)) {


### PR DESCRIPTION
## Summary

- Changes `verifyLibraryBytecodes()` default from `strict=false` to `strict=true` so bytecode mismatches abort instead of logging warnings
- Passes `strict=true` explicitly in `80_upgrade_bridge_v2.ts` to make intent clear
- Prevents Bridge proxy upgrades from proceeding with unreviewed or modified external libraries (Deposit, DepositSweep, Redemption, Wallets, Fraud, MovingFunds)

## Context

Trail of Bits finding **TOB-TBTCAC-45**: "Non-fatal library verification allows Bridge upgrades to link unreviewed external libraries". The `verifyLibraryBytecodes` utility logged warnings on bytecode mismatches but did not abort, allowing `upgradeProxy` to execute with potentially compromised library contracts.

## Test plan

- [ ] Verify upgrade script aborts when a library bytecode mismatch is detected (mock a stale library deployment)
- [ ] Verify upgrade script succeeds when all library bytecodes match
- [ ] Verify existing tests pass with no regressions