### PR TITLE
fix(bridge): drop the vestigial ECDSA IDLE gate from requestNewWallet

### DIFF
--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -16,7 +16,6 @@
 pragma solidity 0.8.17;
 
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
-import {EcdsaDkg} from "@keep-network/ecdsa/contracts/libraries/EcdsaDkg.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "./BitcoinTx.sol";
@@ -209,11 +208,13 @@ library Wallets {
         BridgeState.Storage storage self,
         BitcoinTx.UTXO calldata activeWalletMainUtxo
     ) external {
-        require(
-            self.ecdsaWalletRegistry.getWalletCreationState() ==
-                EcdsaDkg.State.IDLE,
-            "Wallet creation already in progress"
-        );
+        // The "wallet creation must not be in progress" guarantee is enforced
+        // by the FROST registry: requestNewWallet() below calls dkg.lockState(),
+        // which reverts ("Current state is not IDLE") unless the FROST DKG is
+        // IDLE. The previous gate here read the now-retired ECDSA wallet
+        // registry's creation state; with ECDSA wallet creation removed (its
+        // created-callback is gone), a stuck ECDSA DKG must not be able to
+        // permanently block FROST wallet creation.
 
         bytes20 activeWalletPubKeyHash = self.activeWalletPubKeyHash;
 

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -406,46 +406,17 @@ describe("Bridge - Wallets", () => {
         })
       })
 
-      context("when wallet creation is already in progress", () => {
-        const testData = [
-          {
-            testName: "when wallet creation state is AWAITING_SEED",
-            walletCreationState: ecdsaDkgState.AWAITING_SEED,
-          },
-          {
-            testName: "when wallet creation state is AWAITING_RESULT",
-            walletCreationState: ecdsaDkgState.AWAITING_RESULT,
-          },
-          {
-            testName: "when wallet creation state is CHALLENGE",
-            walletCreationState: ecdsaDkgState.CHALLENGE,
-          },
-        ]
-
-        testData.forEach((test) => {
-          context(test.testName, () => {
-            before(async () => {
-              await createSnapshot()
-
-              walletRegistry.getWalletCreationState.returns(
-                test.walletCreationState
-              )
-            })
-
-            after(async () => {
-              walletRegistry.getWalletCreationState.reset()
-
-              await restoreSnapshot()
-            })
-
-            it("should revert", async () => {
-              await expect(
-                bridge.requestNewWallet(NO_MAIN_UTXO)
-              ).to.be.revertedWith("Wallet creation already in progress")
-            })
-          })
-        })
-      })
+      // The Bridge no longer gates FROST wallet creation on the LEGACY ECDSA
+      // wallet registry's DKG state. That gate read
+      // `ecdsaWalletRegistry.getWalletCreationState() == IDLE`; with ECDSA wallet
+      // creation retired (its created-callback removed), a stuck ECDSA DKG could
+      // never return to IDLE and would permanently block FROST wallet creation.
+      // The "one creation at a time" guarantee is now enforced by the FROST
+      // registry itself — FrostWalletRegistry.requestNewWallet() calls
+      // dkg.lockState(), which reverts ("Current state is not IDLE") unless the
+      // FROST DKG is IDLE — so the former "when wallet creation is already in
+      // progress" cases that asserted a revert based on the ECDSA registry's
+      // creation state are removed here (covered at the FROST registry layer).
     })
   })
 


### PR DESCRIPTION
## Summary

Follow-up to #971 (security review finding). Removes a vestigial ECDSA gate that can permanently brick FROST wallet creation.

`Wallets.requestNewWallet` still required the **retired** ECDSA wallet registry to read `EcdsaDkg.State.IDLE` before starting FROST wallet creation:

```solidity
require(
    self.ecdsaWalletRegistry.getWalletCreationState() == EcdsaDkg.State.IDLE,
    "Wallet creation already in progress"
);
```

With ECDSA wallet creation removed (its `__ecdsaWalletCreatedCallback` is gone), an ECDSA DKG stuck in `CHALLENGE` — e.g. a valid result submitted just before the cutover, whose `approveDkgResult` now reverts on the removed callback, and which **no timeout path can clear** — leaves the ECDSA registry permanently out of `IDLE`. Every subsequent `requestNewWallet` then reverts, so **no FROST wallet can ever be created** (recoverable only by another Bridge upgrade). The pre-upgrade "drain all ECDSA DKGs" runbook is the only mitigation, with no on-chain enforcement.

## Fix

Remove the gate. The "wallet creation must not be in progress" guarantee is **preserved by the FROST registry itself**: `requestNewWallet()` → `FrostWalletRegistry.requestNewWallet()` → `dkg.lockState()`, which reverts (`"Current state is not IDLE"`, `FrostDkg.sol:251`) unless the FROST DKG is `IDLE`. The Bridge-level ECDSA gate is therefore redundant for FROST. The now-unused `EcdsaDkg` import is dropped (`ecdsaWalletRegistry` itself stays — still used by `seize`/`closeWallet`/the fraud-callback auth).

**Behavior note:** a concurrent-creation attempt now reverts with the FROST registry's `"Current state is not IDLE"` instead of `"Wallet creation already in progress"` — tests asserting the old string need updating.

## Verification

`hardhat compile` clean.

_Found during security review of #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
