### PR TITLE
fix(frost): lifecycle-router NatSpec + DKG validation order (review #971)

### DIFF
--- a/solidity/contracts/bridge/IBridgeLifecycleRouter.sol
+++ b/solidity/contracts/bridge/IBridgeLifecycleRouter.sol
@@ -22,11 +22,12 @@ pragma solidity 0.8.17;
 /// with one argument) at the cost of one cross-contract view per
 /// dispatch.
 ///
-/// The router is stateless and immutable; replacement is done by
-/// deploying a new router contract and using
-/// `Bridge.setLifecycleRouter` to point the Bridge at the new
-/// implementation. There are no in-flight lifecycle operations to
-/// migrate between router versions.
+/// The router is stateless and immutable. `Bridge.setLifecycleRouter`
+/// is a one-time setter that reverts once a router has been set, so the
+/// Bridge cannot be repointed at a different router after
+/// initialization; replacing the router requires a Bridge
+/// implementation upgrade. There are no in-flight lifecycle operations
+/// to migrate between router versions.
 interface IBridgeLifecycleRouter {
     /// @notice Forwards a closeWallet call for the FROST wallet
     ///         identified by `walletPubKeyHash` to the configured

--- a/solidity/contracts/frost-registry/FrostDkgValidator.sol
+++ b/solidity/contracts/frost-registry/FrostDkgValidator.sol
@@ -89,6 +89,14 @@ contract FrostDkgValidator {
             return (false, error);
         }
 
+        // validateGroupMembers enforces members.length == groupSize and must
+        // run before validateSignatures, which indexes result.members by the
+        // [1, groupSize]-bounded signing member indices -- a shorter members
+        // array would otherwise cause an out-of-bounds read here.
+        if (!validateGroupMembers(result, seed)) {
+            return (false, "Invalid group members");
+        }
+
         if (
             !validateSignatures(
                 result,
@@ -98,10 +106,6 @@ contract FrostDkgValidator {
             )
         ) {
             return (false, "Invalid signatures");
-        }
-
-        if (!validateGroupMembers(result, seed)) {
-            return (false, "Invalid group members");
         }
 
         // At this point all group members and misbehaved members were verified


### PR DESCRIPTION
## Summary

Two fixes from the #971 Solidity custody-surface review.

### 1. `IBridgeLifecycleRouter` NatSpec correction (no-precondition doc bug)
The NatSpec said the router is replaced "using `Bridge.setLifecycleRouter` to point the Bridge at the new implementation" — but `setLifecycleRouter` is a **one-time setter** (reverts `LifecycleRouterAlreadySet` once set). Corrected: the router can't be repointed after init; replacement requires a Bridge implementation upgrade (matching `BridgeState`'s one-time-setter comment and the sibling one-shot setters).

### 2. `FrostDkgValidator`: order the group-member check before the member-index deref (CONFIRMED, low)
`validate()` ran `validateSignatures` — which indexes `result.members[signingMembersIndices[i]-1]` — **before** `validateGroupMembers`, the only check enforcing `members.length == groupSize`. A malformed result with `members.length` below a signing index caused an out-of-bounds **panic** in the view self-check (`isDkgResultValid`) instead of the documented `(false, reason)` return. Benign on the state-changing challenge path (its `try/catch` treats the revert as invalid), but operators' documented pre-submit self-check reverted.

**Fix:** reorder `validateGroupMembers` before `validateSignatures`, so the canonical length check guards the deref. `validateGroupMembers` is safe for a short array (it does `selectGroup(groupSize)` then `if (resultMembers.length != actualGroupMembers.length) return false` before any indexing). `validateFields` is deliberately **left untouched** — it must accept the synthetic short-`members` fixtures other tests use for field-level validations.

## Verification
- Solidity compiles.
- `FrostDkgValidator.DigestBinding` / `DigestParity` tests pass (the misbehaved/signing-index tests call `validateFields` directly and are unaffected).
- The `EdgeCases`/`HappyPath` shared-fixture tests have a pre-existing standalone-isolation failure (the seed-timeout `before all` hook fails on the unmodified base too); `contracts-build-and-test` exercises them in the full suite.

_From the #971 review; the other surfaced items are documented residuals, governance-recoverable, or gated on slashing going live._

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
