### PR TITLE
fix(pr971): wire fraud routers in deploy + correct ecdsaRetired enforcement

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -2344,13 +2344,21 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
 
     /// @notice D-2 canonical setter for ECDSA hard retirement.
     ///         Flips the `ecdsaRetired` storage flag (one-way).
-    ///         Subsequent `requestNewWallet` calls routed to
-    ///         the Ecdsa scheme revert via the request-side
-    ///         guard added in D-1. The structural removal of
-    ///         `__ecdsaWalletCreatedCallback` in D-2.1 hardens
-    ///         the ratchet at the EVM dispatcher level: even
-    ///         bypassing the flag (e.g., via storage poke to
-    ///         flip it back) cannot reopen the create path.
+    ///         The flag is purely an on-chain audit-trail marker
+    ///         that governance has formally retired ECDSA wallet
+    ///         creation; it is NOT load-bearing and no on-chain
+    ///         code path reads it (there is no `requestNewWallet`
+    ///         guard that inspects it — only the public
+    ///         `ecdsaRetired()` getter below returns it, for
+    ///         off-chain observation). ECDSA wallet creation is
+    ///         already blocked structurally, independent of this
+    ///         flag: `requestNewWallet` dispatches only to the
+    ///         FROST registry (the scheme-dispatch branch was
+    ///         removed in D-2.2 slice 3) and
+    ///         `__ecdsaWalletCreatedCallback` was removed in
+    ///         D-2.1. Because the create path is closed at the
+    ///         EVM dispatcher level, even flipping the flag back
+    ///         (e.g., via a storage poke) cannot reopen it.
     ///
     ///         Off-chain consumers observe the transition via
     ///         the public `ecdsaRetired()` getter below (NOT

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -427,25 +427,28 @@ library BridgeState {
         // 1, right after the 1-byte enum. Total slot 37 usage:
         // 17 bytes of 32. No __gap change from C-2.
         uint128 ecdsaWalletCount;
-        // D-1 soft-retirement flag. Set by the one-time
-        // governance setter `Bridge.retireEcdsa()` (the setter
-        // itself is deferred to D-2 — see Bridge.sol). When
-        // true, `Wallets.requestNewWallet` rejects new requests
-        // routed to the ECDSA registry. Late callbacks from an
-        // in-flight DKG that started BEFORE retirement are NOT
-        // blocked: reverting `Wallets.registerNewWallet` would
-        // strand the ECDSA registry in a non-IDLE state and
-        // freeze every subsequent FROST wallet creation via
-        // the unconditional IDLE precheck in `requestNewWallet`
-        // (per PR #443 review). Governance therefore
-        // enforces the "no late ECDSA wallets" invariant
-        // operationally: pause Bridge, wait for in-flight DKGs
-        // to settle (registry returns to IDLE), set the flag,
-        // unpause. Existing ECDSA wallets' lifecycle paths
-        // (sweeps, redemptions, fraud, moving funds, closing,
-        // termination) remain fully functional — D-1 only
-        // closes the *new wallet creation* boundary; D-2
-        // performs the final structural removal.
+        // ECDSA-retirement audit-trail flag. Set by the one-time
+        // governance setter `Bridge.retireEcdsa()`. It is purely
+        // an on-chain marker that governance has formally retired
+        // ECDSA wallet creation and is NOT load-bearing: no code
+        // path reads it (only the public `ecdsaRetired()` getter
+        // returns it, for off-chain observation).
+        // `Wallets.requestNewWallet` does NOT inspect this flag —
+        // ECDSA wallet creation is already blocked structurally,
+        // because that function dispatches only to the FROST
+        // registry (the scheme-dispatch branch was removed in
+        // D-2.2 slice 3) and `__ecdsaWalletCreatedCallback` was
+        // removed in D-2.1. The originally planned D-1 read-side
+        // guard (rejecting ECDSA-routed requests) and the
+        // pre-existing IDLE precheck it depended on were both
+        // dropped when the scheme dispatch was removed, so no such
+        // guard exists today. Governance still sequences
+        // retirement operationally on existing deployments: pause
+        // Bridge, wait for in-flight DKGs to settle (registry
+        // returns to IDLE), then flip the flag. Existing ECDSA
+        // wallets' lifecycle paths (sweeps, redemptions, fraud,
+        // moving funds, closing, termination) remain fully
+        // functional.
         //
         // Packs at slot 37 offset 17 (just after
         // `ecdsaWalletCount`, which occupies bytes 1-16). Total

--- a/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
+++ b/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
@@ -1,23 +1,185 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
-import { DeployFunction } from "hardhat-deploy/types"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, helpers, getNamedAccounts } = hre
+// Returns a signer for `address` only when that account is configured for the
+// current network. Used to decide whether a governance-gated call can be sent by
+// this deployment, or must instead be emitted as calldata for manual governance
+// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
+// signer in production). Mirrors 48_deploy_frost_wallet_registry.
+async function getConfiguredSigner(
+  hre: HardhatRuntimeEnvironment,
+  address: string
+) {
+  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
+    (account) => account.toLowerCase()
+  )
+
+  if (!configuredAccounts.includes(address.toLowerCase())) {
+    return undefined
+  }
+
+  return hre.ethers.getSigner(address)
+}
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { deployments, helpers, getNamedAccounts, ethers } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
   const Bridge = await deployments.get("Bridge")
 
   // EcdsaFraudRouter is a plain (non-upgradeable) contract that
