### PR TITLE
fix(pr-952): address audit findings

### DIFF
--- a/solidity/contracts/bridge/RebateStaking.sol
+++ b/solidity/contracts/bridge/RebateStaking.sol
@@ -975,8 +975,17 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
         newStake.unstakingAmount = oldStake.unstakingAmount;
         newStake.unstakingTimestamp = oldStake.unstakingTimestamp;
         newStake.rebateTreasuryFeeMode = oldStake.rebateTreasuryFeeMode;
-        newStake.rollingWindowStartIndex = oldStake.rollingWindowStartIndex;
-        for (uint256 i = 0; i < oldStake.rebates.length; i++) {
+        // Only migrate the active rebate window. Anything before
+        // `rollingWindowStartIndex` has aged out and is never read again, so
+        // copying it would grow gas cost without bound for long-lived
+        // stakers. The copied window starts at index 0 in the new array.
+        newStake.rollingWindowStartIndex = 0;
+        uint256 rebatesLength = oldStake.rebates.length;
+        for (
+            uint256 i = oldStake.rollingWindowStartIndex;
+            i < rebatesLength;
+            i++
+        ) {
             newStake.rebates.push(oldStake.rebates[i]);
         }
         if (oldStake.delegatee != address(0)) {

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorNtt.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorNtt.sol
@@ -176,7 +176,13 @@ contract L1BTCDepositorNtt is AbstractL1BTCDepositor {
         );
 
         if (_token == address(0)) {
-            payable(_to).transfer(_amount);
+            // `transfer` forwards only 2300 gas, which is insufficient for
+            // smart-contract recipients (multisigs, AA wallets, etc.). Use a
+            // low-level call so the native-token recovery path works for any
+            // legitimate owner-controlled receiver.
+            // slither-disable-next-line arbitrary-send-eth,low-level-calls
+            (bool success, ) = payable(_to).call{value: _amount}("");
+            require(success, "Native transfer failed");
         } else {
             IERC20Upgradeable(_token).safeTransfer(_to, _amount);
         }

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorNtt.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorNtt.sol
@@ -181,6 +181,7 @@ contract L1BTCDepositorNtt is AbstractL1BTCDepositor {
             // low-level call so the native-token recovery path works for any
             // legitimate owner-controlled receiver.
             // slither-disable-next-line arbitrary-send-eth,low-level-calls
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, ) = payable(_to).call{value: _amount}("");
             require(success, "Native transfer failed");
         } else {

--- a/solidity/contracts/cross-chain/wormhole/L1BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCRedeemerWormhole.sol
@@ -58,7 +58,9 @@ contract L1BTCRedeemerWormhole is
     // Custom errors
     error CallerNotOwner();
     error SourceAddressNotAuthorized();
+    error SourceChainNotAuthorized();
     error WormholeTokenBridgeAlreadySet();
+    error WormholeAlreadySet();
 
     struct L2RedemptionPayloadV2 {
         bytes redeemerOutputScript;
@@ -106,6 +108,17 @@ contract L1BTCRedeemerWormhole is
         public timedOutRedemptionRefunds;
     /// @notice L1-to-L2 routes used to return tBTC after redemption timeouts.
     mapping(uint256 => TimeoutRefundRoute) public timeoutRefundRoutes;
+    /// @notice Reference to the Wormhole Core contract. Used to parse the VAA
+    ///         header and authenticate the `emitterChainId` of the sender.
+    ///         Optional: when address(0) the emitter chain check is skipped to
+    ///         preserve backward compatibility for deployments that have not
+    ///         yet been configured with a core reference.
+    IWormhole public wormhole;
+    /// @notice Wormhole chain ID expected for each allowed Wormhole sender.
+    ///         Authenticates the origin chain of a VAA independently of
+    ///         `transfer.fromAddress`, preventing same-address-spoof attacks
+    ///         from foreign chains with a registered Token Bridge.
+    mapping(bytes32 => uint16) public allowedSenderWormholeChainIds;
 
     event RedemptionRequested(
         uint256 indexed redemptionKey,
@@ -134,6 +147,13 @@ contract L1BTCRedeemerWormhole is
         uint256 indexed sourceChainId,
         uint16 wormholeChainId,
         address l2WormholeGateway
+    );
+
+    event WormholeCoreSet(address indexed wormhole);
+
+    event AllowedSenderWormholeChainUpdated(
+        bytes32 indexed sender,
+        uint16 wormholeChainId
     );
 
     event RedemptionRequestedWithRebate(
@@ -245,6 +265,29 @@ contract L1BTCRedeemerWormhole is
         );
     }
 
+    /// @notice Sets the Wormhole Core contract reference used for VAA
+    ///         emitter-chain authentication. Can only be set once; subsequent
+    ///         calls revert. Callers should set this prior to configuring
+    ///         allowed-sender wormhole chain IDs.
+    function setWormhole(address _wormhole) external onlyOwner {
+        if (_wormhole == address(0)) revert ZeroAddress();
+        if (address(wormhole) != address(0)) revert WormholeAlreadySet();
+        wormhole = IWormhole(_wormhole);
+        emit WormholeCoreSet(_wormhole);
+    }
+
+    /// @notice Binds an allowed Wormhole sender to the Wormhole chain ID that
+    ///         its VAAs must originate from. Once the core is configured,
+    ///         messages from senders without an entry here revert, so admins
+    ///         must populate this mapping for every entry in `allowedSenders`.
+    function updateAllowedSenderWormholeChain(
+        bytes32 _sender,
+        uint16 _wormholeChainId
+    ) external onlyOwner {
+        allowedSenderWormholeChainIds[_sender] = _wormholeChainId;
+        emit AllowedSenderWormholeChainUpdated(_sender, _wormholeChainId);
+    }
+
     /// @notice Updates the L2 route used for timeout refunds.
     function updateTimeoutRefundRoute(
         uint256 _sourceChainId,
@@ -325,9 +368,14 @@ contract L1BTCRedeemerWormhole is
                 encoded
             );
 
-        // Validate that the message came from an authorized sender
+        // Validate that the message came from an authorized sender on the
+        // expected source chain. `fromAddress` alone is insufficient because
+        // the same contract address can exist on any chain that has a
+        // registered Wormhole Token Bridge; without an `emitterChainId` check
+        // such foreign contracts could impersonate the authorized sender.
         bytes32 sender = transfer.fromAddress;
         if (!allowedSenders[sender]) revert SourceAddressNotAuthorized();
+        _requireExpectedEmitterChain(encodedVm, sender);
 
         bytes memory redemptionOutputScript = transfer.payload;
 
@@ -396,6 +444,28 @@ contract L1BTCRedeemerWormhole is
         }
     }
 
+    /// @dev Parses the Wormhole VAA header and verifies its `emitterChainId`
+    ///      matches the chain configured for `sender`. No-op when the Wormhole
+    ///      Core reference has not been set, preserving behaviour for
+    ///      deployments that have not yet migrated. Once the core is set,
+    ///      senders without a configured wormhole chain ID are rejected so
+    ///      admins cannot silently skip the check by forgetting to configure.
+    function _requireExpectedEmitterChain(
+        bytes calldata encodedVm,
+        bytes32 sender
+    ) internal view {
+        IWormhole _wormhole = wormhole;
+        if (address(_wormhole) == address(0)) {
+            return;
+        }
+
+        uint16 expected = allowedSenderWormholeChainIds[sender];
+        if (expected == 0) revert SourceChainNotAuthorized();
+
+        IWormhole.VM memory vm = _wormhole.parseVM(encodedVm);
+        if (vm.emitterChainId != expected) revert SourceChainNotAuthorized();
+    }
+
     function _completeTransfer(bytes calldata encodedVm)
         internal
         returns (CompletedRedemptionTransfer memory completedTransfer)
@@ -413,6 +483,7 @@ contract L1BTCRedeemerWormhole is
 
         bytes32 sender = transfer.fromAddress;
         if (!allowedSenders[sender]) revert SourceAddressNotAuthorized();
+        _requireExpectedEmitterChain(encodedVm, sender);
 
         uint256 sourceChainId = allowedSenderSourceChainIds[sender];
         require(sourceChainId != 0, "Source chain ID is not set");

--- a/solidity/contracts/cross-chain/wormhole/L1BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCRedeemerWormhole.sol
@@ -58,9 +58,16 @@ contract L1BTCRedeemerWormhole is
     // Custom errors
     error CallerNotOwner();
     error SourceAddressNotAuthorized();
+    /// @dev The allowed sender has no Wormhole chain ID configured.
     error SourceChainNotAuthorized();
+    /// @dev The VAA emitter chain does not match the chain bound to the
+    ///      allowed sender. Distinct from `SourceChainNotAuthorized` so
+    ///      operators can tell "sender not configured" from "sender
+    ///      configured but VAA arrived from the wrong chain."
+    error WormholeChainMismatch();
     error WormholeTokenBridgeAlreadySet();
     error WormholeAlreadySet();
+    error InvalidArrayLength();
 
     struct L2RedemptionPayloadV2 {
         bytes redeemerOutputScript;
@@ -240,15 +247,24 @@ contract L1BTCRedeemerWormhole is
     /// @param _allowed New allowed status.
     /// @dev Requirements:
     ///      - Can be called only by the contract owner.
+    ///
+    ///      Clears any bound Wormhole chain ID on revocation so the mapping
+    ///      cannot drift out of sync with `allowedSenders`.
     function updateAllowedSender(bytes32 _sender, bool _allowed)
         external
         onlyOwner
     {
         allowedSenders[_sender] = _allowed;
         emit AllowedSenderUpdated(_sender, _allowed);
+        if (!_allowed && allowedSenderWormholeChainIds[_sender] != 0) {
+            delete allowedSenderWormholeChainIds[_sender];
+            emit AllowedSenderWormholeChainUpdated(_sender, 0);
+        }
     }
 
     /// @notice Updates an allowed sender and binds it to an EVM source chain ID.
+    /// @dev Clears any bound Wormhole chain ID on revocation so the mapping
+    ///      cannot drift out of sync with `allowedSenders`.
     function updateAllowedSenderWithSourceChain(
         bytes32 _sender,
         bool _allowed,
@@ -263,23 +279,59 @@ contract L1BTCRedeemerWormhole is
             _allowed,
             allowedSenderSourceChainIds[_sender]
         );
+        if (!_allowed && allowedSenderWormholeChainIds[_sender] != 0) {
+            delete allowedSenderWormholeChainIds[_sender];
+            emit AllowedSenderWormholeChainUpdated(_sender, 0);
+        }
     }
 
     /// @notice Sets the Wormhole Core contract reference used for VAA
