### PR TITLE
docs(bridge): document the P2TR fraud verifier's sighash coverage gap

### DIFF
--- a/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
+++ b/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
@@ -43,6 +43,19 @@ library CheckBitcoinBIP341Sighash {
     /// @param signedInputIndex Index of the input whose key-path signature is
     ///        being checked.
     /// @param sighashType Supported Taproot sighash type: DEFAULT or ALL.
+    /// @dev Scope and KNOWN coverage limitation: this verifier reconstructs only
+    ///      Taproot KEY-PATH spends signed with SIGHASH_DEFAULT or SIGHASH_ALL and
+    ///      no witness annex -- the form honest tBTC wallet operations (sweeps,
+    ///      redemptions, moving-funds) use. A signature using another sighash mode
+    ///      (NONE/SINGLE/ANYONECANPAY), a script-path spend, or an annex cannot be
+    ///      reconstructed here, so a P2TR signature-fraud proof for such a spend
+    ///      cannot be built and the timeout path (P2TRSignatureFraudRouter ->
+    ///      Bridge.slashWalletForP2TRFraud) cannot be reached for it. This is a
+    ///      coverage gap of the on-chain fraud proof, NOT a claim that such spends
+    ///      are harmless: it is a bypass of the P2TR fraud/slashing path for those
+    ///      signing modes. Closing it requires extending the sighash
+    ///      reconstruction to the remaining modes (SINGLE/ANYONECANPAY also need a
+    ///      richer challenge payload carrying per-input/-output context).
     function computeKeyPathSighash(
         uint32 version,
         uint32 locktime,


### PR DESCRIPTION
## Summary

Documents the **known coverage gap** in the P2TR signature-fraud verifier (review finding #2 on #971).

`CheckBitcoinBIP341Sighash.computeKeyPathSighash` reconstructs only Taproot **key-path**, **annex-free**, `SIGHASH_DEFAULT`/`SIGHASH_ALL` signatures. A signature using another sighash mode (`NONE`/`SINGLE`/`ANYONECANPAY`), a script-path spend, or a witness annex cannot be reconstructed, so a P2TR signature-fraud proof for such a spend **cannot be built** — and the timeout path (`P2TRSignatureFraudRouter` → `Bridge.slashWalletForP2TRFraud`) cannot be reached for it.

## Revised after Codex review

The first version of this note claimed the gap was acceptable "because there is no on-chain economic slashing." Codex correctly flagged that as **contradicting the contract's own slashing path**: `slashWalletForP2TRFraud` performs wallet termination + operator stake seizure, so within this contract's model the gap is a real **bypass** of the P2TR fraud/slashing path — and a note asserting "no slashing" could lead a reviewer to wave off a genuine gap.

So this revision documents it factually as a **known coverage gap / slashing bypass for those signing modes**, *not* as benign, and points at what closing it requires (extending the sighash reconstruction; `SINGLE`/`ANYONECANPAY` also need a richer challenge payload). No behavior change.

> Note: there is a broader open question — whether the on-chain slashing path is operationally live or a no-op (staking retirement) — which determines the *severity* of this gap and whether the surrounding Bridge slashing comments are stale. That's a deployment/design call for the team; this note deliberately does not presume an answer.

`hardhat compile` clean.

_Found during security review of #971; revised per the Codex P2 re-review._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
