### PR TITLE
Make tx max fee reimbursement best effort

### DIFF
--- a/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -110,7 +110,8 @@ abstract contract AbstractL1BTCDepositor is
 
     /// @notice **Feature Flag** controlling whether the deposit transaction max fee
     ///         is **reimbursed** (added to the user’s tBTC) or **deducted**.
-    ///         - `true`  => Add `txMaxFee` to the minted tBTC amount
+    ///         - `true`  => Add `txMaxFee` on a best-effort basis when the
+    ///                      contract balance covers it
     ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount
     bool public reimburseTxMaxFee;
 
@@ -141,6 +142,14 @@ abstract contract AbstractL1BTCDepositor is
     /// @notice Emitted whenever the owner toggles the reimbursement of the deposit
     ///         transaction max fee.
     event ReimburseTxMaxFeeUpdated(bool reimburseTxMaxFee);
+
+    /// @notice Emitted when the deposit transaction max fee reimbursement is
+    ///         skipped because the depositor contract balance cannot cover it.
+    event DepositTxMaxFeeReimbursementSkipped(
+        uint256 indexed depositKey,
+        uint256 txMaxFee,
+        uint256 availableBalance
+    );
 
     /// @dev This modifier comes from the `Reimbursable` base contract and
     ///      must be overridden to protect the `updateReimbursementPool` call.
@@ -195,8 +204,9 @@ abstract contract AbstractL1BTCDepositor is
 
     /// @notice Toggles whether the deposit transaction max fee is reimbursed
     ///         or deducted. Only callable by the contract owner.
