### PR TITLE
Validate API redemption wallet candidates on-chain

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -2057,7 +2057,7 @@ Utility functions allowing to perform operations on Bitcoin ECDSA private keys.
 
 #### Defined in
 
-[src/lib/bitcoin/ecdsa-key.ts:77](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L77)
+[src/lib/bitcoin/ecdsa-key.ts:118](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L118)
 
 ___
 
@@ -2073,10 +2073,12 @@ Utility functions allowing to perform operations on Bitcoin ECDSA public keys.
 | :------ | :------ |
 | `compressPublicKey` | (`publicKey`: [`Hex`](classes/Hex.md)) => `string` |
 | `isCompressedPublicKey` | (`publicKey`: [`Hex`](classes/Hex.md)) => `boolean` |
+| `walletKeyToPublicKeyHash` | (`walletKey`: [`Hex`](classes/Hex.md)) => [`Hex`](classes/Hex.md) |
+| `xOnlyToCompressedPublicKey` | (`walletID`: [`Hex`](classes/Hex.md)) => [`Hex`](classes/Hex.md) |
 
 #### Defined in
 
-[src/lib/bitcoin/ecdsa-key.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L51)
+[src/lib/bitcoin/ecdsa-key.ts:90](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/ecdsa-key.ts#L90)
 
 ___
 
@@ -3459,7 +3461,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:948](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L948)
+[src/lib/ethereum/bridge.ts:952](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L952)
 
 ___
 

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -88,7 +88,7 @@ EthersContractHandle\&lt;BridgeTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:132](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L132)
+[src/lib/ethereum/bridge.ts:131](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L131)
 
 ## Properties
 
@@ -158,7 +158,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:606](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L606)
+[src/lib/ethereum/bridge.ts:610](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L610)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:581](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L581)
+[src/lib/ethereum/bridge.ts:585](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L585)
 
 ___
 
@@ -207,7 +207,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:878](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L878)
+[src/lib/ethereum/bridge.ts:882](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L882)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:516](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L516)
+[src/lib/ethereum/bridge.ts:520](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L520)
 
 ___
 
@@ -276,7 +276,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:159](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L159)
+[src/lib/ethereum/bridge.ts:158](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L158)
 
 ___
 
@@ -303,7 +303,7 @@ Bridge.getDepositRevealedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:167](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L167)
+[src/lib/ethereum/bridge.ts:166](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L166)
 
 ___
 
@@ -364,7 +364,7 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:667](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L667)
+[src/lib/ethereum/bridge.ts:671](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L671)
 
 ___
 
@@ -391,7 +391,7 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:895](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L895)
+[src/lib/ethereum/bridge.ts:899](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L899)
 
 ___
 
@@ -411,7 +411,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:641](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L641)
+[src/lib/ethereum/bridge.ts:645](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L645)
 
 ___
 
@@ -435,7 +435,7 @@ Parsed deposit request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:561](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L561)
+[src/lib/ethereum/bridge.ts:565](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L565)
 
 ___
 
@@ -485,7 +485,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:847](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L847)
+[src/lib/ethereum/bridge.ts:851](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L851)
 
 ___
 
@@ -512,7 +512,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:204](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L204)
+[src/lib/ethereum/bridge.ts:203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L203)
 
 ___
 
@@ -655,7 +655,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:465](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L465)
+[src/lib/ethereum/bridge.ts:467](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L467)
 
 ___
 
@@ -728,7 +728,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:774](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L774)
+[src/lib/ethereum/bridge.ts:778](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L778)
 
 ___
 
@@ -754,7 +754,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:798](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L798)
+[src/lib/ethereum/bridge.ts:802](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L802)
 
 ___
 
@@ -774,7 +774,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:710](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L710)
+[src/lib/ethereum/bridge.ts:714](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L714)
 
 ___
 
@@ -800,7 +800,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:727](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L727)
+[src/lib/ethereum/bridge.ts:731](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L731)
 
 ___
 
@@ -826,7 +826,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:745](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L745)
+[src/lib/ethereum/bridge.ts:749](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L749)
 
 ___
 
@@ -851,7 +851,7 @@ Deposit key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:542](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L542)
+[src/lib/ethereum/bridge.ts:546](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L546)
 
 ___
 
@@ -897,7 +897,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L92)
+[src/lib/ethereum/bridge.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L91)
 
 ___
 
@@ -917,7 +917,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L60)
+[src/lib/ethereum/bridge.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L59)
 
 ___
 
@@ -937,7 +937,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L103)
+[src/lib/ethereum/bridge.ts:102](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L102)
 
 ___
 
@@ -957,7 +957,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:119](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L119)
+[src/lib/ethereum/bridge.ts:118](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L118)
 
 ___
 
@@ -982,4 +982,4 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L68)
+[src/lib/ethereum/bridge.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L67)

--- a/typescript/api-reference/classes/RedemptionsService.md
+++ b/typescript/api-reference/classes/RedemptionsService.md
@@ -27,6 +27,8 @@ Service exposing features related to tBTC v2 redemptions.
 - [frostWalletID](RedemptionsService.md#frostwalletid)
 - [getRedeemerOutputScript](RedemptionsService.md#getredeemeroutputscript)
 - [getRedemptionRequests](RedemptionsService.md#getredemptionrequests)
+- [isFrostWallet](RedemptionsService.md#isfrostwallet)
+- [legacyWalletID](RedemptionsService.md#legacywalletid)
 - [redemptionWalletIdentityFromCandidate](RedemptionsService.md#redemptionwalletidentityfromcandidate)
 - [redemptionWalletPublicKey](RedemptionsService.md#redemptionwalletpublickey)
 - [relayRedemptionRequestToL1](RedemptionsService.md#relayredemptionrequesttol1)
@@ -147,7 +149,7 @@ An array of subarrays, where each subarray has a maximum length of `chunkSize`.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:659](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L659)
+[src/services/redemptions/redemptions-service.ts:675](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L675)
 
 ___
 
@@ -237,7 +239,7 @@ Promise holding the wallet main UTXO or undefined value.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:729](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L729)
+[src/services/redemptions/redemptions-service.ts:766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L766)
 
 ___
 
@@ -256,7 +258,7 @@ Array of wallet events.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:921](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L921)
+[src/services/redemptions/redemptions-service.ts:958](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L958)
 
 ___
 
@@ -283,7 +285,7 @@ Promise with the wallet details needed to request a redemption.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:512](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L512)
+[src/services/redemptions/redemptions-service.ts:525](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L525)
 
 ___
 
@@ -303,19 +305,20 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:1008](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L1008)
+[src/services/redemptions/redemptions-service.ts:1045](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L1045)
 
 ___
 
 ### frostWalletID
 
-▸ **frostWalletID**(`wallet`): `undefined` \| [`Hex`](Hex.md)
+▸ **frostWalletID**(`wallet`, `walletPublicKeyHash`): `undefined` \| [`Hex`](Hex.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `wallet` | [`Wallet`](../interfaces/Wallet.md) |
+| `walletPublicKeyHash` | [`Hex`](Hex.md) |
 
 #### Returns
 
@@ -323,7 +326,7 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:707](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L707)
+[src/services/redemptions/redemptions-service.ts:726](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L726)
 
 ___
 
@@ -347,7 +350,7 @@ The output script of the given Bitcoin address.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:946](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L946)
+[src/services/redemptions/redemptions-service.ts:983](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L983)
 
 ___
 
@@ -378,7 +381,47 @@ Throws an error if no redemption request exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:879](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L879)
+[src/services/redemptions/redemptions-service.ts:916](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L916)
+
+___
+
+### isFrostWallet
+
+▸ **isFrostWallet**(`wallet`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `wallet` | [`Wallet`](../interfaces/Wallet.md) |
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:743](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L743)
+
+___
+
+### legacyWalletID
+
+▸ **legacyWalletID**(`walletPublicKeyHash`): [`Hex`](Hex.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `walletPublicKeyHash` | [`Hex`](Hex.md) |
+
+#### Returns
+
+[`Hex`](Hex.md)
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:750](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L750)
 
 ___
 
@@ -404,19 +447,20 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:670](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L670)
+[src/services/redemptions/redemptions-service.ts:686](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L686)
 
 ___
 
 ### redemptionWalletPublicKey
 
-▸ **redemptionWalletPublicKey**(`wallet`): `undefined` \| [`Hex`](Hex.md)
+▸ **redemptionWalletPublicKey**(`wallet`, `walletPublicKeyHash`): `undefined` \| [`Hex`](Hex.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `wallet` | [`Wallet`](../interfaces/Wallet.md) |
+| `walletPublicKeyHash` | [`Hex`](Hex.md) |
 
 #### Returns
 
@@ -424,7 +468,7 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:694](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L694)
+[src/services/redemptions/redemptions-service.ts:710](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L710)
 
 ___
 
@@ -577,7 +621,7 @@ The resolved output script as a Hex object.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:976](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L976)
+[src/services/redemptions/redemptions-service.ts:1013](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L1013)
 
 ___
 

