### PR TITLE
fix(bridge): allow P2TR fraud evidence for real protocol transaction shapes

### DIFF
--- a/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
+++ b/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
@@ -108,17 +108,16 @@ library CheckBitcoinBIP341Sighash {
         pure
         returns (bytes32)
     {
-        bytes memory serialized;
+        bytes[] memory parts = new bytes[](inputs.length);
 
         for (uint256 i = 0; i < inputs.length; i++) {
-            serialized = abi.encodePacked(
-                serialized,
+            parts[i] = abi.encodePacked(
                 inputs[i].txid,
                 P2TRSignatureFraud.uint32LE(inputs[i].vout)
             );
         }
 
-        return sha256(serialized);
+        return sha256(concat(parts));
     }
 
     function hashAmounts(InputPrevout[] memory prevouts)
@@ -126,16 +125,13 @@ library CheckBitcoinBIP341Sighash {
         pure
         returns (bytes32)
     {
-        bytes memory serialized;
+        bytes[] memory parts = new bytes[](prevouts.length);
 
         for (uint256 i = 0; i < prevouts.length; i++) {
-            serialized = abi.encodePacked(
-                serialized,
-                P2TRSignatureFraud.uint64LE(prevouts[i].valueSats)
-            );
+            parts[i] = P2TRSignatureFraud.uint64LE(prevouts[i].valueSats);
         }
 
-        return sha256(serialized);
+        return sha256(concat(parts));
     }
 
     function hashScriptPubKeys(InputPrevout[] memory prevouts)
@@ -143,18 +139,15 @@ library CheckBitcoinBIP341Sighash {
         pure
         returns (bytes32)
     {
-        bytes memory serialized;
+        bytes[] memory parts = new bytes[](prevouts.length);
 
         for (uint256 i = 0; i < prevouts.length; i++) {
-            serialized = abi.encodePacked(
-                serialized,
-                P2TRSignatureFraud.bytesWithCompactSize(
-                    prevouts[i].scriptPubKey
-                )
+            parts[i] = P2TRSignatureFraud.bytesWithCompactSize(
+                prevouts[i].scriptPubKey
             );
         }
 
-        return sha256(serialized);
+        return sha256(concat(parts));
     }
 
     function hashSequences(TransactionInput[] memory inputs)
@@ -162,16 +155,13 @@ library CheckBitcoinBIP341Sighash {
         pure
         returns (bytes32)
     {
-        bytes memory serialized;
+        bytes[] memory parts = new bytes[](inputs.length);
 
         for (uint256 i = 0; i < inputs.length; i++) {
-            serialized = abi.encodePacked(
-                serialized,
-                P2TRSignatureFraud.uint32LE(inputs[i].sequence)
-            );
+            parts[i] = P2TRSignatureFraud.uint32LE(inputs[i].sequence);
         }
 
-        return sha256(serialized);
+        return sha256(concat(parts));
     }
 
     function hashOutputs(TransactionOutput[] memory outputs)
@@ -179,16 +169,43 @@ library CheckBitcoinBIP341Sighash {
         pure
         returns (bytes32)
     {
-        bytes memory serialized;
+        bytes[] memory parts = new bytes[](outputs.length);
 
         for (uint256 i = 0; i < outputs.length; i++) {
-            serialized = abi.encodePacked(
-                serialized,
+            parts[i] = abi.encodePacked(
                 P2TRSignatureFraud.uint64LE(outputs[i].valueSats),
                 P2TRSignatureFraud.bytesWithCompactSize(outputs[i].scriptPubKey)
             );
         }
 
-        return sha256(serialized);
+        return sha256(concat(parts));
+    }
+
+    /// @notice Concatenates `parts` into a single byte string.
+    /// @dev Equivalent to chaining `abi.encodePacked` over `parts`, but copies
+    ///      each byte exactly once (O(total length)) instead of re-copying a
+    ///      growing buffer on every element (which is O(n^2) in the element
+    ///      count). The BIP-341 vector hashes above feed this with one part per
+    ///      input or output, so an O(n^2) build would make large -- but valid --
+    ///      protocol transaction shapes (redemption batches, moving-funds
+    ///      fan-out, multi-input sweeps) exceed the block gas limit and become
+    ///      impossible to submit as fraud challenges.
+    function concat(bytes[] memory parts) internal pure returns (bytes memory) {
+        uint256 totalLength = 0;
+        for (uint256 i = 0; i < parts.length; i++) {
+            totalLength += parts[i].length;
+        }
+
+        bytes memory serialized = new bytes(totalLength);
+        uint256 offset = 0;
+        for (uint256 i = 0; i < parts.length; i++) {
+            bytes memory part = parts[i];
+            for (uint256 j = 0; j < part.length; j++) {
+                serialized[offset] = part[j];
+                offset++;
+            }
+        }
+
+        return serialized;
     }
 }

--- a/solidity/contracts/bridge/CheckBitcoinP2TRSignatureFraud.sol
+++ b/solidity/contracts/bridge/CheckBitcoinP2TRSignatureFraud.sol
@@ -209,48 +209,37 @@ library CheckBitcoinP2TRSignatureFraud {
         CheckBitcoinBIP341Sighash.TransactionOutput[] memory outputs,
         uint32 signedInputIndex
     ) internal pure returns (bytes memory) {
-        bytes memory payload = abi.encodePacked(
+        // Collect every fixed-format field as a separate part and concatenate
+        // once -- each byte is copied exactly once (O(n)). Appending into a
+        // growing `abi.encodePacked` buffer per element would be O(n^2) in the
+        // input/output count, so large but valid protocol-shaped evidence
+        // (redemption batches, moving-funds fan-out, multi-input sweeps) that the
+        // raised shape caps now accept could run out of gas building the
+        // challenge identity before the challenge is recorded. The concatenation
+        // order is byte-identical to the prior incremental encoding.
+        bytes[] memory parts = new bytes[](
+            3 + inputs.length + prevouts.length + outputs.length
+        );
+        uint256 next = 0;
+
+        parts[next++] = abi.encodePacked(
             P2TRSignatureFraud.uint32LE(signedInputIndex),
             P2TRSignatureFraud.uint32LE(version),
             P2TRSignatureFraud.uint32LE(locktime),
             P2TRSignatureFraud.encodeCompactSize(inputs.length)
         );
 
-        payload = encodeBridgeChallengeInputs(payload, inputs);
-        payload = encodeBridgeChallengePrevouts(payload, prevouts);
-        payload = encodeBridgeChallengeOutputs(payload, outputs);
-
-        return payload;
-    }
-
-    function encodeBridgeChallengeInputs(
-        bytes memory payload,
-        CheckBitcoinBIP341Sighash.TransactionInput[] memory inputs
-    ) internal pure returns (bytes memory) {
         for (uint256 i = 0; i < inputs.length; i++) {
-            payload = abi.encodePacked(
-                payload,
+            parts[next++] = abi.encodePacked(
                 inputs[i].txid,
                 P2TRSignatureFraud.uint32LE(inputs[i].vout),
                 P2TRSignatureFraud.uint32LE(inputs[i].sequence)
             );
         }
 
-        return payload;
-    }
-
-    function encodeBridgeChallengePrevouts(
-        bytes memory payload,
-        CheckBitcoinBIP341Sighash.InputPrevout[] memory prevouts
-    ) internal pure returns (bytes memory) {
-        payload = abi.encodePacked(
-            payload,
-            P2TRSignatureFraud.encodeCompactSize(prevouts.length)
-        );
-
+        parts[next++] = P2TRSignatureFraud.encodeCompactSize(prevouts.length);
         for (uint256 i = 0; i < prevouts.length; i++) {
-            payload = abi.encodePacked(
-                payload,
+            parts[next++] = abi.encodePacked(
                 P2TRSignatureFraud.uint64LE(prevouts[i].valueSats),
                 P2TRSignatureFraud.bytesWithCompactSize(
                     prevouts[i].scriptPubKey
@@ -258,27 +247,15 @@ library CheckBitcoinP2TRSignatureFraud {
             );
         }
 
-        return payload;
-    }
-
-    function encodeBridgeChallengeOutputs(
-        bytes memory payload,
-        CheckBitcoinBIP341Sighash.TransactionOutput[] memory outputs
-    ) internal pure returns (bytes memory) {
-        payload = abi.encodePacked(
-            payload,
-            P2TRSignatureFraud.encodeCompactSize(outputs.length)
-        );
-
+        parts[next++] = P2TRSignatureFraud.encodeCompactSize(outputs.length);
         for (uint256 i = 0; i < outputs.length; i++) {
-            payload = abi.encodePacked(
-                payload,
+            parts[next++] = abi.encodePacked(
                 P2TRSignatureFraud.uint64LE(outputs[i].valueSats),
                 P2TRSignatureFraud.bytesWithCompactSize(outputs[i].scriptPubKey)
             );
         }
 
-        return payload;
+        return CheckBitcoinBIP341Sighash.concat(parts);
     }
 
     /// @notice Validates bounded Taproot signature-fraud payload shape.

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -132,21 +132,39 @@ contract P2TRSignatureFraudRouter {
 
     // P2TR signature-fraud evidence shape limits, enforced by
     // CheckBitcoinP2TRSignatureFraud.validatePayloadShape. The input/output caps
-    // are sized to comfortably exceed the largest valid protocol transaction
-    // shapes the Bridge accepts -- redemption batches, moving-funds fan-out to
-    // many target wallets, and multi-input deposit/moving-funds sweeps -- so a
-    // fraudulent signature over any real protocol spend can be challenged. The
-    // BIP-341 sighash reconstruction (CheckBitcoinBIP341Sighash) now builds its
-    // vector hashes in O(n), so these caps no longer double as a quadratic-gas
-    // guard; they remain only as a DoS bound on per-challenge work and calldata.
-    // They are fixed (not governance-tunable) so fraud-evidence validity cannot
-    // be censored or stranded by mutable state. (The standard output/prevout
-    // scripts the protocol uses -- P2PKH/P2SH/P2WPKH/P2WSH/P2TR -- are all <= 34
-    // bytes, so the script cap is unchanged.)
-    uint16 internal constant P2TRSignatureFraudMaxInputs = 512;
-    uint16 internal constant P2TRSignatureFraudMaxOutputs = 512;
+    // cover every shape the honest protocol produces, with comfortable gas margin:
+    // deposit sweeps (<= DEPOSIT_SWEEP_MAX_SIZE = 20 deposits, ~21 inputs),
+    // redemption batches (<= 20 outputs), moved-funds sweeps (1-2 in / 1 out), and
+    // moving-funds fan-out (one output per live target wallet, normally well below
+    // 128). They are NOT sized to the largest conceivable transaction: a
+    // signature-fraud challenge reconstructs the whole transaction on-chain, and
+    // even with the O(n) BIP-341 sighash and challenge-identity encoders a
+    // ~512-in/out challenge exceeds the block gas limit (empirically ~192 in/out
+    // is the edge; 256+ runs out of gas). 128 leaves margin under that ceiling.
+    //
+    // RESIDUAL (documented, accepted): a malicious wallet could sign a transaction
+    // with more than 128 outputs to make that (fraudulent) signature
+    // un-challengeable via this path. This is an inherent limit of on-chain fraud
+    // proofs -- Bitcoin permits far more outputs than fit in a block's gas, so no
+    // finite cap closes it -- and is currently non-impactful: this verifier is not
+    // yet wired into Bridge fraud entrypoints and operator slashing is
+    // economically inert (the on-chain slashing code is wired, but operators are
+    // not backed by slashable stake).
+    // Raising the cap further (e.g. to 512) requires replacing the linear
+    // byte-copy concat (CheckBitcoinBIP341Sighash.concat) with an assembly
+    // word-copy; revisit that, with fuzzing, if the path is wired in and slashing
+    // becomes economically active.
+    //
+    // Fixed (not governance-tunable) so fraud-evidence validity cannot be censored
+    // or stranded by mutable state. The standard output/prevout scripts the
+    // protocol uses (P2PKH/P2SH/P2WPKH/P2WSH/P2TR) are all <= 34 bytes.
+    uint16 internal constant P2TRSignatureFraudMaxInputs = 128;
+    uint16 internal constant P2TRSignatureFraudMaxOutputs = 128;
     uint16 internal constant P2TRSignatureFraudMaxScriptPubKeyBytes = 34;
-    uint32 internal constant P2TRSignatureFraudMaxPayloadBytes = 262144;
+    // 128 KiB: comfortably above the ~62 KB maximum ABI-encoded 128-in/128-out
+    // payload (34-byte scripts), so the pre-decode length gate never rejects a
+    // valid max-shape challenge.
+    uint32 internal constant P2TRSignatureFraudMaxPayloadBytes = 131072;
 
     event P2TRSignatureFraudChallengeSubmitted(
         bytes32 indexed walletID,

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -130,10 +130,23 @@ contract P2TRSignatureFraudRouter {
         uint256 challengeKey;
     }
 
-    uint16 internal constant P2TRSignatureFraudMaxInputs = 2;
-    uint16 internal constant P2TRSignatureFraudMaxOutputs = 2;
+    // P2TR signature-fraud evidence shape limits, enforced by
+    // CheckBitcoinP2TRSignatureFraud.validatePayloadShape. The input/output caps
+    // are sized to comfortably exceed the largest valid protocol transaction
+    // shapes the Bridge accepts -- redemption batches, moving-funds fan-out to
+    // many target wallets, and multi-input deposit/moving-funds sweeps -- so a
+    // fraudulent signature over any real protocol spend can be challenged. The
+    // BIP-341 sighash reconstruction (CheckBitcoinBIP341Sighash) now builds its
+    // vector hashes in O(n), so these caps no longer double as a quadratic-gas
+    // guard; they remain only as a DoS bound on per-challenge work and calldata.
+    // They are fixed (not governance-tunable) so fraud-evidence validity cannot
+    // be censored or stranded by mutable state. (The standard output/prevout
+    // scripts the protocol uses -- P2PKH/P2SH/P2WPKH/P2WSH/P2TR -- are all <= 34
+    // bytes, so the script cap is unchanged.)
+    uint16 internal constant P2TRSignatureFraudMaxInputs = 512;
+    uint16 internal constant P2TRSignatureFraudMaxOutputs = 512;
     uint16 internal constant P2TRSignatureFraudMaxScriptPubKeyBytes = 34;
-    uint16 internal constant P2TRSignatureFraudMaxPayloadBytes = 4096;
+    uint32 internal constant P2TRSignatureFraudMaxPayloadBytes = 262144;
 
     event P2TRSignatureFraudChallengeSubmitted(
         bytes32 indexed walletID,

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -640,6 +640,83 @@ describe("Bridge - P2TR signature fraud", () => {
     })
   }
 
+  // The shape caps accept up to 512 inputs/outputs. The challenge-identity
+  // encoder (encodeBridgeChallengeTransactionPayload) and the BIP-341 sighash
+  // reconstruction must build that payload in LINEAR time -- a quadratic encoder
+  // lets a maximum-size but valid protocol shape pass the shape check yet run out
+  // of gas before the challenge is recorded. Submitting at the cap must still
+  // reach (and fail) signature verification rather than exhausting gas.
+  // The shape caps accept up to 128 inputs/outputs (see P2TRSignatureFraudRouter
+  // for why 128 and not higher). A maximum-size but valid shape must reconstruct
+  // on-chain within the block gas limit: the linearized challenge-identity encoder
+  // and BIP-341 sighash reconstruction make 128 in/out reach signature
+  // verification with margin (empirically ~192 is the edge, 256+ runs out of gas),
+  // whereas a quadratic encoder -- or a higher cap -- would exhaust gas before the
+  // challenge is recorded.
+  it("builds the challenge identity for a maximum-size (128 in/out) shape within gas", async () => {
+    const base = vectorPayload(vector)
+    await registerP2TRWallet(base.walletID)
+
+    const count = 128
+    const maxShapePayload = {
+      ...base,
+      inputs: Array.from({ length: count }, () => base.inputs[0]),
+      prevouts: Array.from({ length: count }, () => base.prevouts[0]),
+      outputs: Array.from({ length: count }, () => base.outputs[0]),
+      signedInputIndex: 0,
+    }
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(maxShapePayload),
+          [],
+          { value: fraudChallengeDepositAmount, gasLimit: 29500000 }
+        )
+    ).to.be.revertedWith("Signature verification failure")
+  })
+
+  // One past the cap must be rejected cheaply at the shape check (before the
+  // encoder/sighash run), so an oversized payload cannot grief the challenger.
+  it("rejects P2TR challenges that exceed the 128 input/output caps", async () => {
+    const base = vectorPayload(vector)
+    await registerP2TRWallet(base.walletID)
+
+    const tooManyInputs = {
+      ...base,
+      inputs: Array.from({ length: 129 }, () => base.inputs[0]),
+      prevouts: Array.from({ length: 129 }, () => base.prevouts[0]),
+      signedInputIndex: 0,
+    }
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(tooManyInputs),
+          [],
+          { value: fraudChallengeDepositAmount, gasLimit: 29500000 }
+        )
+    ).to.be.revertedWith("Too many inputs")
+
+    const tooManyOutputs = {
+      ...base,
+      outputs: Array.from({ length: 129 }, () => base.outputs[0]),
+    }
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(tooManyOutputs),
+          [],
+          { value: fraudChallengeDepositAmount, gasLimit: 29500000 }
+        )
+    ).to.be.revertedWith("Too many outputs")
+  })
+
   for (const action of [
     p2trFraudAction.Submit,
     p2trFraudAction.Defeat,
@@ -651,7 +728,7 @@ describe("Bridge - P2TR signature fraud", () => {
           .connect(thirdParty)
           .processP2TRSignatureFraudChallenge(
             action,
-            `0x${"00".repeat(262145)}`,
+            `0x${"00".repeat(131073)}`,
             [],
             {
               value:

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -522,27 +522,6 @@ describe("Bridge - P2TR signature fraud", () => {
     revertMessage: string
   }[] = [
     {
-      name: "too many inputs",
-      mutatePayload: (payload) => ({
-        ...payload,
-        inputs: [...payload.inputs, payload.inputs[0], payload.inputs[0]],
-        prevouts: [
-          ...payload.prevouts,
-          payload.prevouts[0],
-          payload.prevouts[0],
-        ],
-      }),
-      revertMessage: "Too many inputs",
-    },
-    {
-      name: "too many outputs",
-      mutatePayload: (payload) => ({
-        ...payload,
-        outputs: [...payload.outputs, payload.outputs[0], payload.outputs[0]],
-      }),
-      revertMessage: "Too many outputs",
-    },
-    {
       name: "prevout count mismatch",
       mutatePayload: (payload) => ({
         ...payload,
@@ -614,6 +593,53 @@ describe("Bridge - P2TR signature fraud", () => {
     })
   }
 
+  // The router must accept protocol-realistic shapes with more than two inputs
+  // or outputs (redemption batches, moving-funds fan-out, multi-input sweeps).
+  // The shape check no longer rejects them, so an altered shape reaches -- and
+  // fails -- signature verification instead of being rejected as "Too many".
+  const acceptedLargerShapeScenarios: {
+    name: string
+    mutatePayload: (payload: BridgeChallengePayload) => BridgeChallengePayload
+  }[] = [
+    {
+      name: "more than two inputs",
+      mutatePayload: (payload) => ({
+        ...payload,
+        inputs: [...payload.inputs, payload.inputs[0], payload.inputs[0]],
+        prevouts: [
+          ...payload.prevouts,
+          payload.prevouts[0],
+          payload.prevouts[0],
+        ],
+      }),
+    },
+    {
+      name: "more than two outputs",
+      mutatePayload: (payload) => ({
+        ...payload,
+        outputs: [...payload.outputs, payload.outputs[0], payload.outputs[0]],
+      }),
+    },
+  ]
+
+  for (const scenario of acceptedLargerShapeScenarios) {
+    it(`accepts P2TR challenges with ${scenario.name} past the shape check`, async () => {
+      const payload = vectorPayload(vector)
+      await registerP2TRWallet(payload.walletID)
+
+      await expect(
+        p2trFraudRouter
+          .connect(thirdParty)
+          .processP2TRSignatureFraudChallenge(
+            p2trFraudAction.Submit,
+            encodePayload(scenario.mutatePayload(payload)),
+            [],
+            { value: fraudChallengeDepositAmount }
+          )
+      ).to.be.revertedWith("Signature verification failure")
+    })
+  }
+
   for (const action of [
     p2trFraudAction.Submit,
     p2trFraudAction.Defeat,
@@ -625,13 +651,19 @@ describe("Bridge - P2TR signature fraud", () => {
           .connect(thirdParty)
           .processP2TRSignatureFraudChallenge(
             action,
-            `0x${"00".repeat(4097)}`,
+            `0x${"00".repeat(262145)}`,
             [],
             {
               value:
                 action === p2trFraudAction.Submit
                   ? fraudChallengeDepositAmount
                   : 0,
+              // The payload exceeds P2TRSignatureFraudMaxPayloadBytes so the call
+              // reverts at the early length check before ABI decode. Set the gas
+              // limit explicitly: eth_estimateGas cannot price a tx that always
+              // reverts and otherwise falls back above the block gas limit for a
+              // calldata this large.
+              gasLimit: 29000000,
             }
           )
       ).to.be.revertedWith("P2TR payload too large")


### PR DESCRIPTION
## Summary

Makes valid P2TR signature-fraud evidence for **real protocol transaction shapes** challengeable, without the fraud-challenge submission running out of gas. Addresses a Codex P1 (and its re-review).

## The problem

1. The router capped inputs/outputs at **2**, so common protocol spends (redemption batches, moving-funds fan-out, multi-input sweeps) were rejected by `_validatePayloadShape` before the signature was even checked.
2. The on-chain challenge reconstructs the whole transaction twice — the BIP-341 sighash **and** the Bridge challenge-identity payload. **Both** built their byte strings with incremental `abi.encodePacked(buf, …)` in loops, which is **O(n²)** in memory. So merely raising the caps would let large evidence pass the shape check yet exhaust gas before the challenge is recorded.

## Changes

- **Linearize both reconstructions to O(n):** the five BIP-341 vector hash builders (`CheckBitcoinBIP341Sighash`) and the challenge-identity encoder (`encodeBridgeChallengeTransactionPayloadFields`) now collect per-element bytes into a `bytes[]` and concatenate once via a single-allocation `concat` (each byte copied exactly once). **Byte-identical** preimages — the existing BIP-341 sighash and challenge-identity vector tests pass unchanged.
- **Raise the shape caps to 128** in / 128 out (`MaxPayloadBytes` → 131072, `uint32`; script cap stays 34). Gas measurement shows that **even with both encoders linear, ~512 in/out exceeds the 30M block gas limit** (128/192 reach signature verification; 256+ run out of gas), so 512 is not submittable on mainnet. 128 covers every honest protocol shape with margin — deposit sweeps ≤21 inputs (`DEPOSIT_SWEEP_MAX_SIZE = 20`), redemptions ≤21 outputs, moving-funds fan-out normally well below 128.
- **Documented residual:** a malicious wallet could place >128 outputs to make that fraudulent signature un-challengeable via this path. This is an **inherent limit of on-chain fraud proofs** (Bitcoin permits far more outputs than fit in a block's gas, so no finite cap closes it), and is currently non-impactful — the verifier is not yet wired into Bridge fraud entrypoints and operator slashing is economically inert. Raising the cap further requires replacing the linear byte-copy `concat` with an assembly word-copy; revisit (with fuzzing) if the path is wired in and slashing becomes active.

The caps are fixed (not governance-tunable) so fraud-evidence validity can't be censored or stranded by mutable state.

## Verification

- Byte-exactness: BIP-341 sighash vectors and challenge-identity vectors pass unchanged.
- A maximum-size (128 in/out) challenge reaches signature verification **within gas**; 129 in/out reverts `Too many inputs`/`Too many outputs` cheaply; oversized raw payload (>131072 B) rejected before ABI decode. Full P2TR suite green; `contracts-build-and-test` green.
- Two adversarial review passes (sighash linearization; identity-encoder linearization + cap sizing) found no correctness/gas issues — only doc nits, folded in. The cap value and gas edge were confirmed empirically and with Codex.

> Supersedes the count-limit doc note removed from #986; the sighash-**mode** coverage note from #985 still stands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
