### PR TITLE
docs(bridge): fix stale requestNewWallet-gate comment + document P2TR fraud shape limits

### DIFF
--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -130,6 +130,17 @@ contract P2TRSignatureFraudRouter {
         uint256 challengeKey;
     }
 
+    // P2TR signature-fraud proof transaction-shape limits, enforced by
+    // CheckBitcoinP2TRSignatureFraud.validatePayloadShape. These are a
+    // deliberate COVERAGE LIMIT and — like the SIGHASH-mode limitation
+    // documented on CheckBitcoinBIP341Sighash.computeKeyPathSighash — a bypass:
+    // a spend whose transaction exceeds these bounds (e.g. a theft tx with 3+
+    // outputs, such as an added change output, or 3+ inputs) cannot be
+    // challenged via processP2TRSignatureFraudChallenge, so the defeat-timeout
+    // slashing path (slashWalletForP2TRFraud) cannot be reached for it. The
+    // constants are not governance-tunable; widening the provable shape requires
+    // a contract upgrade. Closing the gap requires extending the verifier and
+    // the challenge payload to larger transaction shapes.
     uint16 internal constant P2TRSignatureFraudMaxInputs = 2;
     uint16 internal constant P2TRSignatureFraudMaxOutputs = 2;
     uint16 internal constant P2TRSignatureFraudMaxScriptPubKeyBytes = 34;

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -130,17 +130,6 @@ contract P2TRSignatureFraudRouter {
         uint256 challengeKey;
     }
 
-    // P2TR signature-fraud proof transaction-shape limits, enforced by
-    // CheckBitcoinP2TRSignatureFraud.validatePayloadShape. These are a
-    // deliberate COVERAGE LIMIT and — like the SIGHASH-mode limitation
-    // documented on CheckBitcoinBIP341Sighash.computeKeyPathSighash — a bypass:
-    // a spend whose transaction exceeds these bounds (e.g. a theft tx with 3+
-    // outputs, such as an added change output, or 3+ inputs) cannot be
-    // challenged via processP2TRSignatureFraudChallenge, so the defeat-timeout
-    // slashing path (slashWalletForP2TRFraud) cannot be reached for it. The
-    // constants are not governance-tunable; widening the provable shape requires
-    // a contract upgrade. Closing the gap requires extending the verifier and
-    // the challenge payload to larger transaction shapes.
     uint16 internal constant P2TRSignatureFraudMaxInputs = 2;
     uint16 internal constant P2TRSignatureFraudMaxOutputs = 2;
     uint16 internal constant P2TRSignatureFraudMaxScriptPubKeyBytes = 34;

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -299,22 +299,27 @@ library Wallets {
         // this callback would propagate up through
         // `EcdsaWalletRegistry.approveDkgResult`, preventing the
         // registry's own `dkg.complete()` transition and leaving
-        // the ECDSA registry stuck in a non-IDLE state. The
-        // `Wallets.requestNewWallet` gate above checks
-        // `ecdsaWalletRegistry.getWalletCreationState() == IDLE`
-        // unconditionally (before the scheme branch), so a
-        // stuck ECDSA registry would also block every subsequent
-        // FROST wallet creation — exactly the failure mode D-1
-        // is meant to prevent (per PR #443 review).
+        // the ECDSA registry stuck in a non-IDLE state — which is
+        // why this callback is never reverted.
         //
-        // The retirement contract instead relies on operational
-        // sequencing: governance pauses Bridge, waits for any
-        // in-flight ECDSA DKG to settle (callback fires, this
-        // function runs, registry returns to IDLE), then sets
-        // `ecdsaRetired = true`, then unpauses. The
-        // `requestNewWallet` request-side guard (above) and the
-        // `setNewWalletScheme(Frost)` dispatch handle every
-        // subsequent attempt to create an ECDSA wallet.
+        // (A prior `Wallets.requestNewWallet` gate read
+        // `ecdsaWalletRegistry.getWalletCreationState() == IDLE`, so a
+        // stuck ECDSA registry would also have blocked every subsequent
+        // FROST wallet creation. That gate has since been removed —
+        // FROST wallet creation no longer reads the ECDSA registry's
+        // state — so a stuck registry can no longer block FROST
+        // creation, and not reverting here is retained only to avoid
+        // breaking the ECDSA registry's own DKG completion.)
+        //
+        // The retirement contract relies on operational sequencing:
+        // governance pauses Bridge, waits for any in-flight ECDSA DKG
+        // to settle (callback fires, this function runs, registry
+        // returns to IDLE), then sets `ecdsaRetired = true`, then
+        // unpauses. Bridge no longer dispatches ECDSA wallet creation
+        // at all: `requestNewWallet` dispatches only to the FROST
+        // registry (the scheme branch and the `setNewWalletScheme`
+        // setters were removed), so no subsequent ECDSA wallet can be
+        // created.
         // Reserve `ecdsaWalletID == bytes32(0)` as the on-chain marker for
         // FROST-keyed wallets registered via `registerNewFrostWallet`. The
         // Bridge enforces this invariant at the registration boundary so


### PR DESCRIPTION
## Summary

Two doc-accuracy fixes surfaced by a **re-review of #971** after #982–985 merged (the re-review confirmed all four of those fixes are correct/complete and storage layout is clean).

**1. Stale `Wallets.registerNewWallet` D-1 comment** (low, my own #982's leftover). The D-1 late-callback rationale cited two now-removed mechanisms: the `requestNewWallet` `ecdsaWalletRegistry.getWalletCreationState() == IDLE` gate (removed in #982) and the `setNewWalletScheme(Frost)` dispatch (removed in slice 3). Corrected to state the truth: a stuck ECDSA registry can no longer block FROST wallet creation (the gate is gone); not reverting the late callback is retained only to avoid breaking the ECDSA registry's own `dkg.complete()`.

**2. Undocumented P2TR fraud-proof transaction-shape limit** (medium coverage gap, documented). The verifier only accepts **≤2 inputs, ≤2 outputs, ≤34-byte scriptPubKeys** (`validatePayloadShape`). This is a *second* bypass on top of the SIGHASH-mode gap (#985), and an easier one: a rogue signer structures the theft tx with 3+ outputs (e.g. a change output, which real txs almost always have), `processP2TRSignatureFraudChallenge(Submit)` reverts, and the timeout-slashing path (`slashWalletForP2TRFraud`) is never reachable. The constants are `internal constant` (not governance-tunable). Documented at the constants, cross-referenced to the #985 sighash note, so the full P2TR fraud-coverage picture is recorded rather than mistaken for full coverage.

Both are NatSpec/comment-only — no behavior change; `hardhat compile` clean.

> Same disposition as #985: under the current enforcement model (operators carry no slashable T → `TokenStaking.seize` is a no-op) the practical impact is informational; it becomes a real latent-medium bypass if T-staking-backed slashing is reactivated. Closing it = extending the verifier (a deliberate, test-vector-backed task), not a quick patch.

_Found during the re-review of #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
