### PR TITLE
fix(pr971): resolve CodeRabbit review follow-ups

### DIFF
--- a/.github/workflows/services-watchtower.yml
+++ b/.github/workflows/services-watchtower.yml
@@ -24,10 +24,12 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -49,17 +51,19 @@ jobs:
         || needs.watchtower-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
 
       # The watchtower is a pnpm workspace (`pnpm-workspace.yaml`: typescript +
       # services/watchtower) and uses the `workspace:*` protocol, which yarn
       # classic cannot resolve -- so this service is installed with pnpm, not
       # the yarn flow used by `typescript.yml`.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: "10.17.1"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "22.x"
 

--- a/docs/rfc/frost-migration/audit-prep-findings-2026-05-25.md
+++ b/docs/rfc/frost-migration/audit-prep-findings-2026-05-25.md
@@ -1,9 +1,9 @@
 # FROST migration audit-prep findings (2026-05-25)
 
 Sweep of the merged FROST migration surface
-(`contracts/frost-registry/`, `contracts/bridge/`,
-`test/frost-registry/`, `test/integration/utils/`,
-`docs/frost-migration/`) for residual hygiene issues prior to
+(`solidity/contracts/frost-registry/`, `solidity/contracts/bridge/`,
+`solidity/test/frost-registry/`, `solidity/test/integration/utils/`,
+`docs/rfc/frost-migration/`) for residual hygiene issues prior to
 external audit. Categorized by load-bearingness.
 
 ## Methodology
@@ -29,7 +29,7 @@ external audit. Categorized by load-bearingness.
 
 ### MUST-FIX — stale plan-doc claims that mislead readers
 
