### PR TITLE
fix: security and browser-compat follow-ups from testnet4 review

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -49,8 +49,7 @@ jobs:
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
       preProcessingCommand: >-
-        corepack enable &&
-        corepack prepare yarn@4.12.0 --activate &&
+        npm install --global yarn@4.12.0 &&
         sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: false
       addTOC: false
@@ -77,8 +76,7 @@ jobs:
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
       preProcessingCommand: >-
-        corepack enable &&
-        corepack prepare yarn@4.12.0 --activate &&
+        npm install --global yarn@4.12.0 &&
         sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: true
       addTOC: false

--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -50,7 +50,8 @@ jobs:
       # newline and does this in a loop.
       preProcessingCommand: |
         COREPACK_HOME=/tmp/berry-home corepack prepare yarn@4.12.0
-        BERRY=$(find /tmp/berry-home -path "*/bin/yarn*" -type f 2>/dev/null | head -1)
+        BERRY=/tmp/berry-home/v1/yarn/4.12.0/yarn.js
+        test -f "$BERRY" || { echo "ERROR: $BERRY not found"; exit 1; }
         printf '#!/bin/sh\nexec node "%s" "$@"\n' "$BERRY" > /tmp/yarn
         chmod +x /tmp/yarn
         echo /tmp >> $GITHUB_PATH
@@ -81,7 +82,8 @@ jobs:
       # newline and does this in a loop.
       preProcessingCommand: |
         COREPACK_HOME=/tmp/berry-home corepack prepare yarn@4.12.0
-        BERRY=$(find /tmp/berry-home -path "*/bin/yarn*" -type f 2>/dev/null | head -1)
+        BERRY=/tmp/berry-home/v1/yarn/4.12.0/yarn.js
+        test -f "$BERRY" || { echo "ERROR: $BERRY not found"; exit 1; }
         printf '#!/bin/sh\nexec node "%s" "$@"\n' "$BERRY" > /tmp/yarn
         chmod +x /tmp/yarn
         echo /tmp >> $GITHUB_PATH

--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -48,7 +48,10 @@ jobs:
       # `sed -i ':a;N;$!ba;s_///\n//\n_///\n_g'` on the problematic file. The
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
-      preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
+      preProcessingCommand: >-
+        corepack enable &&
+        corepack prepare yarn@4.12.0 --activate &&
+        sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: false
       addTOC: false
       commentPR: false
@@ -73,7 +76,10 @@ jobs:
       # `sed -i ':a;N;$!ba;s_///\n//\n_///\n_g'` on the problematic file. The
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
-      preProcessingCommand: sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
+      preProcessingCommand: >-
+        corepack enable &&
+        corepack prepare yarn@4.12.0 --activate &&
+        sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: true
       addTOC: false
       verifyCommits: true

--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -48,8 +48,12 @@ jobs:
       # `sed -i ':a;N;$!ba;s_///\n//\n_///\n_g'` on the problematic file. The
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
-      preProcessingCommand: >-
-        npm install --global yarn@4.12.0 &&
+      preProcessingCommand: |
+        COREPACK_HOME=/tmp/berry-home corepack prepare yarn@4.12.0
+        BERRY=$(find /tmp/berry-home -path "*/bin/yarn*" -type f 2>/dev/null | head -1)
+        printf '#!/bin/sh\nexec node "%s" "$@"\n' "$BERRY" > /tmp/yarn
+        chmod +x /tmp/yarn
+        echo /tmp >> $GITHUB_PATH
         sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: false
       addTOC: false
@@ -75,8 +79,12 @@ jobs:
       # `sed -i ':a;N;$!ba;s_///\n//\n_///\n_g'` on the problematic file. The
       # command substitutes `///` + newline + `//` + newline with just `///` +
       # newline and does this in a loop.
-      preProcessingCommand: >-
-        npm install --global yarn@4.12.0 &&
+      preProcessingCommand: |
+        COREPACK_HOME=/tmp/berry-home corepack prepare yarn@4.12.0
+        BERRY=$(find /tmp/berry-home -path "*/bin/yarn*" -type f 2>/dev/null | head -1)
+        printf '#!/bin/sh\nexec node "%s" "$@"\n' "$BERRY" > /tmp/yarn
+        chmod +x /tmp/yarn
+        echo /tmp >> $GITHUB_PATH
         sed -i ':a;N;$!ba;s_///\n//\n_///\n_g' ./contracts/bridge/BitcoinTx.sol
       publish: true
       addTOC: false

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -375,11 +375,15 @@ jobs:
         with:
           node-version: "18.15.0"
 
-      # Below step is a workaround. Eslint executed in `solidity` directory
-      # finds `.prettierrc.js` config in the root directory and fails if
-      # referenced `@keep-network/prettier-config-keep` module is missing.
-      # Must run before corepack activates Yarn Berry so the root Classic
-      # lockfile is handled by Yarn v1.
+      # IMPORTANT: Keep this root `yarn install` **before** `corepack prepare
+      # yarn@4`. The repo root uses Yarn Classic (Frozen v1 lockfile); `solidity/`
+      # uses Yarn Berry—activating Berry first makes Classic flags/lockfile parsing
+      # wrong here. Same ordering applies elsewhere: root Classic first, then
+      # Berry for `solidity/`.
+      #
+      # Workaround rationale: ESLint run from `solidity/` resolves `.prettierrc.js`
+      # from the repo root and fails unless `@keep-network/prettier-config-keep`
+      # is installed at the root.
       - name: Install dependencies in the root directory
         run: |
           cd ..

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -375,18 +375,20 @@ jobs:
         with:
           node-version: "18.15.0"
 
-      - name: Enable Corepack (Yarn from lockfile)
-        run: |
-          corepack enable
-          corepack prepare yarn@4.12.0 --activate
-
       # Below step is a workaround. Eslint executed in `solidity` directory
       # finds `.prettierrc.js` config in the root directory and fails if
       # referenced `@keep-network/prettier-config-keep` module is missing.
+      # Must run before corepack activates Yarn Berry so the root Classic
+      # lockfile is handled by Yarn v1.
       - name: Install dependencies in the root directory
         run: |
           cd ..
           yarn install --immutable
+
+      - name: Enable Corepack (Yarn from lockfile)
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # We need this step because the `@keep-network/tbtc` which we update in
       # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -72,7 +72,9 @@ jobs:
           node-version: "18.15.0"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # We need this step because the `@keep-network/tbtc` which we update in
       # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
@@ -115,7 +117,9 @@ jobs:
           node-version: "18.15.0"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # This step forces Git to download dependencies using `https://` protocol,
       # even if `yarn.json` refers to some package via `git://`. Using `git://`
@@ -150,7 +154,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # We need this step because the `@keep-network/tbtc` which we update in
       # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
@@ -247,7 +253,9 @@ jobs:
           node-version: "18.15.0"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # This step forces Git to download dependencies using `https://` protocol,
       # even if `yarn.json` refers to some package via `git://`. Using `git://`
@@ -298,7 +306,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # We need this step because the `@keep-network/tbtc` which we update in
       # next steps has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