-    ///         emitter-chain authentication. Can only be set once; subsequent
-    ///         calls revert. Callers should set this prior to configuring
-    ///         allowed-sender wormhole chain IDs.
-    function setWormhole(address _wormhole) external onlyOwner {
+    ///         emitter-chain authentication and atomically binds every
+    ///         currently-allowed sender to the Wormhole chain ID its VAAs
+    ///         must originate from.
+    /// @dev Can only be called once.
+    ///
+    ///      Supplying the bindings in the same call prevents the window
+    ///      where the core reference is active but one or more existing
+    ///      `allowedSenders` entries have no matching Wormhole chain ID --
+    ///      in that window every `requestRedemption` reverts with
+    ///      `SourceChainNotAuthorized`. Admins must pass every currently
+    ///      allowed sender; the contract does not enumerate the allowlist.
+    ///
+    ///      `_senders` and `_wormholeChainIds` may be empty (pristine
+    ///      deployment with no senders yet).
+    /// @param _wormhole Wormhole Core contract address.
+    /// @param _senders Wormhole sender addresses (bytes32) to bind.
+    /// @param _wormholeChainIds Wormhole chain IDs (uint16) to bind,
+    ///        matched pairwise with `_senders`.
+    function setWormhole(
+        address _wormhole,
+        bytes32[] calldata _senders,
+        uint16[] calldata _wormholeChainIds
+    ) external onlyOwner {
         if (_wormhole == address(0)) revert ZeroAddress();
         if (address(wormhole) != address(0)) revert WormholeAlreadySet();
+        if (_senders.length != _wormholeChainIds.length) {
+            revert InvalidArrayLength();
+        }
+
         wormhole = IWormhole(_wormhole);
         emit WormholeCoreSet(_wormhole);
+
+        for (uint256 i = 0; i < _senders.length; i++) {
+            allowedSenderWormholeChainIds[_senders[i]] = _wormholeChainIds[i];
+            emit AllowedSenderWormholeChainUpdated(
+                _senders[i],
+                _wormholeChainIds[i]
+            );
+        }
     }
 
     /// @notice Binds an allowed Wormhole sender to the Wormhole chain ID that
-    ///         its VAAs must originate from. Once the core is configured,
-    ///         messages from senders without an entry here revert, so admins
-    ///         must populate this mapping for every entry in `allowedSenders`.
+    ///         its VAAs must originate from. Used to amend the mapping after
+    ///         `setWormhole`; prefer the atomic `setWormhole` constructor for
+    ///         the initial bindings.
+    /// @dev Passing `_wormholeChainId == 0` clears the binding.
     function updateAllowedSenderWormholeChain(
         bytes32 _sender,
         uint16 _wormholeChainId
@@ -450,6 +502,11 @@ contract L1BTCRedeemerWormhole is
     ///      deployments that have not yet migrated. Once the core is set,
     ///      senders without a configured wormhole chain ID are rejected so
     ///      admins cannot silently skip the check by forgetting to configure.
+    ///
+    ///      Wormhole chain ID 0 is unallocated by convention in the Wormhole
+    ///      chain registry, so treating 0 as the "not configured" sentinel
+    ///      is safe today; if Wormhole ever allocates chain 0, the code
+    ///      would have to carry a separate configured-flag.
     function _requireExpectedEmitterChain(
         bytes calldata encodedVm,
         bytes32 sender
@@ -463,7 +520,7 @@ contract L1BTCRedeemerWormhole is
         if (expected == 0) revert SourceChainNotAuthorized();
 
         IWormhole.VM memory vm = _wormhole.parseVM(encodedVm);
-        if (vm.emitterChainId != expected) revert SourceChainNotAuthorized();
+        if (vm.emitterChainId != expected) revert WormholeChainMismatch();
     }
 
     function _completeTransfer(bytes calldata encodedVm)

--- a/solidity/contracts/cross-chain/wormhole/L2BTCDepositorWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCDepositorWormhole.sol
@@ -151,7 +151,12 @@ contract L2BTCDepositorWormhole is IWormholeReceiver, OwnableUpgradeable {
         bytes calldata rebateAuthorization
     ) external {
         if (rebateAuthorization.length == 0) {
-            require(msg.sender.code.length == 0, "Signed auth required");
+            // `code.length == 0` is bypassable from a contract's constructor,
+            // letting intermediate contracts mint rebates on behalf of an EOA
+            // address they control. Require the transaction to originate
+            // directly from `msg.sender` to block constructor-based spoofing.
+            // slither-disable-next-line tx-origin
+            require(tx.origin == msg.sender, "Signed auth required");
             require(
                 rebateBeneficiary == l2DepositOwner,
                 "Beneficiary must match L2 owner"

--- a/solidity/contracts/cross-chain/wormhole/L2BTCDepositorWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCDepositorWormhole.sol
@@ -156,6 +156,7 @@ contract L2BTCDepositorWormhole is IWormholeReceiver, OwnableUpgradeable {
             // address they control. Require the transaction to originate
             // directly from `msg.sender` to block constructor-based spoofing.
             // slither-disable-next-line tx-origin
+            // solhint-disable-next-line avoid-tx-origin
             require(tx.origin == msg.sender, "Signed auth required");
             require(
                 rebateBeneficiary == l2DepositOwner,

--- a/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
@@ -267,6 +267,7 @@ contract L2BTCRedeemerWormhole is
             // address they control. Require the transaction to originate
             // directly from `msg.sender` to block constructor-based spoofing.
             // slither-disable-next-line tx-origin
+            // solhint-disable-next-line avoid-tx-origin
             require(tx.origin == msg.sender, "Signed auth required");
             require(
                 params.rebateBeneficiary == msg.sender,

--- a/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
@@ -124,12 +124,14 @@ contract L2BTCRedeemerWormhole is
 
     event MinimumRedemptionAmountUpdated(uint256 newMinimumAmount);
 
-    /// @dev Locks initializers on the implementation contract so it cannot be
-    ///      initialized directly. Only the proxy's storage is ever initialized.
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
-        _disableInitializers();
-    }
+    // NOTE: A `_disableInitializers()` constructor was considered (mirroring
+    // the fix applied to L2WormholeGateway and L2TBTC) but the current
+    // toolchain (@openzeppelin/hardhat-upgrades 1.22.0 /
+    // @openzeppelin/upgrades-core 1.20.0) mis-applies cross-contract
+    // library link references to this contract's bytecode during its
+    // version check and rejects every `deployProxy` call. The lock should
+    // be added as a follow-up once the plugin is upgraded to a version
+    // that no longer exhibits the bug.
 
     function initialize(
         address _tbtc,

--- a/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
@@ -124,6 +124,13 @@ contract L2BTCRedeemerWormhole is
 
     event MinimumRedemptionAmountUpdated(uint256 newMinimumAmount);
 
+    /// @dev Locks initializers on the implementation contract so it cannot be
+    ///      initialized directly. Only the proxy's storage is ever initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(
         address _tbtc,
         address _gateway,

--- a/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
@@ -132,6 +132,7 @@ contract L2BTCRedeemerWormhole is
     // version check and rejects every `deployProxy` call. The lock should
     // be added as a follow-up once the plugin is upgraded to a version
     // that no longer exhibits the bug.
+    // Tracking issue: https://github.com/threshold-network/tbtc-v2/issues/954
 
     function initialize(
         address _tbtc,

--- a/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2BTCRedeemerWormhole.sol
@@ -253,7 +253,12 @@ contract L2BTCRedeemerWormhole is
         if (amount < minimumRedemptionAmount) revert AmountTooLowToRedeem();
 
         if (params.rebateAuthorization.length == 0) {
-            require(msg.sender.code.length == 0, "Signed auth required");
+            // `code.length == 0` is bypassable from a contract's constructor,
+            // letting intermediate contracts mint rebates on behalf of an EOA
+            // address they control. Require the transaction to originate
+            // directly from `msg.sender` to block constructor-based spoofing.
+            // slither-disable-next-line tx-origin
+            require(tx.origin == msg.sender, "Signed auth required");
             require(
                 params.rebateBeneficiary == msg.sender,
                 "Beneficiary must match sender"

--- a/solidity/contracts/cross-chain/wormhole/L2TBTC.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2TBTC.sol
@@ -86,6 +86,13 @@ contract L2TBTC is
         _;
     }
 
+    /// @dev Locks initializers on the implementation contract so it cannot be
+    ///      initialized directly. Only the proxy's storage is ever initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Initializes the token contract.
     /// @param _name The name of the token.
     /// @param _symbol The symbol of the token, usually a shorter version of the

--- a/solidity/contracts/cross-chain/wormhole/L2WormholeGateway.sol
+++ b/solidity/contracts/cross-chain/wormhole/L2WormholeGateway.sol
@@ -109,6 +109,13 @@ contract L2WormholeGateway is
 
     event MintingLimitUpdated(uint256 mintingLimit);
 
+    /// @dev Locks initializers on the implementation contract so it cannot be
+    ///      initialized directly. Only the proxy's storage is ever initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(
         IWormholeTokenBridge _bridge,
         IERC20Upgradeable _bridgeToken,

--- a/solidity/contracts/cross-chain/wormhole/Wormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/Wormhole.sol
@@ -37,11 +37,48 @@ interface IWormholeGateway {
 /// @notice Wormhole interface.
 /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol#L6
 interface IWormhole {
+    /// @dev Signature on a Wormhole VAA. Included here only so `VM` can be
+    ///      declared; callers that only need VAA header fields can ignore it.
+    struct Signature {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        uint8 guardianIndex;
+    }
+
+    /// @dev Decoded Wormhole VAA. Only `emitterChainId` and `emitterAddress`
+    ///      are consumed in this codebase; the remaining fields are declared
+    ///      to match the upstream Wormhole Core struct layout returned by
+    ///      `parseVM`.
+    struct VM {
+        uint8 version;
+        uint32 timestamp;
+        uint32 nonce;
+        uint16 emitterChainId;
+        bytes32 emitterAddress;
+        uint64 sequence;
+        uint8 consistencyLevel;
+        bytes payload;
+        uint32 guardianSetIndex;
+        Signature[] signatures;
+        bytes32 hash;
+    }
+
     /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol#L109
     function chainId() external view returns (uint16);
 
     /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol#L117
     function messageFee() external view returns (uint256);
+
+    /// @notice Parses a Wormhole VAA without verifying signatures. Used by
+    ///         token-bridge integrators to read VAA header fields such as
+    ///         `emitterChainId` that are not exposed by `TransferWithPayload`.
+    ///         Signature verification is still performed by the token bridge
+    ///         when it calls `completeTransferWithPayload`.
+    function parseVM(bytes memory encodedVM)
+        external
+        pure
+        returns (VM memory vm);
 }
 
 /// @title IWormholeRelayer

--- a/solidity/contracts/cross-chain/wormhole/Wormhole.sol
+++ b/solidity/contracts/cross-chain/wormhole/Wormhole.sol
@@ -39,6 +39,7 @@ interface IWormholeGateway {
 interface IWormhole {
     /// @dev Signature on a Wormhole VAA. Included here only so `VM` can be
     ///      declared; callers that only need VAA header fields can ignore it.
+    /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol
     struct Signature {
         bytes32 r;
         bytes32 s;
@@ -50,6 +51,7 @@ interface IWormhole {
     ///      are consumed in this codebase; the remaining fields are declared
     ///      to match the upstream Wormhole Core struct layout returned by
     ///      `parseVM`.
+    /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol
     struct VM {
         uint8 version;
         uint32 timestamp;
@@ -75,6 +77,7 @@ interface IWormhole {
     ///         `emitterChainId` that are not exposed by `TransferWithPayload`.
     ///         Signature verification is still performed by the token bridge
     ///         when it calls `completeTransferWithPayload`.
+    /// @dev See: https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/2b7db51f99b49eda99b44f4a044e751cb0b2e8ea/src/interfaces/IWormhole.sol
     function parseVM(bytes memory encodedVM)
         external
         pure

--- a/solidity/contracts/test/ConstructorRebateCaller.sol
+++ b/solidity/contracts/test/ConstructorRebateCaller.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity 0.8.17;
 
+/* solhint-disable avoid-low-level-calls, no-inline-assembly */
+
 /// @notice Test helper that drives the audit regression for the
 ///         `code.length == 0` EOA check on L2 rebate entry points. While a
 ///         contract is still executing its constructor its own code length is

--- a/solidity/contracts/test/ConstructorRebateCaller.sol
+++ b/solidity/contracts/test/ConstructorRebateCaller.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.17;
+
+/// @notice Test helper that drives the audit regression for the
+///         `code.length == 0` EOA check on L2 rebate entry points. While a
+///         contract is still executing its constructor its own code length is
+///         zero, which would have allowed an intermediate contract to pass
+///         the pre-fix guard. This helper issues the target call from its
+///         constructor so the test can verify that the tightened
+///         `tx.origin == msg.sender` guard rejects it.
+contract ConstructorRebateCaller {
+    constructor(address target, bytes memory data) {
+        // slither-disable-next-line low-level-calls
+        (bool success, bytes memory ret) = target.call(data);
+        if (!success) {
+            assembly {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+}

--- a/solidity/contracts/test/GreedyReceiver.sol
+++ b/solidity/contracts/test/GreedyReceiver.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.17;
+
+/// @notice Test helper that consumes more than 2300 gas in its receive()
+///         handler. Any native-token transfer that forwards only the
+///         `.transfer()` / `.send()` stipend (2300 gas) will out-of-gas
+///         before the SSTORE below can run. Used to pin the audit fix
+///         that replaced `.transfer()` with a low-level `.call{value:}`
+///         in `L1BTCDepositorNtt.retrieveTokens`.
+contract GreedyReceiver {
+    uint256 public received;
+    uint256 public lastAmount;
+
+    // Writing to two cold storage slots costs well above 2300 gas, so
+    // this call succeeds only when the sender forwards (sufficient) gas.
+    receive() external payable {
+        received += 1;
+        lastAmount = msg.value;
+    }
+}

--- a/solidity/contracts/test/MockL1BTCRedeemerWormhole.sol
+++ b/solidity/contracts/test/MockL1BTCRedeemerWormhole.sol
@@ -16,13 +16,16 @@ contract MockL1BTCRedeemerWormhole is
     // Custom errors
     error SourceAddressNotAuthorized();
     error SourceChainNotAuthorized();
+    error WormholeChainMismatch();
     error WormholeAlreadySet();
+    error InvalidArrayLength();
 
     // State variables from L1BTCRedeemerWormhole
     IWormholeTokenBridge public wormholeTokenBridge;
     uint256 public requestRedemptionGasOffset;
     mapping(address => bool) public reimbursementAuthorizations;
     mapping(bytes32 => bool) public allowedSenders;
+    mapping(bytes32 => uint256) public allowedSenderSourceChainIds;
     // Mirror the production contract's emitter-chain authentication fields
     // so tests can exercise the guard through this mock.
     IWormhole public wormhole;
@@ -48,6 +51,12 @@ contract MockL1BTCRedeemerWormhole is
     );
 
     event AllowedSenderUpdated(bytes32 indexed sender, bool allowed);
+
+    event AllowedSenderSourceChainUpdated(
+        bytes32 indexed sender,
+        bool allowed,
+        uint256 sourceChainId
+    );
 
     event WormholeCoreSet(address indexed wormhole);
 
@@ -118,13 +127,51 @@ contract MockL1BTCRedeemerWormhole is
     {
         allowedSenders[_sender] = _allowed;
         emit AllowedSenderUpdated(_sender, _allowed);
+        if (!_allowed && allowedSenderWormholeChainIds[_sender] != 0) {
+            delete allowedSenderWormholeChainIds[_sender];
+            emit AllowedSenderWormholeChainUpdated(_sender, 0);
+        }
     }
 
-    function setWormhole(address _wormhole) external onlyOwner {
+    function updateAllowedSenderWithSourceChain(
+        bytes32 _sender,
+        bool _allowed,
+        uint256 _sourceChainId
+    ) external onlyOwner {
+        require(!_allowed || _sourceChainId != 0, "Source chain ID is zero");
+        allowedSenders[_sender] = _allowed;
+        allowedSenderSourceChainIds[_sender] = _allowed ? _sourceChainId : 0;
+        emit AllowedSenderUpdated(_sender, _allowed);
+        emit AllowedSenderSourceChainUpdated(
+            _sender,
+            _allowed,
+            allowedSenderSourceChainIds[_sender]
+        );
+        if (!_allowed && allowedSenderWormholeChainIds[_sender] != 0) {
+            delete allowedSenderWormholeChainIds[_sender];
+            emit AllowedSenderWormholeChainUpdated(_sender, 0);
+        }
+    }
+
+    function setWormhole(
+        address _wormhole,
+        bytes32[] calldata _senders,
+        uint16[] calldata _wormholeChainIds
+    ) external onlyOwner {
         if (_wormhole == address(0)) revert ZeroAddress();
         if (address(wormhole) != address(0)) revert WormholeAlreadySet();
+        if (_senders.length != _wormholeChainIds.length) {
+            revert InvalidArrayLength();
+        }
         wormhole = IWormhole(_wormhole);
         emit WormholeCoreSet(_wormhole);
+        for (uint256 i = 0; i < _senders.length; i++) {
+            allowedSenderWormholeChainIds[_senders[i]] = _wormholeChainIds[i];
+            emit AllowedSenderWormholeChainUpdated(
+                _senders[i],
+                _wormholeChainIds[i]
+            );
+        }
     }
 
     function updateAllowedSenderWormholeChain(
@@ -148,7 +195,7 @@ contract MockL1BTCRedeemerWormhole is
         if (expected == 0) revert SourceChainNotAuthorized();
 
         IWormhole.VM memory vm = _wormhole.parseVM(encodedVm);
-        if (vm.emitterChainId != expected) revert SourceChainNotAuthorized();
+        if (vm.emitterChainId != expected) revert WormholeChainMismatch();
     }
 
     // Mock implementation of requestRedemption

--- a/solidity/contracts/test/MockL1BTCRedeemerWormhole.sol
+++ b/solidity/contracts/test/MockL1BTCRedeemerWormhole.sol
@@ -15,12 +15,18 @@ contract MockL1BTCRedeemerWormhole is
 {
     // Custom errors
     error SourceAddressNotAuthorized();
+    error SourceChainNotAuthorized();
+    error WormholeAlreadySet();
 
     // State variables from L1BTCRedeemerWormhole
     IWormholeTokenBridge public wormholeTokenBridge;
     uint256 public requestRedemptionGasOffset;
     mapping(address => bool) public reimbursementAuthorizations;
     mapping(bytes32 => bool) public allowedSenders;
+    // Mirror the production contract's emitter-chain authentication fields
+    // so tests can exercise the guard through this mock.
+    IWormhole public wormhole;
+    mapping(bytes32 => uint16) public allowedSenderWormholeChainIds;
 
     // Mock-specific state
     uint256 public mockRedemptionAmountTBTC;
@@ -42,6 +48,13 @@ contract MockL1BTCRedeemerWormhole is
     );
 
     event AllowedSenderUpdated(bytes32 indexed sender, bool allowed);
+
+    event WormholeCoreSet(address indexed wormhole);
+
+    event AllowedSenderWormholeChainUpdated(
+        bytes32 indexed sender,
+        uint16 wormholeChainId
+    );
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -107,6 +120,37 @@ contract MockL1BTCRedeemerWormhole is
         emit AllowedSenderUpdated(_sender, _allowed);
     }
 
+    function setWormhole(address _wormhole) external onlyOwner {
+        if (_wormhole == address(0)) revert ZeroAddress();
+        if (address(wormhole) != address(0)) revert WormholeAlreadySet();
+        wormhole = IWormhole(_wormhole);
+        emit WormholeCoreSet(_wormhole);
+    }
+
+    function updateAllowedSenderWormholeChain(
+        bytes32 _sender,
+        uint16 _wormholeChainId
+    ) external onlyOwner {
+        allowedSenderWormholeChainIds[_sender] = _wormholeChainId;
+        emit AllowedSenderWormholeChainUpdated(_sender, _wormholeChainId);
+    }
+
+    function _requireExpectedEmitterChain(
+        bytes calldata encodedVm,
+        bytes32 sender
+    ) internal view {
+        IWormhole _wormhole = wormhole;
+        if (address(_wormhole) == address(0)) {
+            return;
+        }
+
+        uint16 expected = allowedSenderWormholeChainIds[sender];
+        if (expected == 0) revert SourceChainNotAuthorized();
+
+        IWormhole.VM memory vm = _wormhole.parseVM(encodedVm);
+        if (vm.emitterChainId != expected) revert SourceChainNotAuthorized();
+    }
+
     // Mock implementation of requestRedemption
     function requestRedemption(
         bytes20 walletPubKeyHash,
@@ -127,9 +171,11 @@ contract MockL1BTCRedeemerWormhole is
                 encoded
             );
 
-        // Validate that the message came from an authorized sender
+        // Validate that the message came from an authorized sender on the
+        // expected source chain.
         bytes32 sender = transfer.fromAddress;
         if (!allowedSenders[sender]) revert SourceAddressNotAuthorized();
+        _requireExpectedEmitterChain(encodedVm, sender);
 
         bytes memory redemptionOutputScriptToUse = transfer.payload;
 

--- a/solidity/contracts/test/RevertingReceiver.sol
+++ b/solidity/contracts/test/RevertingReceiver.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.17;
+
+/// @notice Test helper whose `receive()` always reverts. Used to verify
+///         that `L1BTCDepositorNtt.retrieveTokens` surfaces the
+///         low-level-call failure rather than silently succeeding.
+contract RevertingReceiver {
+    receive() external payable {
+        revert("receiver rejects");
+    }
+}

--- a/solidity/test/bridge/RebateStaking.test.ts
+++ b/solidity/test/bridge/RebateStaking.test.ts
@@ -1,7 +1,7 @@
 import { helpers, waffle, ethers } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { expect } from "chai"
-import { Contract, ContractTransaction } from "ethers"
+import { BigNumber, Contract, ContractTransaction } from "ethers"
 import type {
   Bridge,
   BridgeGovernance,
@@ -1993,6 +1993,95 @@ describe("RebateStaking", () => {
         await expect(tx)
           .to.emit(rebateStaking, "TransferFinished")
           .withArgs(thirdParty.address, governance.address)
+      })
+    })
+
+    // Regression coverage for the audit fix: transferring a stake with
+    // historical rebates must only copy the active rolling window so that
+    // long-lived accounts never trip the block gas limit.
+    context("when some rebates have aged out of the rolling window", () => {
+      const rebateCap = to1e18(1)
+      const feeA = rebateCap.div(10)
+      const feeB = rebateCap.div(10)
+      const feeC = rebateCap.div(10)
+
+      let rebateCAmount: BigNumber
+      let rebateBAmount: BigNumber
+      let expiredRebateAmount: BigNumber
+
+      before(async () => {
+        await createSnapshot()
+
+        const rollingWindow = (await rebateStaking.rollingWindow()).toNumber()
+
+        // Stage 1: earliest rebate; will fall out of the window after the
+        // next increaseTime call.
+        await bridge.applyForRebate(thirdParty.address, feeA)
+        ;[, expiredRebateAmount] = await rebateStaking.getRebate(
+          thirdParty.address,
+          0
+        )
+
+        // Age the first rebate out of the window and record a new one; this
+        // call also bumps `rollingWindowStartIndex` past index 0.
+        await increaseTime(rollingWindow + 1)
+        await bridge.applyForRebate(thirdParty.address, feeB)
+        ;[, rebateBAmount] = await rebateStaking.getRebate(
+          thirdParty.address,
+          1
+        )
+
+        // And one more still inside the window.
+        await bridge.applyForRebate(thirdParty.address, feeC)
+        ;[, rebateCAmount] = await rebateStaking.getRebate(
+          thirdParty.address,
+          2
+        )
+
+        await rebateStaking
+          .connect(deployer)
+          .forceStakeTransfer(thirdParty.address, governance.address)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should drop rebates that aged out of the window", async () => {
+        // Three rebates existed before the transfer; only the two still in
+        // the rolling window survive, and the stale entry must not leak
+        // into the new staker's history.
+        expect(
+          await rebateStaking.getRebateLength(governance.address)
+        ).to.be.equal(2)
+      })
+
+      it("should rebase the copied window to start at index 0", async () => {
+        const [, firstCopied] = await rebateStaking.getRebate(
+          governance.address,
+          0
+        )
+        const [, secondCopied] = await rebateStaking.getRebate(
+          governance.address,
+          1
+        )
+        // The new array begins with the first in-window entry, so the
+        // available rebate is determined purely by feeB + feeC.
+        expect(firstCopied).to.be.equal(rebateBAmount)
+        expect(secondCopied).to.be.equal(rebateCAmount)
+        expect(firstCopied).to.not.be.equal(expiredRebateAmount)
+      })
+
+      it("should preserve the correct available rebate for the new staker", async () => {
+        expect(
+          await rebateStaking.getAvailableRebate(governance.address)
+        ).to.be.equal(rebateCap.sub(rebateBAmount).sub(rebateCAmount))
+      })
+
+      it("should clear the old staker's rebate array", async () => {
+        expect(
+          await rebateStaking.getRebateLength(thirdParty.address)
+        ).to.be.equal(0)
       })
     })
   })

--- a/solidity/test/bridge/RebateStaking.test.ts
+++ b/solidity/test/bridge/RebateStaking.test.ts
@@ -2001,9 +2001,12 @@ describe("RebateStaking", () => {
     // long-lived accounts never trip the block gas limit.
     context("when some rebates have aged out of the rolling window", () => {
       const rebateCap = to1e18(1)
+      // Distinct values so each recorded rebate is uniquely identifiable
+      // after the copy and we can tell the in-window entries from the
+      // stale one.
       const feeA = rebateCap.div(10)
-      const feeB = rebateCap.div(10)
-      const feeC = rebateCap.div(10)
+      const feeB = rebateCap.div(5)
+      const feeC = rebateCap.mul(3).div(10)
 
       let rebateCAmount: BigNumber
       let rebateBAmount: BigNumber
@@ -2066,7 +2069,7 @@ describe("RebateStaking", () => {
           1
         )
         // The new array begins with the first in-window entry, so the
-        // available rebate is determined purely by feeB + feeC.
+        // copied entries correspond to feeB then feeC, not feeA.
         expect(firstCopied).to.be.equal(rebateBAmount)
         expect(secondCopied).to.be.equal(rebateCAmount)
         expect(firstCopied).to.not.be.equal(expiredRebateAmount)
@@ -2076,12 +2079,6 @@ describe("RebateStaking", () => {
         expect(
           await rebateStaking.getAvailableRebate(governance.address)
         ).to.be.equal(rebateCap.sub(rebateBAmount).sub(rebateCAmount))
-      })
-
-      it("should clear the old staker's rebate array", async () => {
-        expect(
-          await rebateStaking.getRebateLength(thirdParty.address)
-        ).to.be.equal(0)
       })
     })
   })

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorNtt.utils.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorNtt.utils.test.ts
@@ -451,6 +451,65 @@ describe("L1BTCDepositorNtt Utilities and Edge Cases", () => {
           const finalBalance = await tbtcToken.balanceOf(user.address)
           expect(finalBalance.sub(initialBalance)).to.equal(transferAmount)
         })
+
+        // Regression for the audit fix that replaced `.transfer()` with a
+        // low-level `.call{value:}` in the native-token branch. A
+        // contract receiver that writes to storage in its `receive()`
+        // consumes well over the 2300 gas stipend; without the fix this
+        // call would out-of-gas.
+        it("should forward native tokens to a smart-wallet receiver that needs > 2300 gas", async () => {
+          const receiverFactory = await ethers.getContractFactory(
+            "GreedyReceiver"
+          )
+          const receiver = await receiverFactory.deploy()
+          await receiver.deployed()
+
+          const transferAmount = ethers.utils.parseEther("0.5")
+          // Fund the depositor directly (it has no receive()); setBalance
+          // is the canonical hardhat-network pattern.
+          await ethers.provider.send("hardhat_setBalance", [
+            l1BtcDepositorNtt.address,
+            transferAmount.toHexString().replace(/^0x0+/, "0x"),
+          ])
+
+          const before = await ethers.provider.getBalance(receiver.address)
+          await l1BtcDepositorNtt
+            .connect(governance)
+            .retrieveTokens(
+              ethers.constants.AddressZero,
+              receiver.address,
+              transferAmount
+            )
+          const after = await ethers.provider.getBalance(receiver.address)
+
+          expect(after.sub(before)).to.equal(transferAmount)
+          expect(await receiver.received()).to.equal(1)
+          expect(await receiver.lastAmount()).to.equal(transferAmount)
+        })
+
+        it("should revert when the native receiver rejects the transfer", async () => {
+          const rejecterFactory = await ethers.getContractFactory(
+            "RevertingReceiver"
+          )
+          const rejecter = await rejecterFactory.deploy()
+          await rejecter.deployed()
+
+          const transferAmount = ethers.utils.parseEther("0.5")
+          await ethers.provider.send("hardhat_setBalance", [
+            l1BtcDepositorNtt.address,
+            transferAmount.toHexString().replace(/^0x0+/, "0x"),
+          ])
+
+          await expect(
+            l1BtcDepositorNtt
+              .connect(governance)
+              .retrieveTokens(
+                ethers.constants.AddressZero,
+                rejecter.address,
+                transferAmount
+              )
+          ).to.be.revertedWith("Native transfer failed")
+        })
       })
     })
 

--- a/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
@@ -5,6 +5,7 @@ import { FakeContract, smock } from "@defi-wonderland/smock"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { BigNumber, ContractTransaction } from "ethers"
 import {
+  IWormhole,
   IWormholeTokenBridge,
   MockL1BTCRedeemerWormhole,
   MockBank,
@@ -1709,6 +1710,265 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
 
       expect(estimatedGas).to.be.gt(0)
       expect(estimatedGas).to.be.lt(500000) // Reasonable upper bound
+    })
+  })
+
+  // Regression tests for the audit fix that adds VAA emitter-chain
+  // authentication. Without these checks, any contract deployed at the
+  // same address on a foreign chain with a registered Wormhole Token
+  // Bridge could pass the `allowedSenders` check.
+  describe("setWormhole", () => {
+    context("when called by a non-owner", () => {
+      it("should revert", async () => {
+        await expect(
+          l1BtcRedeemer.connect(relayer).setWormhole(thirdParty.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should reject the zero address", async () => {
+        await expect(
+          l1BtcRedeemer
+            .connect(governance)
+            .setWormhole(ethers.constants.AddressZero)
+        ).to.be.revertedWith("ZeroAddress")
+      })
+
+      it("should set the core reference and emit WormholeCoreSet", async () => {
+        const wormhole = await smock.fake<IWormhole>("IWormhole")
+        await expect(
+          l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
+        )
+          .to.emit(l1BtcRedeemer, "WormholeCoreSet")
+          .withArgs(wormhole.address)
+        expect(await l1BtcRedeemer.wormhole()).to.equal(wormhole.address)
+      })
+
+      it("should revert on a second set", async () => {
+        const wormhole = await smock.fake<IWormhole>("IWormhole")
+        await expect(
+          l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
+        ).to.be.revertedWith("WormholeAlreadySet")
+      })
+    })
+  })
+
+  describe("updateAllowedSenderWormholeChain", () => {
+    const sender = ethers.utils.hexZeroPad("0xAAAA", 32)
+
+    context("when called by a non-owner", () => {
+      it("should revert", async () => {
+        await expect(
+          l1BtcRedeemer
+            .connect(relayer)
+            .updateAllowedSenderWormholeChain(sender, 2)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should update the mapping and emit the event", async () => {
+        await expect(
+          l1BtcRedeemer
+            .connect(governance)
+            .updateAllowedSenderWormholeChain(sender, 30)
+        )
+          .to.emit(l1BtcRedeemer, "AllowedSenderWormholeChainUpdated")
+          .withArgs(sender, 30)
+        expect(
+          await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+        ).to.equal(30)
+      })
+
+      it("should overwrite an existing entry", async () => {
+        await l1BtcRedeemer
+          .connect(governance)
+          .updateAllowedSenderWormholeChain(sender, 23)
+        expect(
+          await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+        ).to.equal(23)
+      })
+    })
+  })
+
+  describe("requestRedemption emitter-chain guard", () => {
+    const encodedVm = "0x1234567890"
+    const defaultSender = ethers.utils.hexZeroPad("0xABCD", 32)
+    const expectedWormholeChainId = 30
+
+    let wormhole: FakeContract<IWormhole>
+
+    // Mirrors the helper used in the main requestRedemption describe block.
+    function encodeTransfer(payload: string, fromAddress = defaultSender) {
+      const transfer = {
+        payloadID: 1,
+        amount: 2,
+        tokenAddress: ethers.utils.hexZeroPad("0x3000", 32),
+        tokenChain: 4,
+        to: ethers.utils.hexZeroPad("0x5000", 32),
+        toChain: 6,
+        fromAddress,
+        payload,
+      }
+      return ethers.utils.defaultAbiCoder.encode(
+        [
+          "tuple(uint8 payloadID, uint256 amount, bytes32 tokenAddress, uint16 tokenChain, bytes32 to, uint16 toChain, bytes32 fromAddress, bytes payload)",
+        ],
+        [transfer]
+      )
+    }
+
+    beforeEach(async () => {
+      await createSnapshot()
+
+      wormhole = await smock.fake<IWormhole>("IWormhole")
+
+      wormholeTokenBridge.completeTransferWithPayload.reset()
+      wormholeTokenBridge.parseTransferWithPayload.reset()
+
+      const encodedTransfer = encodeTransfer(exampleRedeemerOutputScript)
+      wormholeTokenBridge.completeTransferWithPayload.returns(encodedTransfer)
+      wormholeTokenBridge.parseTransferWithPayload
+        .whenCalledWith(encodedTransfer)
+        .returns({
+          payloadID: 1,
+          amount: 2,
+          tokenAddress: ethers.utils.hexZeroPad("0x3000", 32),
+          tokenChain: 4,
+          to: ethers.utils.hexZeroPad("0x5000", 32),
+          toChain: 6,
+          fromAddress: defaultSender,
+          payload: exampleRedeemerOutputScript,
+        })
+
+      await l1BtcRedeemer
+        .connect(governance)
+        .updateAllowedSender(defaultSender, true)
+      await tbtcToken.mint(l1BtcRedeemer.address, exampleAmount)
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when the Wormhole Core reference is not set", () => {
+      it("should not call parseVM (backwards-compatible path)", async () => {
+        await l1BtcRedeemer
+          .connect(relayer)
+          .requestRedemption(
+            exampleWalletPubKeyHash,
+            exampleMainUtxo,
+            encodedVm
+          )
+        // The fake had no calls wired up; asserting it was never invoked
+        // ensures we preserved the migration path for existing deployments.
+        expect(wormhole.parseVM).to.not.have.been.called
+      })
+    })
+
+    context("when the Wormhole Core reference is set", () => {
+      beforeEach(async () => {
+        await l1BtcRedeemer
+          .connect(governance)
+          .setWormhole(wormhole.address)
+      })
+
+      it("should revert when the sender has no wormhole chain configured", async () => {
+        await expect(
+          l1BtcRedeemer
+            .connect(relayer)
+            .requestRedemption(
+              exampleWalletPubKeyHash,
+              exampleMainUtxo,
+              encodedVm
+            )
+        ).to.be.revertedWith("SourceChainNotAuthorized")
+      })
+
+      it("should revert when the VAA emitter chain does not match", async () => {
+        await l1BtcRedeemer
+          .connect(governance)
+          .updateAllowedSenderWormholeChain(
+            defaultSender,
+            expectedWormholeChainId
+          )
+
+        wormhole.parseVM.whenCalledWith(encodedVm).returns({
+          version: 1,
+          timestamp: 0,
+          nonce: 0,
+          // Attacker-controlled chain id that does not match the one we
+          // bound `defaultSender` to above.
+          emitterChainId: 7,
+          emitterAddress: ethers.utils.hexZeroPad("0x0", 32),
+          sequence: 0,
+          consistencyLevel: 0,
+          payload: "0x",
+          guardianSetIndex: 0,
+          signatures: [],
+          hash: ethers.utils.hexZeroPad("0x0", 32),
+        })
+
+        await expect(
+          l1BtcRedeemer
+            .connect(relayer)
+            .requestRedemption(
+              exampleWalletPubKeyHash,
+              exampleMainUtxo,
+              encodedVm
+            )
+        ).to.be.revertedWith("SourceChainNotAuthorized")
+      })
+
+      it("should accept when the VAA emitter chain matches", async () => {
+        await l1BtcRedeemer
+          .connect(governance)
+          .updateAllowedSenderWormholeChain(
+            defaultSender,
+            expectedWormholeChainId
+          )
+
+        wormhole.parseVM.whenCalledWith(encodedVm).returns({
+          version: 1,
+          timestamp: 0,
+          nonce: 0,
+          emitterChainId: expectedWormholeChainId,
+          emitterAddress: ethers.utils.hexZeroPad("0x0", 32),
+          sequence: 0,
+          consistencyLevel: 0,
+          payload: "0x",
+          guardianSetIndex: 0,
+          signatures: [],
+          hash: ethers.utils.hexZeroPad("0x0", 32),
+        })
+
+        await expect(
+          l1BtcRedeemer
+            .connect(relayer)
+            .requestRedemption(
+              exampleWalletPubKeyHash,
+              exampleMainUtxo,
+              encodedVm
+            )
+        ).to.emit(l1BtcRedeemer, "RedemptionRequested")
+      })
     })
   })
 })

--- a/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
@@ -1882,6 +1882,34 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
     })
   })
 
+  // Regression: re-enabling a revoked sender must NOT resurrect the old
+  // wormhole chain ID binding. Otherwise an admin who revokes and
+  // re-registers at a different chain would silently reuse the stale
+  // mapping from before the revocation.
+  describe("updateAllowedSender revocation round-trip", () => {
+    const sender = ethers.utils.hexZeroPad("0xeeee", 32)
+
+    before(async () => {
+      await createSnapshot()
+      await l1BtcRedeemer.connect(governance).updateAllowedSender(sender, true)
+      await l1BtcRedeemer
+        .connect(governance)
+        .updateAllowedSenderWormholeChain(sender, 30)
+      await l1BtcRedeemer.connect(governance).updateAllowedSender(sender, false)
+      await l1BtcRedeemer.connect(governance).updateAllowedSender(sender, true)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should leave the wormhole chain ID cleared after disable/re-enable", async () => {
+      expect(
+        await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+      ).to.equal(0)
+    })
+  })
+
   describe("updateAllowedSenderWormholeChain", () => {
     const sender = ethers.utils.hexZeroPad("0xaaaa", 32)
 
@@ -2055,6 +2083,77 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
               encodedVm
             )
         ).to.be.revertedWith("WormholeChainMismatch")
+      })
+
+      it("should accept immediately after setWormhole with atomic binding", async () => {
+        // End-to-end regression for the atomic-binding signature: a
+        // single setWormhole call must be enough to activate the guard
+        // AND configure the sender -> chain mapping. The fixture's
+        // setWormhole is called with empty arrays above, but this test
+        // overrides by reverting the snapshot inside the context and
+        // running the atomic form.
+        //
+        // Re-deploy a fresh pair of fakes so the `setWormhole` one-shot
+        // guard isn't tripped by the outer beforeEach.
+        await restoreSnapshot()
+        await createSnapshot()
+
+        wormhole = await smock.fake<IWormhole>("IWormhole")
+        wormholeTokenBridge.completeTransferWithPayload.reset()
+        wormholeTokenBridge.parseTransferWithPayload.reset()
+
+        const encodedTransfer = encodeTransfer(exampleRedeemerOutputScript)
+        wormholeTokenBridge.completeTransferWithPayload.returns(encodedTransfer)
+        wormholeTokenBridge.parseTransferWithPayload
+          .whenCalledWith(encodedTransfer)
+          .returns({
+            payloadID: 1,
+            amount: 2,
+            tokenAddress: ethers.utils.hexZeroPad("0x3000", 32),
+            tokenChain: 4,
+            to: ethers.utils.hexZeroPad("0x5000", 32),
+            toChain: 6,
+            fromAddress: defaultSender,
+            payload: exampleRedeemerOutputScript,
+          })
+
+        await l1BtcRedeemer
+          .connect(governance)
+          .updateAllowedSender(defaultSender, true)
+        await tbtcToken.mint(l1BtcRedeemer.address, exampleAmount)
+
+        // Atomic: core + binding in the same call.
+        await l1BtcRedeemer
+          .connect(governance)
+          .setWormhole(
+            wormhole.address,
+            [defaultSender],
+            [expectedWormholeChainId]
+          )
+
+        wormhole.parseVM.whenCalledWith(encodedVm).returns({
+          version: 1,
+          timestamp: 0,
+          nonce: 0,
+          emitterChainId: expectedWormholeChainId,
+          emitterAddress: ethers.utils.hexZeroPad("0x0", 32),
+          sequence: 0,
+          consistencyLevel: 0,
+          payload: "0x",
+          guardianSetIndex: 0,
+          signatures: [],
+          hash: ethers.utils.hexZeroPad("0x0", 32),
+        })
+
+        await expect(
+          l1BtcRedeemer
+            .connect(relayer)
+            .requestRedemption(
+              exampleWalletPubKeyHash,
+              exampleMainUtxo,
+              encodedVm
+            )
+        ).to.emit(l1BtcRedeemer, "RedemptionRequested")
       })
 
       it("should accept when the VAA emitter chain matches", async () => {

--- a/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
@@ -1763,7 +1763,7 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
   })
 
   describe("updateAllowedSenderWormholeChain", () => {
-    const sender = ethers.utils.hexZeroPad("0xAAAA", 32)
+    const sender = ethers.utils.hexZeroPad("0xaaaa", 32)
 
     context("when called by a non-owner", () => {
       it("should revert", async () => {

--- a/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
@@ -1718,10 +1718,12 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
   // same address on a foreign chain with a registered Wormhole Token
   // Bridge could pass the `allowedSenders` check.
   describe("setWormhole", () => {
+    const binding = ethers.utils.hexZeroPad("0xbbbb", 32)
+
     context("when called by a non-owner", () => {
       it("should revert", async () => {
         await expect(
-          l1BtcRedeemer.connect(relayer).setWormhole(thirdParty.address)
+          l1BtcRedeemer.connect(relayer).setWormhole(thirdParty.address, [], [])
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
@@ -1739,14 +1741,25 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
         await expect(
           l1BtcRedeemer
             .connect(governance)
-            .setWormhole(ethers.constants.AddressZero)
+            .setWormhole(ethers.constants.AddressZero, [], [])
         ).to.be.revertedWith("ZeroAddress")
       })
 
-      it("should set the core reference and emit WormholeCoreSet", async () => {
+      it("should reject mismatched array lengths", async () => {
         const wormhole = await smock.fake<IWormhole>("IWormhole")
         await expect(
-          l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
+          l1BtcRedeemer
+            .connect(governance)
+            .setWormhole(wormhole.address, [binding], [])
+        ).to.be.revertedWith("InvalidArrayLength")
+      })
+
+      it("should accept an empty binding list", async () => {
+        const wormhole = await smock.fake<IWormhole>("IWormhole")
+        await expect(
+          l1BtcRedeemer
+            .connect(governance)
+            .setWormhole(wormhole.address, [], [])
         )
           .to.emit(l1BtcRedeemer, "WormholeCoreSet")
           .withArgs(wormhole.address)
@@ -1756,9 +1769,116 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
       it("should revert on a second set", async () => {
         const wormhole = await smock.fake<IWormhole>("IWormhole")
         await expect(
-          l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
+          l1BtcRedeemer
+            .connect(governance)
+            .setWormhole(wormhole.address, [], [])
         ).to.be.revertedWith("WormholeAlreadySet")
       })
+    })
+
+    context("when bindings are provided atomically", () => {
+      let wormhole: FakeContract<IWormhole>
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+        wormhole = await smock.fake<IWormhole>("IWormhole")
+        const senderA = ethers.utils.hexZeroPad("0xc0de", 32)
+        const senderB = ethers.utils.hexZeroPad("0xd0de", 32)
+        tx = await l1BtcRedeemer
+          .connect(governance)
+          .setWormhole(wormhole.address, [senderA, senderB], [30, 23])
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should populate allowedSenderWormholeChainIds for each binding", async () => {
+        expect(
+          await l1BtcRedeemer.allowedSenderWormholeChainIds(
+            ethers.utils.hexZeroPad("0xc0de", 32)
+          )
+        ).to.equal(30)
+        expect(
+          await l1BtcRedeemer.allowedSenderWormholeChainIds(
+            ethers.utils.hexZeroPad("0xd0de", 32)
+          )
+        ).to.equal(23)
+      })
+
+      it("should emit AllowedSenderWormholeChainUpdated for each binding", async () => {
+        await expect(tx)
+          .to.emit(l1BtcRedeemer, "AllowedSenderWormholeChainUpdated")
+          .withArgs(ethers.utils.hexZeroPad("0xc0de", 32), 30)
+        await expect(tx)
+          .to.emit(l1BtcRedeemer, "AllowedSenderWormholeChainUpdated")
+          .withArgs(ethers.utils.hexZeroPad("0xd0de", 32), 23)
+      })
+    })
+  })
+
+  describe("updateAllowedSender revocation clears wormhole chain ID", () => {
+    const sender = ethers.utils.hexZeroPad("0xcccc", 32)
+
+    before(async () => {
+      await createSnapshot()
+      await l1BtcRedeemer.connect(governance).updateAllowedSender(sender, true)
+      await l1BtcRedeemer
+        .connect(governance)
+        .updateAllowedSenderWormholeChain(sender, 30)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should clear the wormhole chain ID on revocation", async () => {
+      expect(
+        await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+      ).to.equal(30)
+
+      await expect(
+        l1BtcRedeemer.connect(governance).updateAllowedSender(sender, false)
+      )
+        .to.emit(l1BtcRedeemer, "AllowedSenderWormholeChainUpdated")
+        .withArgs(sender, 0)
+
+      expect(
+        await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+      ).to.equal(0)
+    })
+  })
+
+  describe("updateAllowedSenderWithSourceChain revocation clears wormhole chain ID", () => {
+    const sender = ethers.utils.hexZeroPad("0xdddd", 32)
+
+    before(async () => {
+      await createSnapshot()
+      await l1BtcRedeemer
+        .connect(governance)
+        .updateAllowedSenderWithSourceChain(sender, true, 8453)
+      await l1BtcRedeemer
+        .connect(governance)
+        .updateAllowedSenderWormholeChain(sender, 30)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should clear the wormhole chain ID on revocation", async () => {
+      await expect(
+        l1BtcRedeemer
+          .connect(governance)
+          .updateAllowedSenderWithSourceChain(sender, false, 0)
+      )
+        .to.emit(l1BtcRedeemer, "AllowedSenderWormholeChainUpdated")
+        .withArgs(sender, 0)
+
+      expect(
+        await l1BtcRedeemer.allowedSenderWormholeChainIds(sender)
+      ).to.equal(0)
     })
   })
 
@@ -1885,7 +2005,9 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
 
     context("when the Wormhole Core reference is set", () => {
       beforeEach(async () => {
-        await l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
+        await l1BtcRedeemer
+          .connect(governance)
+          .setWormhole(wormhole.address, [], [])
       })
 
       it("should revert when the sender has no wormhole chain configured", async () => {
@@ -1932,7 +2054,7 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
               exampleMainUtxo,
               encodedVm
             )
-        ).to.be.revertedWith("SourceChainNotAuthorized")
+        ).to.be.revertedWith("WormholeChainMismatch")
       })
 
       it("should accept when the VAA emitter chain matches", async () => {

--- a/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
@@ -1885,9 +1885,7 @@ describe("L1BTCRedeemerWormhole (using Mock)", () => {
 
     context("when the Wormhole Core reference is set", () => {
       beforeEach(async () => {
-        await l1BtcRedeemer
-          .connect(governance)
-          .setWormhole(wormhole.address)
+        await l1BtcRedeemer.connect(governance).setWormhole(wormhole.address)
       })
 
       it("should revert when the sender has no wormhole chain configured", async () => {

--- a/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
@@ -40,18 +40,7 @@ describe("L2 implementation initializer lock (regression)", () => {
     })
   })
 
-  describe("L2BTCRedeemerWormhole", () => {
-    it("should revert initialize on the raw implementation", async () => {
-      const factory = await ethers.getContractFactory("L2BTCRedeemerWormhole")
-      const impl = await factory.deploy()
-      await impl.deployed()
-
-      const tbtc = ethers.Wallet.createRandom().address
-      const gateway = ethers.Wallet.createRandom().address
-      const l1Redeemer = ethers.utils.hexZeroPad("0x1234", 32)
-
-      await expect(impl.initialize(tbtc, gateway, l1Redeemer)).to.be
-        .revertedWith("Initializable: contract is already initialized")
-    })
-  })
+  // NOTE: L2BTCRedeemerWormhole intentionally omits the lock -- see the
+  // in-contract comment explaining the tooling conflict with
+  // @openzeppelin/hardhat-upgrades 1.22.0.
 })

--- a/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
@@ -1,0 +1,57 @@
+import { ethers } from "hardhat"
+import chai, { expect } from "chai"
+import { smock } from "@defi-wonderland/smock"
+
+chai.use(smock.matchers)
+
+// Regression coverage for the audit fix that adds a
+// `_disableInitializers()` constructor to the upgradeable L2 logic
+// contracts. Without it, anyone could call `initialize` on the raw
+// implementation and take ownership of the (otherwise unused) logic
+// instance. The constructor only affects implementations deployed
+// after the fix lands; this test instantiates the contract directly
+// (not behind a proxy) so the lock must fire on every `initialize`
+// attempt.
+describe("L2 implementation initializer lock (regression)", () => {
+  describe("L2WormholeGateway", () => {
+    it("should revert initialize on the raw implementation", async () => {
+      const factory = await ethers.getContractFactory("L2WormholeGateway")
+      const impl = await factory.deploy()
+      await impl.deployed()
+
+      const bridge = ethers.Wallet.createRandom().address
+      const bridgeToken = ethers.Wallet.createRandom().address
+      const tbtc = ethers.Wallet.createRandom().address
+
+      await expect(impl.initialize(bridge, bridgeToken, tbtc)).to.be
+        .revertedWith("Initializable: contract is already initialized")
+    })
+  })
+
+  describe("L2TBTC", () => {
+    it("should revert initialize on the raw implementation", async () => {
+      const factory = await ethers.getContractFactory("L2TBTC")
+      const impl = await factory.deploy()
+      await impl.deployed()
+
+      await expect(impl.initialize("L2 TBTC", "L2TBTC")).to.be.revertedWith(
+        "Initializable: contract is already initialized"
+      )
+    })
+  })
+
+  describe("L2BTCRedeemerWormhole", () => {
+    it("should revert initialize on the raw implementation", async () => {
+      const factory = await ethers.getContractFactory("L2BTCRedeemerWormhole")
+      const impl = await factory.deploy()
+      await impl.deployed()
+
+      const tbtc = ethers.Wallet.createRandom().address
+      const gateway = ethers.Wallet.createRandom().address
+      const l1Redeemer = ethers.utils.hexZeroPad("0x1234", 32)
+
+      await expect(impl.initialize(tbtc, gateway, l1Redeemer)).to.be
+        .revertedWith("Initializable: contract is already initialized")
+    })
+  })
+})

--- a/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts
@@ -23,8 +23,9 @@ describe("L2 implementation initializer lock (regression)", () => {
       const bridgeToken = ethers.Wallet.createRandom().address
       const tbtc = ethers.Wallet.createRandom().address
 
-      await expect(impl.initialize(bridge, bridgeToken, tbtc)).to.be
-        .revertedWith("Initializable: contract is already initialized")
+      await expect(
+        impl.initialize(bridge, bridgeToken, tbtc)
+      ).to.be.revertedWith("Initializable: contract is already initialized")
     })
   })
 

--- a/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
@@ -1,0 +1,146 @@
+import { ethers, helpers, waffle } from "hardhat"
+import { randomBytes } from "crypto"
+import chai, { expect } from "chai"
+import { smock } from "@defi-wonderland/smock"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import {
+  IWormholeGateway,
+  IWormholeRelayer,
+  L2BTCDepositorWormhole,
+  L2BTCRedeemerWormhole,
+} from "../../../typechain"
+import { initializeDepositFixture } from "./L1BTCDepositorWormhole.test"
+
+chai.use(smock.matchers)
+
+// Regression coverage for the audit fix that replaces
+// `msg.sender.code.length == 0` with `tx.origin == msg.sender` in the
+// unsigned-rebate entry points. The pre-fix guard returned true while a
+// contract was still executing its constructor, so a throwaway contract
+// deployed in the same transaction could mint a rebate on behalf of an
+// address it controls. The `tx.origin` check rejects any nested call
+// frame -- constructor or otherwise.
+describe("L2 rebate EOA guard (regression)", () => {
+  const contractsFixture = async () => {
+    const { deployer, governance } = await helpers.signers.getNamedSigners()
+
+    const wormholeRelayer = await smock.fake<IWormholeRelayer>(
+      "IWormholeRelayer"
+    )
+    const l2WormholeGateway = await smock.fake<IWormholeGateway>(
+      "IWormholeGateway"
+    )
+    const l1ChainId = 2
+
+    const depositorDeployment = await helpers.upgrades.deployProxy(
+      `L2BTCDepositorWormhole_${randomBytes(8).toString("hex")}`,
+      {
+        contractName: "L2BTCDepositorWormhole",
+        initializerArgs: [
+          wormholeRelayer.address,
+          l2WormholeGateway.address,
+          l1ChainId,
+        ],
+        factoryOpts: { signer: deployer },
+        proxyOpts: { kind: "transparent" },
+      }
+    )
+    const l2BtcDepositor = depositorDeployment[0] as L2BTCDepositorWormhole
+
+    // A minimal tBTC stand-in for the redeemer fixture. We do not invoke
+    // the happy path in this test, only the guard, so a fake is enough.
+    const tbtc = await (
+      await ethers.getContractFactory("TestERC20")
+    ).deploy()
+    await tbtc.deployed()
+
+    const redeemerDeployment = await helpers.upgrades.deployProxy(
+      `L2BTCRedeemerWormhole_${randomBytes(8).toString("hex")}`,
+      {
+        contractName: "L2BTCRedeemerWormhole",
+        initializerArgs: [
+          tbtc.address,
+          l2WormholeGateway.address,
+          ethers.utils.hexZeroPad("0x0123", 32),
+        ],
+        factoryOpts: { signer: deployer },
+        proxyOpts: { kind: "transparent" },
+      }
+    )
+    const l2BtcRedeemer = redeemerDeployment[0] as L2BTCRedeemerWormhole
+
+    return {
+      deployer,
+      governance,
+      l2BtcDepositor,
+      l2BtcRedeemer,
+    }
+  }
+
+  let deployer: SignerWithAddress
+  let l2BtcDepositor: L2BTCDepositorWormhole
+  let l2BtcRedeemer: L2BTCRedeemerWormhole
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ deployer, l2BtcDepositor, l2BtcRedeemer } = await waffle.loadFixture(
+      contractsFixture
+    ))
+  })
+
+  describe("L2BTCDepositorWormhole.initializeDepositWithRebate", () => {
+    it("rejects contract callers that spoof an EOA during construction", async () => {
+      const l2DepositOwner = deployer.address
+      const maxRebateSat = 0
+      const emptyAuth = "0x"
+      const callData = l2BtcDepositor.interface.encodeFunctionData(
+        "initializeDepositWithRebate",
+        [
+          initializeDepositFixture.fundingTx,
+          initializeDepositFixture.reveal,
+          l2DepositOwner,
+          l2DepositOwner, // beneficiary matches, isolating the EOA guard
+          maxRebateSat,
+          emptyAuth,
+        ]
+      )
+
+      const factory = await ethers.getContractFactory(
+        "ConstructorRebateCaller"
+      )
+      // The helper performs the target call inside its constructor. Its own
+      // code length is zero at call time, but tx.origin is the deployer's
+      // EOA while msg.sender is the helper, so the guard must revert.
+      await expect(factory.deploy(l2BtcDepositor.address, callData)).to.be
+        .revertedWith("Signed auth required")
+    })
+  })
+
+  describe("L2BTCRedeemerWormhole.requestRedemptionWithRebate", () => {
+    it("rejects contract callers that spoof an EOA during construction", async () => {
+      const amount = ethers.utils.parseUnits("1", 18)
+      const outputScript =
+        "0x1976a9140102030405060708090a0b0c0d0e0f101112131488ac"
+      const emptyAuth = "0x"
+
+      const callData = l2BtcRedeemer.interface.encodeFunctionData(
+        "requestRedemptionWithRebate",
+        [
+          amount,
+          30, // arbitrary recipient wormhole chain id
+          outputScript,
+          deployer.address, // rebateBeneficiary
+          0, // maxRebateSat
+          emptyAuth, // rebateAuthorization
+          0, // nonce
+        ]
+      )
+
+      const factory = await ethers.getContractFactory(
+        "ConstructorRebateCaller"
+      )
+      await expect(factory.deploy(l2BtcRedeemer.address, callData)).to.be
+        .revertedWith("Signed auth required")
+    })
+  })
+})

--- a/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
@@ -154,14 +154,13 @@ describe("L2 rebate EOA guard (regression)", () => {
         ]
       )
 
-      const factory = await ethers.getContractFactory(
-        "ConstructorRebateCaller"
-      )
+      const factory = await ethers.getContractFactory("ConstructorRebateCaller")
       // The helper performs the target call inside its constructor. Its own
       // code length is zero at call time, but tx.origin is the deployer's
       // EOA while msg.sender is the helper, so the guard must revert.
-      await expect(factory.deploy(l2BtcDepositor.address, callData)).to.be
-        .revertedWith("Signed auth required")
+      await expect(
+        factory.deploy(l2BtcDepositor.address, callData)
+      ).to.be.revertedWith("Signed auth required")
     })
   })
 
@@ -185,11 +184,10 @@ describe("L2 rebate EOA guard (regression)", () => {
         ]
       )
 
-      const factory = await ethers.getContractFactory(
-        "ConstructorRebateCaller"
-      )
-      await expect(factory.deploy(l2BtcRedeemer.address, callData)).to.be
-        .revertedWith("Signed auth required")
+      const factory = await ethers.getContractFactory("ConstructorRebateCaller")
+      await expect(
+        factory.deploy(l2BtcRedeemer.address, callData)
+      ).to.be.revertedWith("Signed auth required")
     })
   })
 })

--- a/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
+++ b/solidity/test/cross-chain/wormhole/L2RebateEOAGuard.test.ts
@@ -1,5 +1,4 @@
-import { ethers, helpers, waffle } from "hardhat"
-import { randomBytes } from "crypto"
+import { ethers, waffle } from "hardhat"
 import chai, { expect } from "chai"
 import { smock } from "@defi-wonderland/smock"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
@@ -9,7 +8,30 @@ import {
   L2BTCDepositorWormhole,
   L2BTCRedeemerWormhole,
 } from "../../../typechain"
-import { initializeDepositFixture } from "./L1BTCDepositorWormhole.test"
+
+// Minimal, compilation-only deposit fixture. The guard fires before any
+// field is validated, so the exact bytes do not matter -- we just need
+// the calldata shape to encode cleanly.
+const fundingTxFixture = {
+  version: "0x01000000",
+  inputVector:
+    "0x01dfe39760a5edabdab013114053d789ada21e356b59fea41d980396" +
+    "c1a4474fad0100000023220020e57edf10136b0434e46bc08c5ac5a1e4" +
+    "5f64f778a96f984d0051873c7a8240f2ffffffff",
+  outputVector:
+    "0x02804f1200000000002200202f601522e7bb1f7de5c56bdbd45590b3" +
+    "499bad09190581dcaa17e152d8f0c2a9b7e837000000000017a9148688" +
+    "4e6be1525dab5ae0b451bd2c72cee67dcf4187",
+  locktime: "0x00000000",
+}
+const revealFixture = {
+  fundingOutputIndex: 0,
+  blindingFactor: "0xba863847d2d0fee3",
+  walletPubKeyHash: "0xf997563fee8610ca28f99ac05bd8a29506800d4d",
+  refundPubKeyHash: "0x7ac2d9378a1c47e589dfb8095ca95ed2140d2726",
+  refundLocktime: "0xde2b4c67",
+  vault: "0xB5679dE944A79732A75CE556191DF11F489448d5",
+}
 
 chai.use(smock.matchers)
 
@@ -20,9 +42,48 @@ chai.use(smock.matchers)
 // deployed in the same transaction could mint a rebate on behalf of an
 // address it controls. The `tx.origin` check rejects any nested call
 // frame -- constructor or otherwise.
+// Helper to deploy an upgradeable contract behind a minimal
+// TransparentUpgradeableProxy without going through the OpenZeppelin
+// hardhat-upgrades plugin. The plugin's upgrade-safety validation
+// trips on these contracts in the environment used by this repo, but
+// for the regression we only need a live instance at a proxy address
+// -- no storage-layout checks are required.
+async function deployBehindMinimalProxy(
+  contractName: string,
+  initializerName: string,
+  initializerArgs: unknown[],
+  deployer: SignerWithAddress,
+  proxyAdmin: SignerWithAddress
+) {
+  const factory = await ethers.getContractFactory(contractName, deployer)
+  const impl = await factory.deploy()
+  await impl.deployed()
+
+  const initData = impl.interface.encodeFunctionData(
+    initializerName,
+    initializerArgs
+  )
+
+  const ProxyFactory = await ethers.getContractFactory(
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+    deployer
+  )
+  const proxy = await ProxyFactory.deploy(
+    impl.address,
+    proxyAdmin.address,
+    initData
+  )
+  await proxy.deployed()
+
+  return factory.attach(proxy.address)
+}
+
 describe("L2 rebate EOA guard (regression)", () => {
   const contractsFixture = async () => {
-    const { deployer, governance } = await helpers.signers.getNamedSigners()
+    const signers = await ethers.getSigners()
+    const deployer = signers[0]
+    const proxyAdmin = signers[9]
+    const governance = signers[1]
 
     const wormholeRelayer = await smock.fake<IWormholeRelayer>(
       "IWormholeRelayer"
@@ -32,42 +93,30 @@ describe("L2 rebate EOA guard (regression)", () => {
     )
     const l1ChainId = 2
 
-    const depositorDeployment = await helpers.upgrades.deployProxy(
-      `L2BTCDepositorWormhole_${randomBytes(8).toString("hex")}`,
-      {
-        contractName: "L2BTCDepositorWormhole",
-        initializerArgs: [
-          wormholeRelayer.address,
-          l2WormholeGateway.address,
-          l1ChainId,
-        ],
-        factoryOpts: { signer: deployer },
-        proxyOpts: { kind: "transparent" },
-      }
-    )
-    const l2BtcDepositor = depositorDeployment[0] as L2BTCDepositorWormhole
-
-    // A minimal tBTC stand-in for the redeemer fixture. We do not invoke
-    // the happy path in this test, only the guard, so a fake is enough.
     const tbtc = await (
-      await ethers.getContractFactory("TestERC20")
+      await ethers.getContractFactory("TestERC20", deployer)
     ).deploy()
     await tbtc.deployed()
 
-    const redeemerDeployment = await helpers.upgrades.deployProxy(
-      `L2BTCRedeemerWormhole_${randomBytes(8).toString("hex")}`,
-      {
-        contractName: "L2BTCRedeemerWormhole",
-        initializerArgs: [
-          tbtc.address,
-          l2WormholeGateway.address,
-          ethers.utils.hexZeroPad("0x0123", 32),
-        ],
-        factoryOpts: { signer: deployer },
-        proxyOpts: { kind: "transparent" },
-      }
-    )
-    const l2BtcRedeemer = redeemerDeployment[0] as L2BTCRedeemerWormhole
+    const l2BtcRedeemer = (await deployBehindMinimalProxy(
+      "L2BTCRedeemerWormhole",
+      "initialize",
+      [
+        tbtc.address,
+        l2WormholeGateway.address,
+        ethers.utils.hexZeroPad("0x0123", 32),
+      ],
+      deployer,
+      proxyAdmin
+    )) as L2BTCRedeemerWormhole
+
+    const l2BtcDepositor = (await deployBehindMinimalProxy(
+      "L2BTCDepositorWormhole",
+      "initialize",
+      [wormholeRelayer.address, l2WormholeGateway.address, l1ChainId],
+      deployer,
+      proxyAdmin
+    )) as L2BTCDepositorWormhole
 
     return {
       deployer,
@@ -96,8 +145,8 @@ describe("L2 rebate EOA guard (regression)", () => {
       const callData = l2BtcDepositor.interface.encodeFunctionData(
         "initializeDepositWithRebate",
         [
-          initializeDepositFixture.fundingTx,
-          initializeDepositFixture.reveal,
+          fundingTxFixture,
+          revealFixture,
           l2DepositOwner,
           l2DepositOwner, // beneficiary matches, isolating the EOA guard
           maxRebateSat,


### PR DESCRIPTION
Follow-up to #952 addressing findings from an automated Solidity security audit (fabro `audit-solidity` workflow, verified manually). Each commit is a single isolated fix or a targeted regression test.

## Fixed + tested

### High
- **emitterChainId validation on the Wormhole bridge receiver** (d2bd813)
  `L1BTCRedeemerWormhole` authenticated senders solely by `transfer.fromAddress`, letting a contract deployed at the same address on any chain with a registered Wormhole Token Bridge impersonate the authorized L2 redeemer. Introduces a Wormhole Core reference and a `sender -> wormhole chain ID` mapping; once the core is set, every allowed sender must have a matching wormhole chain ID or redemptions revert. Additive, gated so existing deployments migrate without breaking.
  Regression (4286488, 6226404): `setWormhole` one-shot / zero / owner-only; `updateAllowedSenderWormholeChain` owner-only + event; `requestRedemption` backward-compatible when core unset, reverts on unconfigured sender, reverts on chain mismatch, accepts on match.

### Medium
- **Bound gas cost in `forceStakeTransfer`** (f52e42c)
  `rebates[]` grows indefinitely; copying the full array eventually trips the block gas limit. Only the active rolling window is copied, rebased to index 0.
  Regression (17cabe5): three rebates spanning the window, transfer, assert only the in-window entries survive and the available rebate reflects the post-copy state.
- **EOA guard hardening on L2 rebate paths** (5091ee8)
  `msg.sender.code.length == 0` is bypassable from a constructor; replaced with `tx.origin == msg.sender`.
  Regression (bb4d930): a helper contract performs the call from its constructor, asserts both `initializeDepositWithRebate` and `requestRedemptionWithRebate` revert with "Signed auth required".
- **Lock implementation initializers on upgradeable L2 contracts** (4ca6f28)
  `_disableInitializers()` constructor on `L2WormholeGateway` and `L2TBTC`.
  Regression (ac6f770): bare implementations reject `initialize` with the OZ "already initialized" error.
  *Partial*: `L2BTCRedeemerWormhole` reverted (see "Tooling caveat" below).

### Low
- **`.transfer()` -> low-level `.call{}` in `L1BTCDepositorNtt.retrieveTokens`** (05879f5) -- 2300 gas is not enough for smart-wallet owners.

## Tooling caveat (`_disableInitializers` on `L2BTCRedeemerWormhole`)

Adding the `_disableInitializers()` constructor pushed the contract's creation bytecode past a size boundary that triggers a known bug in `@openzeppelin/hardhat-upgrades@1.22.0` / `@openzeppelin/upgrades-core@1.20.0`: the plugin's version-matching loop mis-applies link references from unrelated linkable contracts (e.g., `Bridge` linking `Wallets` at byte offset 7376) to this contract's bytecode, producing a corrupt placeholder that fails the hex-validity check. Every `deployProxy` call in the existing test suite was failing with `Error: Bytecode is not a valid hex string` until the constructor was reverted.

Rather than downgrade the fix on the other two contracts or patch vendored plugin code, I documented the constraint inline and deferred this specific hardening until the plugin is upgraded. The `L2BTCRedeemerWormhole` mock + initializer lock regression test already exercises the guard for `L2WormholeGateway` and `L2TBTC`; a one-line revert will re-enable it on the redeemer when the tooling is bumped.

## Test results (locally, subset of suites I touched)

```
test/cross-chain/wormhole/L1BTCRedeemerWormhole.test.ts
test/cross-chain/wormhole/L2BTCRedeemerWormhole.test.ts
test/cross-chain/wormhole/L2DepositorWormholeAdapter.test.ts
test/cross-chain/wormhole/L2RebateEOAGuard.test.ts           (new)
test/cross-chain/wormhole/L2ImplementationInitializerLock.test.ts (new)
test/cross-chain/L2TBTC.test.ts
test/cross-chain/L2WormholeGateway.test.ts

  278 passing (16s)
```

`test/bridge/RebateStaking.test.ts`: my new regression context compiles and is structurally correct, but the local env's external-deploy setup pulls the mainnet Bridge artifact, which predates `applyForRebate` (added by #952 itself). In CI against the PR branch's Bridge it will execute; the logic is in 17cabe5.

## Deferred (rationale)

| Finding | Sev | Why deferred |
|---|---|---|
| Yearn spot-price sandwich (Curve/Convex/Saddle) | High | Pre-existing; needs TWAP or caller `minOut`, belongs in a dedicated yearn PR. |
| Yearn AMM deadline = `block.timestamp` | Med | Same scope. |
| `LightRelay.proofLength` immediate update | Med | Pre-existing; adding a timelock is a governance-visible behavior change. |
| `__gap` missing in `AbstractL1BTCDepositor` | Med | `BaseL1BitcoinDepositor` (and likely more) already on mainnet; adding a gap now would shift descendant storage on upgrade. Needs a no-add-state constraint or a coordinated migration. |
| `Ownable` -> `Ownable2Step` (LightRelay/Bank/BridgeGovernance/bob L2TBTC) | Low | Behavior-breaking on non-upgradeable governance contracts; adds a storage slot for upgradeable extenders. Requires governance-tool coordination. |