### PR TITLE
fix(watchtower): don't mark post-broadcast submission failures as rejected

### DIFF
--- a/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3285](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3285)
+[src/services/maintenance/p2tr-signature-fraud.ts:3297](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3297)
 
 ## Properties
 
@@ -70,7 +70,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3287](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3287)
+[src/services/maintenance/p2tr-signature-fraud.ts:3299](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3299)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3281](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3281)
+[src/services/maintenance/p2tr-signature-fraud.ts:3293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3293)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3282](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3282)
+[src/services/maintenance/p2tr-signature-fraud.ts:3294](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3294)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3283)
+[src/services/maintenance/p2tr-signature-fraud.ts:3295](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3295)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3280](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3280)
+[src/services/maintenance/p2tr-signature-fraud.ts:3292](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3292)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3288](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3288)
+[src/services/maintenance/p2tr-signature-fraud.ts:3300](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3300)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3286](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3286)
+[src/services/maintenance/p2tr-signature-fraud.ts:3298](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3298)
 
 ## Methods
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3345](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3345)
+[src/services/maintenance/p2tr-signature-fraud.ts:3357](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3357)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3526](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3526)
+[src/services/maintenance/p2tr-signature-fraud.ts:3538](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3538)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3632](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3632)
+[src/services/maintenance/p2tr-signature-fraud.ts:3644](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3644)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3569](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3569)
+[src/services/maintenance/p2tr-signature-fraud.ts:3581](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3581)
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3751](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3751)
+[src/services/maintenance/p2tr-signature-fraud.ts:3763](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3763)
 
 ___
 
@@ -258,7 +258,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3406](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3406)
+[src/services/maintenance/p2tr-signature-fraud.ts:3418](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3418)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3423](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3423)
+[src/services/maintenance/p2tr-signature-fraud.ts:3435](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3435)
 
 ___
 
@@ -298,7 +298,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3440](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3440)
+[src/services/maintenance/p2tr-signature-fraud.ts:3452](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3452)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3365](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3365)
+[src/services/maintenance/p2tr-signature-fraud.ts:3377](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3377)
 
 ___
 
@@ -339,7 +339,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3378](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3378)
+[src/services/maintenance/p2tr-signature-fraud.ts:3390](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3390)
 
 ___
 
@@ -359,7 +359,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3393](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3393)
+[src/services/maintenance/p2tr-signature-fraud.ts:3405](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3405)
 
 ___
 
@@ -388,7 +388,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3731](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3731)
+[src/services/maintenance/p2tr-signature-fraud.ts:3743](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3743)
 
 ___
 
@@ -409,7 +409,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3490](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3490)
+[src/services/maintenance/p2tr-signature-fraud.ts:3502](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3502)
 
 ___
 
@@ -436,7 +436,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3791](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3791)
+[src/services/maintenance/p2tr-signature-fraud.ts:3803](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3803)
 
 ___
 
@@ -458,7 +458,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3662](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3662)
+[src/services/maintenance/p2tr-signature-fraud.ts:3674](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3674)
 
 ___
 
@@ -478,7 +478,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3482](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3482)
+[src/services/maintenance/p2tr-signature-fraud.ts:3494](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3494)
 
 ___
 
@@ -498,7 +498,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3455](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3455)
+[src/services/maintenance/p2tr-signature-fraud.ts:3467](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3467)
 
 ___
 
@@ -518,7 +518,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3355](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3355)
+[src/services/maintenance/p2tr-signature-fraud.ts:3367](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3367)
 
 ___
 
@@ -538,7 +538,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3712](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3712)
+[src/services/maintenance/p2tr-signature-fraud.ts:3724](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3724)
 
 ___
 
@@ -558,4 +558,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3773](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3773)
+[src/services/maintenance/p2tr-signature-fraud.ts:3785](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3785)

--- a/typescript/src/services/maintenance/p2tr-signature-fraud.ts
+++ b/typescript/src/services/maintenance/p2tr-signature-fraud.ts
@@ -3258,21 +3258,33 @@ export class P2TRSignatureFraudWatchtower {
       observationID: observation.observationID,
     })
 
+    let challengeTxHash: Hex | Buffer | string
     try {
-      return recordP2TRWatchtowerChallengeEvent(this.store, {
-        type: "submission-accepted",
-        observationID: observation.observationID,
-        challengeTxHash: await submitter.submitSignatureFraudChallenge(
-          observation
-        ),
-      })
+      challengeTxHash = await submitter.submitSignatureFraudChallenge(
+        observation
+      )
     } catch (error) {
+      // Pre-broadcast failure: the on-chain challenge transaction was not
+      // submitted, so the submission is genuinely rejected and may be retried.
       return recordP2TRWatchtowerChallengeEvent(this.store, {
         type: "submission-rejected",
         observationID: observation.observationID,
         error: watchtowerSubmissionErrorMessage(error),
       })
     }
+
+    // The on-chain challenge transaction has been broadcast. Persist it as
+    // accepted with its transaction hash. A failure here must NOT be recorded
+    // as a rejection: the challenge already exists on-chain, so marking it
+    // rejected would drop the tx hash and leave local state retryable, causing
+    // a duplicate submission or a misleading alert for a challenge that was in
+    // fact submitted. Let the persistence error propagate instead so the caller
+    // can surface it without corrupting the challenge's submitted state.
+    return recordP2TRWatchtowerChallengeEvent(this.store, {
+      type: "submission-accepted",
+      observationID: observation.observationID,
+      challengeTxHash,
+    })
   }
 }
 