--- a/typescript/api-reference/classes/RedemptionsService.md
+++ b/typescript/api-reference/classes/RedemptionsService.md
@@ -52,7 +52,7 @@ Service exposing features related to tBTC v2 redemptions.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L47)
+[src/services/redemptions/redemptions-service.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L48)
 
 ## Properties
 
@@ -78,7 +78,7 @@ Gets cross-chain contracts for the given supported L2 chain.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L45)
+[src/services/redemptions/redemptions-service.ts:46](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L46)
 
 ___
 
@@ -90,7 +90,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L38)
+[src/services/redemptions/redemptions-service.ts:39](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L39)
 
 ___
 
@@ -102,7 +102,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L34)
+[src/services/redemptions/redemptions-service.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L35)
 
 ## Methods
 
@@ -133,7 +133,7 @@ An array of subarrays, where each subarray has a maximum length of `chunkSize`.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:580](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L580)
+[src/services/redemptions/redemptions-service.ts:643](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L643)
 
 ___
 
@@ -160,7 +160,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:315](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L315)
+[src/services/redemptions/redemptions-service.ts:316](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L316)
 
 ___
 
@@ -195,7 +195,7 @@ Throws an error if no valid redemption wallet exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:359](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L359)
+[src/services/redemptions/redemptions-service.ts:360](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L360)
 
 ___
 
@@ -222,7 +222,7 @@ Promise holding the wallet main UTXO or undefined value.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:599](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L599)
+[src/services/redemptions/redemptions-service.ts:662](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L662)
 
 ___
 
@@ -241,7 +241,7 @@ Array of wallet events.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:753](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L753)
+[src/services/redemptions/redemptions-service.ts:816](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L816)
 
 ___
 
@@ -268,7 +268,7 @@ Promise with the wallet details needed to request a redemption.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:439](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L439)
+[src/services/redemptions/redemptions-service.ts:502](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L502)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:840](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L840)
+[src/services/redemptions/redemptions-service.ts:903](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L903)
 
 ___
 
@@ -312,7 +312,7 @@ The output script of the given Bitcoin address.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:778](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L778)
+[src/services/redemptions/redemptions-service.ts:841](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L841)
 
 ___
 
@@ -343,7 +343,7 @@ Throws an error if no redemption request exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:711](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L711)
+[src/services/redemptions/redemptions-service.ts:774](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L774)
 
 ___
 
@@ -379,7 +379,7 @@ Throws an error if no wallet with sufficient funds can be found.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:244](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L244)
+[src/services/redemptions/redemptions-service.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L245)
 
 ___
 
@@ -409,7 +409,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:200](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L200)
+[src/services/redemptions/redemptions-service.ts:201](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L201)
 
 ___
 
@@ -438,7 +438,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:84](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L84)
+[src/services/redemptions/redemptions-service.ts:85](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L85)
 
 ___
 
@@ -470,7 +470,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L156)
+[src/services/redemptions/redemptions-service.ts:157](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L157)
 
 ___
 
@@ -496,7 +496,7 @@ The resolved output script as a Hex object.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:808](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L808)
+[src/services/redemptions/redemptions-service.ts:871](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L871)
 
 ___
 
@@ -520,4 +520,4 @@ once the loader is ready.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L65)
+[src/services/redemptions/redemptions-service.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L66)

--- a/typescript/api-reference/classes/RedemptionsService.md
+++ b/typescript/api-reference/classes/RedemptionsService.md
@@ -13,6 +13,7 @@ Service exposing features related to tBTC v2 redemptions.
 - [#crossChainContracts](RedemptionsService.md##crosschaincontracts)
 - [bitcoinClient](RedemptionsService.md#bitcoinclient)
 - [tbtcContracts](RedemptionsService.md#tbtccontracts)
+- [ZeroBytes32](RedemptionsService.md#zerobytes32)
 
 ### Methods
 
@@ -23,8 +24,11 @@ Service exposing features related to tBTC v2 redemptions.
 - [fetchWalletsForRedemption](RedemptionsService.md#fetchwalletsforredemption)
 - [findWalletForRedemption](RedemptionsService.md#findwalletforredemption)
 - [fromSerializableWallet](RedemptionsService.md#fromserializablewallet)
+- [frostWalletID](RedemptionsService.md#frostwalletid)
 - [getRedeemerOutputScript](RedemptionsService.md#getredeemeroutputscript)
 - [getRedemptionRequests](RedemptionsService.md#getredemptionrequests)
+- [redemptionWalletIdentityFromCandidate](RedemptionsService.md#redemptionwalletidentityfromcandidate)
+- [redemptionWalletPublicKey](RedemptionsService.md#redemptionwalletpublickey)
 - [relayRedemptionRequestToL1](RedemptionsService.md#relayredemptionrequesttol1)
 - [requestCrossChainRedemption](RedemptionsService.md#requestcrosschainredemption)
 - [requestRedemption](RedemptionsService.md#requestredemption)
@@ -52,7 +56,7 @@ Service exposing features related to tBTC v2 redemptions.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L48)
+[src/services/redemptions/redemptions-service.ts:54](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L54)
 
 ## Properties
 
@@ -78,7 +82,7 @@ Gets cross-chain contracts for the given supported L2 chain.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:46](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L46)
+[src/services/redemptions/redemptions-service.ts:52](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L52)
 
 ___
 
@@ -90,7 +94,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:39](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L39)
+[src/services/redemptions/redemptions-service.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L45)
 
 ___
 
@@ -102,7 +106,17 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L35)
+[src/services/redemptions/redemptions-service.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L41)
+
+___
+
+### ZeroBytes32
+
+▪ `Static` `Private` `Readonly` **ZeroBytes32**: [`Hex`](Hex.md)
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L34)
 
 ## Methods
 
@@ -133,7 +147,7 @@ An array of subarrays, where each subarray has a maximum length of `chunkSize`.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:643](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L643)
+[src/services/redemptions/redemptions-service.ts:659](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L659)
 
 ___
 
@@ -160,7 +174,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:316](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L316)
+[src/services/redemptions/redemptions-service.ts:322](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L322)
 
 ___
 
@@ -195,13 +209,13 @@ Throws an error if no valid redemption wallet exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:360](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L360)
+[src/services/redemptions/redemptions-service.ts:366](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L366)
 
 ___
 
 ### determineWalletMainUtxo
 
-▸ **determineWalletMainUtxo**(`walletPublicKeyHash`, `bitcoinNetwork`): `Promise`\<`undefined` \| [`BitcoinUtxo`](../README.md#bitcoinutxo)\>
+▸ **determineWalletMainUtxo**(`walletPublicKeyHash`, `bitcoinNetwork`, `taprootWalletID?`): `Promise`\<`undefined` \| [`BitcoinUtxo`](../README.md#bitcoinutxo)\>
 
 Determines the plain-text wallet main UTXO currently registered in the
 Bridge on-chain contract. The returned main UTXO can be undefined if the
@@ -213,6 +227,7 @@ wallet does not have a main UTXO registered in the Bridge at the moment.
 | :------ | :------ | :------ |
 | `walletPublicKeyHash` | [`Hex`](Hex.md) | Public key hash of the wallet. |
 | `bitcoinNetwork` | [`BitcoinNetwork`](../enums/BitcoinNetwork-1.md) | Bitcoin network. |
+| `taprootWalletID?` | [`Hex`](Hex.md) | Optional 32-byte x-only FROST wallet ID. When present, P2TR wallet history is scanned as well. |
 
 #### Returns
 
@@ -222,7 +237,7 @@ Promise holding the wallet main UTXO or undefined value.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:662](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L662)
+[src/services/redemptions/redemptions-service.ts:729](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L729)
 
 ___
 
@@ -241,7 +256,7 @@ Array of wallet events.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:816](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L816)
+[src/services/redemptions/redemptions-service.ts:911](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L911)
 
 ___
 
@@ -268,7 +283,7 @@ Promise with the wallet details needed to request a redemption.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:502](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L502)
+[src/services/redemptions/redemptions-service.ts:512](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L512)
 
 ___
 
@@ -288,7 +303,27 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:903](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L903)
+[src/services/redemptions/redemptions-service.ts:998](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L998)
+
+___
+
+### frostWalletID
+
+▸ **frostWalletID**(`wallet`): `undefined` \| [`Hex`](Hex.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `wallet` | [`Wallet`](../interfaces/Wallet.md) |
+
+#### Returns
+
+`undefined` \| [`Hex`](Hex.md)
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:707](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L707)
 
 ___
 
@@ -312,7 +347,7 @@ The output script of the given Bitcoin address.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:841](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L841)
+[src/services/redemptions/redemptions-service.ts:936](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L936)
 
 ___
 
@@ -343,7 +378,53 @@ Throws an error if no redemption request exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:774](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L774)
+[src/services/redemptions/redemptions-service.ts:869](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L869)
+
+___
+
+### redemptionWalletIdentityFromCandidate
+
+▸ **redemptionWalletIdentityFromCandidate**(`walletKey`): `Object`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `walletKey` | [`Hex`](Hex.md) |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `walletID?` | [`Hex`](Hex.md) |
+| `walletPublicKey` | [`Hex`](Hex.md) |
+| `walletPublicKeyHash` | [`Hex`](Hex.md) |
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:670](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L670)
+
+___
+
+### redemptionWalletPublicKey
+
+▸ **redemptionWalletPublicKey**(`wallet`): `undefined` \| [`Hex`](Hex.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `wallet` | [`Wallet`](../interfaces/Wallet.md) |
+
+#### Returns
+
+`undefined` \| [`Hex`](Hex.md)
+
+#### Defined in
+
+[src/services/redemptions/redemptions-service.ts:694](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L694)
 
 ___
 
@@ -379,7 +460,7 @@ Throws an error if no wallet with sufficient funds can be found.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L245)
+[src/services/redemptions/redemptions-service.ts:251](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L251)
 
 ___
 
@@ -409,7 +490,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:201](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L201)
+[src/services/redemptions/redemptions-service.ts:207](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L207)
 
 ___
 
@@ -438,7 +519,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:85](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L85)
+[src/services/redemptions/redemptions-service.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L91)
 
 ___
 