-    /// @param _reimburseTxMaxFee `true` => reimburse (add) the deposit tx max fee,
-    ///                        `false` => deduct the deposit tx max fee.
+    /// @param _reimburseTxMaxFee `true` => reimburse the deposit tx max fee
+    ///        on a best-effort basis when the contract balance covers it,
+    ///        `false` => deduct the deposit tx max fee.
     function setReimburseTxMaxFee(bool _reimburseTxMaxFee) external onlyOwner {
         reimburseTxMaxFee = _reimburseTxMaxFee;
         emit ReimburseTxMaxFeeUpdated(_reimburseTxMaxFee);
@@ -362,6 +372,11 @@ abstract contract AbstractL1BTCDepositor is
     ///        is responsible for executing the deposit finalization on the
     ///        corresponding destination chain. The payment must be equal to the
     ///        value returned by the `quoteFinalizeDeposit` function.
+    /// @dev When `reimburseTxMaxFee` is true, the deposit transaction max fee
+    ///      reimbursement is applied only if this contract's tBTC balance can
+    ///      cover the base deposit amount plus the reimbursement. Otherwise,
+    ///      only the base deposit amount is transferred and a
+    ///      `DepositTxMaxFeeReimbursementSkipped` event is emitted.
     function finalizeDeposit(uint256 depositKey) external payable {
         uint256 gasStart = gasleft();
 
@@ -387,8 +402,23 @@ abstract contract AbstractL1BTCDepositor is
             // Retrieve deposit tx max fee in 1e8 sat precision -> scale it to 1e18.
             (, , uint64 depositTxMaxFee, ) = bridge.depositParameters();
             uint256 txMaxFee = depositTxMaxFee * SATOSHI_MULTIPLIER;
-            // The DAO is "refunding" it by adding it to the tBTC minted.
-            tbtcAmount += txMaxFee;
+            uint256 reimbursedAmount = tbtcAmount + txMaxFee;
+
+            // The DAO is "refunding" the deposit tx max fee by adding it to
+            // the tBTC minted. This is best-effort: if earlier finalizations
+            // have consumed the shared contract balance, skip the reimbursement
+            // instead of blocking this deposit until later deposits top up the
+            // contract.
+            uint256 availableBalance = tbtcToken.balanceOf(address(this));
+            if (availableBalance >= reimbursedAmount) {
+                tbtcAmount = reimbursedAmount;
+            } else {
+                emit DepositTxMaxFeeReimbursementSkipped(
+                    depositKey,
+                    txMaxFee,
+                    availableBalance
+                );
+            }
         }
 
         // slither-disable-next-line reentrancy-events

--- a/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -108,8 +108,8 @@ abstract contract AbstractL1BTCDepositor is
     ///         granted by the contract owner.
     mapping(address => bool) public reimbursementAuthorizations;
 
-    /// @notice **Feature Flag** controlling whether the deposit transaction max fee
-    ///         is **reimbursed** (added to the user’s tBTC) or **deducted**.
+    /// @notice Feature flag controlling whether the deposit transaction max fee
+    ///         is reimbursed (added to the user's tBTC) or deducted.
     ///         - `true`  => Add `txMaxFee` on a best-effort basis when the
     ///                      contract balance covers it
     ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount

--- a/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/cross-chain/starknet/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -216,7 +216,7 @@ abstract contract AbstractL1BTCDepositor is
     ///         data (funding transaction and components of the P2(W)SH deposit
     ///         address) to the tBTC Bridge. Once tBTC minting is completed,
     ///         this call should be followed by a call to `finalizeDeposit`.
-    ///         Callers of `initializeDeposit` are eligible for a gas dgasd
+    ///         Callers of `initializeDeposit` are eligible for a gas refund
     ///         that is paid out upon deposit finalization (only if the
     ///         reimbursement pool is attached and the given caller is
     ///         authorized for refunds).
@@ -240,7 +240,7 @@ abstract contract AbstractL1BTCDepositor is
     ///         Where:
     ///
     ///         <depositor-address> 20-byte L1 address of the
-    ///         `` contract.
+    ///         `AbstractL1BTCDepositor` contract.
     ///
     ///         <depositor-extra-data> destination chain deposit owner address in
     ///         the Bytes32 format.

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -203,8 +203,9 @@ abstract contract AbstractL1BTCDepositor is
 
     /// @notice Toggles whether the deposit transaction max fee is reimbursed
     ///         or deducted. Only callable by the contract owner.
-    /// @param _reimburseTxMaxFee `true` => reimburse (add) the deposit tx max fee,
-    ///                        `false` => deduct the deposit tx max fee.
+    /// @param _reimburseTxMaxFee `true` => reimburse the deposit tx max fee
+    ///        on a best-effort basis when the contract balance covers it,
+    ///        `false` => deduct the deposit tx max fee.
     function setReimburseTxMaxFee(bool _reimburseTxMaxFee) external onlyOwner {
         reimburseTxMaxFee = _reimburseTxMaxFee;
         emit ReimburseTxMaxFeeUpdated(_reimburseTxMaxFee);
@@ -370,6 +371,11 @@ abstract contract AbstractL1BTCDepositor is
     ///        is responsible for executing the deposit finalization on the
     ///        corresponding destination chain. The payment must be greater than or
     ///        equal to the value returned by the `quoteFinalizeDeposit` function.
+    /// @dev When `reimburseTxMaxFee` is true, the deposit transaction max fee
+    ///      reimbursement is applied only if this contract's tBTC balance can
+    ///      cover the base deposit amount plus the reimbursement. Otherwise,
+    ///      only the base deposit amount is transferred and a
+    ///      `DepositTxMaxFeeReimbursementSkipped` event is emitted.
     function finalizeDeposit(uint256 depositKey) external payable {
         uint256 gasStart = gasleft();
 

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -108,9 +108,10 @@ abstract contract AbstractL1BTCDepositor is
     ///         granted by the contract owner.
     mapping(address => bool) public reimbursementAuthorizations;
 
-    /// @notice **Feature Flag** controlling whether the deposit transaction max fee
-    ///         is **reimbursed** (added to the user’s tBTC) or **deducted**.
-    ///         - `true`  => Add `txMaxFee` to the minted tBTC amount
+    /// @notice Feature flag controlling whether the deposit transaction max fee
+    ///         is reimbursed (added to the user's tBTC) or deducted.
+    ///         - `true`  => Add `txMaxFee` on a best-effort basis when the
+    ///                      contract balance covers it
     ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount
     bool public reimburseTxMaxFee;
 

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -142,6 +142,14 @@ abstract contract AbstractL1BTCDepositor is
     ///         transaction max fee.
     event ReimburseTxMaxFeeUpdated(bool reimburseTxMaxFee);
 
+    /// @notice Emitted when the deposit transaction max fee reimbursement is
+    ///         skipped because the depositor contract balance cannot cover it.
+    event DepositTxMaxFeeReimbursementSkipped(
+        uint256 indexed depositKey,
+        uint256 txMaxFee,
+        uint256 availableBalance
+    );
+
     /// @dev This modifier comes from the `Reimbursable` base contract and
     ///      must be overridden to protect the `updateReimbursementPool` call.
     modifier onlyReimbursableAdmin() override {
@@ -387,8 +395,23 @@ abstract contract AbstractL1BTCDepositor is
             // Retrieve deposit tx max fee in 1e8 sat precision -> scale it to 1e18.
             (, , uint64 depositTxMaxFee, ) = bridge.depositParameters();
             uint256 txMaxFee = depositTxMaxFee * SATOSHI_MULTIPLIER;
-            // The DAO is "refunding" it by adding it to the tBTC minted.
-            tbtcAmount += txMaxFee;
+            uint256 reimbursedAmount = tbtcAmount + txMaxFee;
+
+            // The DAO is "refunding" the deposit tx max fee by adding it to
+            // the tBTC minted. This is best-effort: if earlier finalizations
+            // have consumed the shared contract balance, skip the reimbursement
+            // instead of blocking this deposit until later deposits top up the
+            // contract.
+            uint256 availableBalance = tbtcToken.balanceOf(address(this));
+            if (availableBalance >= reimbursedAmount) {
+                tbtcAmount = reimbursedAmount;
+            } else {
+                emit DepositTxMaxFeeReimbursementSkipped(
+                    depositKey,
+                    txMaxFee,
+                    availableBalance
+                );
+            }
         }
 
         // slither-disable-next-line reentrancy-events

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -216,7 +216,7 @@ abstract contract AbstractL1BTCDepositor is
     ///         data (funding transaction and components of the P2(W)SH deposit
     ///         address) to the tBTC Bridge. Once tBTC minting is completed,
     ///         this call should be followed by a call to `finalizeDeposit`.
-    ///         Callers of `initializeDeposit` are eligible for a gas dgasd
+    ///         Callers of `initializeDeposit` are eligible for a gas refund
     ///         that is paid out upon deposit finalization (only if the
     ///         reimbursement pool is attached and the given caller is
     ///         authorized for refunds).
@@ -240,7 +240,7 @@ abstract contract AbstractL1BTCDepositor is
     ///         Where:
     ///
     ///         <depositor-address> 20-byte L1 address of the
-    ///         `` contract.
+    ///         `AbstractL1BTCDepositor` contract.
     ///
     ///         <depositor-extra-data> destination chain deposit owner address in
     ///         the Bytes32 format.

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
@@ -128,7 +128,8 @@ contract L1BTCDepositorWormholeV2Arbitrum is
 
     /// @notice Feature flag controlling whether the deposit transaction max fee
     ///         is reimbursed (added to the user's tBTC) or deducted.
-    ///         - `true`  => Add `txMaxFee` to the minted tBTC amount
+    ///         - `true`  => Add `txMaxFee` on a best-effort basis when the
+    ///                      contract balance covers it
     ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount
     bool public reimburseTxMaxFee;
 
@@ -161,6 +162,14 @@ contract L1BTCDepositorWormholeV2Arbitrum is
     );
 
     event ReimburseTxMaxFeeUpdated(bool reimburseTxMaxFee);
+
+    /// @notice Emitted when the deposit transaction max fee reimbursement is
+    ///         skipped because the depositor contract balance cannot cover it.
+    event DepositTxMaxFeeReimbursementSkipped(
+        uint256 indexed depositKey,
+        uint256 txMaxFee,
+        uint256 availableBalance
+    );
 
     /// @notice Emitted when the gas limit field is updated by the owner.
     ///         Preserved for backward compatibility.
@@ -280,8 +289,9 @@ contract L1BTCDepositorWormholeV2Arbitrum is
 
     /// @notice Toggles whether the deposit transaction max fee is reimbursed
     ///         or deducted. Only callable by the contract owner.
-    /// @param _reimburseTxMaxFee `true` => reimburse (add) the deposit tx max fee,
-    ///                        `false` => deduct the deposit tx max fee.
+    /// @param _reimburseTxMaxFee `true` => reimburse the deposit tx max fee
+    ///        on a best-effort basis when the contract balance covers it,
+    ///        `false` => deduct the deposit tx max fee.
     function setReimburseTxMaxFee(bool _reimburseTxMaxFee) external onlyOwner {
         reimburseTxMaxFee = _reimburseTxMaxFee;
         emit ReimburseTxMaxFeeUpdated(_reimburseTxMaxFee);
@@ -406,6 +416,11 @@ contract L1BTCDepositorWormholeV2Arbitrum is
     ///      - ERC20 L1 tBTC was minted by tBTC Bridge to this contract,
     ///      - The function was not called for the given deposit before,
     ///      - The call must carry a payment equal to `quoteFinalizeDeposit`.
+    /// @dev When `reimburseTxMaxFee` is true, the deposit transaction max fee
+    ///      reimbursement is applied only if this contract's tBTC balance can
+    ///      cover the base deposit amount plus the reimbursement. Otherwise,
+    ///      only the base deposit amount is transferred and a
+    ///      `DepositTxMaxFeeReimbursementSkipped` event is emitted.
     function finalizeDeposit(uint256 depositKey) external payable {
         uint256 gasStart = gasleft();
 
@@ -426,7 +441,18 @@ contract L1BTCDepositorWormholeV2Arbitrum is
         if (reimburseTxMaxFee) {
             (, , uint64 depositTxMaxFee, ) = bridge.depositParameters();
             uint256 txMaxFee = depositTxMaxFee * SATOSHI_MULTIPLIER;
-            tbtcAmount += txMaxFee;
+            uint256 reimbursedAmount = tbtcAmount + txMaxFee;
+
+            uint256 availableBalance = tbtcToken.balanceOf(address(this));
+            if (availableBalance >= reimbursedAmount) {
+                tbtcAmount = reimbursedAmount;
+            } else {
+                emit DepositTxMaxFeeReimbursementSkipped(
+                    depositKey,
+                    txMaxFee,
+                    availableBalance
+                );
+            }
         }
 
         // slither-disable-next-line reentrancy-events

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
@@ -124,7 +124,8 @@ contract L1BTCDepositorWormholeV2Base is
 
     /// @notice Feature flag controlling whether the deposit transaction max fee
     ///         is reimbursed (added to the user's tBTC) or deducted.
-    ///         - `true`  => Add `txMaxFee` to the minted tBTC amount
+    ///         - `true`  => Add `txMaxFee` on a best-effort basis when the
+    ///                      contract balance covers it
     ///         - `false` => Subtract `txMaxFee` from the minted tBTC amount
     bool public reimburseTxMaxFee;
 
@@ -157,6 +158,14 @@ contract L1BTCDepositorWormholeV2Base is
     );
 
     event ReimburseTxMaxFeeUpdated(bool reimburseTxMaxFee);
+
+    /// @notice Emitted when the deposit transaction max fee reimbursement is
+    ///         skipped because the depositor contract balance cannot cover it.
+    event DepositTxMaxFeeReimbursementSkipped(
+        uint256 indexed depositKey,
+        uint256 txMaxFee,
+        uint256 availableBalance
+    );
 
     /// @notice Emitted when the gas limit field is updated by the owner.
     ///         Preserved for backward compatibility.
@@ -276,8 +285,9 @@ contract L1BTCDepositorWormholeV2Base is
 
     /// @notice Toggles whether the deposit transaction max fee is reimbursed
     ///         or deducted. Only callable by the contract owner.
-    /// @param _reimburseTxMaxFee `true` => reimburse (add) the deposit tx max fee,
-    ///                        `false` => deduct the deposit tx max fee.
+    /// @param _reimburseTxMaxFee `true` => reimburse the deposit tx max fee
+    ///        on a best-effort basis when the contract balance covers it,
+    ///        `false` => deduct the deposit tx max fee.
     function setReimburseTxMaxFee(bool _reimburseTxMaxFee) external onlyOwner {
         reimburseTxMaxFee = _reimburseTxMaxFee;
         emit ReimburseTxMaxFeeUpdated(_reimburseTxMaxFee);
@@ -402,6 +412,11 @@ contract L1BTCDepositorWormholeV2Base is
     ///      - ERC20 L1 tBTC was minted by tBTC Bridge to this contract,
     ///      - The function was not called for the given deposit before,
     ///      - The call must carry a payment equal to `quoteFinalizeDeposit`.
+    /// @dev When `reimburseTxMaxFee` is true, the deposit transaction max fee
+    ///      reimbursement is applied only if this contract's tBTC balance can
+    ///      cover the base deposit amount plus the reimbursement. Otherwise,
+    ///      only the base deposit amount is transferred and a
+    ///      `DepositTxMaxFeeReimbursementSkipped` event is emitted.
     function finalizeDeposit(uint256 depositKey) external payable {
         uint256 gasStart = gasleft();
 
@@ -422,7 +437,18 @@ contract L1BTCDepositorWormholeV2Base is
         if (reimburseTxMaxFee) {
             (, , uint64 depositTxMaxFee, ) = bridge.depositParameters();
             uint256 txMaxFee = depositTxMaxFee * SATOSHI_MULTIPLIER;
-            tbtcAmount += txMaxFee;
+            uint256 reimbursedAmount = tbtcAmount + txMaxFee;
+
+            uint256 availableBalance = tbtcToken.balanceOf(address(this));
+            if (availableBalance >= reimbursedAmount) {
+                tbtcAmount = reimbursedAmount;
+            } else {
+                emit DepositTxMaxFeeReimbursementSkipped(
+                    depositKey,
+                    txMaxFee,
+                    availableBalance
+                );
+            }
         }
 
         // slither-disable-next-line reentrancy-events

--- a/solidity/test/cross-chain/wormhole/BTCDepositorWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/BTCDepositorWormhole.test.ts
@@ -1568,7 +1568,13 @@ describe("BTCDepositorWormhole", () => {
       // 6) The bridging calls
       wormholeTokenBridge.transferTokensWithPayload.returns(555)
 
-      // 7) Now finalize with enough payment
+      // 7) Mint enough tBTC to cover the reimbursed amount.
+      await tbtcToken.mint(
+        NonEvmBtcDepositor.address,
+        expectedTbtcAmountReimbursed
+      )
+
+      // 8) Now finalize with enough payment
       const tx = await NonEvmBtcDepositor.connect(relayer).finalizeDeposit(
         initializeDepositFixture.depositKey,
         {
@@ -1576,7 +1582,7 @@ describe("BTCDepositorWormhole", () => {
         }
       )
 
-      // 8) The final minted TBTC should be 94525e10
+      // 9) The final minted TBTC should be 94525e10
       await expect(tx)
         .to.emit(NonEvmBtcDepositor, "DepositFinalized")
         .withArgs(

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormhole.test.ts
@@ -1874,14 +1874,17 @@ describe("L1BTCDepositorWormhole", () => {
       wormholeTokenBridge.transferTokensWithPayload.returns(555)
       wormholeRelayer.sendVaasToEvm.returns(999)
 
-      // 7) Now finalize with enough payment
+      // 7) Mint enough tBTC to cover the reimbursed amount.
+      await tbtcToken.mint(l1BtcDepositor.address, expectedTbtcAmountReimbursed)
+
+      // 8) Now finalize with enough payment
       const tx = await l1BtcDepositor
         .connect(relayer)
         .finalizeDeposit(initializeDepositFixture.depositKey, {
           value: messageFee + deliveryCost,
         })
 
-      // 8) The final minted TBTC should be 94525e10
+      // 9) The final minted TBTC should be 94525e10
       await expect(tx)
         .to.emit(l1BtcDepositor, "DepositFinalized")
         .withArgs(

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormhole.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormhole.test.ts
@@ -1803,9 +1803,10 @@ describe("L1BTCDepositorWormhole", () => {
     //
     // The standard _calculateTbtcAmount would do: 99500e10 -4975e10 -1000e10=93525e10
     // Because we reimburse depositTxMaxFee, we add 1000e10 back => 94525e10
+    const expectedTbtcAmountBase = to1ePrecision(93525, 10)
     const expectedTbtcAmountReimbursed = to1ePrecision(94525, 10)
 
-    before(async () => {
+    beforeEach(async () => {
       await createSnapshot()
 
       // Turn the feature flag on
@@ -1821,7 +1822,17 @@ describe("L1BTCDepositorWormhole", () => {
       }
     })
 
-    after(async () => {
+    afterEach(async () => {
+      bridge.depositParameters.reset()
+      tbtcVault.optimisticMintingFeeDivisor.reset()
+      bridge.revealDepositWithExtraData.reset()
+      bridge.deposits.reset()
+      tbtcVault.optimisticMintingRequests.reset()
+      wormhole.messageFee.reset()
+      wormholeRelayer.quoteEVMDeliveryPrice.reset()
+      wormholeTokenBridge.transferTokensWithPayload.reset()
+      wormholeRelayer.sendVaasToEvm.reset()
+
       await restoreSnapshot()
     })
 
@@ -1893,6 +1904,86 @@ describe("L1BTCDepositorWormhole", () => {
           relayer.address,
           depositAmount.mul(satoshiMultiplier),
           expectedTbtcAmountReimbursed
+        )
+    })
+
+    it("should skip depositTxMaxFee reimbursement when contract balance cannot cover it", async () => {
+      // 1) Initialize deposit
+      await l1BtcDepositor
+        .connect(relayer)
+        .initializeDeposit(
+          initializeDepositFixture.fundingTx,
+          initializeDepositFixture.reveal,
+          initializeDepositFixture.destinationChainDepositOwner
+        )
+
+      // 2) Setup Bridge deposit parameters
+      bridge.depositParameters.returns({
+        depositDustThreshold: 0,
+        depositTreasuryFeeDivisor: 0,
+        depositTxMaxFee,
+        depositRevealAheadPeriod: 0,
+      })
+      // 3) Setup vault fees
+      tbtcVault.optimisticMintingFeeDivisor.returns(optimisticMintingFeeDivisor)
+
+      // 4) Prepare deposit finalization
+      const revealedAt = (await lastBlockTime()) - 7200
+      const finalizedAt = await lastBlockTime()
+      bridge.deposits
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns({
+          depositor: l1BtcDepositor.address,
+          amount: depositAmount,
+          revealedAt,
+          vault: initializeDepositFixture.reveal.vault,
+          treasuryFee,
+          sweptAt: finalizedAt,
+          extraData: initializeDepositFixture.destinationChainDepositOwner,
+        })
+      tbtcVault.optimisticMintingRequests
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns([revealedAt, finalizedAt])
+
+      // 5) Setup Wormhole cost
+      wormhole.messageFee.returns(messageFee)
+      wormholeRelayer.quoteEVMDeliveryPrice.returns({
+        nativePriceQuote: BigNumber.from(deliveryCost),
+        targetChainRefundPerGasUnused: BigNumber.from(0),
+      })
+
+      // 6) The bridging calls
+      wormholeTokenBridge.transferTokensWithPayload.returns(555)
+      wormholeRelayer.sendVaasToEvm.returns(999)
+
+      // 7) Mint only the base tBTC amount, simulating a contract balance that
+      // cannot cover the extra depositTxMaxFee reimbursement.
+      await tbtcToken.mint(l1BtcDepositor.address, expectedTbtcAmountBase)
+
+      // 8) Now finalize with enough payment
+      const tx = await l1BtcDepositor
+        .connect(relayer)
+        .finalizeDeposit(initializeDepositFixture.depositKey, {
+          value: messageFee + deliveryCost,
+        })
+
+      const txMaxFee = depositTxMaxFee.mul(satoshiMultiplier)
+      await expect(tx)
+        .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+        .withArgs(
+          initializeDepositFixture.depositKey,
+          txMaxFee,
+          expectedTbtcAmountBase
+        )
+
+      await expect(tx)
+        .to.emit(l1BtcDepositor, "DepositFinalized")
+        .withArgs(
+          initializeDepositFixture.depositKey,
+          initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+          relayer.address,
+          depositAmount.mul(satoshiMultiplier),
+          expectedTbtcAmountBase
         )
     })
   })

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
@@ -821,6 +821,7 @@ describe("L1BTCDepositorWormholeV2Arbitrum", () => {
         const baseTbtcAmount = to1ePrecision(93525, 10)
         const txMaxFeeScaled = to1ePrecision(1000, 10)
         const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+        const initialAmountWei = to1ePrecision(100000, 10)
 
         let tx: ContractTransaction
         let tokenOwner: SignerWithAddress
@@ -912,6 +913,18 @@ describe("L1BTCDepositorWormholeV2Arbitrum", () => {
             "DepositTxMaxFeeReimbursementSkipped"
           )
         })
+
+        it("should emit DepositFinalized carrying the reimbursed tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              reimbursedAmount
+            )
+        })
       }
     )
 
@@ -927,6 +940,7 @@ describe("L1BTCDepositorWormholeV2Arbitrum", () => {
         const baseTbtcAmount = to1ePrecision(93525, 10)
         const txMaxFeeScaled = to1ePrecision(1000, 10)
         const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+        const initialAmountWei = to1ePrecision(100000, 10)
         // One wei short of the full reimbursement: covers base, not the
         // reimbursement-amount check.
         const availableBalance = reimbursedAmount.sub(1)
@@ -1027,112 +1041,154 @@ describe("L1BTCDepositorWormholeV2Arbitrum", () => {
               availableBalance
             )
         })
+
+        it("should emit DepositFinalized carrying only the base tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              baseTbtcAmount
+            )
+        })
       }
     )
 
-    context("when reimburseTxMaxFee is true and proxy holds zero tBTC", () => {
-      const messageFee = 1000
-      const transferSequence = 555
-      const depositAmount = BigNumber.from(100000)
-      const treasuryFee = BigNumber.from(500)
-      const optimisticMintingFeeDivisor = 20
-      const depositTxMaxFee = BigNumber.from(1000)
-      const baseTbtcAmount = to1ePrecision(93525, 10)
-      const txMaxFeeScaled = to1ePrecision(1000, 10)
+    // This is the production-relevant skip-path scenario: the Bridge sweep
+    // delivers (depositAmount - treasuryFee - actualBTCfee) * 1e10 to the
+    // proxy. Whenever actualBTCfee > 0, the proxy ends up holding the base
+    // amount but cannot cover the full `base + txMaxFee` reimbursement. We
+    // model that here by pre-funding with exactly baseTbtcAmount.
+    context(
+      "when reimburseTxMaxFee is true and balance equals baseTbtcAmount",
+      () => {
+        const messageFee = 1000
+        const transferSequence = 555
+        const depositAmount = BigNumber.from(100000)
+        const treasuryFee = BigNumber.from(500)
+        const optimisticMintingFeeDivisor = 20
+        const depositTxMaxFee = BigNumber.from(1000)
+        const baseTbtcAmount = to1ePrecision(93525, 10)
+        const txMaxFeeScaled = to1ePrecision(1000, 10)
+        const initialAmountWei = to1ePrecision(100000, 10)
 
-      let tx: ContractTransaction
+        let tx: ContractTransaction
+        let tokenOwner: SignerWithAddress
 
-      before(async () => {
-        await createSnapshot()
+        before(async () => {
+          await createSnapshot()
 
-        await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
 
-        await l1BtcDepositor
-          .connect(relayer)
-          .initializeDeposit(
-            initializeDepositFixture.fundingTx,
-            initializeDepositFixture.reveal,
-            initializeDepositFixture.destinationChainDepositOwner
+          await l1BtcDepositor
+            .connect(relayer)
+            .initializeDeposit(
+              initializeDepositFixture.fundingTx,
+              initializeDepositFixture.reveal,
+              initializeDepositFixture.destinationChainDepositOwner
+            )
+
+          bridge.depositParameters.returns({
+            depositDustThreshold: 0,
+            depositTreasuryFeeDivisor: 0,
+            depositTxMaxFee,
+            depositRevealAheadPeriod: 0,
+          })
+          tbtcVault.optimisticMintingFeeDivisor.returns(
+            optimisticMintingFeeDivisor
           )
 
-        bridge.depositParameters.returns({
-          depositDustThreshold: 0,
-          depositTreasuryFeeDivisor: 0,
-          depositTxMaxFee,
-          depositRevealAheadPeriod: 0,
+          const revealedAt = (await lastBlockTime()) - 7200
+          const finalizedAt = await lastBlockTime()
+          bridge.deposits
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns({
+              depositor: l1BtcDepositor.address,
+              amount: depositAmount,
+              revealedAt,
+              vault: initializeDepositFixture.reveal.vault,
+              treasuryFee,
+              sweptAt: finalizedAt,
+              extraData: initializeDepositFixture.destinationChainDepositOwner,
+            })
+
+          tbtcVault.optimisticMintingRequests
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns([revealedAt, finalizedAt])
+
+          wormhole.messageFee.returns(messageFee)
+          wormholeTokenBridge.transferTokensWithPayload.returns(
+            transferSequence
+          )
+          ;[tokenOwner] = await ethers.getSigners()
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, baseTbtcAmount)
+
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
         })
-        tbtcVault.optimisticMintingFeeDivisor.returns(
-          optimisticMintingFeeDivisor
-        )
 
-        const revealedAt = (await lastBlockTime()) - 7200
-        const finalizedAt = await lastBlockTime()
-        bridge.deposits
-          .whenCalledWith(initializeDepositFixture.depositKey)
-          .returns({
-            depositor: l1BtcDepositor.address,
-            amount: depositAmount,
-            revealedAt,
-            vault: initializeDepositFixture.reveal.vault,
-            treasuryFee,
-            sweptAt: finalizedAt,
-            extraData: initializeDepositFixture.destinationChainDepositOwner,
-          })
+        after(async () => {
+          bridge.depositParameters.reset()
+          tbtcVault.optimisticMintingFeeDivisor.reset()
+          bridge.revealDepositWithExtraData.reset()
+          bridge.deposits.reset()
+          tbtcVault.optimisticMintingRequests.reset()
+          wormhole.messageFee.reset()
+          wormholeTokenBridge.transferTokensWithPayload.reset()
 
-        tbtcVault.optimisticMintingRequests
-          .whenCalledWith(initializeDepositFixture.depositKey)
-          .returns([revealedAt, finalizedAt])
+          await restoreSnapshot()
+        })
 
-        wormhole.messageFee.returns(messageFee)
-        wormholeTokenBridge.transferTokensWithPayload.returns(transferSequence)
+        it("should transfer only the base tbtcAmount", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(baseTbtcAmount)
+        })
 
-        // No pre-funding: availableBalance == 0 < reimbursedAmount.
+        it("should emit DepositTxMaxFeeReimbursementSkipped with availableBalance equal to baseTbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              txMaxFeeScaled,
+              baseTbtcAmount
+            )
+        })
 
-        tx = await l1BtcDepositor
-          .connect(relayer)
-          .finalizeDeposit(initializeDepositFixture.depositKey, {
-            value: messageFee,
-          })
-      })
+        it("should emit DepositFinalized carrying only the base tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              baseTbtcAmount
+            )
+        })
 
-      after(async () => {
-        bridge.depositParameters.reset()
-        tbtcVault.optimisticMintingFeeDivisor.reset()
-        bridge.revealDepositWithExtraData.reset()
-        bridge.deposits.reset()
-        tbtcVault.optimisticMintingRequests.reset()
-        wormhole.messageFee.reset()
-        wormholeTokenBridge.transferTokensWithPayload.reset()
-
-        await restoreSnapshot()
-      })
-
-      it("should transfer only the base tbtcAmount", async () => {
-        expect(
-          await tbtcToken.allowance(
-            l1BtcDepositor.address,
-            wormholeTokenBridge.address
+        it("should preserve the L2 receiver payload through the skip branch", async () => {
+          const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
+          const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
+            ["bytes32"],
+            call.args[5]
           )
-        ).to.equal(baseTbtcAmount)
-      })
-
-      it("should emit DepositTxMaxFeeReimbursementSkipped with zero available balance", async () => {
-        await expect(tx)
-          .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
-          .withArgs(initializeDepositFixture.depositKey, txMaxFeeScaled, 0)
-      })
-
-      it("should preserve the L2 receiver payload through the skip branch", async () => {
-        const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
-        const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
-          ["bytes32"],
-          call.args[5]
-        )
-        expect(l2Receiver.toLowerCase()).to.equal(
-          initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
-        )
-      })
-    })
+          expect(l2Receiver.toLowerCase()).to.equal(
+            initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
+          )
+        })
+      }
+    )
   })
 
   describe("proxy upgrade mechanics", () => {

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
@@ -799,6 +799,340 @@ describe("L1BTCDepositorWormholeV2Arbitrum", () => {
           .withArgs(expectedTbtcAmount, l2ReceiverAddress, transferSequence)
       })
     })
+
+    // The next three contexts exercise the reimburseTxMaxFee branches of
+    // finalizeDeposit. Math reused: depositAmount=100000, treasuryFee=500,
+    // optimisticMintingFeeDivisor=20, depositTxMaxFee=1000.
+    //   amountSubTreasury = (100000-500) * 1e10 = 99500e10
+    //   omFee             = 99500e10 / 20 = 4975e10
+    //   txMaxFeeScaled    = 1000 * 1e10 = 1000e10
+    //   baseTbtcAmount    = 99500e10 - 4975e10 - 1000e10 = 93525e10
+    //   reimbursedAmount  = 93525e10 + 1000e10 = 94525e10
+
+    context(
+      "when reimburseTxMaxFee is true and balance covers reimbursedAmount",
+      () => {
+        const messageFee = 1000
+        const transferSequence = 555
+        const depositAmount = BigNumber.from(100000)
+        const treasuryFee = BigNumber.from(500)
+        const optimisticMintingFeeDivisor = 20
+        const depositTxMaxFee = BigNumber.from(1000)
+        const baseTbtcAmount = to1ePrecision(93525, 10)
+        const txMaxFeeScaled = to1ePrecision(1000, 10)
+        const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+
+        let tx: ContractTransaction
+        let tokenOwner: SignerWithAddress
+
+        before(async () => {
+          await createSnapshot()
+
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+          await l1BtcDepositor
+            .connect(relayer)
+            .initializeDeposit(
+              initializeDepositFixture.fundingTx,
+              initializeDepositFixture.reveal,
+              initializeDepositFixture.destinationChainDepositOwner
+            )
+
+          bridge.depositParameters.returns({
+            depositDustThreshold: 0,
+            depositTreasuryFeeDivisor: 0,
+            depositTxMaxFee,
+            depositRevealAheadPeriod: 0,
+          })
+          tbtcVault.optimisticMintingFeeDivisor.returns(
+            optimisticMintingFeeDivisor
+          )
+
+          const revealedAt = (await lastBlockTime()) - 7200
+          const finalizedAt = await lastBlockTime()
+          bridge.deposits
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns({
+              depositor: l1BtcDepositor.address,
+              amount: depositAmount,
+              revealedAt,
+              vault: initializeDepositFixture.reveal.vault,
+              treasuryFee,
+              sweptAt: finalizedAt,
+              extraData: initializeDepositFixture.destinationChainDepositOwner,
+            })
+
+          tbtcVault.optimisticMintingRequests
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns([revealedAt, finalizedAt])
+
+          wormhole.messageFee.returns(messageFee)
+          wormholeTokenBridge.transferTokensWithPayload.returns(
+            transferSequence
+          )
+
+          // Pre-fund the proxy with exactly reimbursedAmount so the
+          // best-effort balance check passes.
+          ;[tokenOwner] = await ethers.getSigners()
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, reimbursedAmount)
+
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
+        })
+
+        after(async () => {
+          bridge.depositParameters.reset()
+          tbtcVault.optimisticMintingFeeDivisor.reset()
+          bridge.revealDepositWithExtraData.reset()
+          bridge.deposits.reset()
+          tbtcVault.optimisticMintingRequests.reset()
+          wormhole.messageFee.reset()
+          wormholeTokenBridge.transferTokensWithPayload.reset()
+
+          await restoreSnapshot()
+        })
+
+        it("should transfer the full reimbursedAmount (base + txMaxFee)", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(reimbursedAmount)
+        })
+
+        it("should NOT emit DepositTxMaxFeeReimbursementSkipped", async () => {
+          await expect(tx).to.not.emit(
+            l1BtcDepositor,
+            "DepositTxMaxFeeReimbursementSkipped"
+          )
+        })
+      }
+    )
+
+    context(
+      "when reimburseTxMaxFee is true and balance is below reimbursedAmount",
+      () => {
+        const messageFee = 1000
+        const transferSequence = 555
+        const depositAmount = BigNumber.from(100000)
+        const treasuryFee = BigNumber.from(500)
+        const optimisticMintingFeeDivisor = 20
+        const depositTxMaxFee = BigNumber.from(1000)
+        const baseTbtcAmount = to1ePrecision(93525, 10)
+        const txMaxFeeScaled = to1ePrecision(1000, 10)
+        const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+        // One wei short of the full reimbursement: covers base, not the
+        // reimbursement-amount check.
+        const availableBalance = reimbursedAmount.sub(1)
+
+        let tx: ContractTransaction
+        let tokenOwner: SignerWithAddress
+
+        before(async () => {
+          await createSnapshot()
+
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+          await l1BtcDepositor
+            .connect(relayer)
+            .initializeDeposit(
+              initializeDepositFixture.fundingTx,
+              initializeDepositFixture.reveal,
+              initializeDepositFixture.destinationChainDepositOwner
+            )
+
+          bridge.depositParameters.returns({
+            depositDustThreshold: 0,
+            depositTreasuryFeeDivisor: 0,
+            depositTxMaxFee,
+            depositRevealAheadPeriod: 0,
+          })
+          tbtcVault.optimisticMintingFeeDivisor.returns(
+            optimisticMintingFeeDivisor
+          )
+
+          const revealedAt = (await lastBlockTime()) - 7200
+          const finalizedAt = await lastBlockTime()
+          bridge.deposits
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns({
+              depositor: l1BtcDepositor.address,
+              amount: depositAmount,
+              revealedAt,
+              vault: initializeDepositFixture.reveal.vault,
+              treasuryFee,
+              sweptAt: finalizedAt,
+              extraData: initializeDepositFixture.destinationChainDepositOwner,
+            })
+
+          tbtcVault.optimisticMintingRequests
+            .whenCalledWith(initializeDepositFixture.depositKey)
+            .returns([revealedAt, finalizedAt])
+
+          wormhole.messageFee.returns(messageFee)
+          wormholeTokenBridge.transferTokensWithPayload.returns(
+            transferSequence
+          )
+          ;[tokenOwner] = await ethers.getSigners()
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, availableBalance)
+
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
+        })
+
+        after(async () => {
+          bridge.depositParameters.reset()
+          tbtcVault.optimisticMintingFeeDivisor.reset()
+          bridge.revealDepositWithExtraData.reset()
+          bridge.deposits.reset()
+          tbtcVault.optimisticMintingRequests.reset()
+          wormhole.messageFee.reset()
+          wormholeTokenBridge.transferTokensWithPayload.reset()
+
+          await restoreSnapshot()
+        })
+
+        it("should still finalize the deposit", async () => {
+          expect(
+            await l1BtcDepositor.deposits(initializeDepositFixture.depositKey)
+          ).to.equal(2)
+        })
+
+        it("should transfer only the base tbtcAmount", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(baseTbtcAmount)
+        })
+
+        it("should emit DepositTxMaxFeeReimbursementSkipped with the available balance", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              txMaxFeeScaled,
+              availableBalance
+            )
+        })
+      }
+    )
+
+    context("when reimburseTxMaxFee is true and proxy holds zero tBTC", () => {
+      const messageFee = 1000
+      const transferSequence = 555
+      const depositAmount = BigNumber.from(100000)
+      const treasuryFee = BigNumber.from(500)
+      const optimisticMintingFeeDivisor = 20
+      const depositTxMaxFee = BigNumber.from(1000)
+      const baseTbtcAmount = to1ePrecision(93525, 10)
+      const txMaxFeeScaled = to1ePrecision(1000, 10)
+
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+        await l1BtcDepositor
+          .connect(relayer)
+          .initializeDeposit(
+            initializeDepositFixture.fundingTx,
+            initializeDepositFixture.reveal,
+            initializeDepositFixture.destinationChainDepositOwner
+          )
+
+        bridge.depositParameters.returns({
+          depositDustThreshold: 0,
+          depositTreasuryFeeDivisor: 0,
+          depositTxMaxFee,
+          depositRevealAheadPeriod: 0,
+        })
+        tbtcVault.optimisticMintingFeeDivisor.returns(
+          optimisticMintingFeeDivisor
+        )
+
+        const revealedAt = (await lastBlockTime()) - 7200
+        const finalizedAt = await lastBlockTime()
+        bridge.deposits
+          .whenCalledWith(initializeDepositFixture.depositKey)
+          .returns({
+            depositor: l1BtcDepositor.address,
+            amount: depositAmount,
+            revealedAt,
+            vault: initializeDepositFixture.reveal.vault,
+            treasuryFee,
+            sweptAt: finalizedAt,
+            extraData: initializeDepositFixture.destinationChainDepositOwner,
+          })
+
+        tbtcVault.optimisticMintingRequests
+          .whenCalledWith(initializeDepositFixture.depositKey)
+          .returns([revealedAt, finalizedAt])
+
+        wormhole.messageFee.returns(messageFee)
+        wormholeTokenBridge.transferTokensWithPayload.returns(transferSequence)
+
+        // No pre-funding: availableBalance == 0 < reimbursedAmount.
+
+        tx = await l1BtcDepositor
+          .connect(relayer)
+          .finalizeDeposit(initializeDepositFixture.depositKey, {
+            value: messageFee,
+          })
+      })
+
+      after(async () => {
+        bridge.depositParameters.reset()
+        tbtcVault.optimisticMintingFeeDivisor.reset()
+        bridge.revealDepositWithExtraData.reset()
+        bridge.deposits.reset()
+        tbtcVault.optimisticMintingRequests.reset()
+        wormhole.messageFee.reset()
+        wormholeTokenBridge.transferTokensWithPayload.reset()
+
+        await restoreSnapshot()
+      })
+
+      it("should transfer only the base tbtcAmount", async () => {
+        expect(
+          await tbtcToken.allowance(
+            l1BtcDepositor.address,
+            wormholeTokenBridge.address
+          )
+        ).to.equal(baseTbtcAmount)
+      })
+
+      it("should emit DepositTxMaxFeeReimbursementSkipped with zero available balance", async () => {
+        await expect(tx)
+          .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+          .withArgs(initializeDepositFixture.depositKey, txMaxFeeScaled, 0)
+      })
+
+      it("should preserve the L2 receiver payload through the skip branch", async () => {
+        const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
+        const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
+          ["bytes32"],
+          call.args[5]
+        )
+        expect(l2Receiver.toLowerCase()).to.equal(
+          initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
+        )
+      })
+    })
   })
 
   describe("proxy upgrade mechanics", () => {

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.test.ts
@@ -1,0 +1,421 @@
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import { randomBytes } from "crypto"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, ContractTransaction } from "ethers"
+import {
+  IBridge,
+  IWormholeGateway,
+  ITBTCVault,
+  IWormhole,
+  IWormholeRelayer,
+  IWormholeTokenBridge,
+  L1BTCDepositorWormholeV2Base,
+  ReimbursementPool,
+  TestERC20,
+} from "../../../typechain"
+import { to1ePrecision } from "../../helpers/contract-test-helpers"
+import {
+  initializeDepositFixture,
+  toWormholeAddress,
+} from "./L1BTCDepositorWormhole.test"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime } = helpers.time
+
+const l1ChainId = 10
+const l2ChainId = 20
+const tbtcVaultAddress = "0xB5679dE944A79732A75CE556191DF11F489448d5"
+
+describe("L1BTCDepositorWormholeV2Base", () => {
+  const contractsFixture = async () => {
+    const { deployer, governance } = await helpers.signers.getNamedSigners()
+    // The TestERC20 mint owner is set indirectly below via the default
+    // factory signer; expose deployer only for proxy deployment.
+
+    const accounts = await getUnnamedAccounts()
+    const relayer = await ethers.getSigner(accounts[1])
+
+    const bridge = await smock.fake<IBridge>("IBridge")
+    const tbtcToken = await (
+      await ethers.getContractFactory("TestERC20")
+    ).deploy()
+    const tbtcVault = await smock.fake<ITBTCVault>("ITBTCVault", {
+      address: tbtcVaultAddress,
+    })
+    tbtcVault.tbtcToken.returns(tbtcToken.address)
+
+    const wormhole = await smock.fake<IWormhole>("IWormhole")
+    wormhole.chainId.returns(l1ChainId)
+
+    const wormholeRelayer = await smock.fake<IWormholeRelayer>(
+      "IWormholeRelayer"
+    )
+    const wormholeTokenBridge = await smock.fake<IWormholeTokenBridge>(
+      "IWormholeTokenBridge"
+    )
+    const l2WormholeGateway = await smock.fake<IWormholeGateway>(
+      "IWormholeGateway"
+    )
+    const l2BitcoinDepositor = "0xeE6F5f69860f310114185677D017576aed0dEC83"
+    const reimbursementPool = await smock.fake<ReimbursementPool>(
+      "ReimbursementPool"
+    )
+
+    const deployment = await helpers.upgrades.deployProxy(
+      `L1BTCDepositorWormholeV2Base_${randomBytes(8).toString("hex")}`,
+      {
+        contractName: "L1BTCDepositorWormholeV2Base",
+        initializerArgs: [
+          bridge.address,
+          tbtcVault.address,
+          wormhole.address,
+          wormholeRelayer.address,
+          wormholeTokenBridge.address,
+          l2WormholeGateway.address,
+          l2ChainId,
+        ],
+        factoryOpts: { signer: deployer },
+        proxyOpts: {
+          kind: "transparent",
+        },
+      }
+    )
+    const l1BtcDepositor = deployment[0] as L1BTCDepositorWormholeV2Base
+
+    await l1BtcDepositor.connect(deployer).transferOwnership(governance.address)
+
+    return {
+      governance,
+      relayer,
+      bridge,
+      tbtcToken,
+      tbtcVault,
+      wormhole,
+      wormholeRelayer,
+      wormholeTokenBridge,
+      l2WormholeGateway,
+      l2BitcoinDepositor,
+      reimbursementPool,
+      l1BtcDepositor,
+    }
+  }
+
+  let governance: SignerWithAddress
+  let relayer: SignerWithAddress
+  // The TestERC20 token is deployed via the factory's default signer
+  // (the first hardhat account). That account owns the token and can mint.
+  let tokenOwner: SignerWithAddress
+
+  let bridge: FakeContract<IBridge>
+  let tbtcToken: TestERC20
+  let tbtcVault: FakeContract<ITBTCVault>
+  let wormhole: FakeContract<IWormhole>
+  let wormholeTokenBridge: FakeContract<IWormholeTokenBridge>
+  let l2WormholeGateway: FakeContract<IWormholeGateway>
+  let l2BitcoinDepositor: string
+  let l1BtcDepositor: L1BTCDepositorWormholeV2Base
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      governance,
+      relayer,
+      bridge,
+      tbtcToken,
+      tbtcVault,
+      wormhole,
+      wormholeTokenBridge,
+      l2WormholeGateway,
+      l2BitcoinDepositor,
+      l1BtcDepositor,
+    } = await waffle.loadFixture(contractsFixture))
+    ;[tokenOwner] = await ethers.getSigners()
+  })
+
+  describe("finalizeDeposit", () => {
+    before(async () => {
+      await createSnapshot()
+
+      await l1BtcDepositor
+        .connect(governance)
+        .attachL2BitcoinDepositor(l2BitcoinDepositor)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    // Shared deposit math used by every reimbursement-flag context below.
+    //
+    // amountSubTreasury = (depositAmount - treasuryFee) * satoshiMultiplier
+    //                   = (100000 - 500) * 1e10 = 99500 * 1e10
+    // omFee             = amountSubTreasury / optimisticMintingFeeDivisor
+    //                   = 99500e10 / 20 = 4975 * 1e10
+    // txMaxFeeScaled    = depositTxMaxFee * satoshiMultiplier
+    //                   = 1000 * 1e10
+    // baseTbtcAmount    = amountSubTreasury - omFee - txMaxFeeScaled
+    //                   = (99500 - 4975 - 1000) * 1e10 = 93525 * 1e10
+    // reimbursedAmount  = baseTbtcAmount + txMaxFeeScaled = 94525 * 1e10
+    const messageFee = 1000
+    const transferSequence = 555
+    const depositAmount = BigNumber.from(100000)
+    const treasuryFee = BigNumber.from(500)
+    const optimisticMintingFeeDivisor = 20
+    const depositTxMaxFee = BigNumber.from(1000)
+    const baseTbtcAmount = to1ePrecision(93525, 10)
+    const txMaxFeeScaled = to1ePrecision(1000, 10)
+    const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+
+    const stageDeposit = async () => {
+      await l1BtcDepositor
+        .connect(relayer)
+        .initializeDeposit(
+          initializeDepositFixture.fundingTx,
+          initializeDepositFixture.reveal,
+          initializeDepositFixture.destinationChainDepositOwner
+        )
+
+      bridge.depositParameters.returns({
+        depositDustThreshold: 0,
+        depositTreasuryFeeDivisor: 0,
+        depositTxMaxFee,
+        depositRevealAheadPeriod: 0,
+      })
+      tbtcVault.optimisticMintingFeeDivisor.returns(optimisticMintingFeeDivisor)
+
+      const revealedAt = (await lastBlockTime()) - 7200
+      const finalizedAt = await lastBlockTime()
+      bridge.deposits
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns({
+          depositor: l1BtcDepositor.address,
+          amount: depositAmount,
+          revealedAt,
+          vault: initializeDepositFixture.reveal.vault,
+          treasuryFee,
+          sweptAt: finalizedAt,
+          extraData: initializeDepositFixture.destinationChainDepositOwner,
+        })
+
+      tbtcVault.optimisticMintingRequests
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns([revealedAt, finalizedAt])
+
+      wormhole.messageFee.returns(messageFee)
+      wormholeTokenBridge.transferTokensWithPayload.returns(transferSequence)
+    }
+
+    const resetMocks = () => {
+      bridge.depositParameters.reset()
+      tbtcVault.optimisticMintingFeeDivisor.reset()
+      bridge.revealDepositWithExtraData.reset()
+      bridge.deposits.reset()
+      tbtcVault.optimisticMintingRequests.reset()
+      wormhole.messageFee.reset()
+      wormholeTokenBridge.transferTokensWithPayload.reset()
+    }
+
+    context("when reimburseTxMaxFee is false", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+        await stageDeposit()
+        tx = await l1BtcDepositor
+          .connect(relayer)
+          .finalizeDeposit(initializeDepositFixture.depositKey, {
+            value: messageFee,
+          })
+      })
+
+      after(async () => {
+        resetMocks()
+        await restoreSnapshot()
+      })
+
+      it("should transfer the base tbtcAmount (no reimbursement added)", async () => {
+        expect(
+          await tbtcToken.allowance(
+            l1BtcDepositor.address,
+            wormholeTokenBridge.address
+          )
+        ).to.equal(baseTbtcAmount)
+      })
+
+      it("should NOT emit DepositTxMaxFeeReimbursementSkipped", async () => {
+        await expect(tx).to.not.emit(
+          l1BtcDepositor,
+          "DepositTxMaxFeeReimbursementSkipped"
+        )
+      })
+    })
+
+    context(
+      "when reimburseTxMaxFee is true and balance covers reimbursedAmount",
+      () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+          await stageDeposit()
+
+          // Pre-fund the proxy with exactly reimbursedAmount so the
+          // best-effort check passes and the reimbursement is paid.
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, reimbursedAmount)
+
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
+        })
+
+        after(async () => {
+          resetMocks()
+          await restoreSnapshot()
+        })
+
+        it("should transfer the full reimbursedAmount (base + txMaxFee)", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(reimbursedAmount)
+        })
+
+        it("should NOT emit DepositTxMaxFeeReimbursementSkipped", async () => {
+          await expect(tx).to.not.emit(
+            l1BtcDepositor,
+            "DepositTxMaxFeeReimbursementSkipped"
+          )
+        })
+      }
+    )
+
+    context(
+      "when reimburseTxMaxFee is true and balance is below reimbursedAmount",
+      () => {
+        let tx: ContractTransaction
+        // Available balance is exactly one wei short of reimbursedAmount,
+        // which is sufficient to pay the base tbtcAmount but not the full
+        // reimbursement.
+        const availableBalance = reimbursedAmount.sub(1)
+
+        before(async () => {
+          await createSnapshot()
+
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+          await stageDeposit()
+
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, availableBalance)
+
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
+        })
+
+        after(async () => {
+          resetMocks()
+          await restoreSnapshot()
+        })
+
+        it("should still finalize the deposit", async () => {
+          expect(
+            await l1BtcDepositor.deposits(initializeDepositFixture.depositKey)
+          ).to.equal(2)
+        })
+
+        it("should transfer only the base tbtcAmount, not the reimbursed amount", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(baseTbtcAmount)
+        })
+
+        it("should emit DepositTxMaxFeeReimbursementSkipped with the available balance", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              txMaxFeeScaled,
+              availableBalance
+            )
+        })
+      }
+    )
+
+    context("when reimburseTxMaxFee is true and proxy holds zero tBTC", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+
+        await stageDeposit()
+
+        // No pre-funding. availableBalance == 0 < reimbursedAmount.
+
+        tx = await l1BtcDepositor
+          .connect(relayer)
+          .finalizeDeposit(initializeDepositFixture.depositKey, {
+            value: messageFee,
+          })
+      })
+
+      after(async () => {
+        resetMocks()
+        await restoreSnapshot()
+      })
+
+      it("should transfer only the base tbtcAmount", async () => {
+        expect(
+          await tbtcToken.allowance(
+            l1BtcDepositor.address,
+            wormholeTokenBridge.address
+          )
+        ).to.equal(baseTbtcAmount)
+      })
+
+      it("should emit DepositTxMaxFeeReimbursementSkipped with zero available balance", async () => {
+        await expect(tx)
+          .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+          .withArgs(initializeDepositFixture.depositKey, txMaxFeeScaled, 0)
+      })
+
+      it("should encode the L2 receiver in the payload", async () => {
+        // Sanity check that the skip path does not corrupt the L2 routing.
+        const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
+        const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
+          ["bytes32"],
+          call.args[5]
+        )
+        expect(l2Receiver.toLowerCase()).to.equal(
+          initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
+        )
+        // The Wormhole gateway is passed as the recipient field; the L2
+        // owner travels inside the payload (V2 design).
+        expect(call.args[3]).to.equal(
+          toWormholeAddress(l2WormholeGateway.address.toLowerCase())
+        )
+      })
+    })
+  })
+})

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.test.ts
@@ -160,6 +160,8 @@ describe("L1BTCDepositorWormholeV2Base", () => {
     // baseTbtcAmount    = amountSubTreasury - omFee - txMaxFeeScaled
     //                   = (99500 - 4975 - 1000) * 1e10 = 93525 * 1e10
     // reimbursedAmount  = baseTbtcAmount + txMaxFeeScaled = 94525 * 1e10
+    // initialAmountWei  = depositAmount * satoshiMultiplier
+    //                   = 100000 * 1e10 = 1e15
     const messageFee = 1000
     const transferSequence = 555
     const depositAmount = BigNumber.from(100000)
@@ -169,6 +171,7 @@ describe("L1BTCDepositorWormholeV2Base", () => {
     const baseTbtcAmount = to1ePrecision(93525, 10)
     const txMaxFeeScaled = to1ePrecision(1000, 10)
     const reimbursedAmount = baseTbtcAmount.add(txMaxFeeScaled)
+    const initialAmountWei = to1ePrecision(100000, 10)
 
     const stageDeposit = async () => {
       await l1BtcDepositor
@@ -299,6 +302,18 @@ describe("L1BTCDepositorWormholeV2Base", () => {
             "DepositTxMaxFeeReimbursementSkipped"
           )
         })
+
+        it("should emit DepositFinalized carrying the reimbursed tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              reimbursedAmount
+            )
+        })
       }
     )
 