-  // pins the Bridge address at construction. Wiring is a separate
-  // one-time governance step (Bridge.setEcdsaFraudRouter) performed
-  // by the deployment pipeline after this script runs.
+  // pins the Bridge address at construction.
   const ecdsaFraudRouter = await deploy("EcdsaFraudRouter", {
     from: deployer,
     args: [Bridge.address],
     log: true,
     waitConfirmations: 1,
   })
+
+  // Wire the router onto the Bridge via the one-time governance setter
+  // `Bridge.setEcdsaFraudRouter`. Until this lands, `Bridge.ecdsaFraudRouter()`
+  // stays `address(0)`, `slashWalletForFraud` (the router's only privileged
+  // Bridge entry point, gated by `onlyEcdsaFraudRouter`) is unreachable, and
+  // all ECDSA fraud slashing is dead -- the router is deployed-but-dead until
+  // this call runs. The setter is one-time (reverts
+  // `EcdsaFraudRouterAlreadySet()` once set), so this wiring is idempotent and
+  // must skip cleanly on re-runs.
+  //
+  // This mirrors the `setFrostWalletRegistry` wiring in
+  // 48_deploy_frost_wallet_registry: read the current Bridge value, send the
+  // setter when the deployer/governance owner is a configured signer, else emit
+  // the exact governance calldata for manual execution, and verify idempotently.
+  const bridgeContract = await ethers.getContractAt("Bridge", Bridge.address)
+  const bridgeGovernance = await ethers.getContractAt(
+    "BridgeGovernance",
+    (
+      await deployments.get("BridgeGovernance")
+    ).address
+  )
+
+  // Route the setter based on the current `Bridge.governance()`. On a fresh
+  // deploy chain (test/local) `21_transfer_bridge_governance.ts` runs last
+  // (`runAtTheEnd = true`), so this script executes while `Bridge.governance`
+  // is still the `deployer` named account -- the only address that passes
+  // `Bridge.onlyGovernance` in that window (routing through `BridgeGovernance`
+  // there would revert with "Caller is not the governance"). Once governance
+  // has been transferred, `Bridge.governance` is the `BridgeGovernance`
+  // contract and the setter must be routed through its `onlyOwner` wrapper
+  // (production deploys substitute the governance multisig signer there).
+  const currentBridgeGovernance = await bridgeContract.governance()
+  const governanceIsDeployer =
+    currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
+  const ALREADY_SET_SELECTOR = ethers.utils
+    .id("EcdsaFraudRouterAlreadySet()")
+    .slice(0, 10)
+
+  // Idempotency pre-check via the public getter. `setEcdsaFraudRouter` is a
+  // one-shot setter, so a re-run must skip cleanly on EVERY governance
+  // configuration -- including a multisig owner that is not a configured
+  // signer, where the wiring is emitted as calldata (not sent) and the
+  // AlreadySet revert path is never reached.
+  const currentEcdsaFraudRouter = await bridgeContract.ecdsaFraudRouter()
+
+  if (
+    currentEcdsaFraudRouter.toLowerCase() ===
+    ecdsaFraudRouter.address.toLowerCase()
+  ) {
+    console.log(
+      `EcdsaFraudRouter already wired on this Bridge at ${ecdsaFraudRouter.address}; skipping`
+    )
+  } else if (currentEcdsaFraudRouter !== ethers.constants.AddressZero) {
+    throw new Error(
+      "Bridge is already wired to a different EcdsaFraudRouter " +
+        `(${currentEcdsaFraudRouter}); refusing to wire ` +
+        `${ecdsaFraudRouter.address}`
+    )
+  } else {
+    // Resolve the authorized caller. In the governance-wrapper case the setter
+    // is `BridgeGovernance.onlyOwner`, so the call must come from the wrapper
+    // owner -- which post-handoff is the governance multisig, not `deployer`.
+    // When that owner is not a configured signer, emit the calldata for manual
+    // governance execution and skip (mainnet) rather than sending from
+    // `deployer` and reverting.
+    const setterContract = governanceIsDeployer
+      ? bridgeContract
+      : bridgeGovernance
+    const setterCaller = governanceIsDeployer
+      ? deployer
+      : await bridgeGovernance.owner()
+    const setterSigner = await getConfiguredSigner(hre, setterCaller)
+
+    if (!setterSigner) {
+      const calldata = setterContract.interface.encodeFunctionData(
+        "setEcdsaFraudRouter",
+        [ecdsaFraudRouter.address]
+      )
+      const message =
+        `EcdsaFraudRouter wiring must be executed by ${setterCaller}, ` +
+        `which is not a configured signer for network ${hre.network.name}. ` +
+        "Submit this call from governance:\n" +
+        `  target: ${setterContract.address}\n` +
+        `  data:   ${calldata}`
+
+      if (hre.network.name === "mainnet") {
+        console.log(`${message}\nskipping for manual governance execution`)
+      } else {
+        throw new Error(message)
+      }
+    } else {
+      try {
+        const tx = await setterContract
+          .connect(setterSigner)
+          .setEcdsaFraudRouter(ecdsaFraudRouter.address)
+        await tx.wait(1)
+        console.log(
+          `wired EcdsaFraudRouter at ${ecdsaFraudRouter.address} onto Bridge ${
+            governanceIsDeployer
+              ? "directly (governance is still deployer)"
+              : "via BridgeGovernance"
+          }`
+        )
+      } catch (err) {
+        // Tolerate only a concurrent deployment that wired the SAME router
+        // between the pre-check read above and this call (AlreadySet revert).
+        const errAny = err as {
+          data?: string
+          error?: { data?: string }
+          message?: string
+        }
+        const revertData =
+          errAny.data || errAny.error?.data || errAny.message || ""
+        if (
+          typeof revertData === "string" &&
+          revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
+        ) {
+          console.log("EcdsaFraudRouter already wired on this Bridge; skipping")
+        } else {
+          console.error(
+            "setEcdsaFraudRouter call reverted with an unexpected error;",
+            "deploy aborted so the operator can investigate:",
+            errAny.message || err
+          )
+          throw err
+        }
+      }
+
+      // Idempotent post-check: assert the on-chain value now reflects this
+      // router. Only meaningful when the setter was actually sent; the
+      // calldata-emit path skips before reaching here. Also catches a
+      // concurrent deploy that wired a DIFFERENT router (AlreadySet caught
+      // above) between the pre-check and this send.
+      const wiredRouter = await bridgeContract.ecdsaFraudRouter()
+      if (
+        wiredRouter.toLowerCase() !== ecdsaFraudRouter.address.toLowerCase()
+      ) {
+        throw new Error(
+          "Bridge.ecdsaFraudRouter mismatch after deploy: " +
+            `expected ${ecdsaFraudRouter.address}, got ${wiredRouter}`
+        )
+      }
+    }
+  }
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(ecdsaFraudRouter)
@@ -34,4 +196,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["EcdsaFraudRouter"]
-func.dependencies = ["Bridge"]
+func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
+++ b/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
@@ -79,7 +79,31 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // configuration -- including a multisig owner that is not a configured
   // signer, where the wiring is emitted as calldata (not sent) and the
   // AlreadySet revert path is never reached.
