### PR TITLE
fix(deploy): route lifecycle-router wiring through governance

### DIFF
--- a/solidity/deploy/48_deploy_frost_wallet_registry.ts
+++ b/solidity/deploy/48_deploy_frost_wallet_registry.ts
@@ -1,6 +1,26 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
+// Returns a signer for `address` only when that account is configured for the
+// current network. Used to decide whether a governance-gated call can be sent by
+// this deployment, or must instead be emitted as calldata for manual governance
+// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
+// signer in production). Mirrors 49_deploy_bridge_lifecycle_router.
+async function getConfiguredSigner(
+  hre: HardhatRuntimeEnvironment,
+  address: string
+) {
+  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
+    (account) => account.toLowerCase()
+  )
+
+  if (!configuredAccounts.includes(address.toLowerCase())) {
+    return undefined
+  }
+
+  return hre.ethers.getSigner(address)
+}
+
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
@@ -62,11 +82,11 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // re-called, so this is a one-shot wiring at deploy time.
   //
   // Bridge governance lives on BridgeGovernance which forwards
-  // through to Bridge.setFrostWalletRegistry. Production deploys
-  // call BridgeGovernance from the governance multisig; this
-  // script wires directly via the helper for dev/test flows. A
-  // separate later deploy script will repeat the call on
-  // production networks under the governance multisig.
+  // through to Bridge.setFrostWalletRegistry. On dev/test, where
+  // governance is still the deployer, this script sends the wiring
+  // directly; once governance has been handed off it sends from the
+  // BridgeGovernance owner when that owner is a configured signer, or
+  // emits the calldata for manual governance execution otherwise.
   //
   // NOTE: B-1 ships the registry deployed-but-dead from Bridge's
   // perspective: until C-2 governance flips
@@ -117,41 +137,105 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const ALREADY_SET_SELECTOR = ethers.utils
     .id("FrostWalletRegistryAlreadySet()")
     .slice(0, 10)