@@ -358,64 +373,99 @@ describe("L1BTCDepositorWormholeV2Base", () => {
               availableBalance
             )
         })
+
+        it("should emit DepositFinalized carrying only the base tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              baseTbtcAmount
+            )
+        })
       }
     )
 
-    context("when reimburseTxMaxFee is true and proxy holds zero tBTC", () => {
-      let tx: ContractTransaction
+    // This is the production-relevant skip-path scenario: the Bridge sweep
+    // delivers (depositAmount - treasuryFee - actualBTCfee) * 1e10 to the
+    // proxy. Whenever actualBTCfee > 0, the proxy ends up holding the
+    // base amount but cannot cover the full `base + txMaxFee` reimbursement.
+    // We model that here by pre-funding with exactly baseTbtcAmount.
+    context(
+      "when reimburseTxMaxFee is true and balance equals baseTbtcAmount",
+      () => {
+        let tx: ContractTransaction
 
-      before(async () => {
-        await createSnapshot()
+        before(async () => {
+          await createSnapshot()
 
-        await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
+          await l1BtcDepositor.connect(governance).setReimburseTxMaxFee(true)
 
-        await stageDeposit()
+          await stageDeposit()
 
-        // No pre-funding. availableBalance == 0 < reimbursedAmount.
+          await tbtcToken
+            .connect(tokenOwner)
+            .mint(l1BtcDepositor.address, baseTbtcAmount)
 
-        tx = await l1BtcDepositor
-          .connect(relayer)
-          .finalizeDeposit(initializeDepositFixture.depositKey, {
-            value: messageFee,
-          })
-      })
+          tx = await l1BtcDepositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey, {
+              value: messageFee,
+            })
+        })
 
-      after(async () => {
-        resetMocks()
-        await restoreSnapshot()
-      })
+        after(async () => {
+          resetMocks()
+          await restoreSnapshot()
+        })
 
-      it("should transfer only the base tbtcAmount", async () => {
-        expect(
-          await tbtcToken.allowance(
-            l1BtcDepositor.address,
-            wormholeTokenBridge.address
+        it("should transfer only the base tbtcAmount", async () => {
+          expect(
+            await tbtcToken.allowance(
+              l1BtcDepositor.address,
+              wormholeTokenBridge.address
+            )
+          ).to.equal(baseTbtcAmount)
+        })
+
+        it("should emit DepositTxMaxFeeReimbursementSkipped with availableBalance equal to baseTbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              txMaxFeeScaled,
+              baseTbtcAmount
+            )
+        })
+
+        it("should emit DepositFinalized carrying only the base tbtcAmount", async () => {
+          await expect(tx)
+            .to.emit(l1BtcDepositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner.toLowerCase(),
+              relayer.address,
+              initialAmountWei,
+              baseTbtcAmount
+            )
+        })
+
+        it("should preserve the L2 receiver payload through the skip branch", async () => {
+          const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
+          const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
+            ["bytes32"],
+            call.args[5]
           )
-        ).to.equal(baseTbtcAmount)
-      })
-
-      it("should emit DepositTxMaxFeeReimbursementSkipped with zero available balance", async () => {
-        await expect(tx)
-          .to.emit(l1BtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
-          .withArgs(initializeDepositFixture.depositKey, txMaxFeeScaled, 0)
-      })
-
-      it("should encode the L2 receiver in the payload", async () => {
-        // Sanity check that the skip path does not corrupt the L2 routing.
-        const call = wormholeTokenBridge.transferTokensWithPayload.getCall(0)
-        const [l2Receiver] = ethers.utils.defaultAbiCoder.decode(
-          ["bytes32"],
-          call.args[5]
-        )
-        expect(l2Receiver.toLowerCase()).to.equal(
-          initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
-        )
-        // The Wormhole gateway is passed as the recipient field; the L2
-        // owner travels inside the payload (V2 design).
-        expect(call.args[3]).to.equal(
-          toWormholeAddress(l2WormholeGateway.address.toLowerCase())
-        )
-      })
-    })
+          expect(l2Receiver.toLowerCase()).to.equal(
+            initializeDepositFixture.destinationChainDepositOwner.toLowerCase()
+          )
+          expect(call.args[3]).to.equal(
+            toWormholeAddress(l2WormholeGateway.address.toLowerCase())
+          )
+        })
+      }
+    )
   })
 })