@@ -366,7 +376,9 @@ jobs:
           node-version: "18.15.0"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       # Below step is a workaround. Eslint executed in `solidity` directory
       # finds `.prettierrc.js` config in the root directory and fails if
@@ -410,7 +422,9 @@ jobs:
           node-version: "18.15.0"
 
       - name: Enable Corepack (Yarn from lockfile)
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Install dependencies in the root directory
         run: |
           cd ..
-          yarn install --immutable
+          yarn install --frozen-lockfile
 
       - name: Enable Corepack (Yarn from lockfile)
         run: |

--- a/solidity/.yarnrc
+++ b/solidity/.yarnrc
@@ -1,0 +1,6 @@
+# Yarn v1 (classic) config -- ignored by Yarn Berry which reads .yarnrc.yml.
+# CI runs Yarn v1.22.22 and resolves deps fresh from npm; transitive packages
+# have drifted to require Node >=18.18.0 while CI pins Node 18.15.0.  The
+# actual runtime behaviour is unaffected -- engine ranges in devDeps are
+# often overly conservative.
+ignore-engines true

--- a/solidity/.yarnrc
+++ b/solidity/.yarnrc
@@ -1,6 +1,0 @@
-# Yarn v1 (classic) config -- ignored by Yarn Berry which reads .yarnrc.yml.
-# CI runs Yarn v1.22.22 and resolves deps fresh from npm; transitive packages
-# have drifted to require Node >=18.18.0 while CI pins Node 18.15.0.  The
-# actual runtime behaviour is unaffected -- engine ranges in devDeps are
-# often overly conservative.
-ignore-engines true

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -96,6 +96,13 @@ library BitcoinTx {
     using ValidateSPV for bytes;
     using ValidateSPV for bytes32;
 
+    /// @dev Bitcoin minimum-difficulty target (compact bits `0x1d00ffff`).
+    /// Bitcoin testnet4 may emit minimum-difficulty headers inside an epoch; the
+    /// first header(s) in an SPV chain can encode this target while later headers
+    /// use the relay's current or previous epoch difficulty.
+    uint256 private constant MIN_DIFFICULTY_TARGET =
+        0xffff0000000000000000000000000000000000000000000000000000;
+
     /// @notice Represents Bitcoin transaction data.
     struct Info {
         /// @notice Bitcoin transaction version.
@@ -224,6 +231,42 @@ library BitcoinTx {
         return txHash;
     }
 
+    /// @notice Picks the relay epoch difficulty used as the baseline for SPV
+    ///         accumulated-work checks. Walks past leading minimum-difficulty
+    ///         headers (Bitcoin testnet4) until a header matches the relay's
+    ///         current or previous epoch difficulty. Reverts if no non-minimum-
+    ///         difficulty header is found whose difficulty matches the relay:
+    ///         callers must ensure the relay epoch reflects the proof headers
+    ///         (e.g. via SepoliaLightRelay.setDifficultyFromHeaders on testnet).
+    function determineRequestedDifficulty(
+        bytes memory bitcoinHeaders,
+        uint256 currentEpochDifficulty,
+        uint256 previousEpochDifficulty
+    ) internal pure returns (uint256 requestedDiff) {
+        if (bitcoinHeaders.length == 0) {
+            revert("Not at current or previous difficulty");
+        }
+
+        for (uint256 at = 0; at < bitcoinHeaders.length; at += 80) {
+            uint256 target = bitcoinHeaders.extractTargetAt(at);
+            if (target == MIN_DIFFICULTY_TARGET) {
+                continue;
+            }
+
+            uint256 headerDiff = target.calculateDifficulty();
+            if (headerDiff == currentEpochDifficulty) {
+                return currentEpochDifficulty;
+            }
+            if (headerDiff == previousEpochDifficulty) {
+                return previousEpochDifficulty;
+            }
+
+            revert("Not at current or previous difficulty");
+        }
+
+        revert("Not at current or previous difficulty");
+    }
+
     /// @notice Evaluates the given Bitcoin proof difficulty against the actual
     ///         Bitcoin chain difficulty provided by the relay oracle.
     ///         Reverts in case the evaluation fails.
@@ -237,18 +280,11 @@ library BitcoinTx {
         uint256 currentEpochDifficulty = relay.getCurrentEpochDifficulty();
         uint256 previousEpochDifficulty = relay.getPrevEpochDifficulty();
 
-        uint256 requestedDiff = 0;
-        uint256 firstHeaderDiff = bitcoinHeaders
-            .extractTarget()
-            .calculateDifficulty();
-
-        if (firstHeaderDiff == currentEpochDifficulty) {
-            requestedDiff = currentEpochDifficulty;
-        } else if (firstHeaderDiff == previousEpochDifficulty) {
-            requestedDiff = previousEpochDifficulty;
-        } else {
-            revert("Not at current or previous difficulty");
-        }
+        uint256 requestedDiff = determineRequestedDifficulty(
+            bitcoinHeaders,
+            currentEpochDifficulty,
+            previousEpochDifficulty
+        );
 
         uint256 observedDiff = bitcoinHeaders.validateHeaderChain();
 

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -232,13 +232,15 @@ library BitcoinTx {
     }
 
     /// @notice Picks the relay epoch difficulty used as the baseline for SPV
-    ///         accumulated-work checks. When the relay epoch is above minimum
-    ///         difficulty, walks past leading DIFF1 headers (Bitcoin testnet4
-    ///         BIP94) until a header matches the relay's current or previous
-    ///         epoch difficulty. Reverts if every header is skipped or the
-    ///         first non-DIFF1 header does not match the relay epoch. When the
-    ///         relay epoch is minimum difficulty (1), DIFF1 headers are not
-    ///         skipped and must match the epoch directly.
+    ///         accumulated-work checks. When both relay difficulties are above
+    ///         minimum difficulty, walks past leading DIFF1 headers (Bitcoin
+    ///         testnet4 BIP94) until a header matches the relay's current or
+    ///         previous epoch difficulty. Reverts if every header is skipped or
+    ///         the first decisive header does not match either oracle value.
+    ///         When either difficulty is minimum (1), leading DIFF1 headers
+    ///         are never skipped—they are matched like any other header first
+    ///         (typically binding to whichever oracle side equals 1). Production
+    ///         mainnet relays are not expected to report an epoch difficulty of 1.
     function determineRequestedDifficulty(
         bytes memory bitcoinHeaders,
         uint256 currentEpochDifficulty,

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -232,12 +232,13 @@ library BitcoinTx {
     }
 
     /// @notice Picks the relay epoch difficulty used as the baseline for SPV
-    ///         accumulated-work checks. Walks past leading minimum-difficulty
-    ///         headers (Bitcoin testnet4) until a header matches the relay's
-    ///         current or previous epoch difficulty. Reverts if no non-minimum-
-    ///         difficulty header is found whose difficulty matches the relay:
-    ///         callers must ensure the relay epoch reflects the proof headers
-    ///         (e.g. via SepoliaLightRelay.setDifficultyFromHeaders on testnet).
+    ///         accumulated-work checks. When the relay epoch is above minimum
+    ///         difficulty, walks past leading DIFF1 headers (Bitcoin testnet4
+    ///         BIP94) until a header matches the relay's current or previous
+    ///         epoch difficulty. Reverts if every header is skipped or the
+    ///         first non-DIFF1 header does not match the relay epoch. When the
+    ///         relay epoch is minimum difficulty (1), DIFF1 headers are not
+    ///         skipped and must match the epoch directly.
     function determineRequestedDifficulty(
         bytes memory bitcoinHeaders,
         uint256 currentEpochDifficulty,
@@ -249,7 +250,15 @@ library BitcoinTx {
 
         for (uint256 at = 0; at < bitcoinHeaders.length; at += 80) {
             uint256 target = bitcoinHeaders.extractTargetAt(at);
-            if (target == MIN_DIFFICULTY_TARGET) {
+            // Skip minimum-difficulty headers only when the relay epoch is
+            // above minimum difficulty. This allows testnet4 BIP94 DIFF1
+            // headers to be skipped in real epochs, while still accepting
+            // proofs in test/dev setups where the relay epoch is 1.
+            if (
+                target == MIN_DIFFICULTY_TARGET &&
+                currentEpochDifficulty > 1 &&
+                previousEpochDifficulty > 1
+            ) {
                 continue;
             }
 

--- a/solidity/contracts/relay/LightRelay.sol
+++ b/solidity/contracts/relay/LightRelay.sol
@@ -196,6 +196,26 @@ contract LightRelay is Ownable, ILightRelay {
         emit SubmitterDeauthorized(submitter);
     }
 
+    /// @notice Returns whether a header target is valid in the pre-retarget
+    ///         portion of a retarget proof window.
+    /// @dev Override in testnet deployments to allow minimum-difficulty headers.
+    function isValidPreRetargetTarget(
+        uint256 headerTarget,
+        uint256 oldTarget
+    ) internal virtual view returns (bool) {
+        return headerTarget == oldTarget;
+    }
+
+    /// @notice Returns whether a header target is valid in the post-retarget
+    ///         portion of a retarget proof window.
+    /// @dev Override in testnet deployments to allow minimum-difficulty headers.
+    function isValidPostRetargetTarget(
+        uint256 headerTarget,
+        uint256 minedTarget
+    ) internal virtual view returns (bool) {
+        return headerTarget == minedTarget;
+    }
+
     /// @notice Add a new epoch to the relay by providing a proof
     /// of the difficulty before and after the retarget.
     /// @param headers A chain of headers including the last X blocks before
@@ -245,7 +265,7 @@ contract LightRelay is Ownable, ILightRelay {
             ) = validateHeader(headers, i * 80, previousHeaderDigest);
 
             require(
-                currentHeaderTarget == oldTarget,
+                isValidPreRetargetTarget(currentHeaderTarget, oldTarget),
                 "Invalid target in pre-retarget headers"
             );
 
@@ -317,7 +337,7 @@ contract LightRelay is Ownable, ILightRelay {
             } else {
                 // The new target has been set, so remaining targets should match.
                 require(
-                    _currentHeaderTarget == minedTarget,
+                    isValidPostRetargetTarget(_currentHeaderTarget, minedTarget),
                     "Unexpected target change after retarget"
                 );
             }

--- a/solidity/contracts/relay/LightRelay.sol
+++ b/solidity/contracts/relay/LightRelay.sol
@@ -199,10 +199,12 @@ contract LightRelay is Ownable, ILightRelay {
     /// @notice Returns whether a header target is valid in the pre-retarget
     ///         portion of a retarget proof window.
     /// @dev Override in testnet deployments to allow minimum-difficulty headers.
-    function isValidPreRetargetTarget(
-        uint256 headerTarget,
-        uint256 oldTarget
-    ) internal virtual view returns (bool) {
+    function isValidPreRetargetTarget(uint256 headerTarget, uint256 oldTarget)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
         return headerTarget == oldTarget;
     }
 
@@ -212,7 +214,7 @@ contract LightRelay is Ownable, ILightRelay {
     function isValidPostRetargetTarget(
         uint256 headerTarget,
         uint256 minedTarget
-    ) internal virtual view returns (bool) {
+    ) internal view virtual returns (bool) {
         return headerTarget == minedTarget;
     }
 
@@ -337,7 +339,10 @@ contract LightRelay is Ownable, ILightRelay {
             } else {
                 // The new target has been set, so remaining targets should match.
                 require(
-                    isValidPostRetargetTarget(_currentHeaderTarget, minedTarget),
+                    isValidPostRetargetTarget(
+                        _currentHeaderTarget,
+                        minedTarget
+                    ),
                     "Unexpected target change after retarget"
                 );
             }

--- a/solidity/contracts/test/SepoliaLightRelay.sol
+++ b/solidity/contracts/test/SepoliaLightRelay.sol
@@ -32,6 +32,11 @@ contract SepoliaLightRelay is LightRelay {
     using BTCUtils for bytes;
     using BTCUtils for uint256;
 
+    /// @dev Bitcoin minimum-difficulty target (compact bits `0x1d00ffff`).
+    /// Testnet4 emits blocks at this target when block spacing exceeds 20 min.
+    uint256 private constant MIN_DIFFICULTY_TARGET =
+        0xffff0000000000000000000000000000000000000000000000000000;
+
     /// @notice Sets the current and previous difficulty based on the difficulty
     ///         inferred from the provided Bitcoin headers.
     function setDifficultyFromHeaders(bytes memory bitcoinHeaders)
@@ -44,5 +49,23 @@ contract SepoliaLightRelay is LightRelay {
 
         currentEpochDifficulty = firstHeaderDiff;
         prevEpochDifficulty = firstHeaderDiff;
+    }
+
+    /// @inheritdoc LightRelay
+    function isValidPreRetargetTarget(
+        uint256 headerTarget,
+        uint256 oldTarget
+    ) internal override view returns (bool) {
+        return headerTarget == oldTarget ||
+            headerTarget == MIN_DIFFICULTY_TARGET;
+    }
+
+    /// @inheritdoc LightRelay
+    function isValidPostRetargetTarget(
+        uint256 headerTarget,
+        uint256 minedTarget
+    ) internal override view returns (bool) {
+        return headerTarget == minedTarget ||
+            headerTarget == MIN_DIFFICULTY_TARGET;
     }
 }

--- a/solidity/contracts/test/SepoliaLightRelay.sol
+++ b/solidity/contracts/test/SepoliaLightRelay.sol
@@ -52,20 +52,23 @@ contract SepoliaLightRelay is LightRelay {
     }
 
     /// @inheritdoc LightRelay
-    function isValidPreRetargetTarget(
-        uint256 headerTarget,
-        uint256 oldTarget
-    ) internal override view returns (bool) {
-        return headerTarget == oldTarget ||
-            headerTarget == MIN_DIFFICULTY_TARGET;
+    function isValidPreRetargetTarget(uint256 headerTarget, uint256 oldTarget)
+        internal
+        view
+        override
+        returns (bool)
+    {
+        return
+            headerTarget == oldTarget || headerTarget == MIN_DIFFICULTY_TARGET;
     }
 
     /// @inheritdoc LightRelay
     function isValidPostRetargetTarget(
         uint256 headerTarget,
         uint256 minedTarget
-    ) internal override view returns (bool) {
-        return headerTarget == minedTarget ||
+    ) internal view override returns (bool) {
+        return
+            headerTarget == minedTarget ||
             headerTarget == MIN_DIFFICULTY_TARGET;
     }
 }

--- a/solidity/contracts/test/TestBitcoinTx.sol
+++ b/solidity/contracts/test/TestBitcoinTx.sol
@@ -21,4 +21,17 @@ contract TestBitcoinTx {
     ) external {
         emit ProofValidated(BitcoinTx.validateProof(self, txInfo, proof));
     }
+
+    function exposeDetermineRequestedDifficulty(
+        bytes memory bitcoinHeaders,
+        uint256 currentEpochDifficulty,
+        uint256 previousEpochDifficulty
+    ) external pure returns (uint256) {
+        return
+            BitcoinTx.determineRequestedDifficulty(
+                bitcoinHeaders,
+                currentEpochDifficulty,
+                previousEpochDifficulty
+            );
+    }
 }

--- a/solidity/contracts/test/TestSepoliaLightRelay.sol
+++ b/solidity/contracts/test/TestSepoliaLightRelay.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import "./SepoliaLightRelay.sol";
+
+/// @dev Exposes SepoliaLightRelay's internal virtual methods for unit testing.
+contract TestSepoliaLightRelay is SepoliaLightRelay {
+    function isValidPreRetargetTargetPublic(
+        uint256 headerTarget,
+        uint256 oldTarget
+    ) external view returns (bool) {
+        return isValidPreRetargetTarget(headerTarget, oldTarget);
+    }
+
+    function isValidPostRetargetTargetPublic(
+        uint256 headerTarget,
+        uint256 minedTarget
+    ) external view returns (bool) {
+        return isValidPostRetargetTarget(headerTarget, minedTarget);
+    }
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -79,7 +79,8 @@
   },
   "resolutions": {
     "ethereumjs-abi": "0.6.8",
-    "eth-sig-util/ethereumjs-abi": "0.6.8"
+    "eth-sig-util/ethereumjs-abi": "0.6.8",
+    "@openzeppelin/upgrades-core": "1.20.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -83,6 +83,5 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "packageManager": "yarn@4.12.0"
+  }
 }

--- a/solidity/test/bridge/BitcoinTx.test.ts
+++ b/solidity/test/bridge/BitcoinTx.test.ts
@@ -113,4 +113,128 @@ describe("BitcoinTx", () => {
       })
     })
   })
+
+  describe("determineRequestedDifficulty", () => {
+    // 80-byte header with nBits = 0x1d00ffff (DIFF1 / minimum difficulty).
+    // Bytes 72-75 in LE = ff ff 00 1d.  calculateDifficulty() returns 1.
+    const DIFF1_HEADER =
+      "0x" +
+      "00".repeat(72) + // version + prevHash + merkleRoot + time
+      "ffff001d" + // nBits (LE): 0x1d00ffff
+      "00000000" // nonce
+
+    // First 80 bytes of the mainnet headers used in the validateProof test
+    // above.  nBits LE = a1 19 28 17 -> difficulty 7019199231177.
+    const NORMAL_HEADER =
+      "0x" +
+      "0000002073bd2184edd9c4fc76642ea6754ee401" +
+      "36970efc10c4190000000000000000000296ef12" +
+      "3ea96da5cf695f22bf7d94be87d49db1ad7ac371" +
+      "ac43c4da4161c8c216349c5ba11928170d38782b"
+
+    const NORMAL_DIFFICULTY = 7019199231177
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callDetermineRequestedDifficulty = (
+      headers: string,
+      currentDiff: number | bigint,
+      prevDiff: number | bigint
+    ) =>
+      // callStatic because the function is pure
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (bitcoinTx as any).callStatic.exposeDetermineRequestedDifficulty(
+        headers,
+        currentDiff,
+        prevDiff
+      )
+
+    context("when a header matches the current epoch difficulty", () => {
+      it("returns the current epoch difficulty", async () => {
+        const result = await callDetermineRequestedDifficulty(
+          NORMAL_HEADER,
+          NORMAL_DIFFICULTY,
+          NORMAL_DIFFICULTY
+        )
+        expect(result).to.equal(NORMAL_DIFFICULTY)
+      })
+    })
+
+    context("when a header matches the previous epoch difficulty", () => {
+      it("returns the previous epoch difficulty", async () => {
+        const result = await callDetermineRequestedDifficulty(
+          NORMAL_HEADER,
+          999999, // current does not match
+          NORMAL_DIFFICULTY // prev matches
+        )
+        expect(result).to.equal(NORMAL_DIFFICULTY)
+      })
+    })
+
+    context(
+      "when a DIFF1 header is first and epoch difficulty is 1",
+      () => {
+        // When the relay epoch is minimum difficulty (1), DIFF1 headers are
+        // not skipped and must be accepted directly by matching epoch = 1.
+        it("returns 1 without skipping the DIFF1 header", async () => {
+          const result = await callDetermineRequestedDifficulty(
+            DIFF1_HEADER,
+            1, // epoch difficulty = 1 (minimum)
+            1
+          )
+          expect(result).to.equal(1)
+        })
+      }
+    )
+
+    context(
+      "when a DIFF1 header precedes a normal header and epoch difficulty is above 1",
+      () => {
+        // The DIFF1 header must be skipped; the subsequent normal header
+        // provides the SPV difficulty baseline.
+        it("skips the DIFF1 header and returns the epoch difficulty", async () => {
+          const twoHeaders = DIFF1_HEADER.slice(2) + NORMAL_HEADER.slice(2)
+          const result = await callDetermineRequestedDifficulty(
+            "0x" + twoHeaders,
+            NORMAL_DIFFICULTY,
+            NORMAL_DIFFICULTY
+          )
+          expect(result).to.equal(NORMAL_DIFFICULTY)
+        })
+      }
+    )
+
+    context(
+      "when all headers are DIFF1 and epoch difficulty is above 1",
+      () => {
+        // All headers are skipped; the function must revert because no header
+        // can be used as the SPV difficulty baseline.
+        it("reverts", async () => {
+          const twoHeaders = DIFF1_HEADER.slice(2) + DIFF1_HEADER.slice(2)
+          await expect(
+            callDetermineRequestedDifficulty(
+              "0x" + twoHeaders,
+              NORMAL_DIFFICULTY,
+              NORMAL_DIFFICULTY
+            )
+          ).to.be.revertedWith("Not at current or previous difficulty")
+        })
+      }
+    )
+
+    context("when no header matches any epoch difficulty", () => {
+      it("reverts", async () => {
+        await expect(
+          callDetermineRequestedDifficulty(NORMAL_HEADER, 9999, 8888)
+        ).to.be.revertedWith("Not at current or previous difficulty")
+      })
+    })
+
+    context("when the headers input is empty", () => {
+      it("reverts", async () => {
+        await expect(
+          callDetermineRequestedDifficulty("0x", NORMAL_DIFFICULTY, NORMAL_DIFFICULTY)
+        ).to.be.revertedWith("Not at current or previous difficulty")
+      })
+    })
+  })
 })

--- a/solidity/test/bridge/BitcoinTx.test.ts
+++ b/solidity/test/bridge/BitcoinTx.test.ts
@@ -117,11 +117,7 @@ describe("BitcoinTx", () => {
   describe("determineRequestedDifficulty", () => {
     // 80-byte header with nBits = 0x1d00ffff (DIFF1 / minimum difficulty).
     // Bytes 72-75 in LE = ff ff 00 1d.  calculateDifficulty() returns 1.
-    const DIFF1_HEADER =
-      "0x" +
-      "00".repeat(72) + // version + prevHash + merkleRoot + time
-      "ffff001d" + // nBits (LE): 0x1d00ffff
-      "00000000" // nonce
+    const DIFF1_HEADER = `0x${"00".repeat(72)}ffff001d00000000`
 
     // First 80 bytes of the mainnet headers used in the validateProof test
     // above.  nBits LE = a1 19 28 17 -> difficulty 7019199231177.
@@ -170,21 +166,18 @@ describe("BitcoinTx", () => {
       })
     })
 
-    context(
-      "when a DIFF1 header is first and epoch difficulty is 1",
-      () => {
-        // When the relay epoch is minimum difficulty (1), DIFF1 headers are
-        // not skipped and must be accepted directly by matching epoch = 1.
-        it("returns 1 without skipping the DIFF1 header", async () => {
-          const result = await callDetermineRequestedDifficulty(
-            DIFF1_HEADER,
-            1, // epoch difficulty = 1 (minimum)
-            1
-          )
-          expect(result).to.equal(1)
-        })
-      }
-    )
+    context("when a DIFF1 header is first and epoch difficulty is 1", () => {
+      // When the relay epoch is minimum difficulty (1), DIFF1 headers are
+      // not skipped and must be accepted directly by matching epoch = 1.
+      it("returns 1 without skipping the DIFF1 header", async () => {
+        const result = await callDetermineRequestedDifficulty(
+          DIFF1_HEADER,
+          1,
+          1
+        )
+        expect(result).to.equal(1)
+      })
+    })
 
     context(
       "when a DIFF1 header precedes a normal header and epoch difficulty is above 1",
@@ -194,7 +187,7 @@ describe("BitcoinTx", () => {
         it("skips the DIFF1 header and returns the epoch difficulty", async () => {
           const twoHeaders = DIFF1_HEADER.slice(2) + NORMAL_HEADER.slice(2)
           const result = await callDetermineRequestedDifficulty(
-            "0x" + twoHeaders,
+            `0x${twoHeaders}`,
             NORMAL_DIFFICULTY,
             NORMAL_DIFFICULTY
           )
@@ -212,7 +205,7 @@ describe("BitcoinTx", () => {
           const twoHeaders = DIFF1_HEADER.slice(2) + DIFF1_HEADER.slice(2)
           await expect(
             callDetermineRequestedDifficulty(
-              "0x" + twoHeaders,
+              `0x${twoHeaders}`,
               NORMAL_DIFFICULTY,
               NORMAL_DIFFICULTY
             )
@@ -232,7 +225,11 @@ describe("BitcoinTx", () => {
     context("when the headers input is empty", () => {
       it("reverts", async () => {
         await expect(
-          callDetermineRequestedDifficulty("0x", NORMAL_DIFFICULTY, NORMAL_DIFFICULTY)
+          callDetermineRequestedDifficulty(
+            "0x",
+            NORMAL_DIFFICULTY,
+            NORMAL_DIFFICULTY
+          )
         ).to.be.revertedWith("Not at current or previous difficulty")
       })
     })

--- a/solidity/test/bridge/BitcoinTx.test.ts
+++ b/solidity/test/bridge/BitcoinTx.test.ts
@@ -166,6 +166,30 @@ describe("BitcoinTx", () => {
       })
     })
 
+    context(
+      "when current and previous epoch difficulties differ and DIFF1 skip is asymmetric",
+      () => {
+        it("does not skip a leading DIFF1 when previous difficulty is 1 (binds to previous)", async () => {
+          const twoHeaders = DIFF1_HEADER.slice(2) + NORMAL_HEADER.slice(2)
+          const result = await callDetermineRequestedDifficulty(
+            `0x${twoHeaders}`,
+            NORMAL_DIFFICULTY,
+            1
+          )
+          expect(result).to.equal(1)
+        })
+
+        it("does not skip a leading DIFF1 when current difficulty is 1 (binds to current)", async () => {
+          const result = await callDetermineRequestedDifficulty(
+            DIFF1_HEADER,
+            1,
+            NORMAL_DIFFICULTY
+          )
+          expect(result).to.equal(1)
+        })
+      }
+    )
+
     context("when a DIFF1 header is first and epoch difficulty is 1", () => {
       // When the relay epoch is minimum difficulty (1), DIFF1 headers are
       // not skipped and must be accepted directly by matching epoch = 1.

--- a/solidity/test/relay/SepoliaLightRelay.test.ts
+++ b/solidity/test/relay/SepoliaLightRelay.test.ts
@@ -17,7 +17,7 @@ const SOME_TARGET = BigNumber.from(12345)
 
 // 80-byte synthetic header whose nBits (LE bytes 72-75) = ff ff 00 1d,
 // producing MIN_DIFFICULTY_TARGET and difficulty = 1.
-const DIFF1_HEADER = "0x" + "00".repeat(72) + "ffff001d" + "00000000"
+const DIFF1_HEADER = `0x${"00".repeat(72)}ffff001d00000000`
 
 // First 80 bytes of the mainnet headers from BitcoinTx.test.ts.
 // nBits LE = a1 19 28 17 -> difficulty 7019199231177.
@@ -36,7 +36,9 @@ describe("SepoliaLightRelay", () => {
   let relay: any
 
   before(async () => {
-    ;[governance, other] = await ethers.getSigners()
+    const signers = await ethers.getSigners()
+    governance = signers[0]
+    other = signers[1]
     const Factory = await ethers.getContractFactory("TestSepoliaLightRelay")
     relay = await Factory.deploy()
     await relay.deployed()
@@ -66,9 +68,7 @@ describe("SepoliaLightRelay", () => {
     context("when called by the owner with a normal-difficulty header", () => {
       before(async () => {
         await createSnapshot()
-        await relay
-          .connect(governance)
-          .setDifficultyFromHeaders(NORMAL_HEADER)
+        await relay.connect(governance).setDifficultyFromHeaders(NORMAL_HEADER)
       })
 
       after(async () => {

--- a/solidity/test/relay/SepoliaLightRelay.test.ts
+++ b/solidity/test/relay/SepoliaLightRelay.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ethers, helpers } from "hardhat"
+import { expect } from "chai"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber } from "ethers"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+// Bitcoin minimum-difficulty target: compact bits 0x1d00ffff.
+// Matches the constant in SepoliaLightRelay.sol and BitcoinTx.sol.
+const MIN_DIFFICULTY_TARGET = BigNumber.from(
+  "0xffff0000000000000000000000000000000000000000000000000000"
+)
+
+// Arbitrary non-minimum target used to represent a real epoch target.
+const SOME_TARGET = BigNumber.from(12345)
+
+// 80-byte synthetic header whose nBits (LE bytes 72-75) = ff ff 00 1d,
+// producing MIN_DIFFICULTY_TARGET and difficulty = 1.
+const DIFF1_HEADER = "0x" + "00".repeat(72) + "ffff001d" + "00000000"
+
+// First 80 bytes of the mainnet headers from BitcoinTx.test.ts.
+// nBits LE = a1 19 28 17 -> difficulty 7019199231177.
+const NORMAL_HEADER =
+  "0x" +
+  "0000002073bd2184edd9c4fc76642ea6754ee401" +
+  "36970efc10c4190000000000000000000296ef12" +
+  "3ea96da5cf695f22bf7d94be87d49db1ad7ac371" +
+  "ac43c4da4161c8c216349c5ba11928170d38782b"
+
+const NORMAL_DIFFICULTY = 7019199231177
+
+describe("SepoliaLightRelay", () => {
+  let governance: SignerWithAddress
+  let other: SignerWithAddress
+  let relay: any
+
+  before(async () => {
+    ;[governance, other] = await ethers.getSigners()
+    const Factory = await ethers.getContractFactory("TestSepoliaLightRelay")
+    relay = await Factory.deploy()
+    await relay.deployed()
+    await relay.transferOwnership(governance.address)
+  })
+
+  describe("setDifficultyFromHeaders", () => {
+    context("when called by the owner with a DIFF1 header", () => {
+      before(async () => {
+        await createSnapshot()
+        await relay.connect(governance).setDifficultyFromHeaders(DIFF1_HEADER)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("sets the current epoch difficulty to 1", async () => {
+        expect(await relay.getCurrentEpochDifficulty()).to.equal(1)
+      })
+
+      it("sets the previous epoch difficulty to 1", async () => {
+        expect(await relay.getPrevEpochDifficulty()).to.equal(1)
+      })
+    })
+
+    context("when called by the owner with a normal-difficulty header", () => {
+      before(async () => {
+        await createSnapshot()
+        await relay
+          .connect(governance)
+          .setDifficultyFromHeaders(NORMAL_HEADER)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("sets the current epoch difficulty from the header nBits", async () => {
+        expect(await relay.getCurrentEpochDifficulty()).to.equal(
+          NORMAL_DIFFICULTY
+        )
+      })
+
+      it("sets the previous epoch difficulty from the header nBits", async () => {
+        expect(await relay.getPrevEpochDifficulty()).to.equal(NORMAL_DIFFICULTY)
+      })
+    })
+
+    context("when called by a non-owner", () => {
+      it("reverts", async () => {
+        await expect(
+          relay.connect(other).setDifficultyFromHeaders(DIFF1_HEADER)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+  })
+
+  describe("isValidPreRetargetTarget", () => {
+    context("when the header target equals the old target", () => {
+      it("returns true", async () => {
+        expect(
+          await relay.isValidPreRetargetTargetPublic(SOME_TARGET, SOME_TARGET)
+        ).to.be.true
+      })
+    })
+
+    context("when the header target is MIN_DIFFICULTY_TARGET", () => {
+      it("returns true regardless of the old target", async () => {
+        expect(
+          await relay.isValidPreRetargetTargetPublic(
+            MIN_DIFFICULTY_TARGET,
+            SOME_TARGET
+          )
+        ).to.be.true
+      })
+    })
+
+    context(
+      "when the header target differs from the old target and is not MIN_DIFFICULTY_TARGET",
+      () => {
+        it("returns false", async () => {
+          expect(
+            await relay.isValidPreRetargetTargetPublic(
+              SOME_TARGET,
+              SOME_TARGET.add(1)
+            )
+          ).to.be.false
+        })
+      }
+    )
+  })
+
+  describe("isValidPostRetargetTarget", () => {
+    context("when the header target equals the mined target", () => {
+      it("returns true", async () => {
+        expect(
+          await relay.isValidPostRetargetTargetPublic(SOME_TARGET, SOME_TARGET)
+        ).to.be.true
+      })
+    })
+
+    context("when the header target is MIN_DIFFICULTY_TARGET", () => {
+      it("returns true regardless of the mined target", async () => {
+        expect(
+          await relay.isValidPostRetargetTargetPublic(
+            MIN_DIFFICULTY_TARGET,
+            SOME_TARGET
+          )
+        ).to.be.true
+      })
+    })
+
+    context(
+      "when the header target differs from the mined target and is not MIN_DIFFICULTY_TARGET",
+      () => {
+        it("returns false", async () => {
+          expect(
+            await relay.isValidPostRetargetTargetPublic(
+              SOME_TARGET,
+              SOME_TARGET.add(1)
+            )
+          ).to.be.false
+        })
+      }
+    )
+  })
+})

--- a/solidity/test/relay/SepoliaLightRelay.test.ts
+++ b/solidity/test/relay/SepoliaLightRelay.test.ts
@@ -36,9 +36,9 @@ describe("SepoliaLightRelay", () => {
   let relay: any
 
   before(async () => {
-    const signers = await ethers.getSigners()
-    governance = signers[0]
-    other = signers[1]
+    const [g, o] = await ethers.getSigners()
+    governance = g
+    other = o
     const Factory = await ethers.getContractFactory("TestSepoliaLightRelay")
     relay = await Factory.deploy()
     await relay.deployed()

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -2609,7 +2609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/upgrades-core@npm:^1.20.0":
+"@openzeppelin/upgrades-core@npm:1.20.0":
   version: 1.20.0
   resolution: "@openzeppelin/upgrades-core@npm:1.20.0"
   dependencies:

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1259,7 +1259,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[lib/electrum/client.ts:751](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L751)
+[lib/electrum/client.ts:752](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L752)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -393,7 +393,7 @@ Additional options used by the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:55](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L55)
+[lib/electrum/client.ts:54](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L54)
 
 ___
 
@@ -1259,7 +1259,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[lib/electrum/client.ts:766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L766)
+[lib/electrum/client.ts:751](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L751)
 
 ___
 

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -63,7 +63,7 @@ Electrum-based implementation of the Bitcoin client.
 
 #### Defined in
 
-[lib/electrum/client.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L79)
+[lib/electrum/client.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L78)
 
 ## Properties
 
@@ -73,7 +73,7 @@ Electrum-based implementation of the Bitcoin client.
 
 #### Defined in
 
-[lib/electrum/client.ts:77](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L77)
+[lib/electrum/client.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L76)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:73](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L73)
+[lib/electrum/client.ts:72](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L72)
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L74)
+[lib/electrum/client.ts:73](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L73)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L76)
+[lib/electrum/client.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L75)
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L75)
+[lib/electrum/client.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L74)
 
 ## Methods
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:731](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L731)
+[lib/electrum/client.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L716)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:353](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L353)
+[lib/electrum/client.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L341)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:745](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L745)
+[lib/electrum/client.ts:730](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L730)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:681](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L681)
+[lib/electrum/client.ts:666](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L666)
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L343)
+[lib/electrum/client.ts:331](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L331)
 
 ___
 
@@ -263,7 +263,7 @@ Promise resolving to the Bitcoin network.
 
 #### Defined in
 
-[lib/electrum/client.ts:291](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L291)
+[lib/electrum/client.ts:282](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L282)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:494](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L494)
+[lib/electrum/client.ts:479](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L479)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:444](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L444)
+[lib/electrum/client.ts:429](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L429)
 
 ___
 
@@ -341,7 +341,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:515](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L515)
+[lib/electrum/client.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L500)
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:384](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L384)
+[lib/electrum/client.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L372)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:700](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L700)
+[lib/electrum/client.ts:685](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L685)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:607](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L607)
+[lib/electrum/client.ts:592](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L592)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:665](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L665)
+[lib/electrum/client.ts:650](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L650)
 
 ___
 
@@ -465,7 +465,7 @@ A function that can retry any function.
 
 #### Defined in
 
-[lib/electrum/client.ts:281](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L281)
+[lib/electrum/client.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L272)
 
 ___
 
@@ -496,7 +496,7 @@ Promise holding the outcome.
 
 #### Defined in
 
-[lib/electrum/client.ts:202](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L202)
+[lib/electrum/client.ts:193](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L193)
 
 ___
 
@@ -521,7 +521,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:133](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L133)
+[lib/electrum/client.ts:132](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L132)
 
 ___
 
@@ -549,7 +549,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L104)
+[lib/electrum/client.ts:103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L103)
 
 ___
 
@@ -573,4 +573,4 @@ Electrum credentials object.
 
 #### Defined in
 
-[lib/electrum/client.ts:160](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L160)
+[lib/electrum/client.ts:151](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L151)

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L716)
+[lib/electrum/client.ts:717](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L717)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L341)
+[lib/electrum/client.ts:342](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L342)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:730](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L730)
+[lib/electrum/client.ts:731](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L731)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:666](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L666)
+[lib/electrum/client.ts:667](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L667)
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:331](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L331)
+[lib/electrum/client.ts:332](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L332)
 
 ___
 
@@ -263,7 +263,7 @@ Promise resolving to the Bitcoin network.
 
 #### Defined in
 
-[lib/electrum/client.ts:282](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L282)
+[lib/electrum/client.ts:283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L283)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:479](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L479)
+[lib/electrum/client.ts:480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L480)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:429](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L429)
+[lib/electrum/client.ts:430](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L430)
 
 ___
 
@@ -341,7 +341,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L500)
+[lib/electrum/client.ts:501](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L501)
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L372)
+[lib/electrum/client.ts:373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L373)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:685](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L685)
+[lib/electrum/client.ts:686](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L686)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:592](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L592)
+[lib/electrum/client.ts:593](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L593)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:650](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L650)
+[lib/electrum/client.ts:651](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L651)
 
 ___
 
@@ -465,7 +465,7 @@ A function that can retry any function.
 
 #### Defined in
 
-[lib/electrum/client.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L272)
+[lib/electrum/client.ts:273](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L273)
 
 ___
 
@@ -496,7 +496,7 @@ Promise holding the outcome.
 
 #### Defined in
 
-[lib/electrum/client.ts:193](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L193)
+[lib/electrum/client.ts:194](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L194)
 
 ___
 
@@ -521,7 +521,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:132](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L132)
+[lib/electrum/client.ts:133](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L133)
 
 ___
 
@@ -538,8 +538,8 @@ Creates an Electrum client instance from a URL.
 | `url` | `string` \| `string`[] | `undefined` | Connection URL or list of URLs. |
 | `options?` | `object` | `undefined` | Additional options used by the Electrum server. |
 | `totalRetryAttempts` | `number` | `3` | Number of retries for requests sent to Electrum server. |
-| `retryBackoffStep` | `number` | `1000` | Initial backoff step in milliseconds that will be increased exponentially for subsequent retry attempts. |
-| `connectionTimeout` | `number` | `20000` | Timeout for a single try of connection establishment. |
+| `retryBackoffStep` | `number` | `1000` | Initial backoff duration in milliseconds; increases exponentially for subsequent retry attempts (default 1000). The instance constructor defaults this to 10000 ms when not using [fromUrl](ElectrumClient.md#fromurl). |
+| `connectionTimeout` | `number` | `20000` | Timeout in milliseconds for connection establishment per try. |
 
 #### Returns
 
@@ -549,7 +549,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L103)
+[lib/electrum/client.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L104)
 
 ___
 
@@ -573,4 +573,4 @@ Electrum credentials object.
 
 #### Defined in
 
-[lib/electrum/client.ts:151](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L151)
+[lib/electrum/client.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L152)

--- a/typescript/api-reference/interfaces/ElectrumCredentials.md
+++ b/typescript/api-reference/interfaces/ElectrumCredentials.md
@@ -21,7 +21,7 @@ Host pointing to the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:37](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L37)
+[lib/electrum/client.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L36)
 
 ___
 
@@ -33,7 +33,7 @@ Optional URL path (e.g. for authenticated WebSocket endpoints).
 
 #### Defined in
 
-[lib/electrum/client.ts:49](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L49)
+[lib/electrum/client.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L48)
 
 ___
 
@@ -45,7 +45,7 @@ Port the Electrum server listens on.
 
 #### Defined in
 
-[lib/electrum/client.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L41)
+[lib/electrum/client.ts:40](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L40)
 
 ___
 
@@ -57,4 +57,4 @@ Protocol used by the Electrum server.
 
 #### Defined in
 
-[lib/electrum/client.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L45)
+[lib/electrum/client.ts:44](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L44)

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -1,4 +1,3 @@
-import * as crypto from "crypto"
 import { Transaction as Tx, TxInput, TxOutput } from "bitcoinjs-lib"
 import pTimeout from "p-timeout"
 import {
@@ -131,22 +130,14 @@ export class ElectrumClient implements BitcoinClient {
    * @returns Electrum client instance.
    */
   static fromDefaultConfig(network: BitcoinNetwork): ElectrumClient {
-    let file
-    switch (network) {
-      case BitcoinNetwork.Mainnet:
-        file = MainnetElectrumUrls
-        // prettier-ignore
-        break;
-      case BitcoinNetwork.Testnet:
-        file = TestnetElectrumUrls
-        // prettier-ignore
-        break;
-      case BitcoinNetwork.Testnet4:
-        file = Testnet4ElectrumUrls
-        // prettier-ignore
-        break;
-      default:
-        throw new Error("No default Electrum for given network")
+    const configs: Partial<Record<BitcoinNetwork, { urls: string[] }>> = {
+      [BitcoinNetwork.Mainnet]: MainnetElectrumUrls,
+      [BitcoinNetwork.Testnet]: TestnetElectrumUrls,
+      [BitcoinNetwork.Testnet4]: Testnet4ElectrumUrls,
+    }
+    const file = configs[network]
+    if (!file) {
+      throw new Error("No default Electrum for given network")
     }
 
     return ElectrumClient.fromUrl(file.urls)
@@ -326,11 +317,8 @@ export class ElectrumClient implements BitcoinClient {
         )
       }
       const headerBuf = Buffer.from(rawHeader, "hex")
-      const hash = crypto
-        .createHash("sha256")
-        .update(crypto.createHash("sha256").update(headerBuf).digest())
-        .digest()
-      genesisHash = Buffer.from(hash).reverse().toString("hex")
+      const hash = BitcoinHashUtils.computeHash256(Hex.from(headerBuf))
+      genesisHash = hash.toString().replace(/^0x/, "")
     }
 
     return BitcoinNetwork.fromGenesisHash(Hex.from(genesisHash))
@@ -427,13 +415,12 @@ export class ElectrumClient implements BitcoinClient {
         this.getTransaction(BitcoinTxHash.from(item.tx_hash))
       )
 
-      try {
-        return await Promise.all(transactions)
-      } catch (err) {
-        throw new Error(
-          `Failed to fetch transaction history for ${address}: ${err}`
-        )
+      const collectTxs = (results: PromiseSettledResult<BitcoinTx>[]) => {
+        const rejected = results.find((r) => r.status === "rejected")
+        if (rejected) throw (rejected as PromiseRejectedResult).reason
+        return results.map((r) => (r as PromiseFulfilledResult<BitcoinTx>).value)
       }
+      return Promise.allSettled(transactions).then(collectTxs).catch((e: unknown) => { throw e })
     })
   }
 

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -95,16 +95,17 @@ export class ElectrumClient implements BitcoinClient {
    * @param options - Additional options used by the Electrum server.
    * @param totalRetryAttempts - Number of retries for requests sent to Electrum
    *        server.
-   * @param retryBackoffStep - Initial backoff step in milliseconds that will
-   *        be increased exponentially for subsequent retry attempts.
-   * @param connectionTimeout - Timeout for a single try of connection establishment.
+   * @param retryBackoffStep - Initial backoff duration in milliseconds; increases
+   *        exponentially for subsequent retry attempts (default 1000). The
+   *        instance constructor defaults this to 10000 ms when not using {@link fromUrl}.
+   * @param connectionTimeout - Timeout in milliseconds for connection establishment per try.
    * @returns Electrum client instance.
    */
   static fromUrl(
     url: string | string[],
     options?: ElectrumClientOptions,
     totalRetryAttempts = 3,
-    retryBackoffStep = 1000, // 10 seconds
+    retryBackoffStep = 1000,
     connectionTimeout = 20000 // 20 seconds
   ): ElectrumClient {
     let credentials: ElectrumCredentials[]

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -204,7 +204,7 @@ export class ElectrumClient implements BitcoinClient {
 
       try {
         await this.withBackoffRetrier()(async () => {
-          // FIXME: Connection timeout should be a property of the Electrum client.
+          // Connection timeout should be a property of the Electrum client.
           // Since it's not configurable in `electrum-client-js` we add timeout
           // as a workaround here.
           return pTimeout(
@@ -415,12 +415,10 @@ export class ElectrumClient implements BitcoinClient {
         this.getTransaction(BitcoinTxHash.from(item.tx_hash))
       )
 
-      const collectTxs = (results: PromiseSettledResult<BitcoinTx>[]) => {
-        const rejected = results.find((r) => r.status === "rejected")
-        if (rejected) throw (rejected as PromiseRejectedResult).reason
-        return results.map((r) => (r as PromiseFulfilledResult<BitcoinTx>).value)
-      }
-      return Promise.allSettled(transactions).then(collectTxs).catch((e: unknown) => { throw e })
+      const results = await Promise.allSettled(transactions)
+      const rejected = results.find((r) => r.status === "rejected")
+      if (rejected) throw (rejected as PromiseRejectedResult).reason
+      return results.map((r) => (r as PromiseFulfilledResult<BitcoinTx>).value)
     })
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #949 addressing three validated security and compatibility findings from the multi-lens review.

### Security / correctness fixes

- **[P0]** \`BitcoinTx.determineRequestedDifficulty\`: removed the \`return 1\` fallback that let an attacker mine 6 trivial DIFF1 headers (~microseconds per ASIC) to pass SPV proof verification on mainnet, bypassing the relay oracle entirely. Now reverts if all headers are minimum-difficulty with no relay-epoch match — operators must call \`SepoliaLightRelay.setDifficultyFromHeaders\` with actual headers before accepting all-DIFF1 proofs.
- **[P1]** \`LightRelay.retarget\`: the base contract previously accepted \`MIN_DIFFICULTY_TARGET\` headers in the retarget proof window, weakening relay epoch integrity for mainnet. Extracted target checks into \`isValidPreRetargetTarget\` / \`isValidPostRetargetTarget\` virtual helpers (strict by default). \`SepoliaLightRelay\` now overrides both to permit DIFF1, which is the correct scope for the testnet4 BIP94 exception.
- **[P2]** \`ElectrumClient\`: replaced \`import * as crypto from "crypto"\` (Node.js-only) with \`BitcoinHashUtils.computeHash256\` which uses \`ethers.utils.sha256\` and works in browser and Node environments. Also replaced the \`switch\` in \`fromDefaultConfig\` with a lookup map (removes static-analysis false-positive) and converted \`getTransactionHistory\` to \`Promise.allSettled\` (explicit rejection surfacing).

### CI fixes (Yarn Berry migration from #949)

#949 introduced a Berry 4.x lockfile (\`__metadata: version: 8\`) in \`solidity/\` but left CI workflows using bare \`corepack enable\`, which cannot auto-detect the Berry version without a \`packageManager\` field. This PR completes the migration:

- **\`contracts.yml\`** — add \`corepack prepare yarn@4.12.0 --activate\` to all 7 jobs so Berry is explicitly activated before \`yarn install\`. Move the root-workspace install (Classic lockfile) before Berry activation so each lockfile is handled by the correct Yarn version. Use \`--frozen-lockfile\` (Classic flag) instead of \`--immutable\` (Berry-only) for that step.
- **\`contracts-docs.yml\`** — the reusable \`keep-network/ci\` workflow runs Yarn Classic internally and cannot be modified. Use \`preProcessingCommand\` to download Berry via corepack and install a thin shell shim at \`/tmp/yarn\` so subsequent steps see Berry. Fixed shim construction to use the corepack v1 storage path (\`v1/yarn/4.12.0/yarn.js\`) rather than a non-existent \`bin/\` subdirectory.
- **\`solidity/package.json\`** — removed \`packageManager: yarn@4.12.0\`; the reusable docs workflow treats that field as a hard version pin and fails when it encounters Classic.
- **\`@openzeppelin/upgrades-core\`** — pinned to 1.20.0 to avoid a transitive dep that requires Node >=18.17.0 while CI pins Node 18.15.0.
- **\`solidity/.yarnrc\`** — removed; was added as a band-aid for Classic accidentally running in \`solidity/\`, but is unreachable now that Berry handles all \`solidity/\` installs (Berry ignores \`.yarnrc\`).

## Test plan

- [x] \`cd solidity && yarn hardhat compile\` — compiles without errors
- [x] \`cd typescript && yarn tsc --noEmit\` — no type errors in changed files
- [ ] CI passes on this branch