### PR TITLE
Add permissionless rebate stake return

### DIFF
--- a/solidity/contracts/bridge/RebateStaking.sol
+++ b/solidity/contracts/bridge/RebateStaking.sol
@@ -514,7 +514,21 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
         if (!deprecated) revert RebateStakingNotDeprecated();
         if (receiver == address(0)) revert ZeroAddress();
 
-        Stake storage stakeInfo = stakes[msg.sender];
+        _withdrawStake(msg.sender, receiver);
+    }
+
+    /// @notice Returns a staker's entire stake to the staker after rebate
+    ///         staking is deprecated.
+    /// @param staker Address of the staker receiving their stake.
+    function returnStake(address staker) external {
+        if (!deprecated) revert RebateStakingNotDeprecated();
+        if (staker == address(0)) revert ZeroAddress();
+
+        _withdrawStake(staker, staker);
+    }
+
+    function _withdrawStake(address staker, address receiver) internal {
+        Stake storage stakeInfo = stakes[staker];
         uint96 amount = stakeInfo.stakedAmount;
         if (amount == 0) revert NotAStaker();
 
@@ -526,7 +540,7 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
             stakeInfo.delegatee = address(0);
         }
 
-        emit StakeWithdrawn(msg.sender, receiver, amount);
+        emit StakeWithdrawn(staker, receiver, amount);
         token.safeTransfer(receiver, amount);
     }
 

--- a/solidity/test/bridge/RebateStaking.test.ts
+++ b/solidity/test/bridge/RebateStaking.test.ts
@@ -1682,9 +1682,49 @@ describe("RebateStaking", () => {
         .withArgs(thirdParty.address, governance.address, stakeAmount)
     })
 
+    it("should return a staker's entire stake to the staker after deprecation", async () => {
+      const unstakeAmount = stakeAmount.div(4)
+      await stakeFor(thirdParty, stakeAmount)
+      await rebateStaking.connect(thirdParty).startUnstaking(unstakeAmount)
+      await rebateStaking.connect(thirdParty).setDelegatee(deployer.address)
+      await rebateStaking.connect(deployer).deprecate()
+
+      const stakerBalanceBefore = await t.balanceOf(thirdParty.address)
+      const callerBalanceBefore = await t.balanceOf(governance.address)
+      const tx = await rebateStaking
+        .connect(governance)
+        .returnStake(thirdParty.address)
+
+      expect(await t.balanceOf(thirdParty.address)).to.be.equal(
+        stakerBalanceBefore.add(stakeAmount)
+      )
+      expect(await t.balanceOf(governance.address)).to.be.equal(
+        callerBalanceBefore
+      )
+      expect(await rebateStaking.getStake(thirdParty.address)).to.be.equal(0)
+
+      const [unstakingAmount, unstakingTimestamp] =
+        await rebateStaking.getUnstakingAmount(thirdParty.address)
+      expect(unstakingAmount).to.be.equal(0)
+      expect(unstakingTimestamp).to.be.equal(0)
+      expect(await rebateStaking.getDelegatee(thirdParty.address)).to.be.equal(
+        ZERO_ADDRESS
+      )
+      expect(await rebateStaking.delegates(deployer.address)).to.be.equal(
+        ZERO_ADDRESS
+      )
+
+      await expect(tx)
+        .to.emit(rebateStaking, "StakeWithdrawn")
+        .withArgs(thirdParty.address, thirdParty.address, stakeAmount)
+    })
+
     it("should reject stake withdrawal when unavailable", async () => {
       await expect(
         rebateStaking.connect(thirdParty).withdrawStake(thirdParty.address)
+      ).to.be.revertedWith("RebateStakingNotDeprecated")
+      await expect(
+        rebateStaking.connect(thirdParty).returnStake(thirdParty.address)
       ).to.be.revertedWith("RebateStakingNotDeprecated")
 
       await rebateStaking.connect(deployer).deprecate()
@@ -1693,7 +1733,13 @@ describe("RebateStaking", () => {
         rebateStaking.connect(thirdParty).withdrawStake(ZERO_ADDRESS)
       ).to.be.revertedWith("ZeroAddress")
       await expect(
+        rebateStaking.connect(thirdParty).returnStake(ZERO_ADDRESS)
+      ).to.be.revertedWith("ZeroAddress")
+      await expect(
         rebateStaking.connect(thirdParty).withdrawStake(thirdParty.address)
+      ).to.be.revertedWith("NotAStaker")
+      await expect(
+        rebateStaking.connect(thirdParty).returnStake(thirdParty.address)
       ).to.be.revertedWith("NotAStaker")
     })
 


### PR DESCRIPTION
## Summary
- add permissionless RebateStaking.returnStake(staker) after deprecation
- reuse the existing full-stake withdrawal cleanup path
- keep third-party returns constrained to staker -> staker so callers cannot redirect funds
- cover successful third-party return and unavailable return cases

## Stack
- Stacked on #981 / codex/protocol-peg-keeper

## Tests
- npm run test -- ./test/bridge/RebateStaking.test.ts --grep deprecate
- npm exec eslint -- test/bridge/RebateStaking.test.ts