### PR TITLE
fix(bridge): verify Taproot deposit spend signatures

### DIFF
--- a/docs/rfc/frost-migration/b1-implementation-plan.md
+++ b/docs/rfc/frost-migration/b1-implementation-plan.md
@@ -245,9 +245,17 @@ fails fast.
    this fail-fast guard). The `approveDkgResult` path also
    re-checks the same invariant so any in-flight DKG can't
    register a live wallet without an active lifecycle path.
-6. No scheme flip is required in the canonical mirror: D-2.2
+6. Upgrade the Bridge to the Taproot deposit-commitment implementation before
+   the first FROST wallet or P2TR deposit is enabled. The commitment mapping is
+   populated only by successful reveals after this upgrade and has no automatic
+   backfill. As an activation preflight, replay `TaprootDepositRevealed` events
+   and require every still-unspent revealed P2TR outpoint to have the expected
+   nonzero `taprootDepositOutputKeyCommitment`. If any outstanding reveal lacks
+   a commitment, delay activation until it is swept or refunded, or deploy an
+   independently audited backfill mechanism first.
+7. No scheme flip is required in the canonical mirror: D-2.2
    slice 3 removed the scheme setter and `Bridge.requestNewWallet`
-   dispatches only to the FROST registry. With steps 1-5 complete,
+   dispatches only to the FROST registry. With steps 1-6 complete,
    the call succeeds and DKG starts.
 
 Skipping step 5 strands every newly-created FROST wallet — the

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1760,6 +1760,16 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
         return self.deposits[depositKey];
     }
 
+    /// @notice Returns the wallet/output-key commitment recorded for a
+    ///         Taproot-native deposit, or zero for other outpoints.
+    function taprootDepositOutputKeyCommitment(uint256 depositKey)
+        external
+        view
+        returns (bytes32)
+    {
+        return self.taprootDepositOutputKeyCommitments[depositKey];
+    }
+
     /// @notice Collection of all pending redemption requests indexed by
     ///         redemption key built as
     ///         `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -464,8 +464,10 @@ library BridgeState {
         bool slashingActive;
         // Binds each revealed Taproot-native deposit outpoint to its registered
         // wallet ID and deposit-specific output key. The value is
-        // keccak256(walletID || outputKey); zero denotes a legacy deposit or a
-        // non-deposit outpoint.
+        // keccak256(walletID || outputKey). Zero denotes a legacy, unrevealed,
+        // pre-upgrade, or non-deposit outpoint. Pre-upgrade reveals are not
+        // backfilled automatically; without a commitment, fraud verification
+        // falls back to the registered wallet's base x-only key.
         mapping(uint256 => bytes32) taprootDepositOutputKeyCommitments;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -335,9 +335,9 @@ library BridgeState {
         // governance wiring; changing it afterwards requires a dedicated
         // upgrade path of the Bridge implementation.
         address rebateStaking;
-        // Upgrade note: the FROST wallet ID fields below and the FROST
-        // FROST extraction state consumes eight reserved slots, reducing
-        // `__gap` from 48 to 40 for storage-layout compatibility.
+        // Upgrade note: the FROST extraction state and Taproot deposit
+        // commitment mapping below consume nine reserved slots, reducing
+        // `__gap` from 48 to 39 for storage-layout compatibility.
         // Maps canonical wallet identifier to the wallet public key hash used
         // by legacy Bridge paths. For legacy ECDSA wallets, canonical wallet
         // ID is a left-padded 20-byte wallet public key hash. New wallet
@@ -462,6 +462,11 @@ library BridgeState {
         // unaffected. Packs at slot 37 offset 18 (one byte after `ecdsaRetired`);
         // total slot 37 usage: 19 bytes of 32. No __gap change.
         bool slashingActive;
+        // Binds each revealed Taproot-native deposit outpoint to its registered
+        // wallet ID and deposit-specific output key. The value is
+        // keccak256(walletID || outputKey); zero denotes a legacy deposit or a
+        // non-deposit outpoint.
+        mapping(uint256 => bytes32) taprootDepositOutputKeyCommitments;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -469,7 +474,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[40] __gap;
+        uint256[39] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -159,6 +159,9 @@ library Deposit {
         uint32 sweptAt;
         // The 32-byte deposit extra data. Optional, can be bytes32(0).
         bytes32 extraData;
+        // Commitment binding a Taproot-native deposit's wallet ID to its
+        // deposit-specific output key. Zero for legacy P2(W)SH deposits.
+        bytes32 taprootOutputKeyCommitment;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are
         // not contiguous with other values.
@@ -458,6 +461,22 @@ library Deposit {
                 extraData
             );
 
+        self
+            .deposits[
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            fundingTxHash,
+                            reveal.fundingOutputIndex
+                        )
+                    )
+                )
+            ]
+            .taprootOutputKeyCommitment = taprootOutputKeyCommitment(
+            reveal.walletXOnlyPublicKey,
+            taprootOutputKey
+        );
+
         _emitTaprootDepositRevealedEvents(
             fundingTxHash,
             fundingOutputAmount,
@@ -723,6 +742,15 @@ library Deposit {
                     merkleRoot
                 )
             );