-  const currentEcdsaFraudRouter = await bridgeContract.ecdsaFraudRouter()
+  //
+  // When preparing the atomic upgrade of an EXISTING Bridge, the proxy is
+  // still on the pre-upgrade implementation, which has no `ecdsaFraudRouter()`
+  // selector until the governance proposal executes -- so this read reverts
+  // with a CALL_EXCEPTION (the eth_call returns no data to decode). A plain
+  // getter cannot revert for any other reason, so tolerate ONLY that case:
+  // treat the router as unwired and fall through to emit the setter calldata
+  // the operator needs for the upgrade/wiring proposal, rather than aborting
+  // before that branch is reached. Any other error (e.g. an RPC failure)
+  // rethrows so it is not silently swallowed (cf. the blanket-catch regression
+  // fixed in 48_deploy_frost_wallet_registry).
+  let currentEcdsaFraudRouter: string
+  try {
+    currentEcdsaFraudRouter = await bridgeContract.ecdsaFraudRouter()
+  } catch (err) {
+    if ((err as { code?: string }).code !== "CALL_EXCEPTION") {
+      throw err
+    }
+    console.log(
+      "Bridge.ecdsaFraudRouter() reverted (no such selector on the current " +
+        "Bridge implementation -- pre-upgrade proxy); treating the router as " +
+        "unwired and emitting wiring for the upgrade proposal"
+    )
+    currentEcdsaFraudRouter = ethers.constants.AddressZero
+  }
 
   if (
     currentEcdsaFraudRouter.toLowerCase() ===

--- a/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
+++ b/solidity/deploy/44_deploy_ecdsa_fraud_router.ts
@@ -91,6 +91,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // rethrows so it is not silently swallowed (cf. the blanket-catch regression
   // fixed in 48_deploy_frost_wallet_registry).
   let currentEcdsaFraudRouter: string
+  let bridgeExposesGetter = true
   try {
     currentEcdsaFraudRouter = await bridgeContract.ecdsaFraudRouter()
   } catch (err) {
@@ -103,6 +104,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         "unwired and emitting wiring for the upgrade proposal"
     )
     currentEcdsaFraudRouter = ethers.constants.AddressZero
+    bridgeExposesGetter = false
   }
 
   if (
@@ -131,21 +133,35 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     const setterCaller = governanceIsDeployer
       ? deployer
       : await bridgeGovernance.owner()
-    const setterSigner = await getConfiguredSigner(hre, setterCaller)
+    // A pre-upgrade Bridge has no `setEcdsaFraudRouter` selector yet, so the
+    // transaction cannot be sent regardless of who is a configured signer.
+    // Force the calldata-emission path in that case (leave the signer
+    // unresolved) rather than attempting -- and reverting -- the send.
+    const setterSigner = bridgeExposesGetter
+      ? await getConfiguredSigner(hre, setterCaller)
+      : undefined
 
     if (!setterSigner) {
       const calldata = setterContract.interface.encodeFunctionData(
         "setEcdsaFraudRouter",
         [ecdsaFraudRouter.address]
       )
+      const reason = !bridgeExposesGetter
+        ? `the Bridge at ${Bridge.address} does not yet expose ` +
+          "setEcdsaFraudRouter (pre-upgrade implementation); wire it as part " +
+          "of the upgrade proposal"
+        : `${setterCaller} is not a configured signer for network ${hre.network.name}`
       const message =
-        `EcdsaFraudRouter wiring must be executed by ${setterCaller}, ` +
-        `which is not a configured signer for network ${hre.network.name}. ` +
+        `EcdsaFraudRouter wiring must be executed by governance -- ${reason}. ` +
         "Submit this call from governance:\n" +
         `  target: ${setterContract.address}\n` +
         `  data:   ${calldata}`
 
-      if (hre.network.name === "mainnet") {
+      // A pre-upgrade Bridge genuinely cannot be wired now on ANY network, so
+      // emit the calldata and continue. Otherwise keep the existing guard:
+      // skip on mainnet (a non-signer governance owner is expected there) and
+      // error elsewhere so an unexpected non-signer is surfaced.
+      if (!bridgeExposesGetter || hre.network.name === "mainnet") {
         console.log(`${message}\nskipping for manual governance execution`)
       } else {
         throw new Error(message)

--- a/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
+++ b/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
@@ -1,8 +1,28 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
-import { DeployFunction } from "hardhat-deploy/types"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, helpers, getNamedAccounts } = hre
+// Returns a signer for `address` only when that account is configured for the
+// current network. Used to decide whether a governance-gated call can be sent by
+// this deployment, or must instead be emitted as calldata for manual governance
+// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
+// signer in production). Mirrors 48_deploy_frost_wallet_registry.
+async function getConfiguredSigner(
+  hre: HardhatRuntimeEnvironment,
+  address: string
+) {
+  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
+    (account) => account.toLowerCase()
+  )
+
+  if (!configuredAccounts.includes(address.toLowerCase())) {
+    return undefined
+  }
+
+  return hre.ethers.getSigner(address)
+}
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { deployments, helpers, getNamedAccounts, ethers } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
@@ -10,16 +30,158 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // P2TRSignatureFraudRouter is a plain (non-upgradeable) contract
   // that pins the Bridge address at construction. Sister sidecar to
-  // EcdsaFraudRouter for the P2TR signature-fraud lifecycle. Wiring
-  // is a separate one-time governance step
-  // (Bridge.setP2TRFraudRouter) performed by the deployment pipeline
-  // after this script runs.
+  // EcdsaFraudRouter for the P2TR signature-fraud lifecycle.
   const p2trFraudRouter = await deploy("P2TRSignatureFraudRouter", {
     from: deployer,
     args: [Bridge.address],
     log: true,
     waitConfirmations: 1,
   })
+
+  // Wire the router onto the Bridge via the one-time governance setter
+  // `Bridge.setP2TRFraudRouter`. Until this lands, `Bridge.p2trFraudRouter()`
+  // stays `address(0)`, `slashWalletForP2TRFraud` (the router's only privileged
+  // Bridge entry point, gated by `onlyP2TRFraudRouter`) is unreachable, and all
+  // P2TR fraud slashing is dead -- the router is deployed-but-dead until this
+  // call runs. The setter is one-time (reverts `P2TRFraudRouterAlreadySet()`
+  // once set), so this wiring is idempotent and must skip cleanly on re-runs.
+  //
+  // This mirrors the `setFrostWalletRegistry` wiring in
+  // 48_deploy_frost_wallet_registry: read the current Bridge value, send the
+  // setter when the deployer/governance owner is a configured signer, else emit
+  // the exact governance calldata for manual execution, and verify idempotently.
+  const bridgeContract = await ethers.getContractAt("Bridge", Bridge.address)
+  const bridgeGovernance = await ethers.getContractAt(
+    "BridgeGovernance",
+    (
+      await deployments.get("BridgeGovernance")
+    ).address
+  )
+
+  // Route the setter based on the current `Bridge.governance()`. On a fresh
+  // deploy chain (test/local) `21_transfer_bridge_governance.ts` runs last
+  // (`runAtTheEnd = true`), so this script executes while `Bridge.governance`
+  // is still the `deployer` named account -- the only address that passes
+  // `Bridge.onlyGovernance` in that window (routing through `BridgeGovernance`
+  // there would revert with "Caller is not the governance"). Once governance
+  // has been transferred, `Bridge.governance` is the `BridgeGovernance`
+  // contract and the setter must be routed through its `onlyOwner` wrapper
+  // (production deploys substitute the governance multisig signer there).
+  const currentBridgeGovernance = await bridgeContract.governance()
+  const governanceIsDeployer =
+    currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
+  const ALREADY_SET_SELECTOR = ethers.utils
+    .id("P2TRFraudRouterAlreadySet()")
+    .slice(0, 10)
+
+  // Idempotency pre-check via the public getter. `setP2TRFraudRouter` is a
+  // one-shot setter, so a re-run must skip cleanly on EVERY governance
+  // configuration -- including a multisig owner that is not a configured
+  // signer, where the wiring is emitted as calldata (not sent) and the
+  // AlreadySet revert path is never reached.
+  const currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
+
+  if (
+    currentP2TRFraudRouter.toLowerCase() ===
+    p2trFraudRouter.address.toLowerCase()
+  ) {
+    console.log(
+      `P2TRSignatureFraudRouter already wired on this Bridge at ${p2trFraudRouter.address}; skipping`
+    )
+  } else if (currentP2TRFraudRouter !== ethers.constants.AddressZero) {
+    throw new Error(
+      "Bridge is already wired to a different P2TRSignatureFraudRouter " +
+        `(${currentP2TRFraudRouter}); refusing to wire ` +
+        `${p2trFraudRouter.address}`
+    )
+  } else {
+    // Resolve the authorized caller. In the governance-wrapper case the setter
+    // is `BridgeGovernance.onlyOwner`, so the call must come from the wrapper
+    // owner -- which post-handoff is the governance multisig, not `deployer`.
+    // When that owner is not a configured signer, emit the calldata for manual
+    // governance execution and skip (mainnet) rather than sending from
+    // `deployer` and reverting.
+    const setterContract = governanceIsDeployer
+      ? bridgeContract
+      : bridgeGovernance
+    const setterCaller = governanceIsDeployer
+      ? deployer
+      : await bridgeGovernance.owner()
+    const setterSigner = await getConfiguredSigner(hre, setterCaller)
+
+    if (!setterSigner) {
+      const calldata = setterContract.interface.encodeFunctionData(
+        "setP2TRFraudRouter",
+        [p2trFraudRouter.address]
+      )
+      const message =
+        `P2TRSignatureFraudRouter wiring must be executed by ${setterCaller}, ` +
+        `which is not a configured signer for network ${hre.network.name}. ` +
+        "Submit this call from governance:\n" +
+        `  target: ${setterContract.address}\n` +
+        `  data:   ${calldata}`
+
+      if (hre.network.name === "mainnet") {
+        console.log(`${message}\nskipping for manual governance execution`)
+      } else {
+        throw new Error(message)
+      }
+    } else {
+      try {
+        const tx = await setterContract
+          .connect(setterSigner)
+          .setP2TRFraudRouter(p2trFraudRouter.address)
+        await tx.wait(1)
+        console.log(
+          `wired P2TRSignatureFraudRouter at ${
+            p2trFraudRouter.address
+          } onto Bridge ${
+            governanceIsDeployer
+              ? "directly (governance is still deployer)"
+              : "via BridgeGovernance"
+          }`
+        )
+      } catch (err) {
+        // Tolerate only a concurrent deployment that wired the SAME router
+        // between the pre-check read above and this call (AlreadySet revert).
+        const errAny = err as {
+          data?: string
+          error?: { data?: string }
+          message?: string
+        }
+        const revertData =
+          errAny.data || errAny.error?.data || errAny.message || ""
+        if (
+          typeof revertData === "string" &&
+          revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
+        ) {
+          console.log(
+            "P2TRSignatureFraudRouter already wired on this Bridge; skipping"
+          )
+        } else {
+          console.error(
+            "setP2TRFraudRouter call reverted with an unexpected error;",
+            "deploy aborted so the operator can investigate:",
+            errAny.message || err
+          )
+          throw err
+        }
+      }
+
+      // Idempotent post-check: assert the on-chain value now reflects this
+      // router. Only meaningful when the setter was actually sent; the
+      // calldata-emit path skips before reaching here. Also catches a
+      // concurrent deploy that wired a DIFFERENT router (AlreadySet caught
+      // above) between the pre-check and this send.
+      const wiredRouter = await bridgeContract.p2trFraudRouter()
+      if (wiredRouter.toLowerCase() !== p2trFraudRouter.address.toLowerCase()) {
+        throw new Error(
+          "Bridge.p2trFraudRouter mismatch after deploy: " +
+            `expected ${p2trFraudRouter.address}, got ${wiredRouter}`
+        )
+      }
+    }
+  }
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(p2trFraudRouter)
@@ -36,4 +198,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["P2TRSignatureFraudRouter"]
-func.dependencies = ["Bridge"]
+func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
+++ b/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
@@ -79,7 +79,31 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // configuration -- including a multisig owner that is not a configured
   // signer, where the wiring is emitted as calldata (not sent) and the
   // AlreadySet revert path is never reached.
-  const currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
+  //
+  // When preparing the atomic upgrade of an EXISTING Bridge, the proxy is
+  // still on the pre-upgrade implementation, which has no `p2trFraudRouter()`
+  // selector until the governance proposal executes -- so this read reverts
+  // with a CALL_EXCEPTION (the eth_call returns no data to decode). A plain
+  // getter cannot revert for any other reason, so tolerate ONLY that case:
+  // treat the router as unwired and fall through to emit the setter calldata
+  // the operator needs for the upgrade/wiring proposal, rather than aborting
+  // before that branch is reached. Any other error (e.g. an RPC failure)
+  // rethrows so it is not silently swallowed (cf. the blanket-catch regression
+  // fixed in 48_deploy_frost_wallet_registry).
+  let currentP2TRFraudRouter: string
+  try {
+    currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
+  } catch (err) {
+    if ((err as { code?: string }).code !== "CALL_EXCEPTION") {
+      throw err
+    }
+    console.log(
+      "Bridge.p2trFraudRouter() reverted (no such selector on the current " +
+        "Bridge implementation -- pre-upgrade proxy); treating the router as " +
+        "unwired and emitting wiring for the upgrade proposal"
+    )
+    currentP2TRFraudRouter = ethers.constants.AddressZero
+  }
 
   if (
     currentP2TRFraudRouter.toLowerCase() ===

--- a/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
+++ b/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
@@ -91,6 +91,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // rethrows so it is not silently swallowed (cf. the blanket-catch regression
   // fixed in 48_deploy_frost_wallet_registry).
   let currentP2TRFraudRouter: string
+  let bridgeExposesGetter = true
   try {
     currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
   } catch (err) {
@@ -103,6 +104,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         "unwired and emitting wiring for the upgrade proposal"
     )
     currentP2TRFraudRouter = ethers.constants.AddressZero
+    bridgeExposesGetter = false
   }
 
   if (
@@ -131,21 +133,35 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     const setterCaller = governanceIsDeployer
       ? deployer
       : await bridgeGovernance.owner()
-    const setterSigner = await getConfiguredSigner(hre, setterCaller)
+    // A pre-upgrade Bridge has no `setP2TRFraudRouter` selector yet, so the
+    // transaction cannot be sent regardless of who is a configured signer.
+    // Force the calldata-emission path in that case (leave the signer
+    // unresolved) rather than attempting -- and reverting -- the send.
+    const setterSigner = bridgeExposesGetter
+      ? await getConfiguredSigner(hre, setterCaller)
+      : undefined
 
     if (!setterSigner) {
       const calldata = setterContract.interface.encodeFunctionData(
         "setP2TRFraudRouter",
         [p2trFraudRouter.address]
       )
+      const reason = !bridgeExposesGetter
+        ? `the Bridge at ${Bridge.address} does not yet expose ` +
+          "setP2TRFraudRouter (pre-upgrade implementation); wire it as part " +
+          "of the upgrade proposal"
+        : `${setterCaller} is not a configured signer for network ${hre.network.name}`
       const message =
-        `P2TRSignatureFraudRouter wiring must be executed by ${setterCaller}, ` +
-        `which is not a configured signer for network ${hre.network.name}. ` +
+        `P2TRSignatureFraudRouter wiring must be executed by governance -- ${reason}. ` +
         "Submit this call from governance:\n" +
         `  target: ${setterContract.address}\n` +
         `  data:   ${calldata}`
 
-      if (hre.network.name === "mainnet") {
+      // A pre-upgrade Bridge genuinely cannot be wired now on ANY network, so
+      // emit the calldata and continue. Otherwise keep the existing guard:
+      // skip on mainnet (a non-signer governance owner is expected there) and
+      // error elsewhere so an unexpected non-signer is surfaced.
+      if (!bridgeExposesGetter || hre.network.name === "mainnet") {
         console.log(`${message}\nskipping for manual governance execution`)
       } else {
         throw new Error(message)

--- a/solidity/test/bridge/Bridge.D1EcdsaRetirement.test.ts
+++ b/solidity/test/bridge/Bridge.D1EcdsaRetirement.test.ts
@@ -22,37 +22,30 @@ const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
 // D-1 ECDSA soft-retirement guards.
 //
-// This phase ships the `ecdsaRetired` storage flag and the
-// matching guards in the `Wallets` external library. The
-// governance-callable setter on Bridge that flips the flag is
-// deferred to D-2 (see `Bridge.sol` after `setNewWalletScheme`
-// for the bytecode-budget rationale); D-1 unit tests reach the
-// flag via a test-only `BridgeStub.setEcdsaRetiredForTest`
-// helper that mirrors how mainnet would activate it through a
+// This suite ships the `ecdsaRetired` storage flag plus its
+// governance setter (`Bridge.retireEcdsa`) and public getter
+// (`Bridge.ecdsaRetired`). Unit tests reach the flag via a
+// test-only `BridgeStub.setEcdsaRetiredForTest` helper that
+// mirrors how mainnet would activate it through a
 // storage-layout-compatible upgrade.
 //
-// One guard site is exercised here:
-//   - `Wallets.requestNewWallet` rejects requests routed to
-//     the ECDSA registry once `ecdsaRetired == true`.
+// The flag is purely an on-chain audit-trail marker and is NOT
+// load-bearing: no code path reads it (only the getter returns
+// it, for off-chain observation). `Wallets.requestNewWallet`
+// does NOT inspect it — the originally planned D-1 read-side
+// guard, and the unconditional ECDSA-registry IDLE precheck it
+// depended on, were both dropped when D-2.2 slice 3 removed the
+// scheme-enum dispatch branch. Post-slice-3 the dispatcher
+// always targets the FROST registry, so dispatch behavior is
+// independent of the flag. The tests below pin exactly that
+// invariant: `requestNewWallet` reverts identically whether the
+// flag is set or not (FROST-only dispatch, unwired registry).
 //
-// `Wallets.registerNewWallet` deliberately does NOT block the
-// late-callback path: reverting from the ECDSA registry's
-// `__ecdsaWalletCreatedCallback` would propagate up through
-// `WalletRegistry.approveDkgResult` and prevent the registry's
-// own DKG state machine from completing, stranding it in a
-// non-IDLE state. Because `Wallets.requestNewWallet` has an
-// unconditional IDLE precheck on the ECDSA registry BEFORE the
-// scheme branch, a stuck ECDSA registry would also block every
-// subsequent FROST wallet creation — the exact failure mode
-// D-1 is meant to prevent (Codex P1 review on PR #443). The
-// "no late ECDSA wallets after retirement" invariant is
-// enforced operationally: governance pauses Bridge, waits for
-// in-flight DKGs to settle (registry returns to IDLE), sets
-// the flag, then unpauses. The second `__ecdsaWalletCreatedCallback`
-// context below pins the explicit no-deadlock invariant: late
-// callbacks under `ecdsaRetired == true` still succeed
-// end-to-end and register the wallet.
-describe("Bridge - ECDSA retirement (D-1 guard + D-2 setter)", () => {
+// ECDSA wallet creation is instead blocked structurally: the
+// scheme branch is gone (D-2.2 slice 3) and
+// `Bridge.__ecdsaWalletCreatedCallback` was removed entirely in
+// D-2 — so there is no late-callback drain path left to test.
+describe("Bridge - ECDSA retirement (informational flag + D-2 setter)", () => {
   let governance: SignerWithAddress
   let thirdParty: SignerWithAddress
 


### PR DESCRIPTION
Stacked on #971 (base `extraction/frost-mirror-2026-05-26`). Fixes two verified activation-wiring correctness gaps.

## Finding 1 (MEDIUM) — fraud routers deployed but never wired

`44_deploy_ecdsa_fraud_router.ts` and `45_deploy_p2tr_signature_fraud_router.ts` deployed `EcdsaFraudRouter` / `P2TRSignatureFraudRouter` but never called the Bridge setter, so `Bridge.ecdsaFraudRouter()` and `Bridge.p2trFraudRouter()` stayed `address(0)`. With the routers unwired, `slashWalletForFraud` / `slashWalletForP2TRFraud` (gated by `onlyEcdsaFraudRouter` / `onlyP2TRFraudRouter`) were unreachable and **all fraud slashing was dead** until a manual, script-less governance step.

### Real function/getter names used
| Purpose | ECDSA | P2TR |
| --- | --- | --- |
| Bridge setter (`onlyGovernance`) | `setEcdsaFraudRouter(address)` | `setP2TRFraudRouter(address)` |
| BridgeGovernance wrapper (`onlyOwner`) | `setEcdsaFraudRouter(address)` | `setP2TRFraudRouter(address)` |
| Bridge getter | `ecdsaFraudRouter()` | `p2trFraudRouter()` |
| One-shot revert | `EcdsaFraudRouterAlreadySet()` | `P2TRFraudRouterAlreadySet()` |

### How the wiring mirrors 48/49
Both scripts now follow the `setFrostWalletRegistry` idiom in `48_deploy_frost_wallet_registry.ts`. Because the fraud routers expose a **direct public getter** (unlike the lifecycle router in 49, which has no getter and is read from an event), the idempotency read maps cleanly onto script 48's `frostLifecycleContext` pre-check:

- **read current value via the getter** → skip if already wired to this router; throw if wired to a *different* router;
- **route by `Bridge.governance()`** → send directly when governance is still the deployer (fresh chains, since `21_transfer_bridge_governance.ts` runs `runAtTheEnd`), else through the `BridgeGovernance` `onlyOwner` wrapper using `await bridgeGovernance.owner()`;
- **authorized-signer gate via `getConfiguredSigner`** → when the required caller is not a configured signer (production Safe), **emit the exact governance calldata** (`interface.encodeFunctionData(...)`) and skip on `mainnet` / throw otherwise — the same "just emit calldata" governance mode 48/49 honor;
- **tolerate only the specific `*AlreadySet()` selector** on a concurrent re-run (byte-for-byte the same `errAny.data || errAny.error?.data || errAny.message` matching 48 uses), rethrow anything else;
- **assert the on-chain value** after sending (post-check).

`func.dependencies` extended to `["Bridge", "BridgeGovernance"]` on both.

## Finding 2 (LOW) — `ecdsaRetired` write-only; comments overclaimed enforcement

`ecdsaRetired` is written by `Bridge.retireEcdsa()` and read **only** by the public `ecdsaRetired()` getter — no on-chain path reads it. `Wallets.requestNewWallet` dispatches only to the FROST registry (the scheme-dispatch branch was removed in D-2.2 slice 3) and `__ecdsaWalletCreatedCallback` was removed in D-2.1, so ECDSA wallet creation is already blocked **structurally**, independent of the flag.

**Decision: correct the comments, do not add a guard.** There is no ECDSA-creation branch left in `requestNewWallet` to attach a guard to. An unconditional `require(!self.ecdsaRetired, ...)` would revert **FROST** wallet creation after retirement — a harmful behavior change (FROST is the go-forward scheme), not the no-op the comment implied. So I corrected the misleading comments instead:
- `Bridge.sol` `retireEcdsa` NatSpec — dropped the false "revert via the request-side guard added in D-1" claim;
- `BridgeState.sol` `ecdsaRetired` field comment — dropped the "`requestNewWallet` rejects ECDSA-routed requests" / "unconditional IDLE precheck" claims (that precheck was removed with the scheme dispatch);
- `test/bridge/Bridge.D1EcdsaRetirement.test.ts` header — dropped the "One guard site is exercised here" claim.

The existing test bodies already assert `requestNewWallet` "reverts identically (flag has no dispatch effect post-slice-3)", so the corrected docs now match both the code and the tests. (`BridgeGovernance.retireEcdsa` NatSpec was already accurate — "NOT load-bearing" — and is unchanged.)

## Validation
- `yarn build` (Node 18) — passes; compiles contracts and typechecks deploy scripts in the hardhat context.
- Verified all called signatures exist on the compiled Bridge/BridgeGovernance ABIs (`setEcdsaFraudRouter`, `ecdsaFraudRouter`, `setP2TRFraudRouter`, `p2trFraudRouter`, `governance`, `owner`).
- `prettier --check` and `eslint` clean on changed files (only repo-standard `no-console` warnings, matching 48/49); `solhint` clean on the touched contracts.
- Finding 2 is comment-only (no behavior change). The `Bridge.D1EcdsaRetirement` suite cannot run in this environment due to a pre-existing external-dependency deploy mismatch in `@threshold-network/solidity-contracts` (`07_deploy_token_staking.js`: "expected 6 constructor arguments, got 2") inside the shared `bridgeFixture` — this reproduces identically on the unmodified base and is unrelated to these changes. The lighter-fixture `EcdsaFraudRouter.test.ts` passes 11/11.
- A scoped `hardhat deploy --tags EcdsaFraudRouter,P2TRSignatureFraudRouter` dry-run halts earlier at `06_deploy_bridge.ts` (missing external `WalletRegistry` deployment), before reaching 44/45 — same environment limitation, not a script defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)