### PR TITLE
fix(bridge): restore ECDSA-router parity in P2TRSignatureFraudRouter.acceptMigration

### DIFF
--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -111,6 +111,12 @@ contract P2TRSignatureFraudRouter {
     ///         make any future cross-router migration straightforward.
     mapping(uint256 => Fraud.FraudChallenge) public fraudChallenges;
 
+    /// @notice Number of open (submitted but not yet resolved) P2TR fraud
+    ///         challenges. Mirrors EcdsaFraudRouter.openFraudChallengeCount so
+    ///         governance can assert on-chain that no P2TR challenge is open
+    ///         before retiring the slash-on-timeout callback.
+    uint256 public openFraudChallengeCount;
+
     enum P2TRFraudAction {
         Submit,
         Defeat,
@@ -192,7 +198,16 @@ contract P2TRSignatureFraudRouter {
                 fraudChallenges[challengeKeys[i]].reportedAt == 0,
                 "Challenge already migrated"
             );
+            if (!data[i].resolved) {
+                require(
+                    data[i].reportedAt > 0,
+                    "Unresolved challenge not reported"
+                );
+            }
             fraudChallenges[challengeKeys[i]] = data[i];
+            if (!data[i].resolved) {
+                openFraudChallengeCount++;
+            }
             totalDeposit += data[i].depositAmount;
             emit P2TRFraudChallengeMigratedFromBridge(
                 challengeKeys[i],
@@ -282,6 +297,7 @@ contract P2TRSignatureFraudRouter {
         /* solhint-disable-next-line not-rely-on-time */
         challenge.reportedAt = uint32(block.timestamp);
         challenge.resolved = false;
+        openFraudChallengeCount++;
 
         emit P2TRSignatureFraudChallengeSubmitted(
             payload.walletID,
@@ -315,6 +331,7 @@ contract P2TRSignatureFraudRouter {
         );
 
         challenge.resolved = true;
+        openFraudChallengeCount--;
 
         address treasury = b.treasury();
         /* solhint-disable avoid-low-level-calls */
@@ -357,6 +374,7 @@ contract P2TRSignatureFraudRouter {
         );
 
         challenge.resolved = true;
+        openFraudChallengeCount--;
 
         // The return value is intentionally ignored: a reverting
         // challenger fallback self-griefs the refund but must not block


### PR DESCRIPTION
## Summary

Follow-up to #971 (security review finding). Restores ECDSA-router parity in `P2TRSignatureFraudRouter.acceptMigration`, which was copy-pasted from `EcdsaFraudRouter` but silently dropped two invariants.

**1. Missing `reportedAt > 0` guard (the safety bug).** `EcdsaFraudRouter.acceptMigration` requires, for any **unresolved** migrated challenge, `reportedAt > 0`. The P2TR copy omitted it. If governance migrates a P2TR challenge struct with `resolved == false` and `reportedAt == 0`, the function accepts the ETH but every later `_defeat`/`_notifyTimeout` reverts in `_unresolvedChallenge` (`require(reportedAt > 0)`) — so the **escrowed ETH is permanently stuck and the slashing path is unreachable**.

**2. Missing `openFraudChallengeCount`.** `EcdsaFraudRouter` tracks this so governance can assert on-chain that **zero** fraud challenges are open before retiring the slash-on-timeout callback. The P2TR sibling had no such counter, leaving governance with no on-chain invariant to gate decommissioning `p2trFraudRouter`.

## Fix

Mirror `EcdsaFraudRouter` exactly:
- `acceptMigration`: add the `if (!data[i].resolved) require(data[i].reportedAt > 0, "Unresolved challenge not reported")` guard, and `openFraudChallengeCount++` for unresolved migrations.
- Add `uint256 public openFraudChallengeCount`, incremented on submit (and unresolved migration) and decremented at both resolve sites (`_defeat`, `_notifyTimeout`).

(The unchecked `treasury.call{gas:100000}` flagged alongside this is already `slither`-annotated as intentional fire-and-forget, matching `EcdsaFraudRouter`, so it is left as-is.)

## Verification

`hardhat compile` clean.

_Found during security review of #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