-All four are in `docs/frost-migration/d2-ecdsa-hard-retirement-plan.md`
+All four are in `docs/rfc/frost-migration/d2-ecdsa-hard-retirement-plan.md`
 (the D-2.1 plan doc). After D-2.2 slice 1 (PR #447), several
 claims in this doc are factually wrong about runtime behavior:
 

--- a/docs/rfc/frost-migration/b1-implementation-plan.md
+++ b/docs/rfc/frost-migration/b1-implementation-plan.md
@@ -109,7 +109,7 @@ re-checked in `submitDkgResult` to fail fast.
 ### B-1.4: Deploy script + Bridge fixture wiring
 
 - New deploy script at
-  `contracts/tbtc-v2/deploy/46_deploy_frost_wallet_registry.ts`
+  `contracts/tbtc-v2/deploy/48_deploy_frost_wallet_registry.ts`
   (depends on `Bridge`, `SortitionPool`, `RandomBeacon`; tags
   `["FrostWalletRegistry"]`).
 - Extend `test/fixtures/bridge.ts` to deploy the registry and

--- a/services/watchtower/src/FileBackedP2TRWatchtowerChallengeRecordPersistence.ts
+++ b/services/watchtower/src/FileBackedP2TRWatchtowerChallengeRecordPersistence.ts
@@ -49,7 +49,8 @@ export class FileBackedP2TRWatchtowerChallengeRecordPersistence
   async saveChallengeRecords(
     records: P2TRWatchtowerChallengeRecordJSON[]
   ): Promise<void> {
-    const serializedRecords = `${JSON.stringify(records, null, 2)}\n`
+    const normalizedRecords = records.map(normalizeSerializedRecord)
+    const serializedRecords = `${JSON.stringify(normalizedRecords, null, 2)}\n`
     await this.assertStateFileUnchangedSinceLoad()
 
     await writeFileAtomically(this.filePath, serializedRecords)

--- a/services/watchtower/src/P2TRSignatureFraudWatchtowerLoop.ts
+++ b/services/watchtower/src/P2TRSignatureFraudWatchtowerLoop.ts
@@ -92,16 +92,17 @@ export function abortableDelay(
   }
 
   return new Promise((resolve) => {
-    const timeout = setTimeout(resolve, milliseconds)
+    const onAbort = () => {
+      clearTimeout(timeout)
+      resolve()
+    }
 
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout)
-        resolve()
-      },
-      { once: true }
-    )
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, milliseconds)
+
+    signal?.addEventListener("abort", onAbort, { once: true })
   })
 }
 

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1854,6 +1854,14 @@ contract BridgeGovernance is Ownable {
     ///        classification is required since the legacy Bridge
     ///        mapping was shared between the two lifecycles.
     /// @param challengeKeys Legacy challenge keys to migrate.
+    /// @dev The target `Bridge.migrateLegacyFraudChallenges` helper is
+    ///      intentionally non-operational in the current Bridge
+    ///      implementation: its body is stubbed out and it always
+    ///      reverts with `MigrateLegacyFraudChallengesNotImplemented`.
+    ///      Calls through this forwarder therefore revert until a
+    ///      future Bridge upgrade swaps in the migration body. The
+    ///      forwarder is kept in place so the governance ABI stays
+    ///      stable across that upgrade (a body swap, not an ABI change).
     function migrateLegacyFraudChallenges(
         uint8 routerKind,
         uint256[] calldata challengeKeys

--- a/solidity/contracts/bridge/IBridgeLifecycleRouter.sol
+++ b/solidity/contracts/bridge/IBridgeLifecycleRouter.sol
@@ -7,20 +7,25 @@ pragma solidity 0.8.17;
 ///
 /// The Bridge dispatches FROST-scheme wallet lifecycle operations
 /// (closeWallet, seize, isWalletMember) to a router implementing this
-/// interface. The router resolves the wallet's canonical walletID from
-/// the Bridge's `walletIDByWalletPubKeyHash` mapping and forwards the
-/// call to the configured `frostWalletRegistry`. ECDSA-scheme lifecycle
+/// interface. The router resolves the configured FROST wallet registry
+/// address and the wallet's canonical walletID from the Bridge's
+/// `frostLifecycleContext(walletPubKeyHash)` view and forwards the call
+/// to that registry. ECDSA-scheme lifecycle
 /// operations bypass the router entirely and continue to call
 /// `ecdsaWalletRegistry` directly, preserving the existing
 /// ownership/callback model for ECDSA wallets.
 ///
 /// The Bridge passes only the 20-byte wallet public key hash to the
 /// router; the router reads the rest of the lifecycle state from the
-/// Bridge via its public view functions (lifecycleRouter,
-/// frostWalletRegistry, walletIDByWalletPubKeyHash). This keeps the
-/// per-call-site Bridge bytecode footprint minimal (one external call
-/// with one argument) at the cost of one cross-contract view per
-/// dispatch.
+/// Bridge's single `frostLifecycleContext(walletPubKeyHash)` view,
+/// which returns the configured `frostWalletRegistry` address and the
+/// canonical walletID in one call. The Bridge does not expose separate
+/// `lifecycleRouter`, `frostWalletRegistry`, or
+/// `walletIDByWalletPubKeyHash` getters; folding them into
+/// `frostLifecycleContext` keeps the Bridge implementation under the
+/// EIP-170 deploy limit. This keeps the per-call-site Bridge bytecode
+/// footprint minimal (one external call with one argument) at the cost
+/// of one cross-contract view per dispatch.
 ///
 /// The router is stateless and immutable. `Bridge.setLifecycleRouter`
 /// is a one-time setter that reverts once a router has been set, so the


### PR DESCRIPTION
This PR stacks on top of #971 (`extraction/frost-mirror-2026-05-26`) and addresses its open CodeRabbit review threads. It is based on the PR #971 head branch, not `main`.

## CodeRabbit follow-ups

- [x] **1 & 2. CI action hardening.** CodeRabbit findings 1 & 2 named `ci-pr.yml` and `nightly-formal-invariants.yml`, which do not exist in this repo. The real workflow PR #971 introduces is **`.github/workflows/services-watchtower.yml`**, and it had the exact issue those findings describe (unpinned actions, no `persist-credentials`). Hardened there instead:
  - Added `with: persist-credentials: false` to **both** `actions/checkout` steps.
  - Pinned every `uses:` to a full 40-hex commit SHA with a `# vX.Y.Z` comment (major versions unchanged):
    - `actions/checkout@v3` → `f43a0e5ff2bd294095638e18286ca9a3d1956744` # v3.6.0
    - `dorny/paths-filter@v2` → `4512585405083f25c027a35db413c2b3b9006d50` # v2.11.1
    - `pnpm/action-setup@v4` → `b906affcce14559ad1aafd4ab0e942779e9f58b1` # v4.3.0 (annotated tag, pinned to peeled commit)
    - `actions/setup-node@v3` → `3235b876344d2a9aa001b8d1453c930bba69e610` # v3.9.1
  - Scope limited to `services-watchtower.yml` (the workflow this PR introduces); pre-existing repo workflows are intentionally left untouched — repo-wide pinning is a separate effort.
- [x] **3. `docs/rfc/frost-migration/audit-prep-findings-2026-05-25.md` — canonical paths.** Normalized the scope-summary roots (and the L32 plan-doc reference) to `solidity/contracts/...`, `solidity/test/...`, and `docs/rfc/frost-migration/`.
- [x] **4. `docs/rfc/frost-migration/b1-implementation-plan.md` — deploy-script filename.** The on-disk script is `solidity/deploy/48_deploy_frost_wallet_registry.ts`; corrected the stale `46_` mention to `48_` (the other mention was already `48_`).
- [x] **5. `services/watchtower/src/FileBackedP2TRWatchtowerChallengeRecordPersistence.ts` — validate on save.** `saveChallengeRecords` now maps records through the existing `normalizeSerializedRecord` validator before `JSON.stringify`, mirroring the load path so invalid state can't be written. Atomic-write behavior is unchanged.
- [x] **6. `solidity/contracts/bridge/BridgeGovernance.sol` — forwarder NatSpec.** `Bridge.migrateLegacyFraudChallenges` is stubbed to always `revert MigrateLegacyFraudChallengesNotImplemented()`. Updated the forwarder NatSpec to state it is intentionally non-operational and reverts until a future Bridge upgrade lands. Function retained.
- [x] **7. `solidity/contracts/bridge/IBridgeLifecycleRouter.sol` — interface docs vs. shipped ABI.** The Bridge exposes a single `frostLifecycleContext(walletPubKeyHash)` view and does not expose separate `lifecycleRouter` / `frostWalletRegistry` / `walletIDByWalletPubKeyHash` getters. Updated the doc to point implementers at `frostLifecycleContext(...)` and to state those getters are absent. The one-shot `setLifecycleRouter` note was already present and accurate.
- [x] **8. `services/watchtower/src/P2TRSignatureFraudWatchtowerLoop.ts` — listener leak.** `abortableDelay` now stores the handler in `const onAbort` and removes the abort listener in the timeout path too (`signal?.removeEventListener("abort", onAbort)`), keeping `clearTimeout` in the abort path. Fixes the leak of abort listeners across loop iterations.

## Validation

- Watchtower TS changes typecheck cleanly under Node 18 / TypeScript (isolated typecheck against the two changed files and their local deps).
- Both changed TS files, both changed Markdown files, and `services-watchtower.yml` pass `prettier@2.3.2` (`@keep-network/prettier-config-keep`, i.e. `{ semi: false }`).
- `services-watchtower.yml` parses as valid YAML (`ruby -ryaml`).
- Solidity edits are NatSpec/comment-only; no executable code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