@@ -470,7 +551,7 @@ Object containing:
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:157](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L157)
+[src/services/redemptions/redemptions-service.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L163)
 
 ___
 
@@ -496,7 +577,7 @@ The resolved output script as a Hex object.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:871](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L871)
+[src/services/redemptions/redemptions-service.ts:966](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L966)
 
 ___
 
@@ -520,4 +601,4 @@ once the loader is ready.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L66)
+[src/services/redemptions/redemptions-service.ts:72](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L72)

--- a/typescript/api-reference/classes/RedemptionsService.md
+++ b/typescript/api-reference/classes/RedemptionsService.md
@@ -256,7 +256,7 @@ Array of wallet events.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:911](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L911)
+[src/services/redemptions/redemptions-service.ts:921](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L921)
 
 ___
 
@@ -303,7 +303,7 @@ ___
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:998](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L998)
+[src/services/redemptions/redemptions-service.ts:1008](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L1008)
 
 ___
 
@@ -347,7 +347,7 @@ The output script of the given Bitcoin address.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:936](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L936)
+[src/services/redemptions/redemptions-service.ts:946](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L946)
 
 ___
 
@@ -378,7 +378,7 @@ Throws an error if no redemption request exists for the given
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:869](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L869)
+[src/services/redemptions/redemptions-service.ts:879](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L879)
 
 ___
 
@@ -577,7 +577,7 @@ The resolved output script as a Hex object.
 
 #### Defined in
 
