### PR TITLE
fix(pr971): make P2TR BIP-341 fraud sighash coverage explicit and fail-safe

### DIFF
--- a/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
+++ b/solidity/contracts/bridge/CheckBitcoinBIP341Sighash.sol
@@ -65,6 +65,13 @@ library CheckBitcoinBIP341Sighash {
         uint32 signedInputIndex,
         uint8 sighashType
     ) internal pure returns (bytes32) {
+        // Defense-in-depth boundary guard. Callers already funnel `sighashType`
+        // through `P2TRSignatureFraud.parseWitnessSignature`, which only yields
+        // DEFAULT (0x00) or ALL (0x01); this independent check additionally
+        // fail-closes any direct caller so an unsupported mode (explicit 0x00 via
+        // a non-witness path, NONE, SINGLE, ANYONECANPAY, or any other byte) can
+        // never reach the message reconstruction below -- which only encodes
+        // DEFAULT/ALL key-path semantics.
         require(
             sighashType == SighashDefault || sighashType == SighashAll,
             "Unsupported BIP341 sighash type"

--- a/solidity/contracts/bridge/CheckBitcoinP2TRSignatureFraud.sol
+++ b/solidity/contracts/bridge/CheckBitcoinP2TRSignatureFraud.sol
@@ -12,6 +12,38 @@ import "./P2TRSignatureFraud.sol";
 /// @dev This helper is intentionally not wired into Bridge fraud entrypoints
 ///      yet. It combines the focused BIP-341 sighash and BIP-340 verifier seeds
 ///      behind one contract-facing API for verifier feasibility testing.
+///
+///      SUPPORTED-SHAPE BOUNDARY (in scope). This verifier adjudicates ONLY:
+///        * Taproot KEY-PATH spends (no control block / tapscript),
+///        * signed with SIGHASH_DEFAULT (64-byte witness) or SIGHASH_ALL
+///          (65-byte witness ending in 0x01),
+///        * with NO witness annex.
+///      Every other spend shape is rejected BEFORE any sighash reconstruction:
+///        * unsupported sighash modes (explicit 0x00, NONE, SINGLE, any
+///          ANYONECANPAY variant) revert in
+///          `P2TRSignatureFraud.parseWitnessSignature`;
+///        * an annex reverts in `validateAnnexAbsent` ("Annex not supported");
+///        * a script-path spend is structurally unrepresentable -- the
+///          `BridgeChallengeIdentityPayload` carries no control block or tapleaf
+///          fields, and the reconstructed message hard-codes the key-path
+///          spend_type (ext_flag = 0), so a script-path spend can never be
+///          encoded as an accepted challenge.
+///
+///      WHY THIS CANNOT CAUSE A FALSE SLASH. The security-load-bearing step is
+///      `checkSignature`: it verifies the witness BIP-340 signature against the
+///      reconstructed key-path sighash under the x-only `walletID`. An
+///      out-of-scope spend (other sighash mode, annex, or script path) commits
+///      its signature to a DIFFERENT message (and, for script path, often a
+///      different key) than the reconstructed DEFAULT/ALL key-path sighash, so
+///      that signature cannot pass `checkSignature`. Passing it would require a
+///      genuine `walletID` key-path signature over the reconstructed
+///      transaction -- which is itself the real key-path fraud this verifier
+///      exists to catch. The failure mode is therefore fail-CLOSED: unsupported
+///      shapes are un-challengeable (a documented coverage gap / fraud-escape
+///      for those shapes), never silently mis-verified into an honest-signer
+///      slash. Closing the coverage gap requires adding real multi-mode BIP-341
+///      reconstruction (and, for SINGLE/ANYONECANPAY, a richer challenge
+///      payload); it is deliberately out of scope here.
 library CheckBitcoinP2TRSignatureFraud {
     struct PayloadBounds {
         uint16 maxInputs;
@@ -67,6 +99,16 @@ library CheckBitcoinP2TRSignatureFraud {
         return checkSignature(walletID, sighash, witnessSignature);
     }
 
+    /// @notice Security-load-bearing check: verifies the witness BIP-340
+    ///         signature against the supplied key-path `sighash` under the
+    ///         x-only `walletID`.
+    /// @dev This binding is what makes the supported-shape boundary safe. A
+    ///      signature that actually commits to a different message (any
+    ///      unsupported sighash mode, an annex, or a script-path spend) cannot
+    ///      pass here against the reconstructed DEFAULT/ALL key-path `sighash`,
+    ///      so an out-of-scope spend cannot be smuggled into a passing challenge.
+    ///      `parseWitnessSignature` additionally reverts on any non-DEFAULT/ALL
+    ///      witness encoding before this point.
     function checkSignature(
         bytes32 walletID,
         bytes32 sighash,
@@ -307,6 +349,18 @@ library CheckBitcoinP2TRSignatureFraud {
         }
     }
 
+    /// @notice Rejects annex-bearing spends, which this key-path verifier does
+    ///         not reconstruct.
+    /// @dev Fail-closed guard invoked before sighash reconstruction on every
+    ///      lifecycle path (`validatePayloadShape` and
+    ///      `computeBridgeChallengeIdentitySighash`). The reconstructed message
+    ///      hard-codes the no-annex spend_type, so an annex-bearing spend's
+    ///      sighash (which additionally commits to SHA_ANNEX) would never match;
+    ///      rejecting up front keeps the boundary explicit. Note the flag is
+    ///      challenger-supplied: mis-declaring `annexPresent = false` for an
+    ///      annex-bearing spend does not forge a passing challenge, because the
+    ///      annex-committing signature still cannot verify against the
+    ///      no-annex key-path sighash in `checkSignature`.
     function validateAnnexAbsent(bool annexPresent) internal pure {
         require(!annexPresent, "Annex not supported");
     }

--- a/solidity/contracts/bridge/P2TRSignatureFraud.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraud.sol
@@ -46,8 +46,27 @@ library P2TRSignatureFraud {
 
     /// @notice Parses Taproot key-path witness signature encodings supported by
     ///         the selected P2TR signature-fraud challenge direction.
-    /// @dev BIP-341 represents SIGHASH_DEFAULT by omitting the sighash byte.
-    ///      Explicit 0x00 and any non-SIGHASH_ALL byte are rejected.
+    /// @dev SUPPORTED-SHAPE BOUNDARY (fail-closed). Only two witness-signature
+    ///      encodings are accepted:
+    ///        * 64 bytes -> BIP-341 SIGHASH_DEFAULT (the sighash byte is omitted);
+    ///        * 65 bytes whose trailing byte is exactly 0x01 -> SIGHASH_ALL.
+    ///      Every other encoding is rejected with a revert BEFORE any sighash
+    ///      reconstruction or signature verification, so a challenge for it can
+    ///      never be recorded:
+    ///        * an explicit 0x00 trailing byte (non-canonical SIGHASH_DEFAULT),
+    ///        * SIGHASH_NONE (0x02), SIGHASH_SINGLE (0x03),
+    ///        * any ANYONECANPAY variant (0x81/0x82/0x83, or the 0x80 bit set on
+    ///          any base type),
+    ///        * any other length (empty, short, or long) witness.
+    ///      This is a deliberate coverage boundary, not full BIP-341 support: the
+    ///      reconstructed message in `CheckBitcoinBIP341Sighash.computeKeyPathSighash`
+    ///      only matches DEFAULT/ALL key-path semantics, so admitting any other
+    ///      mode here would let the verifier compare a signature against a message
+    ///      the signer never committed to. Rejecting instead keeps the fraud path
+    ///      fail-closed (an unsupported-mode fraud is un-challengeable via this
+    ///      path, never mis-adjudicated). See the module-level notes in
+    ///      `CheckBitcoinP2TRSignatureFraud` for why this cannot cause a false
+    ///      slash.
     function parseWitnessSignature(bytes memory witnessSignature)
         internal
         pure

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -545,6 +545,42 @@ describe("Bridge - P2TR signature fraud", () => {
       }),
       revertMessage: "Annex not supported",
     },
+    // The base vector is a 64-byte SIGHASH_DEFAULT witness; appending a trailing
+    // sighash byte other than 0x01 produces an out-of-scope 65-byte witness that
+    // the router must refuse to adjudicate (fail-closed), never mis-verify into a
+    // slash. These reject at `parseWitnessSignature`, before signature checking.
+    {
+      name: "unsupported SIGHASH_NONE witness",
+      mutatePayload: (payload) => ({
+        ...payload,
+        witnessSignature: `${payload.witnessSignature}02`,
+      }),
+      revertMessage: "Unsupported witness sighash type",
+    },
+    {
+      name: "unsupported SIGHASH_SINGLE witness",
+      mutatePayload: (payload) => ({
+        ...payload,
+        witnessSignature: `${payload.witnessSignature}03`,
+      }),
+      revertMessage: "Unsupported witness sighash type",
+    },
+    {
+      name: "unsupported ANYONECANPAY witness",
+      mutatePayload: (payload) => ({
+        ...payload,
+        witnessSignature: `${payload.witnessSignature}81`,
+      }),
+      revertMessage: "Unsupported witness sighash type",
+    },
+    {
+      name: "non-canonical explicit-SIGHASH_DEFAULT witness",
+      mutatePayload: (payload) => ({
+        ...payload,
+        witnessSignature: `${payload.witnessSignature}00`,
+      }),
+      revertMessage: "Unsupported witness sighash type",
+    },
     {
       name: "oversized prevout script",
       mutatePayload: (payload) => ({

--- a/solidity/test/bridge/CheckBitcoinBIP341Sighash.test.ts
+++ b/solidity/test/bridge/CheckBitcoinBIP341Sighash.test.ts
@@ -289,4 +289,43 @@ describe("CheckBitcoinBIP341Sighash", () => {
       computeSighash(bip341Harness, vector, { prevouts: [] })
     ).to.be.revertedWith("Prevout count mismatch")
   })
+
+  // The verifier reconstructs only DEFAULT/ALL key-path semantics, so it must
+  // fail closed for every other sighash-type byte rather than compare a
+  // signature against a message the signer never committed to (which could
+  // otherwise mis-adjudicate a fraud challenge). This is the defense-in-depth
+  // boundary guard inside `computeKeyPathSighash`, exercised directly here.
+  it("fails closed for every unsupported BIP341 sighash type byte", async () => {
+    const vector = vectorCorpus.cases[0]
+
+    const unsupportedSighashTypes = [
+      0x02, // SIGHASH_NONE
+      0x03, // SIGHASH_SINGLE
+      0x80, // bare ANYONECANPAY bit
+      0x81, // SIGHASH_ALL | ANYONECANPAY
+      0x82, // SIGHASH_NONE | ANYONECANPAY
+      0x83, // SIGHASH_SINGLE | ANYONECANPAY
+      0x04,
+      0xff,
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const sighashType of unsupportedSighashTypes) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(
+        computeSighash(bip341Harness, vector, { sighashType }),
+        `sighashType=0x${sighashType.toString(16)}`
+      ).to.be.revertedWith("Unsupported BIP341 sighash type")
+    }
+
+    // Both in-scope types still reconstruct without reverting.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const sighashType of [0, 1]) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(
+        computeSighash(bip341Harness, vector, { sighashType }),
+        `sighashType=${sighashType}`
+      ).not.to.be.reverted
+    }
+  })
 })

--- a/solidity/test/bridge/CheckBitcoinP2TRSignatureFraud.test.ts
+++ b/solidity/test/bridge/CheckBitcoinP2TRSignatureFraud.test.ts
@@ -497,6 +497,55 @@ describe("CheckBitcoinP2TRSignatureFraud", () => {
     ).to.be.revertedWith("Annex not supported")
   })
 
