### PR TITLE
docs & tests: clarify DIFF1/oracle behaviour, Yarn CI order, Electrum retry defaults

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -375,11 +375,15 @@ jobs:
         with:
           node-version: "18.15.0"
 
-      # Below step is a workaround. Eslint executed in `solidity` directory
-      # finds `.prettierrc.js` config in the root directory and fails if
-      # referenced `@keep-network/prettier-config-keep` module is missing.
-      # Must run before corepack activates Yarn Berry so the root Classic
-      # lockfile is handled by Yarn v1.
+      # IMPORTANT: Keep this root `yarn install` **before** `corepack prepare
+      # yarn@4`. The repo root uses Yarn Classic (Frozen v1 lockfile); `solidity/`
+      # uses Yarn Berry—activating Berry first makes Classic flags/lockfile parsing
+      # wrong here. Same ordering applies elsewhere: root Classic first, then
+      # Berry for `solidity/`.
+      #
+      # Workaround rationale: ESLint run from `solidity/` resolves `.prettierrc.js`
+      # from the repo root and fails unless `@keep-network/prettier-config-keep`
+      # is installed at the root.
       - name: Install dependencies in the root directory
         run: |
           cd ..

--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -232,13 +232,15 @@ library BitcoinTx {
     }
 
     /// @notice Picks the relay epoch difficulty used as the baseline for SPV
-    ///         accumulated-work checks. When the relay epoch is above minimum
-    ///         difficulty, walks past leading DIFF1 headers (Bitcoin testnet4
-    ///         BIP94) until a header matches the relay's current or previous
-    ///         epoch difficulty. Reverts if every header is skipped or the
-    ///         first non-DIFF1 header does not match the relay epoch. When the
-    ///         relay epoch is minimum difficulty (1), DIFF1 headers are not
-    ///         skipped and must match the epoch directly.
+    ///         accumulated-work checks. When both relay difficulties are above
+    ///         minimum difficulty, walks past leading DIFF1 headers (Bitcoin
+    ///         testnet4 BIP94) until a header matches the relay's current or
+    ///         previous epoch difficulty. Reverts if every header is skipped or
+    ///         the first decisive header does not match either oracle value.
+    ///         When either difficulty is minimum (1), leading DIFF1 headers
+    ///         are never skipped—they are matched like any other header first
+    ///         (typically binding to whichever oracle side equals 1). Production
+    ///         mainnet relays are not expected to report an epoch difficulty of 1.
     function determineRequestedDifficulty(
         bytes memory bitcoinHeaders,
         uint256 currentEpochDifficulty,

--- a/solidity/test/bridge/BitcoinTx.test.ts
+++ b/solidity/test/bridge/BitcoinTx.test.ts
@@ -166,6 +166,30 @@ describe("BitcoinTx", () => {
       })
     })
 
+    context(
+      "when current and previous epoch difficulties differ and DIFF1 skip is asymmetric",
+      () => {
+        it("does not skip a leading DIFF1 when previous difficulty is 1 (binds to previous)", async () => {
+          const twoHeaders = DIFF1_HEADER.slice(2) + NORMAL_HEADER.slice(2)
+          const result = await callDetermineRequestedDifficulty(
+            `0x${twoHeaders}`,
+            NORMAL_DIFFICULTY,
+            1
+          )
+          expect(result).to.equal(1)
+        })
+
+        it("does not skip a leading DIFF1 when current difficulty is 1 (binds to current)", async () => {
+          const result = await callDetermineRequestedDifficulty(
+            DIFF1_HEADER,
+            1,
+            NORMAL_DIFFICULTY
+          )
+          expect(result).to.equal(1)
+        })
+      }
+    )
+
     context("when a DIFF1 header is first and epoch difficulty is 1", () => {
       // When the relay epoch is minimum difficulty (1), DIFF1 headers are
       // not skipped and must be accepted directly by matching epoch = 1.

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1259,7 +1259,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[lib/electrum/client.ts:751](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L751)
+[lib/electrum/client.ts:752](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L752)
 
 ___
 

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L716)
+[lib/electrum/client.ts:717](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L717)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L341)
+[lib/electrum/client.ts:342](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L342)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:730](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L730)
+[lib/electrum/client.ts:731](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L731)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:666](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L666)
+[lib/electrum/client.ts:667](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L667)
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:331](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L331)
+[lib/electrum/client.ts:332](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L332)
 
 ___
 
@@ -263,7 +263,7 @@ Promise resolving to the Bitcoin network.
 
 #### Defined in
 
-[lib/electrum/client.ts:282](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L282)
+[lib/electrum/client.ts:283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L283)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:479](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L479)
+[lib/electrum/client.ts:480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L480)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:429](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L429)
+[lib/electrum/client.ts:430](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L430)
 
 ___
 
@@ -341,7 +341,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L500)
+[lib/electrum/client.ts:501](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L501)
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L372)
+[lib/electrum/client.ts:373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L373)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:685](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L685)
+[lib/electrum/client.ts:686](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L686)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:592](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L592)
+[lib/electrum/client.ts:593](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L593)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[lib/electrum/client.ts:650](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L650)
+[lib/electrum/client.ts:651](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L651)
 
 ___
 
@@ -465,7 +465,7 @@ A function that can retry any function.
 
 #### Defined in
 
-[lib/electrum/client.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L272)
+[lib/electrum/client.ts:273](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L273)
 
 ___
 
@@ -496,7 +496,7 @@ Promise holding the outcome.
 
 #### Defined in
 