-  try {
-    if (governanceIsDeployer) {
-      await bridgeContract
-        .connect(await ethers.getSigner(deployer))
-        .setFrostWalletRegistry(frostWalletRegistry.address)
-      console.log(
-        `wired FrostWalletRegistry at ${frostWalletRegistry.address} onto Bridge directly (governance is still deployer)`
+
+  // Idempotency pre-check. setFrostWalletRegistry is a one-shot setter, so a
+  // re-run must skip cleanly on EVERY governance configuration -- including a
+  // multisig owner that is not a configured signer, where the AlreadySet revert
+  // path is never reached because the wiring is emitted as calldata, not sent.
+  // frostLifecycleContext returns the global frostWalletRegistry as its first
+  // value regardless of the wallet argument.
+  const [currentFrostWalletRegistry] =
+    await bridgeContract.frostLifecycleContext(ethers.constants.AddressZero)
+
+  if (
+    currentFrostWalletRegistry.toLowerCase() ===
+    frostWalletRegistry.address.toLowerCase()
+  ) {
+    console.log(
+      `FrostWalletRegistry already wired on this Bridge at ${frostWalletRegistry.address}; skipping`
+    )
+  } else if (currentFrostWalletRegistry !== ethers.constants.AddressZero) {
+    throw new Error(
+      "Bridge is already wired to a different FrostWalletRegistry " +
+        `(${currentFrostWalletRegistry}); refusing to wire ` +
+        `${frostWalletRegistry.address}`
+    )
+  } else {
+    // Resolve the authorized caller. In the governance-wrapper case the setter
+    // is `BridgeGovernance.onlyOwner`, so the call must come from the wrapper
+    // owner -- which post-handoff is the governance multisig, not `deployer`.
+    // When that owner is not a configured signer, emit the calldata for manual
+    // governance execution and skip (mainnet) rather than sending from
+    // `deployer` and reverting.
+    const registrySetterContract = governanceIsDeployer
+      ? bridgeContract
+      : bridgeGovernance
+    const registrySetterCaller = governanceIsDeployer
+      ? deployer
+      : await bridgeGovernance.owner()
+    const registrySetterSigner = await getConfiguredSigner(
+      hre,
+      registrySetterCaller
+    )
+
+    if (!registrySetterSigner) {
+      const calldata = registrySetterContract.interface.encodeFunctionData(
+        "setFrostWalletRegistry",
+        [frostWalletRegistry.address]
       )
+      const message =
+        `FrostWalletRegistry wiring must be executed by ${registrySetterCaller}, ` +
+        `which is not a configured signer for network ${hre.network.name}. ` +
+        "Submit this call from governance:\n" +
+        `  target: ${registrySetterContract.address}\n` +
+        `  data:   ${calldata}`
+
+      if (hre.network.name === "mainnet") {
+        console.log(`${message}\nskipping for manual governance execution`)
+      } else {
+        throw new Error(message)
+      }
     } else {
-      await bridgeGovernance
-        .connect(await ethers.getSigner(deployer))
-        .setFrostWalletRegistry(frostWalletRegistry.address)
-      console.log(
-        `wired FrostWalletRegistry at ${frostWalletRegistry.address} onto Bridge via BridgeGovernance`
-      )
-    }
-  } catch (err) {
-    const errAny = err as {
-      data?: string
-      error?: { data?: string }
-      message?: string
-    }
-    const revertData = errAny.data || errAny.error?.data || errAny.message || ""
-    if (
-      typeof revertData === "string" &&
-      revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
-    ) {
-      console.log("FrostWalletRegistry already wired on this Bridge; skipping")
-    } else {
-      console.error(
-        "setFrostWalletRegistry call reverted with an unexpected error;",
-        "deploy aborted so the operator can investigate:",
-        errAny.message || err
-      )
-      throw err
+      try {
+        const tx = await registrySetterContract
+          .connect(registrySetterSigner)
+          .setFrostWalletRegistry(frostWalletRegistry.address)
+        await tx.wait(1)
+        console.log(
+          `wired FrostWalletRegistry at ${
+            frostWalletRegistry.address
+          } onto Bridge ${
+            governanceIsDeployer
+              ? "directly (governance is still deployer)"
+              : "via BridgeGovernance"
+          }`
+        )
+      } catch (err) {
+        // Tolerate only a concurrent deployment that wired the SAME registry
+        // between the pre-check read above and this call (AlreadySet revert).
+        const errAny = err as {
+          data?: string
+          error?: { data?: string }
+          message?: string
+        }
+        const revertData =
+          errAny.data || errAny.error?.data || errAny.message || ""
+        if (
+          typeof revertData === "string" &&
+          revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
+        ) {
+          console.log(
+            "FrostWalletRegistry already wired on this Bridge; skipping"
+          )
+        } else {
+          console.error(
+            "setFrostWalletRegistry call reverted with an unexpected error;",
+            "deploy aborted so the operator can investigate:",
+            errAny.message || err
+          )
+          throw err
+        }
+      }
     }
   }
 

--- a/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
+++ b/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
@@ -1,5 +1,6 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
+import type { Contract } from "ethers"
 
 function revertDataContains(err: unknown, selector: string): boolean {
   const errAny = err as {
@@ -33,6 +34,46 @@ async function getConfiguredSigner(
   }
 
   return hre.ethers.getSigner(address)
+}
+
+// The Bridge exposes no getter for the current lifecycle router (omitted for
+// EIP-170); it is only recoverable from the one-shot LifecycleRouterSet event.
+// Read it newest-first in bounded block ranges so the lookup works on RPC providers
+// that enforce eth_getLogs block-range limits -- an unbounded
+// `queryFilter(0, "latest")` aborts there, breaking the idempotent / manual-governance
+// re-run path.
+//
+// The lower bound is genesis (0): the only stable choice. `Bridge.receipt.blockNumber`
+// is the proxy's LATEST UPGRADE block (hardhat-deploy overwrites the deployment receipt
+// on every upgrade) and can be AFTER the LifecycleRouterSet event, silently missing it.
+// The setter reverts once set, so at most one such event exists; the newest-first scan
+// early-exits on the first (newest) match, so re-runs shortly after wiring settle fast.
+const LIFECYCLE_ROUTER_LOG_QUERY_BLOCK_RANGE = 10000
+
+async function readCurrentLifecycleRouter(
+  bridgeContract: Contract
+): Promise<string | undefined> {
+  const filter = bridgeContract.filters.LifecycleRouterSet()
+  const latestBlock = await bridgeContract.provider.getBlockNumber()
+  for (
+    let toBlock = latestBlock;
+    toBlock >= 0;
+    toBlock -= LIFECYCLE_ROUTER_LOG_QUERY_BLOCK_RANGE
+  ) {
+    const fromBlock = Math.max(
+      toBlock - LIFECYCLE_ROUTER_LOG_QUERY_BLOCK_RANGE + 1,
+      0
+    )
+    // eslint-disable-next-line no-await-in-loop
+    const events = await bridgeContract.queryFilter(filter, fromBlock, toBlock)
+    if (events.length > 0) {
+      return events[events.length - 1].args?.lifecycleRouter as
+        | string
+        | undefined
+    }
+  }
+
+  return undefined
 }
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
@@ -74,19 +115,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   // Wire the router onto the Bridge. The setter is one-time and governance-gated,
   // and the Bridge exposes no getter for the current value -- it is only recoverable
-  // from the LifecycleRouterSet event. Read it first so re-runs are idempotent
-  // regardless of who governance is (the production Safe is not a deployer signer, so
-  // we must not depend on being able to send the setter to learn it is already set).
-  const lifecycleRouterEvents = await bridgeContract.queryFilter(
-    bridgeContract.filters.LifecycleRouterSet(),
-    0,
-    "latest"
+  // from the one-shot LifecycleRouterSet event. Read it first so re-runs are
+  // idempotent regardless of who governance is (the production Safe is not a deployer
+  // signer, so we must not depend on being able to send the setter to learn it is
+  // already set).
+  const currentLifecycleRouter = await readCurrentLifecycleRouter(
+    bridgeContract
   )
-  const currentLifecycleRouter =
-    lifecycleRouterEvents.length > 0
-      ? lifecycleRouterEvents[lifecycleRouterEvents.length - 1].args
-          ?.lifecycleRouter
-      : undefined
 
   if (
     currentLifecycleRouter &&
@@ -170,15 +205,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
           throw err
         }
 
-        const racedEvents = await bridgeContract.queryFilter(
-          bridgeContract.filters.LifecycleRouterSet(),
-          0,
-          "latest"
-        )
-        const racedRouter =
-          racedEvents.length > 0
-            ? racedEvents[racedEvents.length - 1].args?.lifecycleRouter
-            : undefined
+        const racedRouter = await readCurrentLifecycleRouter(bridgeContract)
         if (
           !racedRouter ||
           racedRouter.toLowerCase() !== router.address.toLowerCase()

--- a/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
+++ b/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
@@ -72,100 +72,127 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     FrostWalletRegistry.address
   )
 
-  // Wire the router onto the Bridge. The setter is one-time and governance-gated:
-  // - dev/test: Bridge.governance() is the deployer, so call Bridge.setLifecycleRouter
-  //   directly.
-  // - production: Bridge.governance() is BridgeGovernance, whose setLifecycleRouter is
-  //   onlyOwner. When that owner is the governance Safe (not a configured signer), the
-  //   deployer cannot send the call -- it would revert with Ownable and abort the deploy
-  //   -- so emit the calldata for manual governance execution and skip, instead.
-  const currentBridgeGovernance = await bridgeContract.governance()
-  const governanceIsDeployer =
-    currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
-  const alreadySetSelector = ethers.utils
-    .id("LifecycleRouterAlreadySet()")
-    .slice(0, 10)
+  // Wire the router onto the Bridge. The setter is one-time and governance-gated,
+  // and the Bridge exposes no getter for the current value -- it is only recoverable
+  // from the LifecycleRouterSet event. Read it first so re-runs are idempotent
+  // regardless of who governance is (the production Safe is not a deployer signer, so
+  // we must not depend on being able to send the setter to learn it is already set).
+  const lifecycleRouterEvents = await bridgeContract.queryFilter(
+    bridgeContract.filters.LifecycleRouterSet(),
+    0,
+    "latest"
+  )
+  const currentLifecycleRouter =
+    lifecycleRouterEvents.length > 0
+      ? lifecycleRouterEvents[lifecycleRouterEvents.length - 1].args
+          ?.lifecycleRouter
+      : undefined
 
-  const routerSetterContract = governanceIsDeployer
-    ? bridgeContract
-    : bridgeGovernance
-  const routerSetterCaller = governanceIsDeployer
-    ? deployer
-    : await bridgeGovernance.owner()
-  const routerSetterSigner = await getConfiguredSigner(hre, routerSetterCaller)
-
-  if (!routerSetterSigner) {
-    const calldata = routerSetterContract.interface.encodeFunctionData(
-      "setLifecycleRouter",
-      [router.address]
+  if (
+    currentLifecycleRouter &&
+    currentLifecycleRouter.toLowerCase() === router.address.toLowerCase()
+  ) {
+    console.log(
+      `BridgeLifecycleRouter already wired on this Bridge at ${router.address}; skipping Bridge setter`
     )
-    const message =
-      `BridgeLifecycleRouter wiring must be executed by ${routerSetterCaller}, ` +
-      `which is not a configured signer for network ${hre.network.name}. ` +
-      "Submit this call from governance:\n" +
-      `  target: ${routerSetterContract.address}\n` +
-      `  data:   ${calldata}`
-
-    if (hre.network.name === "mainnet") {
-      console.log(`${message}\nskipping for manual governance execution`)
-    } else {
-      throw new Error(message)
-    }
+  } else if (currentLifecycleRouter) {
+    throw new Error(
+      "Bridge lifecycle router is already set, but the LifecycleRouterSet event " +
+        `does not match this deployment (${router.address}). Refusing to guess ` +
+        "the one-time Bridge router value."
+    )
   } else {
-    let bridgeRouterConfirmed = false
-    try {
-      await routerSetterContract
-        .connect(routerSetterSigner)
-        .setLifecycleRouter(router.address)
-      bridgeRouterConfirmed = true
-      console.log(
-        `wired BridgeLifecycleRouter at ${router.address} onto Bridge ${
-          governanceIsDeployer
-            ? "directly (governance is still deployer)"
-            : "via BridgeGovernance"
-        }`
+    // Not yet wired. Resolve the authorized caller:
+    // - dev/test: Bridge.governance() is the deployer, so call Bridge.setLifecycleRouter
+    //   directly.
+    // - production: Bridge.governance() is BridgeGovernance, whose setLifecycleRouter is
+    //   onlyOwner. When that owner is the governance Safe (not a configured signer), the
+    //   deployer cannot send the call -- it would revert with Ownable -- so emit the
+    //   calldata for manual governance execution and skip, instead.
+    const currentBridgeGovernance = await bridgeContract.governance()
+    const governanceIsDeployer =
+      currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
+    const alreadySetSelector = ethers.utils
+      .id("LifecycleRouterAlreadySet()")
+      .slice(0, 10)
+
+    const routerSetterContract = governanceIsDeployer
+      ? bridgeContract
+      : bridgeGovernance
+    const routerSetterCaller = governanceIsDeployer
+      ? deployer
+      : await bridgeGovernance.owner()
+    const routerSetterSigner = await getConfiguredSigner(
+      hre,
+      routerSetterCaller
+    )
+
+    if (!routerSetterSigner) {
+      const calldata = routerSetterContract.interface.encodeFunctionData(
+        "setLifecycleRouter",
+        [router.address]
       )
-    } catch (err) {
-      if (!revertDataContains(err, alreadySetSelector)) {
-        const errAny = err as { message?: string }
-        console.error(
-          "setLifecycleRouter call reverted with an unexpected error;",
-          "deploy aborted so the operator can investigate:",
-          errAny.message || err
-        )
-        throw err
+      const message =
+        `BridgeLifecycleRouter wiring must be executed by ${routerSetterCaller}, ` +
+        `which is not a configured signer for network ${hre.network.name}. ` +
+        "Submit this call from governance:\n" +
+        `  target: ${routerSetterContract.address}\n` +
+        `  data:   ${calldata}`
+
+      if (hre.network.name === "mainnet") {
+        console.log(`${message}\nskipping for manual governance execution`)
+      } else {
+        throw new Error(message)
       }
+    } else {
+      try {
+        const tx = await routerSetterContract
+          .connect(routerSetterSigner)
+          .setLifecycleRouter(router.address)
+        await tx.wait(1)
+        console.log(
+          `wired BridgeLifecycleRouter at ${router.address} onto Bridge ${
+            governanceIsDeployer
+              ? "directly (governance is still deployer)"
+              : "via BridgeGovernance"
+          }`
+        )
+      } catch (err) {
+        // Tolerate only a concurrent deployment that wired the SAME router between
+        // the event read above and this call (AlreadySet revert + matching event).
+        if (!revertDataContains(err, alreadySetSelector)) {
+          const errAny = err as { message?: string }
+          console.error(
+            "setLifecycleRouter call reverted with an unexpected error;",
+            "deploy aborted so the operator can investigate:",
+            errAny.message || err
+          )
+          throw err
+        }
 
-      const lifecycleRouterEvents = await bridgeContract.queryFilter(
-        bridgeContract.filters.LifecycleRouterSet(),
-        0,
-        "latest"
-      )
-      const lastLifecycleRouter =
-        lifecycleRouterEvents.length > 0
-          ? lifecycleRouterEvents[lifecycleRouterEvents.length - 1].args
-              ?.lifecycleRouter
-          : undefined
-
-      if (
-        lastLifecycleRouter &&
-        lastLifecycleRouter.toLowerCase() === router.address.toLowerCase()
-      ) {
-        bridgeRouterConfirmed = true
+        const racedEvents = await bridgeContract.queryFilter(
+          bridgeContract.filters.LifecycleRouterSet(),
+          0,
+          "latest"
+        )
+        const racedRouter =
+          racedEvents.length > 0
+            ? racedEvents[racedEvents.length - 1].args?.lifecycleRouter
+            : undefined
+        if (
+          !racedRouter ||
+          racedRouter.toLowerCase() !== router.address.toLowerCase()
+        ) {
+          throw new Error(
+            "Bridge lifecycle router is already set, but the LifecycleRouterSet event " +
+              `does not match this deployment (${router.address}). Refusing to guess ` +
+              "the one-time Bridge router value."
+          )
+        }
         console.log(
           `BridgeLifecycleRouter already wired on this Bridge at ${router.address}; skipping Bridge setter`
         )
-      } else {
-        throw new Error(
-          "Bridge lifecycle router is already set, but the LifecycleRouterSet event " +
-            `does not match this deployment (${router.address}). Refusing to guess ` +
-            "the one-time Bridge router value."
-        )
       }
-    }
-
-    if (!bridgeRouterConfirmed) {
-      throw new Error("Bridge lifecycle router was not confirmed")
     }
   }
 
@@ -201,9 +228,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         throw new Error(message)
       }
     } else {
-      await frostWalletRegistryContract
+      const updateTx = await frostWalletRegistryContract
         .connect(registrySigner)
         .updateLifecycleOwner(router.address)
+      await updateTx.wait(1)
       console.log(
         `wired FrostWalletRegistry.lifecycleOwner to BridgeLifecycleRouter ${router.address}`
       )

--- a/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
+++ b/solidity/deploy/49_deploy_bridge_lifecycle_router.ts
@@ -15,10 +15,29 @@ function revertDataContains(err: unknown, selector: string): boolean {
   )
 }
 
+// Returns a signer for `address` only when that account is configured for the
+// current network. Used to decide whether a governance-gated call can be sent by
+// this deployment, or must instead be emitted as calldata for manual governance
+// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
+// signer in production). Mirrors 51_deploy_frost_allowlist.
+async function getConfiguredSigner(
+  hre: HardhatRuntimeEnvironment,
+  address: string
+) {
+  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
+    (account) => account.toLowerCase()
+  )
+
+  if (!configuredAccounts.includes(address.toLowerCase())) {
+    return undefined
+  }
+
+  return hre.ethers.getSigner(address)
+}
+
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
-  const deployerSigner = await ethers.getSigner(deployer)
 
   const Bridge = await deployments.get("Bridge")
   const FrostWalletRegistry = await deployments.get("FrostWalletRegistry")
@@ -53,6 +72,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     FrostWalletRegistry.address
   )
 
+  // Wire the router onto the Bridge. The setter is one-time and governance-gated:
+  // - dev/test: Bridge.governance() is the deployer, so call Bridge.setLifecycleRouter
+  //   directly.
+  // - production: Bridge.governance() is BridgeGovernance, whose setLifecycleRouter is
+  //   onlyOwner. When that owner is the governance Safe (not a configured signer), the
+  //   deployer cannot send the call -- it would revert with Ownable and abort the deploy
+  //   -- so emit the calldata for manual governance execution and skip, instead.
   const currentBridgeGovernance = await bridgeContract.governance()
   const governanceIsDeployer =
     currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
@@ -60,67 +86,93 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     .id("LifecycleRouterAlreadySet()")
     .slice(0, 10)
 
-  let bridgeRouterConfirmed = false
-  try {
-    if (governanceIsDeployer) {
-      await bridgeContract
-        .connect(deployerSigner)
-        .setLifecycleRouter(router.address)
-      console.log(
-        `wired BridgeLifecycleRouter at ${router.address} onto Bridge directly (governance is still deployer)`
-      )
-    } else {
-      await bridgeGovernance
-        .connect(deployerSigner)
-        .setLifecycleRouter(router.address)
-      console.log(
-        `wired BridgeLifecycleRouter at ${router.address} onto Bridge via BridgeGovernance`
-      )
-    }
-    bridgeRouterConfirmed = true
-  } catch (err) {
-    if (!revertDataContains(err, alreadySetSelector)) {
-      const errAny = err as { message?: string }
-      console.error(
-        "setLifecycleRouter call reverted with an unexpected error;",
-        "deploy aborted so the operator can investigate:",
-        errAny.message || err
-      )
-      throw err
-    }
+  const routerSetterContract = governanceIsDeployer
+    ? bridgeContract
+    : bridgeGovernance
+  const routerSetterCaller = governanceIsDeployer
+    ? deployer
+    : await bridgeGovernance.owner()
+  const routerSetterSigner = await getConfiguredSigner(hre, routerSetterCaller)
 
-    const lifecycleRouterEvents = await bridgeContract.queryFilter(
-      bridgeContract.filters.LifecycleRouterSet(),
-      0,
-      "latest"
+  if (!routerSetterSigner) {
+    const calldata = routerSetterContract.interface.encodeFunctionData(
+      "setLifecycleRouter",
+      [router.address]
     )
-    const lastLifecycleRouter =
-      lifecycleRouterEvents.length > 0
-        ? lifecycleRouterEvents[lifecycleRouterEvents.length - 1].args
-            ?.lifecycleRouter
-        : undefined
+    const message =
+      `BridgeLifecycleRouter wiring must be executed by ${routerSetterCaller}, ` +
+      `which is not a configured signer for network ${hre.network.name}. ` +
+      "Submit this call from governance:\n" +
+      `  target: ${routerSetterContract.address}\n` +
+      `  data:   ${calldata}`
 
-    if (
-      lastLifecycleRouter &&
-      lastLifecycleRouter.toLowerCase() === router.address.toLowerCase()
-    ) {
+    if (hre.network.name === "mainnet") {
+      console.log(`${message}\nskipping for manual governance execution`)
+    } else {
+      throw new Error(message)
+    }
+  } else {
+    let bridgeRouterConfirmed = false
+    try {
+      await routerSetterContract
+        .connect(routerSetterSigner)
+        .setLifecycleRouter(router.address)
       bridgeRouterConfirmed = true
       console.log(
-        `BridgeLifecycleRouter already wired on this Bridge at ${router.address}; skipping Bridge setter`
+        `wired BridgeLifecycleRouter at ${router.address} onto Bridge ${
+          governanceIsDeployer
+            ? "directly (governance is still deployer)"
+            : "via BridgeGovernance"
+        }`
       )
-    } else {
-      throw new Error(
-        "Bridge lifecycle router is already set, but the LifecycleRouterSet event " +
-          `does not match this deployment (${router.address}). Refusing to guess ` +
-          "the one-time Bridge router value."
+    } catch (err) {
+      if (!revertDataContains(err, alreadySetSelector)) {
+        const errAny = err as { message?: string }
+        console.error(
+          "setLifecycleRouter call reverted with an unexpected error;",
+          "deploy aborted so the operator can investigate:",
+          errAny.message || err
+        )
+        throw err
+      }
+
+      const lifecycleRouterEvents = await bridgeContract.queryFilter(
+        bridgeContract.filters.LifecycleRouterSet(),
+        0,
+        "latest"
       )
+      const lastLifecycleRouter =
+        lifecycleRouterEvents.length > 0
+          ? lifecycleRouterEvents[lifecycleRouterEvents.length - 1].args
+              ?.lifecycleRouter
+          : undefined
+
+      if (
+        lastLifecycleRouter &&
+        lastLifecycleRouter.toLowerCase() === router.address.toLowerCase()
+      ) {
+        bridgeRouterConfirmed = true
+        console.log(
+          `BridgeLifecycleRouter already wired on this Bridge at ${router.address}; skipping Bridge setter`
+        )
+      } else {
+        throw new Error(
+          "Bridge lifecycle router is already set, but the LifecycleRouterSet event " +
+            `does not match this deployment (${router.address}). Refusing to guess ` +
+            "the one-time Bridge router value."
+        )
+      }
+    }
+
+    if (!bridgeRouterConfirmed) {
+      throw new Error("Bridge lifecycle router was not confirmed")
     }
   }
 
-  if (!bridgeRouterConfirmed) {
-    throw new Error("Bridge lifecycle router was not confirmed")
-  }
-
+  // Wire FrostWalletRegistry.lifecycleOwner onto the router. Also governance-gated:
+  // updateLifecycleOwner is restricted to the registry governance. When that is not a
+  // configured signer (production Safe), emit the calldata for manual governance
+  // execution rather than aborting the deployment.
   const currentLifecycleOwner =
     await frostWalletRegistryContract.lifecycleOwner()
   if (currentLifecycleOwner.toLowerCase() === router.address.toLowerCase()) {
@@ -129,28 +181,42 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     )
   } else {
     const registryGovernance = await frostWalletRegistryContract.governance()
-    if (registryGovernance.toLowerCase() !== deployer.toLowerCase()) {
-      throw new Error(
-        "FrostWalletRegistry.lifecycleOwner must be updated to " +
-          `${router.address}, but registry governance is ${registryGovernance}; ` +
-          `deployer ${deployer} cannot call updateLifecycleOwner directly`
+    const registrySigner = await getConfiguredSigner(hre, registryGovernance)
+
+    if (!registrySigner) {
+      const calldata = frostWalletRegistryContract.interface.encodeFunctionData(
+        "updateLifecycleOwner",
+        [router.address]
       )
+      const message =
+        "FrostWalletRegistry.lifecycleOwner update must be executed by registry " +
+        `governance ${registryGovernance}, which is not a configured signer for ` +
+        `network ${hre.network.name}. Submit this call from governance:\n` +
+        `  target: ${frostWalletRegistryContract.address}\n` +
+        `  data:   ${calldata}`
+
+      if (hre.network.name === "mainnet") {
+        console.log(`${message}\nskipping for manual governance execution`)
+      } else {
+        throw new Error(message)
+      }
+    } else {
+      await frostWalletRegistryContract
+        .connect(registrySigner)
+        .updateLifecycleOwner(router.address)
+      console.log(
+        `wired FrostWalletRegistry.lifecycleOwner to BridgeLifecycleRouter ${router.address}`
+      )
+
+      const finalLifecycleOwner =
+        await frostWalletRegistryContract.lifecycleOwner()
+      if (finalLifecycleOwner.toLowerCase() !== router.address.toLowerCase()) {
+        throw new Error(
+          "FrostWalletRegistry.lifecycleOwner mismatch after deploy: " +
+            `expected ${router.address}, got ${finalLifecycleOwner}`
+        )
+      }
     }
-
-    await frostWalletRegistryContract
-      .connect(deployerSigner)
-      .updateLifecycleOwner(router.address)
-    console.log(
-      `wired FrostWalletRegistry.lifecycleOwner to BridgeLifecycleRouter ${router.address}`
-    )
-  }
-
-  const finalLifecycleOwner = await frostWalletRegistryContract.lifecycleOwner()
-  if (finalLifecycleOwner.toLowerCase() !== router.address.toLowerCase()) {
-    throw new Error(
-      "FrostWalletRegistry.lifecycleOwner mismatch after deploy: " +
-        `expected ${router.address}, got ${finalLifecycleOwner}`
-    )
   }
 
   if (hre.network.tags.etherscan) {


### PR DESCRIPTION
## Summary

Fixes a Codex **P2**: `49_deploy_bridge_lifecycle_router.ts` wired the router from the **deployer** even on networks where Bridge governance is `BridgeGovernance` owned by the governance **Safe**. `BridgeGovernance.setLifecycleRouter` is `onlyOwner`, so the deployer's call reverts with `Ownable` and **aborts the production deployment** — with no calldata emitted for manual governance execution. (The `FrostWalletRegistry.lifecycleOwner` update had the same class of issue: it hard-threw when registry governance wasn't the deployer.)

## Fix

Mirror the established `51_deploy_frost_allowlist` pattern via a `getConfiguredSigner` helper, for **both** governance-gated steps:
- Resolve the authorized caller — Bridge governance when it's the deployer, else `BridgeGovernance.owner()` for the router, and `FrostWalletRegistry.governance()` for the registry.
- Send the tx **only** when that account is a configured signer.
- Otherwise emit `target` + ABI-encoded `calldata` and, on **mainnet**, log `skipping for manual governance execution` and continue (so the deploy completes, router deployed + verified, wiring deferred to a governance Safe tx); on other networks, throw (the executor is expected to be configured in test).

## Scope / testing

- The **dev/test path** (Bridge governance is the deployer) is unchanged and is the one exercised by the deployment fixtures — so `contracts-build-and-test` continues to cover it.
- The **production skip path** (Safe-owned governance) is not fixture-exercised; it's a straightforward calldata-emit-and-skip that mirrors `51_deploy_frost_allowlist`, but worth a staging-deploy check before mainnet.
- `prettier` clean; `eslint` 0 errors (the `no-console` warnings match the original deploy-script style).

_Found during the Codex re-review of PR #971._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
