### PR TITLE
fix(frost-registry): emit an event when initializeV2 wires authorizationSource

### DIFF
--- a/solidity/contracts/frost-registry/FrostWalletRegistry.sol
+++ b/solidity/contracts/frost-registry/FrostWalletRegistry.sol
@@ -244,6 +244,8 @@ contract FrostWalletRegistry is
 
     event LifecycleOwnerUpdated(address lifecycleOwner);
 
+    event AuthorizationSourceUpdated(address authorizationSource);
+
     /// @notice Raised when `requestNewWallet` or `approveDkgResult`
     ///         is called while `lifecycleOwner` is the zero
     ///         address — i.e., before governance has wired the
@@ -462,6 +464,7 @@ contract FrostWalletRegistry is
             "Authorization source address cannot be zero"
         );
         authorizationSource = IFrostAuthorizationSource(_authorizationSource);
+        emit AuthorizationSourceUpdated(_authorizationSource);
     }
 
     /// @notice Withdraws application rewards for the given staking provider.


### PR DESCRIPTION
## Summary

Follow-up to #971 (security review finding). Adds the missing event on a privileged wiring step.

`FrostWalletRegistry.initializeV2` sets `authorizationSource` — the contract that drives `reportMaliciousBehavior` (slashing) and operator-authorization weights — but emits **no event**, unlike every sibling privileged setter (`updateWalletOwner` → `WalletOwnerUpdated`, `updateLifecycleOwner` → `LifecycleOwnerUpdated`, etc.). An off-chain governance/security monitor keyed on events would miss this authority being set.

## Fix

Declare `event AuthorizationSourceUpdated(address authorizationSource)` (next to the sibling events) and emit it in `initializeV2`.

## Verification

`hardhat compile` clean.

_Found during security review of #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