-[lib/electrum/client.ts:193](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L193)
+[lib/electrum/client.ts:194](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L194)
 
 ___
 
@@ -521,7 +521,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:132](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L132)
+[lib/electrum/client.ts:133](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L133)
 
 ___
 
@@ -538,8 +538,8 @@ Creates an Electrum client instance from a URL.
 | `url` | `string` \| `string`[] | `undefined` | Connection URL or list of URLs. |
 | `options?` | `object` | `undefined` | Additional options used by the Electrum server. |
 | `totalRetryAttempts` | `number` | `3` | Number of retries for requests sent to Electrum server. |
-| `retryBackoffStep` | `number` | `1000` | Initial backoff step in milliseconds that will be increased exponentially for subsequent retry attempts. |
-| `connectionTimeout` | `number` | `20000` | Timeout for a single try of connection establishment. |
+| `retryBackoffStep` | `number` | `1000` | Initial backoff duration in milliseconds; increases exponentially for subsequent retry attempts (default 1000). The instance constructor defaults this to 10000 ms when not using [fromUrl](ElectrumClient.md#fromurl). |
+| `connectionTimeout` | `number` | `20000` | Timeout in milliseconds for connection establishment per try. |
 
 #### Returns
 
@@ -549,7 +549,7 @@ Electrum client instance.
 
 #### Defined in
 
-[lib/electrum/client.ts:103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L103)
+[lib/electrum/client.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L104)
 
 ___
 
@@ -573,4 +573,4 @@ Electrum credentials object.
 
 #### Defined in
 
-[lib/electrum/client.ts:151](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L151)
+[lib/electrum/client.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L152)

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -95,16 +95,17 @@ export class ElectrumClient implements BitcoinClient {
    * @param options - Additional options used by the Electrum server.
    * @param totalRetryAttempts - Number of retries for requests sent to Electrum
    *        server.
-   * @param retryBackoffStep - Initial backoff step in milliseconds that will
-   *        be increased exponentially for subsequent retry attempts.
-   * @param connectionTimeout - Timeout for a single try of connection establishment.
+   * @param retryBackoffStep - Initial backoff duration in milliseconds; increases
+   *        exponentially for subsequent retry attempts (default 1000). The
+   *        instance constructor defaults this to 10000 ms when not using {@link fromUrl}.
+   * @param connectionTimeout - Timeout in milliseconds for connection establishment per try.
    * @returns Electrum client instance.
    */
   static fromUrl(
     url: string | string[],
     options?: ElectrumClientOptions,
     totalRetryAttempts = 3,
-    retryBackoffStep = 1000, // 10 seconds
+    retryBackoffStep = 1000,
     connectionTimeout = 20000 // 20 seconds
   ): ElectrumClient {
     let credentials: ElectrumCredentials[]


### PR DESCRIPTION
Small follow-up on fix/testnet4-security-followup: improves on-chain documentation for asymmetric relay difficulties, adds regression tests for those cases, tightens workflow comments so Classic vs Berry install order is hard to break, and fixes misleading JSDoc on ElectrumClient.fromUrl retry defaults.

Revised comments in the contracts workflow to emphasize the importance of the installation order for Yarn Classic and Berry. Clarified the rationale behind the ESLint workaround related to the  configuration. Updated documentation in the BitcoinTx library to reflect changes in difficulty handling and added new test cases for asymmetric DIFF1 skipping scenarios in BitcoinTx tests. Enhanced comments in the ElectrumClient class to improve understanding of retry parameters.

## Changes

### `solidity/contracts/bridge/BitcoinTx.sol`

- Expand `@notice` on `determineRequestedDifficulty` to spell out:
  - **DIFF1 stripping** only when **both** `currentEpochDifficulty` and `previousEpochDifficulty` are **above minimum**.
  - If **either** side is **1**, **leading DIFF1 headers are not skipped** and are matched like any other header (**asymmetric oracle** case).
  - **Mainnet-style** relays are **not expected** to report **epoch difficulty 1**.

### `solidity/test/bridge/BitcoinTx.test.ts`

- Add `determineRequestedDifficulty` tests for **asymmetric** `(current, prev)`:
  - **High current** + **`prev == 1`**, chain **DIFF1 then normal** → first header binds to **previous (1)** (DIFF1 **not** skipped).
  - **`current == 1`** + **high previous**, single **DIFF1** header → binds to **current (1)**.

### `.github/workflows/contracts.yml` (`contracts-format` job)

- Replace/extend the comment above **root** `yarn install --frozen-lockfile` with an **IMPORTANT** guard:
  - **Root Yarn Classic** install must **stay before** `corepack prepare yarn@4` / Berry for `solidity/`.
  - **Rationale:** wrong order breaks Classic lockfile/flags; Berry is for `solidity/` only.
  - **Keep** the **ESLint** / root **`.prettierrc`** dependency explanation.

### `typescript/src/lib/electrum/client.ts`

- **`fromUrl` JSDoc:** document real defaults — `retryBackoffStep` **1000 ms** here vs **10000 ms** on the default constructor; clarify `connectionTimeout` in **milliseconds**.
- Remove incorrect inline `// 10 seconds` on **`1000`** (**1000 ms ≠ 10 s**).

## Test plan
- [x] `cd solidity && npx hardhat test test/bridge/BitcoinTx.test.ts`
- [ ]  `cd solidity && yarn test` (full Solidity suite)
- [ ]  `cd typescript && yarn tsc --noEmit` (TS verification aligned with CI)