--- a/typescript/test/services/p2tr-signature-fraud.test.ts
+++ b/typescript/test/services/p2tr-signature-fraud.test.ts
@@ -337,6 +337,21 @@ class BlockingP2TRWatchtowerChallengeRecordPersistence extends InMemoryP2TRWatch
   }
 }
 
+class RejectAcceptedSaveP2TRWatchtowerChallengeStore extends InMemoryP2TRWatchtowerChallengeStore {
+  async saveChallengeRecord(
+    record: P2TRWatchtowerChallengeRecord
+  ): Promise<void> {
+    // Simulate a durable-store failure that happens AFTER the on-chain challenge
+    // transaction has been broadcast: reject persistence of the accepted
+    // ("submitted") record only.
+    if (record.status === "submitted") {
+      throw new Error("durable write rejected after broadcast")
+    }
+
+    await super.saveChallengeRecord(record)
+  }
+}
+
 class FakeP2TRSignatureFraudChallengeSubmitter
   implements P2TRSignatureFraudChallengeSubmitter
 {
@@ -1502,6 +1517,52 @@ describe("P2TR signature-fraud witness parsing", () => {
     expect(rejected.status).to.equal("rejected")
     expect(rejected.submissionAttempts).to.equal(1)
     expect(rejected.lastError).to.equal("bridge rejected")
+  })
+
+  it("does not record a post-broadcast persistence failure as a rejected submission", async () => {
+    const vector = vectorCorpus.cases[0]
+    const rawTransaction = withInputWitness(
+      vector.unsignedTransactionHex,
+      vector.signedInputIndex,
+      vector.witnessSignatureHex
+    )
+    const store = new RejectAcceptedSaveP2TRWatchtowerChallengeStore()
+    const watchtower = createDraftApprovedP2TRWatchtower(store, [
+      vector.walletIDHex,
+    ])
+    const [observed] = await watchtower.observeMempoolTransaction(
+      rawTransaction,
+      toObservationPrevouts(vector),
+      txHash("8")
+    )
+    // The submitter broadcasts the on-chain challenge successfully...
+    const submitter = new FakeP2TRSignatureFraudChallengeSubmitter(txHash("9"))
+
+    // ...but persisting the accepted record then fails. The error must propagate
+    // rather than being swallowed into a "rejected" record: the challenge already
+    // exists on-chain, so a rejected record would drop the tx hash and leave the
+    // submission retryable, causing a duplicate submission or a misleading alert.
+    let propagatedError: unknown
+    try {
+      await watchtower.submitChallenge(
+        observed.observation,
+        submitter,
+        draftApprovedSubmissionPolicy
+      )
+    } catch (error) {
+      propagatedError = error
+    }
+
+    expect((propagatedError as Error | undefined)?.message).to.equal(
+      "durable write rejected after broadcast"
+    )
+    // The on-chain challenge transaction was broadcast exactly once.
+    expect(submitter.submissionCount).to.equal(1)
+    // Local state was NOT corrupted into a retryable rejected record.
+    const records = await store.listChallengeRecords()
+    expect(records.some((record) => record.status === "rejected")).to.equal(
+      false
+    )
   })
 
   it("submits Bridge challenges and waits for configured finality", async () => {


### PR DESCRIPTION
## Summary

Fixes a Codex-flagged P1 correctness bug in `P2TRSignatureFraudWatchtower.submitChallenge` (`typescript/src/services/maintenance/p2tr-signature-fraud.ts`).

The on-chain broadcast (`submitter.submitSignatureFraudChallenge`) was evaluated **inside** the object literal passed to `recordP2TRWatchtowerChallengeEvent` for the `submission-accepted` event, all wrapped in one `try/catch`:

```ts
try {
  return recordP2TRWatchtowerChallengeEvent(this.store, {
    type: "submission-accepted",
    challengeTxHash: await submitter.submitSignatureFraudChallenge(observation), // broadcasts on-chain
    ...
  })
} catch (error) {
  return recordP2TRWatchtowerChallengeEvent(this.store, { type: "submission-rejected", ... })
}
```

If the broadcast **succeeds** but a later step in the `try` fails — persisting the accepted record, or any post-broadcast work — the `catch` records the challenge as **`submission-rejected`**. That drops the on-chain challenge tx hash and leaves local state retryable, so the watchtower can **resubmit a duplicate** or **raise a misleading alert** for a challenge that already exists on-chain.

## Fix

Capture the broadcast result first:
- A **pre-broadcast** failure → `submission-rejected` (the tx was genuinely not submitted; safe to retry).
- After a successful broadcast → record `submission-accepted` with the tx hash; if **that** persistence fails, the error **propagates** rather than being misattributed as a rejection.

## Test

Adds a regression test using a store that rejects the post-broadcast `submitted`-record save: asserts the persistence error propagates, the tx was broadcast exactly once, and **no** `rejected` record is written. (Against the old code the test fails — it would return a `rejected` record instead of throwing.)

Covered by the existing `typescript.yml` CI (build + test).

_Found during the Codex re-review of #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