--- a/solidity/test/depositor/NativeBTCDepositor.test.ts
+++ b/solidity/test/depositor/NativeBTCDepositor.test.ts
@@ -1316,16 +1316,23 @@ describe("NativeBTCDepositor", () => {
     //
     // The standard _calculateTbtcAmount would do: 99500e10 -4975e10 -1000e10=93525e10
     // Because we reimburse depositTxMaxFee, we add 1000e10 back => 94525e10
+    const expectedTbtcAmountBase = to1ePrecision(93525, 10)
     const expectedTbtcAmountReimbursed = to1ePrecision(94525, 10)
 
-    before(async () => {
+    beforeEach(async () => {
       await createSnapshot()
 
       // Turn the feature flag on
       await nativeBtcDepositor.connect(governance).setReimburseTxMaxFee(true)
     })
 
-    after(async () => {
+    afterEach(async () => {
+      bridge.depositParameters.reset()
+      tbtcVault.optimisticMintingFeeDivisor.reset()
+      bridge.revealDepositWithExtraData.reset()
+      bridge.deposits.reset()
+      tbtcVault.optimisticMintingRequests.reset()
+
       await restoreSnapshot()
     })
 
@@ -1390,6 +1397,85 @@ describe("NativeBTCDepositor", () => {
           depositAmount.mul(satoshiMultiplier),
           expectedTbtcAmountReimbursed
         )
+    })
+
+    it("should skip depositTxMaxFee reimbursement when contract balance cannot cover it", async () => {
+      // 1) Initialize deposit
+      await nativeBtcDepositor
+        .connect(relayer)
+        .initializeDeposit(
+          initializeDepositFixture.fundingTx,
+          initializeDepositFixture.reveal,
+          initializeDepositFixture.ethereumReceiverBytes32
+        )
+
+      // 2) Setup Bridge deposit parameters
+      bridge.depositParameters.returns({
+        depositDustThreshold: 0,
+        depositTreasuryFeeDivisor: 0,
+        depositTxMaxFee,
+        depositRevealAheadPeriod: 0,
+      })
+      // 3) Setup vault fees
+      tbtcVault.optimisticMintingFeeDivisor.returns(optimisticMintingFeeDivisor)
+
+      // 4) Prepare deposit finalization
+      const revealedAt = (await lastBlockTime()) - 7200
+      const finalizedAt = await lastBlockTime()
+      bridge.deposits
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns({
+          depositor: nativeBtcDepositor.address,
+          amount: depositAmount,
+          revealedAt,
+          vault: initializeDepositFixture.reveal.vault,
+          treasuryFee,
+          sweptAt: finalizedAt,
+          extraData: initializeDepositFixture.ethereumReceiverBytes32,
+        })
+      tbtcVault.optimisticMintingRequests
+        .whenCalledWith(initializeDepositFixture.depositKey)
+        .returns([revealedAt, finalizedAt])
+
+      // 5) Mint only the base tBTC amount, simulating a contract balance that
+      // cannot cover the extra depositTxMaxFee reimbursement.
+      await tbtcToken.mint(
+        nativeBtcDepositor.address,
+        expectedTbtcAmountBase
+      )
+
+      // 6) Now finalize
+      const tx = await nativeBtcDepositor
+        .connect(relayer)
+        .finalizeDeposit(initializeDepositFixture.depositKey, {
+          value: 0,
+        })
+
+      const txMaxFee = depositTxMaxFee.mul(satoshiMultiplier)
+      await expect(tx)
+        .to.emit(nativeBtcDepositor, "DepositTxMaxFeeReimbursementSkipped")
+        .withArgs(
+          initializeDepositFixture.depositKey,
+          txMaxFee,
+          expectedTbtcAmountBase
+        )
+
+      await expect(tx)
+        .to.emit(nativeBtcDepositor, "DepositFinalized")
+        .withArgs(
+          initializeDepositFixture.depositKey,
+          initializeDepositFixture.ethereumReceiverBytes32.toLowerCase(),
+          relayer.address,
+          depositAmount.mul(satoshiMultiplier),
+          expectedTbtcAmountBase
+        )
+
+      const receiverAddress = ethers.utils.getAddress(
+        `0x${initializeDepositFixture.ethereumReceiverBytes32.slice(-40)}`
+      )
+      expect(await tbtcToken.balanceOf(receiverAddress)).to.equal(
+        expectedTbtcAmountBase
+      )
     })
   })
 })

--- a/solidity/test/depositor/NativeBTCDepositor.test.ts
+++ b/solidity/test/depositor/NativeBTCDepositor.test.ts
@@ -1439,10 +1439,7 @@ describe("NativeBTCDepositor", () => {
 
       // 5) Mint only the base tBTC amount, simulating a contract balance that
       // cannot cover the extra depositTxMaxFee reimbursement.
-      await tbtcToken.mint(
-        nativeBtcDepositor.address,
-        expectedTbtcAmountBase
-      )
+      await tbtcToken.mint(nativeBtcDepositor.address, expectedTbtcAmountBase)
 
       // 6) Now finalize
       const tx = await nativeBtcDepositor


### PR DESCRIPTION
## Summary

Updates `AbstractL1BTCDepositor.finalizeDeposit` so the deposit transaction max fee reimbursement is best-effort instead of mandatory.

When `reimburseTxMaxFee` is enabled, the depositor now:

- forwards the base finalized tBTC amount as before
- adds the `depositTxMaxFee` reimbursement only if the contract balance can cover the fully reimbursed amount
- emits `DepositTxMaxFeeReimbursementSkipped` when the reimbursement is skipped because the shared depositor balance is short

This keeps finalization live when a small reimbursement shortfall would otherwise block forwarding tBTC to the user's final destination address.

Review follow-ups also:

- mirror the same best-effort reimbursement logic into the separate StarkNet package copy
- mirror the same guard into the standalone Wormhole V2 depositor contracts
- update NatSpec so `reimburseTxMaxFee = true` no longer reads as a guaranteed reimbursement
- add Wormhole skip-path coverage for the inherited abstract depositor flow

## Root cause

The current code always adds `depositTxMaxFee` to the amount forwarded when reimbursement is enabled. If earlier finalizations consume enough of the shared depositor contract balance, a later finalization can have enough tBTC to cover the base deposit amount but not enough to also cover the reimbursement. In that case the final transfer reverts and the depositor waits until unrelated deposits top up the contract.

## Tradeoff

This favors liveness over exact per-deposit reimbursement. A depositor may miss the `depositTxMaxFee` reimbursement when the contract balance is short, but they still receive the base finalized deposit amount immediately instead of being blocked behind later deposits.

That means reimbursement is no longer strictly guaranteed by `reimburseTxMaxFee = true`; it becomes conditional on available contract balance. The new event makes skipped reimbursements visible for monitoring or possible off-chain reconciliation. If the contract cannot cover even the base amount, finalization can still revert; this PR only prevents the extra reimbursement amount from blocking otherwise-forwardable deposits.

## Validation

```bash
cd solidity
npm run test -- test/cross-chain/wormhole/L1BTCDepositorWormhole.test.ts test/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.test.ts
npm run test -- test/depositor/NativeBTCDepositor.test.ts test/cross-chain/wormhole/BTCDepositorWormhole.test.ts
npm run format

cd ../cross-chain/starknet
L1_CHAIN_SEPOLIA_API_URL=http://127.0.0.1:8545 L1_CHAIN_MAINNET_API_URL=http://127.0.0.1:8545 npm run build
npx solhint contracts/cross-chain/AbstractL1BTCDepositor.sol
npx prettier --check contracts/cross-chain/AbstractL1BTCDepositor.sol
```

Results:

- `99 passing` for `L1BTCDepositorWormhole` + `L1BTCDepositorWormholeV2Arbitrum`
- `149 passing` for `NativeBTCDepositor` + `BTCDepositorWormhole`
- Solidity package `npm run format` exits successfully; existing repo warnings remain, with no errors
- StarkNet package build succeeds with dummy local RPC URLs; direct solhint/prettier checks pass for the touched StarkNet Solidity file, with existing solhint warnings only