-[src/services/redemptions/redemptions-service.ts:966](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L966)
+[src/services/redemptions/redemptions-service.ts:976](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/redemptions/redemptions-service.ts#L976)
 
 ___
 

--- a/typescript/src/lib/bitcoin/ecdsa-key.ts
+++ b/typescript/src/lib/bitcoin/ecdsa-key.ts
@@ -3,6 +3,8 @@ import { Hex } from "../utils"
 import { ECPairFactory, ECPairInterface } from "ecpair"
 import * as tinysecp from "@bitcoinerlab/secp256k1"
 import { BitcoinNetwork, toBitcoinJsLibNetwork } from "./network"
+import { BitcoinAddressConverter } from "./address"
+import { BitcoinHashUtils } from "./hash"
 
 /**
  * Checks whether given public key is a compressed Bitcoin public key.
@@ -46,11 +48,50 @@ function compressPublicKey(publicKey: Hex): string {
 }
 
 /**
+ * Converts a wallet key into the Bridge wallet public key hash.
+ * Legacy ECDSA wallets use HASH160(compressedPublicKey). FROST wallets can
+ * identify themselves with their 32-byte x-only wallet ID and use the Bridge
+ * compatibility alias HASH160(0x02 || walletID).
+ * @param walletKey 33-byte compressed ECDSA key or 32-byte FROST x-only key.
+ * @returns 20-byte wallet public key hash accepted by the Bridge.
+ */
+function walletKeyToPublicKeyHash(walletKey: Hex): Hex {
+  const walletKeyBuffer = walletKey.toBuffer()
+
+  if (walletKeyBuffer.length === 32) {
+    return BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+      walletKey
+    )
+  }
+
+  return BitcoinHashUtils.computeHash160(walletKey)
+}
+
+/**
+ * Converts a FROST x-only wallet ID into its compressed-key compatibility
+ * representation. This value is used only by legacy SDK interfaces that carry
+ * a single `walletPublicKey` field and then derive the Bridge wallet hash from
+ * it.
+ * @param walletID 32-byte FROST x-only wallet ID.
+ * @returns 33-byte 0x02-prefixed compatibility key.
+ */
+function xOnlyToCompressedPublicKey(walletID: Hex): Hex {
+  const walletIDBuffer = walletID.toBuffer()
+  if (walletIDBuffer.length !== 32) {
+    throw new Error("FROST wallet ID must be 32-byte")
+  }
+
+  return Hex.from(Buffer.concat([Buffer.from([0x02]), walletIDBuffer]))
+}
+
+/**
  * Utility functions allowing to perform operations on Bitcoin ECDSA public keys.
  */
 export const BitcoinPublicKeyUtils = {
   isCompressedPublicKey,
   compressPublicKey,
+  walletKeyToPublicKeyHash,
+  xOnlyToCompressedPublicKey,
 }
 
 /**

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -24,7 +24,6 @@ import { BigNumber, constants, ContractTransaction, utils } from "ethers"
 import { backoffRetrier, Hex } from "../utils"
 import {
   BitcoinPublicKeyUtils,
-  BitcoinHashUtils,
   BitcoinRawTxVectors,
   BitcoinSpvProof,
   BitcoinCompactSizeUint,
@@ -205,7 +204,8 @@ export class EthereumBridge
     walletPublicKey: Hex,
     redeemerOutputScript: Hex
   ): Promise<RedemptionRequest> {
-    const walletPublicKeyHash = BitcoinHashUtils.computeHash160(walletPublicKey)
+    const walletPublicKeyHash =
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(walletPublicKey)
     return this.pendingRedemptionsByWalletPKH(
       walletPublicKeyHash,
       redeemerOutputScript
@@ -244,7 +244,7 @@ export class EthereumBridge
     redeemerOutputScript: Hex
   ): Promise<RedemptionRequest> {
     const redemptionKey = EthereumBridge.buildRedemptionKey(
-      BitcoinHashUtils.computeHash160(walletPublicKey),
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(walletPublicKey),
       redeemerOutputScript
     )
 
@@ -425,7 +425,9 @@ export class EthereumBridge
     amount: BigNumber
   ): Promise<Hex> {
     const walletPublicKeyHash =
-      BitcoinHashUtils.computeHash160(walletPublicKey).toPrefixedString()
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(
+        walletPublicKey
+      ).toPrefixedString()
 
     const mainUtxoParam = {
       // The Ethereum Bridge expects this hash to be in the Bitcoin internal
@@ -492,7 +494,9 @@ export class EthereumBridge
     }
 
     const walletPublicKeyHash =
-      BitcoinHashUtils.computeHash160(walletPublicKey).toPrefixedString()
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(
+        walletPublicKey
+      ).toPrefixedString()
 
     const tx = await EthersTransactionUtils.sendWithRetry<ContractTransaction>(
       async () => {

--- a/typescript/src/lib/ethereum/l1-bitcoin-redeemer.ts
+++ b/typescript/src/lib/ethereum/l1-bitcoin-redeemer.ts
@@ -16,7 +16,7 @@ import { Hex } from "../utils"
 import SepoliaL1BitcoinRedeemerDeployment from "./artifacts/sepolia/L1BitcoinRedeemer.json"
 import MainnetBaseL1BitcoinRedeemerDeployment from "./artifacts/mainnet/L1BitcoinRedeemer.json"
 import MainnetArbitrumL1BitcoinRedeemerDeployment from "./artifacts/mainnet/L1BitcoinRedeemer.json"
-import { BitcoinHashUtils, BitcoinUtxo } from "../bitcoin"
+import { BitcoinPublicKeyUtils, BitcoinUtxo } from "../bitcoin"
 import { BytesLike } from "ethers"
 
 const artifactLoader = {
@@ -87,7 +87,9 @@ export class EthereumL1BitcoinRedeemer
     encodedVm: BytesLike
   ): Promise<Hex> {
     const walletPublicKeyHash =
-      BitcoinHashUtils.computeHash160(walletPublicKey).toPrefixedString()
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(
+        walletPublicKey
+      ).toPrefixedString()
 
     const mainUtxoParam = {
       // The L1BitcoinRedeemer expects this hash to be in the Bitcoin internal

--- a/typescript/src/lib/ethereum/tbtc-token.ts
+++ b/typescript/src/lib/ethereum/tbtc-token.ts
@@ -1,7 +1,7 @@
 import { TBTC as TBTCTypechain } from "../../../typechain/TBTC"
 import { ChainIdentifier, Chains, TBTCToken } from "../contracts"
 import { BigNumber, ContractTransaction, utils } from "ethers"
-import { BitcoinHashUtils, BitcoinUtxo } from "../bitcoin"
+import { BitcoinPublicKeyUtils, BitcoinUtxo } from "../bitcoin"
 import { Hex } from "../utils"
 import {
   EthersContractConfig,
@@ -142,7 +142,9 @@ export class EthereumTBTCToken
     redeemerOutputScript: Hex
   ) {
     const walletPublicKeyHash =
-      BitcoinHashUtils.computeHash160(walletPublicKey).toPrefixedString()
+      BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(
+        walletPublicKey
+      ).toPrefixedString()
 
     const mainUtxoParam = {
       // The Ethereum Bridge expects this hash to be in the Bitcoin internal

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -402,9 +402,21 @@ export class RedemptionsService {
       const currentWallet = await this.tbtcContracts.bridge.wallets(
         candidatePublicKeyHash
       )
-      const currentWalletPublicKey = currentWallet
-        ? this.redemptionWalletPublicKey(currentWallet)
+      const currentWalletPublicKeyFromRecord = currentWallet
+        ? this.redemptionWalletPublicKey(currentWallet, candidatePublicKeyHash)
         : undefined
+      // With bundled pre-upgrade ABIs, the Bridge cannot return the native
+      // FROST walletID. The API candidate's x-only key is still safe to use
+      // here because bridge.wallets(candidatePublicKeyHash) has already proven
+      // it maps to the on-chain wallet record.
+      const candidateBackedFrostPublicKey =
+        currentWallet &&
+        candidateWalletIdentity.walletID &&
+        this.isFrostWallet(currentWallet)
+          ? candidateWalletIdentity.walletPublicKey
+          : undefined
+      const currentWalletPublicKey =
+        currentWalletPublicKeyFromRecord ?? candidateBackedFrostPublicKey
 
       if (
         !currentWallet ||
@@ -450,7 +462,8 @@ export class RedemptionsService {
         const resolvedMainUtxo = await this.determineWalletMainUtxo(
           candidatePublicKeyHash,
           bitcoinNetwork,
-          this.frostWalletID(currentWallet) ?? candidateWalletIdentity.walletID
+          this.frostWalletID(currentWallet, candidatePublicKeyHash) ??
+            candidateWalletIdentity.walletID
         )
 
         if (!resolvedMainUtxo) {
@@ -544,7 +557,10 @@ export class RedemptionsService {
           walletPublicKeyHash
         )
         const { state, pendingRedemptionsValue } = wallet
-        const walletPublicKey = this.redemptionWalletPublicKey(wallet)
+        const walletPublicKey = this.redemptionWalletPublicKey(
+          wallet,
+          walletPublicKeyHash
+        )
 
         // Wallet must be in Live state.
         if (state !== WalletState.Live || !walletPublicKey) {
@@ -580,7 +596,7 @@ export class RedemptionsService {
         const mainUtxo = await this.determineWalletMainUtxo(
           walletPublicKeyHash,
           bitcoinNetwork,
-          this.frostWalletID(wallet)
+          this.frostWalletID(wallet, walletPublicKeyHash)
         )
         if (!mainUtxo) {
           console.debug(
@@ -691,12 +707,15 @@ export class RedemptionsService {
     }
   }
 
-  private redemptionWalletPublicKey(wallet: Wallet): Hex | undefined {
+  private redemptionWalletPublicKey(
+    wallet: Wallet,
+    walletPublicKeyHash: Hex
+  ): Hex | undefined {
     if (wallet.walletPublicKey) {
       return wallet.walletPublicKey
     }
 
-    const walletID = this.frostWalletID(wallet)
+    const walletID = this.frostWalletID(wallet, walletPublicKeyHash)
     if (walletID) {
       return BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(walletID)
     }
@@ -704,16 +723,34 @@ export class RedemptionsService {
     return undefined
   }
 
-  private frostWalletID(wallet: Wallet): Hex | undefined {
+  private frostWalletID(
+    wallet: Wallet,
+    walletPublicKeyHash: Hex
+  ): Hex | undefined {
+    // Bundled pre-upgrade ABIs synthesize walletID as the legacy left-padded
+    // public key hash fallback. Do not treat that alias as a Taproot x-only ID.
     if (
       wallet.walletID &&
-      wallet.ecdsaWalletID &&
-      wallet.ecdsaWalletID.equals(RedemptionsService.ZeroBytes32)
+      this.isFrostWallet(wallet) &&
+      !wallet.walletID.equals(this.legacyWalletID(walletPublicKeyHash))
     ) {
       return wallet.walletID
     }
 
     return undefined
+  }
+
+  private isFrostWallet(wallet: Wallet): boolean {
+    return (
+      !!wallet.ecdsaWalletID &&
+      wallet.ecdsaWalletID.equals(RedemptionsService.ZeroBytes32)
+    )
+  }
+
+  private legacyWalletID(walletPublicKeyHash: Hex): Hex {
+    return Hex.from(
+      Buffer.concat([Buffer.alloc(12), walletPublicKeyHash.toBuffer()])
+    )
   }
 
   /**

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -753,23 +753,6 @@ export class RedemptionsService {
     // fetch full transaction data (time-consuming calls) starting from
     // the most recent transactions as there is a high chance the main UTXO
     // comes from there.
-    const walletTxHashes = await this.bitcoinClient.getTxHashesForPublicKeyHash(
-      walletPublicKeyHash
-    )
-
-    const walletTransactions = new Map<string, BitcoinTx>()
-    await Promise.all(
-      walletTxHashes.map(async (walletTxHash) => {
-        const walletTransaction = await this.bitcoinClient.getTransaction(
-          walletTxHash
-        )
-        walletTransactions.set(
-          walletTransaction.transactionHash.toString(),
-          walletTransaction
-        )
-      })
-    )
-
     const getOutputScript = (witness: boolean): Hex => {
       const address = BitcoinAddressConverter.publicKeyHashToAddress(
         walletPublicKeyHash,
@@ -795,28 +778,14 @@ export class RedemptionsService {
         bitcoinNetwork
       )
       walletOutputScripts.push(walletP2TR)
-
-      const p2trTransactions =
-        (await this.bitcoinClient.getTransactionHistory(walletP2TRAddress)) ??
-        []
-
-      p2trTransactions.forEach((walletTransaction) => {
-        walletTransactions.set(
-          walletTransaction.transactionHash.toString(),
-          walletTransaction
-        )
-      })
     }
 
     const isWalletOutput = (output: BitcoinTxOutput) =>
       walletOutputScripts.some((script) => script.equals(output.scriptPubKey))
 
-    // Start iterating from the latest transaction as the chance it matches
-    // the wallet main UTXO is the highest.
-    const walletTransactionList = Array.from(walletTransactions.values())
-    for (let i = walletTransactionList.length - 1; i >= 0; i--) {
-      const walletTransaction = walletTransactionList[i]
-
+    const findMatchingUtxo = (
+      walletTransaction: BitcoinTx
+    ): BitcoinUtxo | undefined => {
       // Find the output that locks the funds on the wallet. Only such an output
       // can be a wallet main UTXO.
       const outputIndex = walletTransaction.outputs.findIndex(isWalletOutput)
@@ -827,7 +796,7 @@ export class RedemptionsService {
         console.error(
           `wallet output for transaction ${walletTransaction.transactionHash.toString()} not found`
         )
-        continue
+        return undefined
       }
 
       // Build a candidate UTXO instance based on the detected output.
@@ -840,6 +809,47 @@ export class RedemptionsService {
       // Check whether the candidate UTXO hash matches the main UTXO hash stored
       // on the Bridge.
       if (mainUtxoHash.equals(this.tbtcContracts.bridge.buildUtxoHash(utxo))) {
+        return utxo
+      }
+
+      return undefined
+    }
+
+    // Start iterating from the latest transaction as the chance it matches
+    // the wallet main UTXO is the highest. For FROST wallets, scan P2TR
+    // address history first because their main UTXOs are expected to be
+    // native Taproot wallet outputs.
+    if (taprootWalletID) {
+      const walletP2TRAddress =
+        BitcoinAddressConverter.taprootOutputKeyToAddress(
+          taprootWalletID,
+          bitcoinNetwork
+        )
+
+      const p2trTransactions =
+        (await this.bitcoinClient.getTransactionHistory(walletP2TRAddress)) ??
+        []
+
+      for (let i = p2trTransactions.length - 1; i >= 0; i--) {
+        const utxo = findMatchingUtxo(p2trTransactions[i])
+        if (utxo) {
+          return utxo
+        }
+      }
+    }
+
+    const walletTxHashes = await this.bitcoinClient.getTxHashesForPublicKeyHash(
+      walletPublicKeyHash
+    )
+
+    for (let i = walletTxHashes.length - 1; i >= 0; i--) {
+      const walletTxHash = walletTxHashes[i]
+      const walletTransaction = await this.bitcoinClient.getTransaction(
+        walletTxHash
+      )
+      const utxo = findMatchingUtxo(walletTransaction)
+
+      if (utxo) {
         return utxo
       }
     }

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -4,14 +4,16 @@ import {
   L2Chain,
   RedemptionRequest,
   TBTCContracts,
+  Wallet,
   WalletState,
 } from "../../lib/contracts"
 import {
   BitcoinAddressConverter,
   BitcoinClient,
-  BitcoinHashUtils,
   BitcoinNetwork,
+  BitcoinPublicKeyUtils,
   BitcoinScriptUtils,
+  BitcoinTx,
   BitcoinTxHash,
   BitcoinTxOutput,
   BitcoinUtxo,
@@ -29,6 +31,10 @@ import {
  * Service exposing features related to tBTC v2 redemptions.
  */
 export class RedemptionsService {
+  private static readonly ZeroBytes32 = Hex.from(
+    "0x0000000000000000000000000000000000000000000000000000000000000000"
+  )
+
   /**
    * Handle to tBTC contracts.
    */
@@ -389,19 +395,22 @@ export class RedemptionsService {
         continue
       }
 
-      const candidatePublicKeyHash =
-        BitcoinHashUtils.computeHash160(candidatePublicKey)
+      const candidateWalletIdentity =
+        this.redemptionWalletIdentityFromCandidate(candidatePublicKey)
+      const candidatePublicKeyHash = candidateWalletIdentity.walletPublicKeyHash
 
       const currentWallet = await this.tbtcContracts.bridge.wallets(
         candidatePublicKeyHash
       )
+      const currentWalletPublicKey = currentWallet
+        ? this.redemptionWalletPublicKey(currentWallet)
+        : undefined
 
       if (
         !currentWallet ||
         currentWallet.state !== WalletState.Live ||
-        !currentWallet.walletPublicKey ||
-        currentWallet.walletPublicKey.toString() !==
-          candidatePublicKey.toString()
+        !currentWalletPublicKey ||
+        !currentWalletPublicKey.equals(candidateWalletIdentity.walletPublicKey)
       ) {
         console.debug(
           `The wallet (${candidatePublicKey.toString()})` +
@@ -413,8 +422,8 @@ export class RedemptionsService {
 
       if (redeemerOutputScript) {
         const pendingRedemption =
-          await this.tbtcContracts.bridge.pendingRedemptions(
-            candidatePublicKey,
+          await this.tbtcContracts.bridge.pendingRedemptionsByWalletPKH(
+            candidatePublicKeyHash,
             redeemerOutputScript
           )
 
@@ -440,7 +449,8 @@ export class RedemptionsService {
         const bitcoinNetwork = await this.bitcoinClient.getNetwork()
         const resolvedMainUtxo = await this.determineWalletMainUtxo(
           candidatePublicKeyHash,
-          bitcoinNetwork
+          bitcoinNetwork,
+          this.frostWalletID(currentWallet) ?? candidateWalletIdentity.walletID
         )
 
         if (!resolvedMainUtxo) {
@@ -470,7 +480,7 @@ export class RedemptionsService {
         continue
       }
 
-      walletPublicKey = candidatePublicKey
+      walletPublicKey = currentWalletPublicKey
       mainUtxo = currentMainUtxo
 
       console.debug(
@@ -530,8 +540,11 @@ export class RedemptionsService {
         const globalIndex = cIndex * concurrencyLimit + indexInChunk
 
         const { walletPublicKeyHash } = walletEvent
-        const { state, walletPublicKey, pendingRedemptionsValue } =
-          await this.tbtcContracts.bridge.wallets(walletPublicKeyHash)
+        const wallet = await this.tbtcContracts.bridge.wallets(
+          walletPublicKeyHash
+        )
+        const { state, pendingRedemptionsValue } = wallet
+        const walletPublicKey = this.redemptionWalletPublicKey(wallet)
 
         // Wallet must be in Live state.
         if (state !== WalletState.Live || !walletPublicKey) {
@@ -546,8 +559,8 @@ export class RedemptionsService {
 
         if (redeemerOutputScript) {
           const pendingRedemption =
-            await this.tbtcContracts.bridge.pendingRedemptions(
-              walletPublicKey,
+            await this.tbtcContracts.bridge.pendingRedemptionsByWalletPKH(
+              walletPublicKeyHash,
               redeemerOutputScript
             )
 
@@ -566,7 +579,8 @@ export class RedemptionsService {
 
         const mainUtxo = await this.determineWalletMainUtxo(
           walletPublicKeyHash,
-          bitcoinNetwork
+          bitcoinNetwork,
+          this.frostWalletID(wallet)
         )
         if (!mainUtxo) {
           console.debug(
@@ -577,7 +591,9 @@ export class RedemptionsService {
           return
         }
 
-        const walletBTCBalance = mainUtxo.value.sub(pendingRedemptionsValue)
+        const walletBTCBalance = mainUtxo.value.gt(pendingRedemptionsValue)
+          ? mainUtxo.value.sub(pendingRedemptionsValue)
+          : BigNumber.from(0)
 
         if (walletBTCBalance.gt(maxAmount)) {
           maxAmount = walletBTCBalance
@@ -651,17 +667,69 @@ export class RedemptionsService {
     return result
   }
 
+  private redemptionWalletIdentityFromCandidate(walletKey: Hex): {
+    walletPublicKeyHash: Hex
+    walletPublicKey: Hex
+    walletID?: Hex
+  } {
+    const walletKeyBuffer = walletKey.toBuffer()
+
+    if (walletKeyBuffer.length === 32) {
+      return {
+        walletPublicKeyHash:
+          BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(walletKey),
+        walletPublicKey:
+          BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(walletKey),
+        walletID: walletKey,
+      }
+    }
+
+    return {
+      walletPublicKeyHash:
+        BitcoinPublicKeyUtils.walletKeyToPublicKeyHash(walletKey),
+      walletPublicKey: walletKey,
+    }
+  }
+
+  private redemptionWalletPublicKey(wallet: Wallet): Hex | undefined {
+    if (wallet.walletPublicKey) {
+      return wallet.walletPublicKey
+    }
+
+    const walletID = this.frostWalletID(wallet)
+    if (walletID) {
+      return BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(walletID)
+    }
+
+    return undefined
+  }
+
+  private frostWalletID(wallet: Wallet): Hex | undefined {
+    if (
+      wallet.walletID &&
+      wallet.ecdsaWalletID &&
+      wallet.ecdsaWalletID.equals(RedemptionsService.ZeroBytes32)
+    ) {
+      return wallet.walletID
+    }
+
+    return undefined
+  }
+
   /**
    * Determines the plain-text wallet main UTXO currently registered in the
    * Bridge on-chain contract. The returned main UTXO can be undefined if the
    * wallet does not have a main UTXO registered in the Bridge at the moment.
    * @param walletPublicKeyHash - Public key hash of the wallet.
    * @param bitcoinNetwork - Bitcoin network.
+   * @param taprootWalletID - Optional 32-byte x-only FROST wallet ID. When
+   *        present, P2TR wallet history is scanned as well.
    * @returns Promise holding the wallet main UTXO or undefined value.
    */
   protected async determineWalletMainUtxo(
     walletPublicKeyHash: Hex,
-    bitcoinNetwork: BitcoinNetwork
+    bitcoinNetwork: BitcoinNetwork,
+    taprootWalletID?: Hex
   ): Promise<BitcoinUtxo | undefined> {
     const { mainUtxoHash } = await this.tbtcContracts.bridge.wallets(
       walletPublicKeyHash
@@ -669,13 +737,7 @@ export class RedemptionsService {
 
     // Valid case when the wallet doesn't have a main UTXO registered into
     // the Bridge.
-    if (
-      mainUtxoHash.equals(
-        Hex.from(
-          "0x0000000000000000000000000000000000000000000000000000000000000000"
-        )
-      )
-    ) {
+    if (mainUtxoHash.equals(RedemptionsService.ZeroBytes32)) {
       return undefined
     }
 
@@ -695,6 +757,19 @@ export class RedemptionsService {
       walletPublicKeyHash
     )
 
+    const walletTransactions = new Map<string, BitcoinTx>()
+    await Promise.all(
+      walletTxHashes.map(async (walletTxHash) => {
+        const walletTransaction = await this.bitcoinClient.getTransaction(
+          walletTxHash
+        )
+        walletTransactions.set(
+          walletTransaction.transactionHash.toString(),
+          walletTransaction
+        )
+      })
+    )
+
     const getOutputScript = (witness: boolean): Hex => {
       const address = BitcoinAddressConverter.publicKeyHashToAddress(
         walletPublicKeyHash,
@@ -707,20 +782,40 @@ export class RedemptionsService {
       )
     }
 
-    const walletP2PKH = getOutputScript(false)
-    const walletP2WPKH = getOutputScript(true)
+    const walletOutputScripts = [getOutputScript(false), getOutputScript(true)]
+
+    if (taprootWalletID) {
+      const walletP2TRAddress =
+        BitcoinAddressConverter.taprootOutputKeyToAddress(
+          taprootWalletID,
+          bitcoinNetwork
+        )
+      const walletP2TR = BitcoinAddressConverter.addressToOutputScript(
+        walletP2TRAddress,
+        bitcoinNetwork
+      )
+      walletOutputScripts.push(walletP2TR)
+
+      const p2trTransactions =
+        (await this.bitcoinClient.getTransactionHistory(walletP2TRAddress)) ??
+        []
+
+      p2trTransactions.forEach((walletTransaction) => {
+        walletTransactions.set(
+          walletTransaction.transactionHash.toString(),
+          walletTransaction
+        )
+      })
+    }
 
     const isWalletOutput = (output: BitcoinTxOutput) =>
-      walletP2PKH.equals(output.scriptPubKey) ||
-      walletP2WPKH.equals(output.scriptPubKey)
+      walletOutputScripts.some((script) => script.equals(output.scriptPubKey))
 
     // Start iterating from the latest transaction as the chance it matches
     // the wallet main UTXO is the highest.
-    for (let i = walletTxHashes.length - 1; i >= 0; i--) {
-      const walletTxHash = walletTxHashes[i]
-      const walletTransaction = await this.bitcoinClient.getTransaction(
-        walletTxHash
-      )
+    const walletTransactionList = Array.from(walletTransactions.values())
+    for (let i = walletTransactionList.length - 1; i >= 0; i--) {
+      const walletTransaction = walletTransactionList[i]
 
       // Find the output that locks the funds on the wallet. Only such an output
       // can be a wallet main UTXO.

--- a/typescript/src/services/redemptions/redemptions-service.ts
+++ b/typescript/src/services/redemptions/redemptions-service.ts
@@ -9,6 +9,7 @@ import {
 import {
   BitcoinAddressConverter,
   BitcoinClient,
+  BitcoinHashUtils,
   BitcoinNetwork,
   BitcoinScriptUtils,
   BitcoinTxHash,
@@ -374,15 +375,37 @@ export class RedemptionsService {
     for (let index = 0; index < potentialCandidateWallets.length; index++) {
       const serializableWallet = potentialCandidateWallets[index]
       const {
-        walletBTCBalance: candidateBTCBalance,
+        walletBTCBalance: apiCandidateBTCBalance,
         walletPublicKey: candidatePublicKey,
         mainUtxo: candidateMainUtxo,
       } = this.fromSerializableWallet(serializableWallet)
 
-      if (candidateBTCBalance.lt(amount)) {
+      if (apiCandidateBTCBalance.lt(amount)) {
         console.debug(
           `The wallet (${candidatePublicKey.toString()})` +
             `cannot handle the redemption request. ` +
+            `Continue the loop execution to the next wallet...`
+        )
+        continue
+      }
+
+      const candidatePublicKeyHash =
+        BitcoinHashUtils.computeHash160(candidatePublicKey)
+
+      const currentWallet = await this.tbtcContracts.bridge.wallets(
+        candidatePublicKeyHash
+      )
+
+      if (
+        !currentWallet ||
+        currentWallet.state !== WalletState.Live ||
+        !currentWallet.walletPublicKey ||
+        currentWallet.walletPublicKey.toString() !==
+          candidatePublicKey.toString()
+      ) {
+        console.debug(
+          `The wallet (${candidatePublicKey.toString()})` +
+            `is not Live or does not match the on-chain wallet record. ` +
             `Continue the loop execution to the next wallet...`
         )
         continue
@@ -407,8 +430,48 @@ export class RedemptionsService {
           continue
         }
       }
+
+      let currentMainUtxo = candidateMainUtxo
+      if (
+        !this.tbtcContracts.bridge
+          .buildUtxoHash(currentMainUtxo)
+          .equals(currentWallet.mainUtxoHash)
+      ) {
+        const bitcoinNetwork = await this.bitcoinClient.getNetwork()
+        const resolvedMainUtxo = await this.determineWalletMainUtxo(
+          candidatePublicKeyHash,
+          bitcoinNetwork
+        )
+
+        if (!resolvedMainUtxo) {
+          console.debug(
+            `Could not resolve current main UTXO for wallet ` +
+              `(${candidatePublicKey.toString()}). ` +
+              `Continue the loop execution to the next wallet...`
+          )
+          continue
+        }
+
+        currentMainUtxo = resolvedMainUtxo
+      }
+
+      const onChainCandidateBTCBalance = currentMainUtxo.value.gt(
+        currentWallet.pendingRedemptionsValue
+      )
+        ? currentMainUtxo.value.sub(currentWallet.pendingRedemptionsValue)
+        : BigNumber.from(0)
+
+      if (onChainCandidateBTCBalance.lt(amount)) {
+        console.debug(
+          `The wallet (${candidatePublicKey.toString()})` +
+            `cannot handle the redemption request based on on-chain state. ` +
+            `Continue the loop execution to the next wallet...`
+        )
+        continue
+      }
+
       walletPublicKey = candidatePublicKey
-      mainUtxo = candidateMainUtxo
+      mainUtxo = currentMainUtxo
 
       console.debug(
         `The wallet (${walletPublicKey.toString()})` +

--- a/typescript/test/services/redemptions.test.ts
+++ b/typescript/test/services/redemptions.test.ts
@@ -760,6 +760,24 @@ describe("Redemptions", () => {
         }
       }
 
+      class WalletValidationGuardService extends RedemptionsService {
+        public async determineValidRedemptionWallet(
+          amount: BigNumber,
+          potentialCandidateWallets: any[],
+          redeemerAddressOrScript?: string
+        ): Promise<{
+          walletPublicKey: Hex
+          mainUtxo: BitcoinUtxo
+          redeemerOutputScript?: Hex
+        }> {
+          return super.determineValidRedemptionWallet(
+            amount,
+            potentialCandidateWallets,
+            redeemerAddressOrScript
+          )
+        }
+      }
+
       // Test data
       const testAmount = BigNumber.from("100000000000000000") // 0.1 TBTC (1e17)
       const testEncodedVm = "0x1234567890abcdef" // Mock Wormhole VAA
@@ -1140,6 +1158,19 @@ describe("Redemptions", () => {
             const tbtcContracts = new MockTBTCContracts()
             const bitcoinClient = new MockBitcoinClient()
             bitcoinClient.network = BitcoinNetwork.Mainnet
+            const wallet = findWalletForRedemptionData.liveWallet
+
+            tbtcContracts.bridge.setWallet(
+              wallet.event.walletPublicKeyHash.toPrefixedString(),
+              {
+                state: WalletState.Live,
+                walletPublicKey: wallet.data.walletPublicKey,
+                pendingRedemptionsValue: BigNumber.from(0),
+                mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(
+                  wallet.data.mainUtxo
+                ),
+              } as Wallet
+            )
 
             const redemptionsService = new ApiSuccessGuardService(
               tbtcContracts,
@@ -1331,6 +1362,140 @@ describe("Redemptions", () => {
             )
           ).to.be.rejectedWith(
             "Currently, there are no live wallets in the network."
+          )
+        })
+      })
+
+      context("when API candidates disagree with on-chain wallet state", () => {
+        it("should skip API candidates if stale main UTXO cannot be resolved", async () => {
+          const tbtcContracts = new MockTBTCContracts()
+          const bitcoinClient = new MockBitcoinClient()
+          bitcoinClient.network = BitcoinNetwork.Mainnet
+          const staleWallet =
+            findWalletForRedemptionData.walletWithPendingRedemption
+          const liveWallet = findWalletForRedemptionData.liveWallet
+          const amountInSatoshi = testAmount.div(BigNumber.from("10000000000"))
+          const staleWalletPublicKeyHash = BitcoinHashUtils.computeHash160(
+            staleWallet.data.walletPublicKey
+          )
+          const staleMainUtxo: BitcoinUtxo = {
+            transactionHash: Hex.from(
+              "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            outputIndex: 0,
+            value: liveWallet.data.mainUtxo.value,
+          }
+
+          tbtcContracts.bridge.setWallet(
+            staleWalletPublicKeyHash.toPrefixedString(),
+            {
+              state: WalletState.Live,
+              walletPublicKey: staleWallet.data.walletPublicKey,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(
+                staleWallet.data.mainUtxo
+              ),
+            } as Wallet
+          )
+          tbtcContracts.bridge.setWallet(
+            liveWallet.event.walletPublicKeyHash.toPrefixedString(),
+            {
+              state: WalletState.Live,
+              walletPublicKey: liveWallet.data.walletPublicKey,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(
+                liveWallet.data.mainUtxo
+              ),
+            } as Wallet
+          )
+
+          const redemptionsService = new WalletValidationGuardService(
+            tbtcContracts,
+            bitcoinClient,
+            createCrossChainResolver(createMockL1BitcoinRedeemer())
+          )
+
+          const result =
+            await redemptionsService.determineValidRedemptionWallet(
+              amountInSatoshi,
+              [
+                serializeRedemptionWalletCandidate(
+                  staleWallet.data.walletPublicKey,
+                  staleMainUtxo
+                ),
+                serializeRedemptionWalletCandidate(
+                  liveWallet.data.walletPublicKey,
+                  liveWallet.data.mainUtxo
+                ),
+              ],
+              testRedeemerOutputScript
+            )
+
+          expect(result.walletPublicKey.toString()).to.equal(
+            liveWallet.data.walletPublicKey.toString()
+          )
+        })
+
+        it("should skip API candidates if on-chain pending redemptions exceed main UTXO value", async () => {
+          const tbtcContracts = new MockTBTCContracts()
+          const bitcoinClient = new MockBitcoinClient()
+          bitcoinClient.network = BitcoinNetwork.Mainnet
+          const overReservedWallet =
+            findWalletForRedemptionData.walletWithPendingRedemption
+          const liveWallet = findWalletForRedemptionData.liveWallet
+          const amountInSatoshi = testAmount.div(BigNumber.from("10000000000"))
+          const overReservedWalletPublicKeyHash =
+            BitcoinHashUtils.computeHash160(
+              overReservedWallet.data.walletPublicKey
+            )
+
+          tbtcContracts.bridge.setWallet(
+            overReservedWalletPublicKeyHash.toPrefixedString(),
+            {
+              state: WalletState.Live,
+              walletPublicKey: overReservedWallet.data.walletPublicKey,
+              pendingRedemptionsValue: liveWallet.data.mainUtxo.value.add(1),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(
+                liveWallet.data.mainUtxo
+              ),
+            } as Wallet
+          )
+          tbtcContracts.bridge.setWallet(
+            liveWallet.event.walletPublicKeyHash.toPrefixedString(),
+            {
+              state: WalletState.Live,
+              walletPublicKey: liveWallet.data.walletPublicKey,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(
+                liveWallet.data.mainUtxo
+              ),
+            } as Wallet
+          )
+
+          const redemptionsService = new WalletValidationGuardService(
+            tbtcContracts,
+            bitcoinClient,
+            createCrossChainResolver(createMockL1BitcoinRedeemer())
+          )
+
+          const result =
+            await redemptionsService.determineValidRedemptionWallet(
+              amountInSatoshi,
+              [
+                serializeRedemptionWalletCandidate(
+                  overReservedWallet.data.walletPublicKey,
+                  liveWallet.data.mainUtxo
+                ),
+                serializeRedemptionWalletCandidate(
+                  liveWallet.data.walletPublicKey,
+                  liveWallet.data.mainUtxo
+                ),
+              ],
+              testRedeemerOutputScript
+            )
+
+          expect(result.walletPublicKey.toString()).to.equal(
+            liveWallet.data.walletPublicKey.toString()
           )
         })
       })
@@ -1804,6 +1969,22 @@ function prepareRedemptionsService(mainUtxo: BitcoinUtxo) {
     (_: L2Chain) => undefined
   )
   return { redemptionsService, tbtcContracts, bitcoinClient }
+}
+
+function serializeRedemptionWalletCandidate(
+  walletPublicKey: Hex,
+  mainUtxo: BitcoinUtxo
+) {
+  return {
+    index: 0,
+    walletPublicKey: walletPublicKey.toString(),
+    mainUtxo: {
+      transactionHash: mainUtxo.transactionHash.toString(),
+      outputIndex: mainUtxo.outputIndex,
+      value: mainUtxo.value.toString(),
+    },
+    walletBTCBalance: mainUtxo.value.toString(),
+  }
 }
 
 export async function runRedemptionScenario(

--- a/typescript/test/services/redemptions.test.ts
+++ b/typescript/test/services/redemptions.test.ts
@@ -2127,17 +2127,67 @@ describe("Redemptions", () => {
                     })
 
                     it("should return the expected main UTXO", async () => {
-                      const mainUtxo =
+                      const actualMainUtxo =
                         await redemptionsService.determineWalletMainUtxo(
                           walletPublicKeyHash,
                           bitcoinNetwork
                         )
 
-                      expect(mainUtxo).to.be.eql(mainUtxo)
+                      expect(actualMainUtxo).to.be.eql(mainUtxo)
                     })
                   })
                 })
               })
+            })
+
+            it("should stop fetching legacy transactions after the newest matching UTXO", async () => {
+              const mainUtxo: BitcoinUtxo = {
+                transactionHash: Hex.from(
+                  "00cc0cd13fc4de7a15cb41ab6d58f8b31c75b6b9b4194958c381441a67d09b08"
+                ),
+                outputIndex: 1,
+                value: BigNumber.from(200000),
+              }
+              const transactions = new Map<string, BitcoinTx>()
+              walletTransactionHistory.forEach((tx) => {
+                transactions.set(tx.transactionHash.toString(), tx)
+              })
+              bitcoinClient.transactions = transactions
+
+              const transactionHashes = new Map<string, BitcoinTxHash[]>()
+              transactionHashes.set(
+                walletPublicKeyHash.toString(),
+                walletTransactionHistory.map((tx) => tx.transactionHash)
+              )
+              bitcoinClient.transactionHashes = transactionHashes
+
+              const fetchedTransactionHashes: string[] = []
+              const getTransaction =
+                bitcoinClient.getTransaction.bind(bitcoinClient)
+              bitcoinClient.getTransaction = async (
+                transactionHash: BitcoinTxHash
+              ) => {
+                fetchedTransactionHashes.push(transactionHash.toString())
+                return getTransaction(transactionHash)
+              }
+
+              tbtcContracts.bridge.setWallet(
+                walletPublicKeyHash.toPrefixedString(),
+                {
+                  mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(mainUtxo),
+                } as Wallet
+              )
+
+              const actualMainUtxo =
+                await redemptionsService.determineWalletMainUtxo(
+                  walletPublicKeyHash,
+                  BitcoinNetwork.Testnet
+                )
+
+              expect(actualMainUtxo).to.be.eql(mainUtxo)
+              expect(fetchedTransactionHashes).to.deep.equal([
+                mainUtxo.transactionHash.toString(),
+              ])
             })
           }
         )

--- a/typescript/test/services/redemptions.test.ts
+++ b/typescript/test/services/redemptions.test.ts
@@ -1646,6 +1646,66 @@ describe("Redemptions", () => {
           expect(result.mainUtxo).to.deep.equal(frostMainUtxo)
         })
 
+        it("should not treat stale ABI wallet ID aliases as canonical FROST IDs", async () => {
+          const tbtcContracts = new MockTBTCContracts()
+          const bitcoinClient = new MockBitcoinClient()
+          bitcoinClient.network = BitcoinNetwork.Mainnet
+          const amountInSatoshi = testAmount.div(BigNumber.from("10000000000"))
+          const frostWalletID = Hex.from(
+            "0x1212121212121212121212121212121212121212121212121212121212121212"
+          )
+          const frostWalletPublicKey =
+            BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(frostWalletID)
+          const frostWalletPublicKeyHash =
+            BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+              frostWalletID
+            )
+          const legacyWalletIDAlias = Hex.from(
+            Buffer.concat([
+              Buffer.alloc(12),
+              frostWalletPublicKeyHash.toBuffer(),
+            ])
+          )
+          const frostMainUtxo =
+            findWalletForRedemptionData.liveWallet.data.mainUtxo
+
+          tbtcContracts.bridge.setWallet(
+            frostWalletPublicKeyHash.toPrefixedString(),
+            {
+              walletID: legacyWalletIDAlias,
+              ecdsaWalletID: Hex.from(
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+              ),
+              state: WalletState.Live,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(frostMainUtxo),
+            } as Wallet
+          )
+
+          const redemptionsService = new WalletValidationGuardService(
+            tbtcContracts,
+            bitcoinClient,
+            createCrossChainResolver(createMockL1BitcoinRedeemer())
+          )
+
+          const result =
+            await redemptionsService.determineValidRedemptionWallet(
+              amountInSatoshi,
+              [
+                serializeRedemptionWalletCandidate(
+                  frostWalletID,
+                  frostMainUtxo
+                ),
+              ],
+              testRedeemerOutputScript
+            )
+
+          expect(result.walletPublicKey.toString()).to.equal(
+            frostWalletPublicKey.toString()
+          )
+          expect(result.mainUtxo).to.deep.equal(frostMainUtxo)
+        })
+
         it("should resolve stale FROST API main UTXOs from P2TR history", async () => {
           const tbtcContracts = new MockTBTCContracts()
           const bitcoinClient = new MockBitcoinClient()
@@ -1660,6 +1720,12 @@ describe("Redemptions", () => {
             BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
               frostWalletID
             )
+          const legacyWalletIDAlias = Hex.from(
+            Buffer.concat([
+              Buffer.alloc(12),
+              frostWalletPublicKeyHash.toBuffer(),
+            ])
+          )
           const staleMainUtxo: BitcoinUtxo = {
             transactionHash: Hex.from(
               "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1703,7 +1769,7 @@ describe("Redemptions", () => {
           tbtcContracts.bridge.setWallet(
             frostWalletPublicKeyHash.toPrefixedString(),
             {
-              walletID: frostWalletID,
+              walletID: legacyWalletIDAlias,
               ecdsaWalletID: Hex.from(
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
               ),

--- a/typescript/test/services/redemptions.test.ts
+++ b/typescript/test/services/redemptions.test.ts
@@ -2,6 +2,7 @@ import {
   BitcoinAddressConverter,
   BitcoinHashUtils,
   BitcoinNetwork,
+  BitcoinPublicKeyUtils,
   BitcoinRawTx,
   BitcoinTx,
   BitcoinTxHash,
@@ -357,6 +358,98 @@ describe("Redemptions", () => {
             })
           }
         )
+
+        context("when a FROST wallet can handle the redemption request", () => {
+          const amount: BigNumber = BigNumber.from("1000000") // 0.01 BTC
+          const frostWalletID = Hex.from(
+            "0x3333333333333333333333333333333333333333333333333333333333333333"
+          )
+          const frostWalletPublicKey =
+            BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(frostWalletID)
+          const frostWalletPublicKeyHash =
+            BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+              frostWalletID
+            )
+          const frostMainUtxo: BitcoinUtxo = {
+            transactionHash: Hex.from(
+              "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            ),
+            outputIndex: 0,
+            value: BigNumber.from("2000000"),
+          }
+
+          beforeEach(async () => {
+            tbtcContracts = new MockTBTCContracts()
+            bitcoinClient = new MockBitcoinClient()
+            bitcoinClient.network = BitcoinNetwork.Mainnet
+            tbtcContracts.bridge.newWalletRegisteredEvents = [
+              {
+                walletPublicKeyHash: frostWalletPublicKeyHash,
+              } as NewWalletRegisteredEvent,
+            ]
+
+            const frostWalletAddress =
+              BitcoinAddressConverter.taprootOutputKeyToAddress(
+                frostWalletID,
+                BitcoinNetwork.Mainnet
+              )
+            const frostWalletScript =
+              BitcoinAddressConverter.addressToOutputScript(
+                frostWalletAddress,
+                BitcoinNetwork.Mainnet
+              )
+            bitcoinClient.transactionHistory = new Map<string, BitcoinTx[]>([
+              [
+                frostWalletAddress,
+                [
+                  {
+                    transactionHash: frostMainUtxo.transactionHash,
+                    inputs: [],
+                    outputs: [
+                      {
+                        outputIndex: frostMainUtxo.outputIndex,
+                        value: frostMainUtxo.value,
+                        scriptPubKey: frostWalletScript,
+                      },
+                    ],
+                  } as BitcoinTx,
+                ],
+              ],
+            ])
+
+            tbtcContracts.bridge.setWallet(
+              frostWalletPublicKeyHash.toPrefixedString(),
+              {
+                walletID: frostWalletID,
+                ecdsaWalletID: Hex.from(
+                  "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ),
+                state: WalletState.Live,
+                pendingRedemptionsValue: BigNumber.from(0),
+                mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(frostMainUtxo),
+              } as Wallet
+            )
+
+            redemptionsService = new TestRedemptionsService(
+              tbtcContracts,
+              bitcoinClient,
+              // Mock cross-chain contracts resolver.
+              (_: L2Chain) => undefined
+            )
+
+            result = await redemptionsService.findWalletForRedemption(
+              amount,
+              redeemerOutputScript
+            )
+          })
+
+          it("should return the FROST wallet data", () => {
+            expect(result).to.deep.eq({
+              walletPublicKey: frostWalletPublicKey,
+              mainUtxo: frostMainUtxo,
+            })
+          })
+        })
 
         context(
           "when the redemption request amount is too large and no wallet can handle the request",
@@ -1498,6 +1591,151 @@ describe("Redemptions", () => {
             liveWallet.data.walletPublicKey.toString()
           )
         })
+
+        it("should accept FROST API candidates identified by x-only wallet ID", async () => {
+          const tbtcContracts = new MockTBTCContracts()
+          const bitcoinClient = new MockBitcoinClient()
+          bitcoinClient.network = BitcoinNetwork.Mainnet
+          const amountInSatoshi = testAmount.div(BigNumber.from("10000000000"))
+          const frostWalletID = Hex.from(
+            "0x1111111111111111111111111111111111111111111111111111111111111111"
+          )
+          const frostWalletPublicKey =
+            BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(frostWalletID)
+          const frostWalletPublicKeyHash =
+            BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+              frostWalletID
+            )
+          const frostMainUtxo =
+            findWalletForRedemptionData.liveWallet.data.mainUtxo
+
+          tbtcContracts.bridge.setWallet(
+            frostWalletPublicKeyHash.toPrefixedString(),
+            {
+              walletID: frostWalletID,
+              ecdsaWalletID: Hex.from(
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+              ),
+              state: WalletState.Live,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(frostMainUtxo),
+            } as Wallet
+          )
+
+          const redemptionsService = new WalletValidationGuardService(
+            tbtcContracts,
+            bitcoinClient,
+            createCrossChainResolver(createMockL1BitcoinRedeemer())
+          )
+
+          const result =
+            await redemptionsService.determineValidRedemptionWallet(
+              amountInSatoshi,
+              [
+                serializeRedemptionWalletCandidate(
+                  frostWalletID,
+                  frostMainUtxo
+                ),
+              ],
+              testRedeemerOutputScript
+            )
+
+          expect(result.walletPublicKey.toString()).to.equal(
+            frostWalletPublicKey.toString()
+          )
+          expect(result.mainUtxo).to.deep.equal(frostMainUtxo)
+        })
+
+        it("should resolve stale FROST API main UTXOs from P2TR history", async () => {
+          const tbtcContracts = new MockTBTCContracts()
+          const bitcoinClient = new MockBitcoinClient()
+          bitcoinClient.network = BitcoinNetwork.Mainnet
+          const amountInSatoshi = testAmount.div(BigNumber.from("10000000000"))
+          const frostWalletID = Hex.from(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+          )
+          const frostWalletPublicKey =
+            BitcoinPublicKeyUtils.xOnlyToCompressedPublicKey(frostWalletID)
+          const frostWalletPublicKeyHash =
+            BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+              frostWalletID
+            )
+          const staleMainUtxo: BitcoinUtxo = {
+            transactionHash: Hex.from(
+              "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            outputIndex: 0,
+            value: BigNumber.from("10000000"),
+          }
+          const currentMainUtxo: BitcoinUtxo = {
+            transactionHash: Hex.from(
+              "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            outputIndex: 0,
+            value: BigNumber.from("10000000"),
+          }
+          const frostWalletAddress =
+            BitcoinAddressConverter.taprootOutputKeyToAddress(
+              frostWalletID,
+              BitcoinNetwork.Mainnet
+            )
+          const frostWalletScript =
+            BitcoinAddressConverter.addressToOutputScript(
+              frostWalletAddress,
+              BitcoinNetwork.Mainnet
+            )
+          const frostWalletTransaction: BitcoinTx = {
+            transactionHash: currentMainUtxo.transactionHash,
+            inputs: [],
+            outputs: [
+              {
+                outputIndex: currentMainUtxo.outputIndex,
+                value: currentMainUtxo.value,
+                scriptPubKey: frostWalletScript,
+              },
+            ],
+          }
+
+          bitcoinClient.transactionHistory = new Map<string, BitcoinTx[]>([
+            [frostWalletAddress, [frostWalletTransaction]],
+          ])
+
+          tbtcContracts.bridge.setWallet(
+            frostWalletPublicKeyHash.toPrefixedString(),
+            {
+              walletID: frostWalletID,
+              ecdsaWalletID: Hex.from(
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+              ),
+              state: WalletState.Live,
+              pendingRedemptionsValue: BigNumber.from(0),
+              mainUtxoHash: tbtcContracts.bridge.buildUtxoHash(currentMainUtxo),
+            } as Wallet
+          )
+
+          const redemptionsService = new WalletValidationGuardService(
+            tbtcContracts,
+            bitcoinClient,
+            createCrossChainResolver(createMockL1BitcoinRedeemer())
+          )
+
+          const result =
+            await redemptionsService.determineValidRedemptionWallet(
+              amountInSatoshi,
+              [
+                serializeRedemptionWalletCandidate(
+                  frostWalletID,
+                  staleMainUtxo
+                ),
+              ],
+              testRedeemerOutputScript
+            )
+
+          expect(result.walletPublicKey.toString()).to.equal(
+            frostWalletPublicKey.toString()
+          )
+          expect(result.mainUtxo).to.deep.equal(currentMainUtxo)
+        })
       })
 
       context("when redeemerOutputScript is invalid", () => {
@@ -1591,11 +1829,13 @@ describe("Redemptions", () => {
       class TestRedemptionsService extends RedemptionsService {
         public async determineWalletMainUtxo(
           walletPublicKeyHash: Hex,
-          bitcoinNetwork: BitcoinNetwork
+          bitcoinNetwork: BitcoinNetwork,
+          taprootWalletID?: Hex
         ): Promise<BitcoinUtxo | undefined> {
           return super.determineWalletMainUtxo(
             walletPublicKeyHash,
-            bitcoinNetwork
+            bitcoinNetwork,
+            taprootWalletID
           )
         }
       }


### PR DESCRIPTION
## Summary
- validate API-provided redemption wallet candidates against Bridge wallet state before selecting them
- re-resolve stale API main UTXOs from Bitcoin history and skip unresolved candidates
- compute remaining candidate capacity from on-chain main UTXO value minus pending redemptions
- add coverage for stale API UTXOs and over-reserved on-chain wallets

## Verification
- cd typescript && PATH=/Users/maclane/.nvm/versions/node/v24.11.1/bin:$PATH npm run format
- cd typescript && PATH=/Users/maclane/.nvm/versions/node/v24.11.1/bin:$PATH npm run build
- cd typescript && PATH=/Users/maclane/.nvm/versions/node/v24.11.1/bin:$PATH ./node_modules/.bin/mocha --exit --recursive 'test/**/*.test.ts' --grep 'API candidates disagree|relayRedemptionRequestToL1|determineWalletMainUtxo'
- cd typescript && PATH=/Users/maclane/.nvm/versions/node/v24.11.1/bin:$PATH npm run test

Stacked on #974.