### PR TITLE
Harden Wormhole chain ID imports

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -2382,7 +2382,7 @@ const encoded = encodeDestinationReceiver(
 
 #### Defined in
 
-[src/lib/utils/wormhole.ts:18](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/utils/wormhole.ts#L18)
+[src/lib/utils/wormhole.ts:20](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/utils/wormhole.ts#L20)
 
 ___
 

--- a/typescript/src/lib/utils/wormhole.ts
+++ b/typescript/src/lib/utils/wormhole.ts
@@ -1,4 +1,6 @@
-import { Chains } from "../contracts"
+// Import directly from the leaf module to avoid a contracts barrel circular
+// initialization path when SDK consumers load `lib/contracts` first.
+import { Chains } from "../contracts/chain"
 
 /**
  * Mapping of chain identifiers to their corresponding Wormhole chain IDs.

--- a/typescript/test/lib/contracts-import.test.ts
+++ b/typescript/test/lib/contracts-import.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai"
+import { execFileSync } from "child_process"
+
+describe("Contracts module imports", () => {
+  it("should load the contracts barrel without circular initialization failures", () => {
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [
+          "-e",
+          "require('ts-node/register/files'); require('./src/lib/contracts')",
+        ],
+        {
+          cwd: process.cwd(),
+          stdio: "pipe",
+        }
+      )
+    ).not.to.throw()
+  })
+})


### PR DESCRIPTION
## Summary
- import Chains directly from its defining module in Wormhole utilities
- add a fresh-process regression test that loads the contracts barrel first

## Verification
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH npm exec -- prettier --check src/lib/utils/wormhole.ts test/lib/contracts-import.test.ts
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH npm exec -- mocha --exit test/lib/contracts-import.test.ts
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH npm run build
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH npm exec -- tsc --noEmit --project tsconfig.json
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH npm exec -- eslint src/lib/utils/wormhole.ts test/lib/contracts-import.test.ts
- PATH=/Users/maclane/.nvm/versions/node/v16.20.2/bin:$PATH yarn test