+    }
+
+    /// @notice Commits a Taproot deposit output key to its registered wallet.
+    function taprootOutputKeyCommitment(
+        bytes32 walletXOnlyPublicKey,
+        bytes32 taprootOutputKey
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(abi.encodePacked(walletXOnlyPublicKey, taprootOutputKey));
     }
 
     /// @notice Derives the x-only P2TR output key for a Taproot-native deposit.

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -159,9 +159,6 @@ library Deposit {
         uint32 sweptAt;
         // The 32-byte deposit extra data. Optional, can be bytes32(0).
         bytes32 extraData;
-        // Commitment binding a Taproot-native deposit's wallet ID to its
-        // deposit-specific output key. Zero for legacy P2(W)SH deposits.
-        bytes32 taprootOutputKeyCommitment;
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are
         // not contiguous with other values.
@@ -461,18 +458,13 @@ library Deposit {
                 extraData
             );
 
-        self
-            .deposits[
-                uint256(
-                    keccak256(
-                        abi.encodePacked(
-                            fundingTxHash,
-                            reveal.fundingOutputIndex
-                        )
-                    )
+        self.taprootDepositOutputKeyCommitments[
+            uint256(
+                keccak256(
+                    abi.encodePacked(fundingTxHash, reveal.fundingOutputIndex)
                 )
-            ]
-            .taprootOutputKeyCommitment = taprootOutputKeyCommitment(
+            )
+        ] = taprootOutputKeyCommitment(
             reveal.walletXOnlyPublicKey,
             taprootOutputKey
         );

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -316,7 +316,7 @@ contract P2TRSignatureFraudRouter {
 
         require(
             CheckBitcoinP2TRSignatureFraud.checkSignature(
-                payload.walletID,
+                _signatureVerificationKey(b, payload),
                 context.sighash,
                 payload.witnessSignature
             ),
@@ -500,6 +500,47 @@ contract P2TRSignatureFraudRouter {
             b.spentMainUTXOs(utxoKey) ||
             b.movedFundsSweepRequests(utxoKey).state ==
             MovingFunds.MovedFundsSweepRequestState.Processed;
+    }
+
+    /// @dev Deposit inputs verify against their tweaked output key only after
+    ///      it is bound to the registered wallet by reveal-time Bridge state.
+    ///      All other wallet inputs continue to verify against the wallet ID.
+    function _signatureVerificationKey(
+        IBridgeForP2TRFraud b,
+        CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload
+            memory payload
+    ) internal view returns (bytes32) {
+        bytes32 depositKeyCommitment = b
+            .deposits(_signedInputUtxoKey(payload))
+            .taprootOutputKeyCommitment;
+
+        if (depositKeyCommitment == bytes32(0)) {
+            return payload.walletID;
+        }
+
+        bytes memory scriptPubKey = payload
+            .prevouts[payload.signedInputIndex]
+            .scriptPubKey;
+        require(
+            scriptPubKey.length == 34 &&
+                scriptPubKey[0] == 0x51 &&
+                scriptPubKey[1] == 0x20,
+            "Taproot deposit prevout must be P2TR"
+        );
+
+        bytes32 outputKey;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            outputKey := mload(add(scriptPubKey, 34))
+        }
+
+        require(
+            Deposit.taprootOutputKeyCommitment(payload.walletID, outputKey) ==
+                depositKeyCommitment,
+            "Taproot deposit key mismatch"
+        );
+
+        return outputKey;
     }
 
     function _payloadBounds()

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -46,6 +46,11 @@ interface IBridgeForP2TRFraud {
         view
         returns (Deposit.DepositRequest memory);
 
+    function taprootDepositOutputKeyCommitment(uint256 depositKey)
+        external
+        view
+        returns (bytes32);
+
     function spentMainUTXOs(uint256 utxoKey) external view returns (bool);
 
     function movedFundsSweepRequests(uint256 requestKey)
@@ -510,9 +515,9 @@ contract P2TRSignatureFraudRouter {
         CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload
             memory payload
     ) internal view returns (bytes32) {
-        bytes32 depositKeyCommitment = b
-            .deposits(_signedInputUtxoKey(payload))
-            .taprootOutputKeyCommitment;
+        bytes32 depositKeyCommitment = b.taprootDepositOutputKeyCommitment(
+            _signedInputUtxoKey(payload)
+        );
 
         if (depositKeyCommitment == bytes32(0)) {
             return payload.walletID;

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -508,8 +508,12 @@ contract P2TRSignatureFraudRouter {
     }
 
     /// @dev Deposit inputs verify against their tweaked output key only after
-    ///      it is bound to the registered wallet by reveal-time Bridge state.
-    ///      All other wallet inputs continue to verify against the wallet ID.
+    ///      a successful reveal on a commitment-capable Bridge binds that key
+    ///      to the registered wallet. A zero commitment falls back to the base
+    ///      wallet ID, so a deposit-specific signature is not challengeable
+    ///      through this router before that binding exists. Reveals predating
+    ///      the commitment storage are not backfilled automatically. All other
+    ///      wallet inputs continue to verify against the wallet ID.
     function _signatureVerificationKey(
         IBridgeForP2TRFraud b,
         CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -25,6 +25,18 @@ contract BridgeStub is Bridge {
         }
     }
 
+    function setTaprootDepositOutputKeyCommitment(
+        BitcoinTx.UTXO calldata utxo,
+        bytes32 walletID,
+        bytes32 outputKey
+    ) external {
+        uint256 utxoKey = uint256(
+            keccak256(abi.encodePacked(utxo.txHash, utxo.txOutputIndex))
+        );
+        self.deposits[utxoKey].taprootOutputKeyCommitment = Deposit
+            .taprootOutputKeyCommitment(walletID, outputKey);
+    }
+
     function setSpentMainUtxos(BitcoinTx.UTXO[] calldata utxos) external {
         for (uint256 i = 0; i < utxos.length; i++) {
             uint256 utxoKey = uint256(

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -33,7 +33,7 @@ contract BridgeStub is Bridge {
         uint256 utxoKey = uint256(
             keccak256(abi.encodePacked(utxo.txHash, utxo.txOutputIndex))
         );
-        self.deposits[utxoKey].taprootOutputKeyCommitment = Deposit
+        self.taprootDepositOutputKeyCommitments[utxoKey] = Deposit
             .taprootOutputKeyCommitment(walletID, outputKey);
     }
 

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1334,6 +1334,33 @@ describe("Bridge - Deposit", () => {
           reveal.refundLocktime,
           reveal.vault
         )
+
+      const depositKey = BigNumber.from(
+        ethers.utils.keccak256(
+          ethers.utils.solidityPack(
+            ["bytes32", "uint32"],
+            [
+              await transactionHash(
+                revealTaprootDepositWithExtraDataFixture.P2TRFundingTx
+              ),
+              reveal.fundingOutputIndex,
+            ]
+          )
+        )
+      )
+      expect(
+        await bridge.taprootDepositOutputKeyCommitment(depositKey)
+      ).to.equal(
+        ethers.utils.keccak256(
+          ethers.utils.solidityPack(
+            ["bytes32", "bytes32"],
+            [
+              reveal.walletXOnlyPublicKey,
+              revealTaprootDepositWithExtraDataFixture.expectedOutputKey,
+            ]
+          )
+        )
+      )
     })
 
     it("should reject refund x-only key that does not match refund alias", async () => {

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1296,8 +1296,9 @@ describe("Bridge - Deposit", () => {
           )
         )
       )
-      const deposit = await bridge.deposits(depositKey)
-      expect(deposit.taprootOutputKeyCommitment).to.equal(
+      expect(
+        await bridge.taprootDepositOutputKeyCommitment(depositKey)
+      ).to.equal(
         ethers.utils.keccak256(
           ethers.utils.solidityPack(
             ["bytes32", "bytes32"],

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1287,6 +1287,24 @@ describe("Bridge - Deposit", () => {
           reveal.refundLocktime,
           reveal.vault
         )
+
+      const depositKey = BigNumber.from(
+        ethers.utils.keccak256(
+          ethers.utils.solidityPack(
+            ["bytes32", "uint32"],
+            [await transactionHash(P2TRFundingTx), reveal.fundingOutputIndex]
+          )
+        )
+      )
+      const deposit = await bridge.deposits(depositKey)
+      expect(deposit.taprootOutputKeyCommitment).to.equal(
+        ethers.utils.keccak256(
+          ethers.utils.solidityPack(
+            ["bytes32", "bytes32"],
+            [reveal.walletXOnlyPublicKey, expectedOutputKey]
+          )
+        )
+      )
     })
 
     it("should reveal a Taproot deposit with extra data", async () => {

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -293,6 +293,12 @@ describe("Bridge - P2TR signature fraud", () => {
   const multiInputVector = vectorCorpus.cases.find(
     ({ id }) => id === "bip341-keypath-sighash-default-multi-input-multi-output"
   )!
+  const distinctWalletVector = vectorCorpus.cases.find(
+    ({ walletIDHex }) => walletIDHex !== vector.walletIDHex
+  )
+  if (!distinctWalletVector) {
+    throw new Error("P2TR fraud vector corpus needs two distinct wallets")
+  }
 
   let thirdParty: SignerWithAddress
   let treasury: SignerWithAddress
@@ -409,6 +415,60 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(event.args.bridgeChallengeIdentity).to.equal(bridgeChallengeIdentity)
     expect(event.args.challengeKey).to.equal(challengeKey)
     expect(event.args.sighash).to.equal(hex(vector.expectedBip341SighashHex))
+  })
+
+  it("submits a deposit-spend challenge using the committed Taproot output key", async () => {
+    const payload = {
+      ...vectorPayload(vector),
+      walletID: hex(distinctWalletVector.walletIDHex),
+    }
+    await registerP2TRWallet(payload.walletID)
+
+    const signedPrevout = payload.prevouts[payload.signedInputIndex]
+    const outputKey = ethers.utils.hexDataSlice(signedPrevout.scriptPubKey, 2)
+    await bridge.setTaprootDepositOutputKeyCommitment(
+      signedInputUtxo(payload),
+      payload.walletID,
+      outputKey
+    )
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.emit(p2trFraudRouter, "P2TRSignatureFraudChallengeSubmitted")
+  })
+
+  it("rejects a deposit output key not committed to the registered wallet", async () => {
+    const payload = {
+      ...vectorPayload(vector),
+      walletID: hex(distinctWalletVector.walletIDHex),
+    }
+    await registerP2TRWallet(payload.walletID)
+
+    const signedPrevout = payload.prevouts[payload.signedInputIndex]
+    const outputKey = ethers.utils.hexDataSlice(signedPrevout.scriptPubKey, 2)
+    await bridge.setTaprootDepositOutputKeyCommitment(
+      signedInputUtxo(payload),
+      hex(vector.walletIDHex),
+      outputKey
+    )
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Taproot deposit key mismatch")
   })
 
   it("submits a bounded multi-input multi-output P2TR signature-fraud challenge", async () => {

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -422,7 +422,7 @@ describe("Bridge - P2TR signature fraud", () => {
       ...vectorPayload(vector),
       walletID: hex(distinctWalletVector.walletIDHex),
     }
-    await registerP2TRWallet(payload.walletID)
+    const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
 
     const signedPrevout = payload.prevouts[payload.signedInputIndex]
     const outputKey = ethers.utils.hexDataSlice(signedPrevout.scriptPubKey, 2)
@@ -432,19 +432,25 @@ describe("Bridge - P2TR signature fraud", () => {
       outputKey
     )
 
-    await expect(
-      p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Submit,
-          encodePayload(payload),
-          [],
-          { value: fraudChallengeDepositAmount }
-        )
-    ).to.emit(p2trFraudRouter, "P2TRSignatureFraudChallengeSubmitted")
+    const tx = await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Submit,
+        encodePayload(payload),
+        [],
+        { value: fraudChallengeDepositAmount }
+      )
+
+    const event = await findP2TREvent(
+      tx,
+      p2trFraudRouter.address,
+      "P2TRSignatureFraudChallengeSubmitted"
+    )
+    expect(event.args.walletID).to.equal(payload.walletID)
+    expect(event.args.walletPubKeyHash).to.equal(walletPubKeyHash)
   })
 
-  it("rejects a deposit output key not committed to the registered wallet", async () => {
+  it("rejects a deposit output key committed to a different registered wallet", async () => {
     const payload = {
       ...vectorPayload(vector),
       walletID: hex(distinctWalletVector.walletIDHex),
@@ -471,6 +477,90 @@ describe("Bridge - P2TR signature fraud", () => {
     ).to.be.revertedWith("Taproot deposit key mismatch")
   })
 
+  it("rejects a different deposit output key committed to the registered wallet", async () => {
+    const payload = {
+      ...vectorPayload(vector),
+      walletID: hex(distinctWalletVector.walletIDHex),
+    }
+    await registerP2TRWallet(payload.walletID)
+
+    const signedPrevout = payload.prevouts[payload.signedInputIndex]
+    const outputKey = ethers.utils.hexDataSlice(signedPrevout.scriptPubKey, 2)
+    await bridge.setTaprootDepositOutputKeyCommitment(
+      signedInputUtxo(payload),
+      payload.walletID,
+      mutateLastByte(outputKey)
+    )
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Taproot deposit key mismatch")
+  })
+
+  it("rejects a committed deposit whose signed prevout is not P2TR", async () => {
+    const basePayload = vectorPayload(vector)
+    const payload = {
+      ...basePayload,
+      walletID: hex(distinctWalletVector.walletIDHex),
+      prevouts: basePayload.prevouts.map((prevout, index) =>
+        index === basePayload.signedInputIndex
+          ? {
+              ...prevout,
+              scriptPubKey: `0x0014${"00".repeat(20)}`,
+            }
+          : prevout
+      ),
+    }
+    await registerP2TRWallet(payload.walletID)
+
+    const originalOutputKey = ethers.utils.hexDataSlice(
+      basePayload.prevouts[basePayload.signedInputIndex].scriptPubKey,
+      2
+    )
+    await bridge.setTaprootDepositOutputKeyCommitment(
+      signedInputUtxo(payload),
+      payload.walletID,
+      originalOutputKey
+    )
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Taproot deposit prevout must be P2TR")
+  })
+
+  it("cannot verify a deposit-specific signature before its commitment exists", async () => {
+    const payload = {
+      ...vectorPayload(vector),
+      walletID: hex(distinctWalletVector.walletIDHex),
+    }
+    await registerP2TRWallet(payload.walletID)
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Signature verification failure")
+  })
+
   it("submits a bounded multi-input multi-output P2TR signature-fraud challenge", async () => {
     const payload = vectorPayload(multiInputVector)
     const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
@@ -495,6 +585,38 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(event.args.sighash).to.equal(
       hex(multiInputVector.expectedBip341SighashHex)
     )
+  })
+
+  it("submits a multi-input deposit challenge using only the signed outpoint commitment", async () => {
+    const payload = {
+      ...vectorPayload(multiInputVector),
+      walletID: hex(distinctWalletVector.walletIDHex),
+    }
+    const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
+    const signedPrevout = payload.prevouts[payload.signedInputIndex]
+    const outputKey = ethers.utils.hexDataSlice(signedPrevout.scriptPubKey, 2)
+    await bridge.setTaprootDepositOutputKeyCommitment(
+      signedInputUtxo(payload),
+      payload.walletID,
+      outputKey
+    )
+
+    const tx = await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Submit,
+        encodePayload(payload),
+        [],
+        { value: fraudChallengeDepositAmount }
+      )
+
+    const event = await findP2TREvent(
+      tx,
+      p2trFraudRouter.address,
+      "P2TRSignatureFraudChallengeSubmitted"
+    )
+    expect(event.args.walletID).to.equal(payload.walletID)
+    expect(event.args.walletPubKeyHash).to.equal(walletPubKeyHash)
   })
 
   it("rejects duplicate P2TR signature-fraud challenges", async () => {

--- a/solidity/test/formal/Bridge.storage-layout.json
+++ b/solidity/test/formal/Bridge.storage-layout.json
@@ -37,10 +37,10 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_uint256)40_storage": {
+    "t_array(t_uint256)39_storage": {
       "encoding": "inplace",
-      "label": "uint256[40]",
-      "numberOfBytes": "1280",
+      "label": "uint256[39]",
+      "numberOfBytes": "1248",
       "base": "t_uint256"
     },
     "t_array(t_uint256)49_storage": {
@@ -134,6 +134,13 @@
       "key": "t_uint256",
       "value": "t_bool"
     },
+    "t_mapping(t_uint256,t_bytes32)": {
+      "encoding": "mapping",
+      "label": "mapping(uint256 => bytes32)",
+      "numberOfBytes": "32",
+      "key": "t_uint256",
+      "value": "t_bytes32"
+    },
     "t_mapping(t_uint256,t_struct(DepositRequest)_storage)": {
       "encoding": "mapping",
       "label": "mapping(uint256 => struct Deposit.DepositRequest)",
@@ -165,7 +172,7 @@
     "t_struct(DepositRequest)_storage": {
       "encoding": "inplace",
       "label": "struct Deposit.DepositRequest",
-      "numberOfBytes": "128",
+      "numberOfBytes": "96",
       "members": [
         {
           "label": "depositor",
@@ -207,12 +214,6 @@
           "label": "extraData",
           "offset": 0,
           "slot": "2",
-          "type": "t_bytes32"
-        },
-        {
-          "label": "taprootOutputKeyCommitment",
-          "offset": 0,
-          "slot": "3",
           "type": "t_bytes32"
         }
       ]
@@ -724,10 +725,16 @@
           "type": "t_bool"
         },
         {
-          "label": "__gap",
+          "label": "taprootDepositOutputKeyCommitments",
           "offset": 0,
           "slot": "38",
-          "type": "t_array(t_uint256)40_storage"
+          "type": "t_mapping(t_uint256,t_bytes32)"
+        },
+        {
+          "label": "__gap",
+          "offset": 0,
+          "slot": "39",
+          "type": "t_array(t_uint256)39_storage"
         }
       ]
     },

--- a/solidity/test/formal/Bridge.storage-layout.json
+++ b/solidity/test/formal/Bridge.storage-layout.json
@@ -165,7 +165,7 @@
     "t_struct(DepositRequest)_storage": {
       "encoding": "inplace",
       "label": "struct Deposit.DepositRequest",
-      "numberOfBytes": "96",
+      "numberOfBytes": "128",
       "members": [
         {
           "label": "depositor",
@@ -207,6 +207,12 @@
           "label": "extraData",
           "offset": 0,
           "slot": "2",
+          "type": "t_bytes32"
+        },
+        {
+          "label": "taprootOutputKeyCommitment",
+          "offset": 0,
+          "slot": "3",
           "type": "t_bytes32"
         }
       ]

--- a/solidity/test/formal/BridgeStorageLayout.test.ts
+++ b/solidity/test/formal/BridgeStorageLayout.test.ts
@@ -250,6 +250,10 @@ describe("Bridge storage layout invariant", () => {
     // which packs into the same slot right after `ecdsaRetired`'s byte
     // WITHOUT taking a new slot. No `__gap` decrement; the member+gap
     // total grows by 1 (106 → 107).
+    //
+    // Taproot deposit fraud verification appends the
+    // `taprootDepositOutputKeyCommitments` mapping in slot 38 and reduces
+    // `__gap` from 40 to 39. The explicit-member + gap total remains 107.
     const EXPECTED_RESERVED_TOTAL = 107
 
     const explicitMemberCount = selfType.members!.length - 1


### PR DESCRIPTION
## Summary

First PR in a three-part remediation stack on top of #971.

- persist a reveal-time commitment binding each Taproot deposit output key to its registered FROST wallet ID
- store commitments in a dedicated appended Bridge mapping, preserving the existing `DepositRequest` return tuple
- verify deposit-spend signatures against the tweaked output key while retaining base-key verification for main-wallet inputs
- reject mismatched outpoint, output-key, wallet, and non-P2TR-prevout bindings
- update the Bridge storage-layout fixture (`mapping` at slot 38, `__gap` 40 -> 39)

## Security invariant

A challenge may use a deposit-specific key only when the exact signed outpoint was revealed with `keccak256(walletID || outputKey)`; otherwise signature verification remains bound to the registered wallet ID.

## Accountability boundary

The commitment is written only by a successful reveal on a commitment-capable Bridge. A zero commitment therefore falls back to base-wallet verification, and pre-upgrade reveals are not backfilled automatically. The activation runbook now requires the upgraded Bridge before the first P2TR deposit and an audit of every still-unspent historical `TaprootDepositRevealed` outpoint; any missing commitment must be swept/refunded first or handled by an independently audited backfill.

The router and storage NatSpec document this boundary. Tests also pin the zero-commitment behavior because failed or publicly visible reveal calldata can disclose a deposit tweak without committing Bridge state.

## Validation

- focused P2TR fraud and Bridge deposit files: 185 passing
- adversarial coverage: distinct wrong output key, wrong wallet binding, non-P2TR prevout, zero commitment, committed multi-input attribution, and extra-data commitment
- WalletProposalValidator compatibility: 97 passing
- optimistic-minting compatibility: 99 passing
- Bridge storage-layout tests: 2 passing
- Solidity build, formal P2TR vectors, ESLint, Solhint, and Prettier: passed
- existing seven-field `DepositRequest` ABI preserved

## Stack

- Base: #971
- This PR: 1/3
- 2/3: #1013
- 3/3: #1014