+  // The witness-encoding boundary must fail closed for every sighash byte other
+  // than the two in scope (implicit DEFAULT / explicit ALL). A 65-byte witness
+  // carrying NONE/SINGLE/ANYONECANPAY (or a non-canonical explicit 0x00) is
+  // rejected at parse time -- before any sighash reconstruction or signature
+  // verification -- so such a spend can never be adjudicated by this path.
+  it("fails closed for every unsupported Taproot witness sighash byte", async () => {
+    const vector = vectorCorpus.cases[0] // SIGHASH_DEFAULT: 64-byte witness
+    const baseSignatureHex = vector.witnessSignatureHex
+
+    const unsupportedTrailingBytes = [
+      "00", // explicit, non-canonical SIGHASH_DEFAULT
+      "02", // SIGHASH_NONE
+      "03", // SIGHASH_SINGLE
+      "80", // bare ANYONECANPAY bit
+      "81", // SIGHASH_ALL | ANYONECANPAY
+      "82", // SIGHASH_NONE | ANYONECANPAY
+      "83", // SIGHASH_SINGLE | ANYONECANPAY
+      "ff",
+    ]
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const trailing of unsupportedTrailingBytes) {
+      const unsupportedWitnessSignatureHex = `${baseSignatureHex}${trailing}`
+
+      // eslint-disable-next-line no-await-in-loop
+      await expect(
+        callWithVector(harness, "computeKeyPathSighashForWitness", vector, {
+          witnessSignatureHex: unsupportedWitnessSignatureHex,
+        }),
+        `computeKeyPathSighashForWitness trailing=0x${trailing}`
+      ).to.be.revertedWith("Unsupported witness sighash type")
+
+      // eslint-disable-next-line no-await-in-loop
+      await expect(
+        callWithVector(harness, "checkKeyPathSignature", vector, {
+          witnessSignatureHex: unsupportedWitnessSignatureHex,
+        }),
+        `checkKeyPathSignature trailing=0x${trailing}`
+      ).to.be.revertedWith("Unsupported witness sighash type")
+    }
+
+    // The only accepted 65-byte form (explicit SIGHASH_ALL) is not rejected.
+    await expect(
+      callWithVector(harness, "computeKeyPathSighashForWitness", vector, {
+        witnessSignatureHex: `${baseSignatureHex}01`,
+      })
+    ).not.to.be.reverted
+  })
+
   it("accepts vector payloads within explicit bounds", async () => {
     await Promise.all(
       vectorCorpus.cases.map(async (vector) => {


### PR DESCRIPTION
## Finding (verified, MEDIUM)

The on-chain P2TR signature-fraud verifier reconstructs the BIP-341 signature
message (sighash) only for **annex-free key-path spends** signed with
**SIGHASH_DEFAULT (0x00)** or **SIGHASH_ALL (0x01)**
(`CheckBitcoinBIP341Sighash.computeKeyPathSighash`). Spends using
NONE/SINGLE/ANYONECANPAY, script-path spends, or annex-bearing inputs are out of
scope. The concern: if such a shape were silently accepted, the verifier could
compute a **wrong** sighash and either let a fraudster escape or slash an honest
signer.

## Determination of current behavior: already FAILS CLOSED

I traced how the sighash-type byte, annex flag, and spend shape flow from
`P2TRSignatureFraudRouter.processP2TRSignatureFraudChallenge` through
`CheckBitcoinP2TRSignatureFraud` and `CheckBitcoinBIP341Sighash` into the
BIP-340 check. **The verifier already reverts / cannot mis-verify for every
unsupported case. It does NOT silently compute a wrong sighash that could pass
verification.** Evidence:

- **Unsupported sighash modes** revert **before any reconstruction**, at two
  independent layers:
  - `P2TRSignatureFraud.parseWitnessSignature` (`P2TRSignatureFraud.sol:60-68`):
    a 65-byte witness must end in exactly `0x01`, else
    `require(..., "Unsupported witness sighash type")`. A 64-byte witness is
    DEFAULT; no other length/byte is accepted. This is on every lifecycle path
    (`validatePayloadShape`, `computeBridgeChallengeIdentity[Sighash]`,
    `computeKeyPathSighashForWitness`).
  - `CheckBitcoinBIP341Sighash.computeKeyPathSighash`
    (`CheckBitcoinBIP341Sighash.sol:68-71`):
    `require(sighashType == DEFAULT || sighashType == ALL, "Unsupported BIP341 sighash type")`
    fail-closes any direct caller too (NONE/SINGLE/ANYONECANPAY/explicit-0x00).
- **Annex-bearing spends** revert in
  `CheckBitcoinP2TRSignatureFraud.validateAnnexAbsent`
  (`CheckBitcoinP2TRSignatureFraud.sol:310-312`, `require(!annexPresent, "Annex not supported")`),
  invoked from both `validatePayloadShape` and
  `computeBridgeChallengeIdentitySighash` before reconstruction.
- **Script-path spends** are **structurally unrepresentable**: the
  `BridgeChallengeIdentityPayload` carries no control block / tapleaf fields, and
  the reconstructed message hard-codes the key-path spend_type / `ext_flag = 0`
  (`CheckBitcoinBIP341Sighash.sol:91`).

**Why no false slash is possible.** The security-load-bearing step is
`CheckBitcoinP2TRSignatureFraud.checkSignature`
(`CheckBitcoinP2TRSignatureFraud.sol:70-87`, enforced at
`P2TRSignatureFraudRouter.sol:317-324`): it verifies the witness BIP-340
signature against the *reconstructed key-path sighash* under the x-only
`walletID`. Any out-of-scope spend (other mode, annex, or script path) commits
its signature to a **different** message than the reconstructed DEFAULT/ALL
sighash, so it cannot pass this check. Passing would require a genuine `walletID`
key-path signature over the reconstructed transaction — which is itself the real
key-path fraud this verifier exists to catch. The failure mode is therefore
fail-**closed**: unsupported shapes are un-challengeable (a documented coverage
gap / fraud-escape for those shapes), never mis-verified into an honest-signer
slash. This residual is inherent to on-chain key-path fraud proofs and currently
non-impactful (the path is not wired into Bridge fraud entrypoints and operator
slashing is economically inert).

Because the code already fails closed, this PR takes the "already-reverts"
branch: make the boundary **explicit + documented**, and add the missing
**revert-assertion tests**. No guard logic changed; no new crypto added.

## What changed

**Documentation (NatSpec, no logic change):**
- `CheckBitcoinP2TRSignatureFraud.sol` — module header now enumerates the
  in-scope shapes and the fail-closed rejection of every other shape, with the
  no-false-slash rationale; `checkSignature` and `validateAnnexAbsent` document
  their role in that safety argument.
- `P2TRSignatureFraud.parseWitnessSignature` — enumerates exactly which trailing
  bytes are rejected (explicit 0x00, NONE 0x02, SINGLE 0x03, ANYONECANPAY
  0x81/0x82/0x83, any 0x80-set base).
- `CheckBitcoinBIP341Sighash.computeKeyPathSighash` — notes the guard is the
  second, independent (defense-in-depth) layer.

**Tests (new fail-closed revert assertions):**
- `CheckBitcoinBIP341Sighash.test.ts` — "fails closed for every unsupported
  BIP341 sighash type byte": raw-library revert over {0x02,0x03,0x80,0x81,0x82,
  0x83,0x04,0xff}; DEFAULT/ALL still reconstruct.
- `CheckBitcoinP2TRSignatureFraud.test.ts` — "fails closed for every unsupported
  Taproot witness sighash byte": witness-encoding-layer revert over
  {00,02,03,80,81,82,83,ff} via both `computeKeyPathSighashForWitness` and
  `checkKeyPathSignature`.
- `Bridge.P2TRFrauds.test.ts` — router-entrypoint revert scenarios for NONE,
  SINGLE, ANYONECANPAY, and non-canonical explicit-DEFAULT witnesses, asserting
  rejection **before** signature verification.

Previously the negative matrix only exercised explicit-0x00 and a single 0x02;
SINGLE and every ANYONECANPAY variant were untested. No doc claimed full
coverage (the RFC execution spec, contract NatSpec, and vector-corpus
`openCoverageGaps` already state the key-path/DEFAULT+ALL boundary correctly), so
no doc correction was needed.

## Validation (Node 18, from `solidity/`)

- `yarn build` — passes.
- `yarn test` (non-fixture P2TR/BIP suites): **34 passing**
  (`CheckBitcoinBIP341Sighash`, `CheckBitcoinP2TRSignatureFraud`,
  `CheckBitcoinBIP340Sigs`, `P2TRSignatureFraudChallenge`), including both new
  "fails closed" tests.
- `prettier --check`, `solhint`, `eslint` — clean on changed files (0 errors).
- `Bridge.P2TRFrauds.test.ts` (router suite) could not run in this environment:
  its `bridgeFixture` fails in the `before all` hook with
  `07_deploy_token_staking.js: expected 6 constructor arguments, got 2` — a
  dependency-version skew (the repo's 2-arg TokenStaking deploy-patch vs. the
  installed 6-arg artifact) that breaks **every** bridge-fixture test
  (reproduced identically on unmodified `Bridge.Parameters.test.ts`), unrelated
  to this change. The added router scenarios are data entries in the existing,
  passing `payloadBoundRejectionScenarios` loop and are exercised end-to-end by
  the equivalent library-level assertions; they will run in CI where the fixture
  deploys.

## Recommended follow-up (out of scope here)

Full multi-mode BIP-341 coverage (NONE/SINGLE/ANYONECANPAY, script-path, annex)
is a large, high-risk crypto change and is **not** implemented here.
**Recommendation: implement it before this P2TR fraud path is wired into Bridge
fraud entrypoints and operator slashing becomes economically active.** Until
then the residual is a fraud-escape (un-challengeable) gap for non-key-path
spends, not a false-slash risk. SINGLE/ANYONECANPAY additionally require a richer
challenge payload carrying per-input/-output context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
