### PR TITLE
fix(typescript): safely gate Taproot proxy deposits

### DIFF
--- a/docs/frost-local-e2e-testnet-runbook.adoc
+++ b/docs/frost-local-e2e-testnet-runbook.adoc
@@ -23,6 +23,9 @@ Not validated by this run:
 * A full ECDSA-to-FROST upgrade from an existing ECDSA deployment state.
 * A public shared Ethereum testnet deployment.
 * Production governance batching.
+* Deposits routed through a depositor proxy or any cross-chain depositor. This
+  run used the direct L1 `revealTaprootDeposit` path and does not establish that
+  destination contracts or relayers preserve Taproot x-only reveal keys.
 
 == Required branches
 

--- a/docs/rfc/frost-migration/b1-implementation-plan.md
+++ b/docs/rfc/frost-migration/b1-implementation-plan.md
@@ -253,9 +253,31 @@ fails fast.
    nonzero `taprootDepositOutputKeyCommitment`. If any outstanding reveal lacks
    a commitment, delay activation until it is swept or refunded, or deploy an
    independently audited backfill mechanism first.
-7. No scheme flip is required in the canonical mirror: D-2.2
+7. Choose and verify the proxy/cross-chain deposit policy before the first
+   FROST wallet can become active. Direct L1 Taproot deposits can proceed, but
+   every proxy-based route MUST remain disabled unless it explicitly declares
+   end-to-end Taproot support. For each enabled destination, verify all of the
+   following before allowing the SDK to return a P2TR deposit address:
+
+   - the destination-chain depositor accepts and preserves
+     `walletXOnlyPublicKey` and `refundXOnlyPublicKey`;
+   - the L1 depositor accepts the Taproot reveal tuple and calls the Bridge's
+     Taproot reveal entry point;
+   - the relayer preserves both x-only keys across the complete route;
+   - the deployed contract artifacts and SDK adapters match those versions and
+     both adapters report `supportsTaprootDeposits() == true`; and
+   - a staging deposit has completed reveal, sweep, and minting through that
+     exact route.
+
+   Existing deployed cross-chain depositors expose legacy reveal tuples. Until
+   they and their relayers are upgraded, shipped SDK adapters MUST report the
+   capability as false and reject P2TR before constructing a receipt or handing
+   out a Bitcoin address. Activating FROST therefore temporarily disables those
+   cross-chain deposit routes; it must never silently fall back to P2WSH.
+
+8. No scheme flip is required in the canonical mirror: D-2.2
    slice 3 removed the scheme setter and `Bridge.requestNewWallet`
-   dispatches only to the FROST registry. With steps 1-6 complete,
+   dispatches only to the FROST registry. With steps 1-7 complete,
    the call succeeds and DKG starts.
 
 Skipping step 5 strands every newly-created FROST wallet — the

--- a/docs/rfc/frost-migration/c1-companion-services-plan.md
+++ b/docs/rfc/frost-migration/c1-companion-services-plan.md
@@ -17,14 +17,14 @@ preference + counter).
 C-1 is **not a single PR**. It is a fan-out of independent updates
 to downstream repositories:
 
-| Sub-phase | Repo / path                                 | Scope                                                                                                         |
-| --------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| C-1.1     | `data/tbtc-subgraph/`                       | Bridge ABI refresh; new sidecar datasources; schema additions; mapping handlers                               |
-| C-1.2     | `data/v3-indexer/`                          | Mirror of C-1.1's contract-surface deltas; whatever ingestion path the v3 indexer uses                        |
-| C-1.3     | `services/p2tr-signature-fraud-watchtower/` | Already prepared in #435 (duck-typed contract reference); production wiring to router address at deploy time  |
-| C-1.4     | `services/crosschain-relayer/`              | Wallet-aware fields for FROST scheme + new event types                                                        |
-| C-1.5     | `services/backend/src/interfaces/Bridge.ts` | If it references fraud entry points, retarget to the routers                                                  |
-| C-1.6     | `sdk/tbtc-v2-ts/`                           | Type rename `...BridgeChallengeContract` → `...RouterContract` (queued for follow-up breaking-change release) |
+| Sub-phase | Repo / path                                                      | Scope                                                                                                                                   |
+| --------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| C-1.1     | `data/tbtc-subgraph/`                                            | Bridge ABI refresh; new sidecar datasources; schema additions; mapping handlers                                                         |
+| C-1.2     | `data/v3-indexer/`                                               | Mirror of C-1.1's contract-surface deltas; whatever ingestion path the v3 indexer uses                                                  |
+| C-1.3     | `services/p2tr-signature-fraud-watchtower/`                      | Already prepared in #435 (duck-typed contract reference); production wiring to router address at deploy time                            |
+| C-1.4     | `services/crosschain-relayer/` + cross-chain depositor contracts | Preserve Taproot reveal x-only keys end to end; deploy matching destination/L1 contracts and relayer before enabling the SDK capability |
+| C-1.5     | `services/backend/src/interfaces/Bridge.ts`                      | If it references fraud entry points, retarget to the routers                                                                            |
+| C-1.6     | `sdk/tbtc-v2-ts/`                                                | Type rename `...BridgeChallengeContract` → `...RouterContract` (queued for follow-up breaking-change release)                           |
 
 The sub-phases are **independent**. Each can ship on its own
 timeline subject to its own deploy/release cadence; they share no
@@ -188,7 +188,13 @@ Recommended cutover sequence for C-1 work:
 - [ ] (External) Contract upgrade deployed on Sepolia → mainnet.
 - [ ] (External) Sidecar contract addresses captured into the
       deployment record.
-- [ ] C-1.4: crosschain-relayer scheme awareness.
+- [ ] C-1.4: cross-chain Taproot reveal support. Upgrade each destination
+      depositor event/payload, the corresponding L1 depositor reveal tuple,
+      and the relayer so `walletXOnlyPublicKey` and
+      `refundXOnlyPublicKey` reach the Bridge's Taproot reveal entry point.
+      Update deployment artifacts and enable the SDK adapter capability only
+      after an end-to-end staging reveal, sweep, and mint succeeds. Until then,
+      the SDK must reject P2TR before returning a deposit address.
 - [ ] C-1.5: backend Bridge interface retargeting (if needed).
 - [ ] C-1.6: SDK type rename, fold into the next breaking-change SDK
       release.
@@ -205,10 +211,10 @@ Recommended cutover sequence for C-1 work:
    for downstream queries that don't want to handle nulls but
    requires a one-time grafting / re-sync; nullable preserves
    indexer compatibility at the cost of consumer complexity.
-3. **Does the crosschain-relayer need scheme-aware logic?** The relayer
-   forwards Bridge state to L2s. If the L2 representation of a
-   wallet doesn't distinguish scheme, no relayer change is needed.
-   Audit required.
+3. **Which destination is upgraded first for cross-chain Taproot deposits?**
+   The relayer and both destination/L1 depositor contracts require explicit
+   Taproot reveal support. All legacy routes remain disabled until a destination
+   completes the C-1.4 readiness checklist.
 
 ## Out of scope for C-1
 

--- a/system-tests/FROST_TESTNET4_E2E.md
+++ b/system-tests/FROST_TESTNET4_E2E.md
@@ -11,6 +11,12 @@ It is the reference/runbook for `test/frost-testnet4-lifecycle.test.ts` (a
 gated, full-stack e2e template). Every step below was executed and verified once
 end-to-end; the resulting Bitcoin/Ethereum artifacts are quoted as evidence.
 
+This runbook validates a direct L1 Taproot deposit. It does not validate a
+depositor proxy or cross-chain route. A destination route is not Taproot-ready
+until its destination depositor, L1 depositor, relayer, and SDK adapters all
+preserve both x-only reveal keys and a deposit completes reveal, sweep, and mint
+through that exact deployed path.
+
 ## Why testnet4 (and why the Ethereum side stays local)
 
 The Bridge validates SPV proofs against real Bitcoin proof-of-work

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -109,6 +109,7 @@
 - [StarkNetTBTCTokenConfig](interfaces/StarkNetTBTCTokenConfig.md)
 - [TBTCToken](interfaces/TBTCToken.md)
 - [TBTCVault](interfaces/TBTCVault.md)
+- [TaprootDepositorCapability](interfaces/TaprootDepositorCapability.md)
 - [ValidRedemptionWallet](interfaces/ValidRedemptionWallet.md)
 - [Wallet](interfaces/Wallet.md)
 - [WalletRegistry](interfaces/WalletRegistry.md)
@@ -270,6 +271,7 @@
 - [amountToSatoshi](README.md#amounttosatoshi)
 - [applyP2TRWatchtowerChallengeEvent](README.md#applyp2trwatchtowerchallengeevent)
 - [assembleBitcoinSpvProof](README.md#assemblebitcoinspvproof)
+- [assertTaprootDepositSupported](README.md#asserttaprootdepositsupported)
 - [backoffRetrier](README.md#backoffretrier)
 - [buildP2TRSignatureFraudBridgeChallengePayload](README.md#buildp2trsignaturefraudbridgechallengepayload)
 - [chainIdFromSigner](README.md#chainidfromsigner)
@@ -318,6 +320,7 @@
 - [skipRetryWhenMatched](README.md#skipretrywhenmatched)
 - [stripWitnessesFromBitcoinRawTransaction](README.md#stripwitnessesfrombitcoinrawtransaction)
 - [summarizeP2TRWatchtowerChallengeRecords](README.md#summarizep2trwatchtowerchallengerecords)
+- [supportsTaprootDeposits](README.md#supportstaprootdeposits)
 - [toBitcoinJsLibNetwork](README.md#tobitcoinjslibnetwork)
 - [validateBitcoinHeadersChain](README.md#validatebitcoinheaderschain)
 - [validateBitcoinSpvProof](README.md#validatebitcoinspvproof)
@@ -385,7 +388,7 @@ Use CrossChainInterfaces instead
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:252](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L252)
+[src/lib/contracts/cross-chain.ts:253](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L253)
 
 ___
 
@@ -402,7 +405,7 @@ Mode of operation for the cross-chain depositor proxy:
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:21](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L21)
+[src/services/deposits/cross-chain.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L23)
 
 ___
 
@@ -416,7 +419,7 @@ Use ExtraDataEncoder instead
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L272)
+[src/lib/contracts/cross-chain.ts:273](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L273)
 
 ___
 
@@ -429,7 +432,7 @@ between TBTC L1 ledger chain and a specific supported destination chain.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:13](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L13)
+[src/lib/contracts/cross-chain.ts:14](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L14)
 
 ___
 
@@ -483,7 +486,7 @@ Aggregates destination chain-specific TBTC cross-chain contracts.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:19](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L19)
+[src/lib/contracts/cross-chain.ts:20](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L20)
 
 ___
 
@@ -624,7 +627,7 @@ specific to the given L2 chain, deployed on the L1 chain.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L163)
+[src/lib/contracts/cross-chain.ts:164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L164)
 
 ___
 
@@ -643,7 +646,7 @@ Aggregates L1-specific TBTC cross-chain contracts.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L28)
+[src/lib/contracts/cross-chain.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L29)
 
 ___
 
@@ -657,7 +660,7 @@ Use BitcoinDepositor instead
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:267](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L267)
+[src/lib/contracts/cross-chain.ts:268](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L268)
 
 ___
 
@@ -685,7 +688,7 @@ Use DestinationChainInterfaces instead
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:257](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L257)
+[src/lib/contracts/cross-chain.ts:258](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L258)
 
 ___
 
@@ -699,7 +702,7 @@ Use DestinationChainTBTCToken instead
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L262)
+[src/lib/contracts/cross-chain.ts:263](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L263)
 
 ___
 
@@ -1893,7 +1896,7 @@ Use StarkNetBitcoinDepositorConfig instead
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L67)
+[src/lib/starknet/starknet-depositor.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L68)
 
 ___
 
@@ -1970,7 +1973,7 @@ Use ArbitrumExtraDataEncoder instead
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:159](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L159)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:170](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L170)
 
 ___
 
@@ -1984,7 +1987,7 @@ Use ArbitrumBitcoinDepositor instead
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L154)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L165)
 
 ___
 
@@ -2012,7 +2015,7 @@ Use BaseBitcoinDepositor instead
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:124](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L124)
+[src/lib/base/l2-bitcoin-depositor.ts:135](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L135)
 
 ___
 
@@ -2279,7 +2282,7 @@ Use EthereumExtraDataEncoder instead
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:221](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L221)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:232](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L232)
 
 ___
 
@@ -2545,7 +2548,7 @@ Use StarkNetBitcoinDepositor instead
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:527](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L527)
+[src/lib/starknet/starknet-depositor.ts:538](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L538)
 
 ___
 
@@ -2665,6 +2668,30 @@ Bitcoin transaction along with the inclusion proof.
 #### Defined in
 
 [src/lib/bitcoin/spv.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/bitcoin/spv.ts#L75)
+
+___
+
+### assertTaprootDepositSupported
+
+▸ **assertTaprootDepositSupported**(`depositor`, `deposit`): `void`
+
+Rejects a Taproot receipt when the target deposit handler has not explicitly
+declared end-to-end Taproot support.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `depositor` | [`TaprootDepositorCapability`](interfaces/TaprootDepositorCapability.md) | Deposit handler whose capability should be checked. |
+| `deposit` | [`DepositReceipt`](interfaces/DepositReceipt.md) | Deposit receipt about to be revealed. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/lib/contracts/depositor-proxy.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L38)
 
 ___
 
@@ -3953,6 +3980,31 @@ ___
 #### Defined in
 
 [src/services/maintenance/p2tr-signature-fraud.ts:1413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1413)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(`depositor`): `boolean`
+
+Checks whether a deposit handler explicitly supports Taproot deposits.
+Missing capability declarations fail closed for backward compatibility.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `depositor` | [`TaprootDepositorCapability`](interfaces/TaprootDepositorCapability.md) | Deposit handler whose capability should be checked. |
+
+#### Returns
+
+`boolean`
+
+True only when Taproot support is explicitly declared.
+
+#### Defined in
+
+[src/lib/contracts/depositor-proxy.ts:25](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L25)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -454,7 +454,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L31)
+[src/services/deposits/deposit.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L32)
 
 ___
 
@@ -464,9 +464,9 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:22](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L22)
+[src/services/deposits/deposit.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L23)
 
-[src/services/deposits/deposit.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L28)
+[src/services/deposits/deposit.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L29)
 
 ___
 
@@ -2266,9 +2266,9 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:22](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L22)
+[src/services/deposits/deposit.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L23)
 
-[src/services/deposits/deposit.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L28)
+[src/services/deposits/deposit.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L29)
 
 ___
 

--- a/typescript/api-reference/classes/ArbitrumBitcoinDepositor.md
+++ b/typescript/api-reference/classes/ArbitrumBitcoinDepositor.md
@@ -39,6 +39,7 @@ for reference.
 - [getEvents](ArbitrumBitcoinDepositor.md#getevents)
 - [initializeDeposit](ArbitrumBitcoinDepositor.md#initializedeposit)
 - [setDepositOwner](ArbitrumBitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](ArbitrumBitcoinDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -63,7 +64,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L33)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L34)
 
 ## Properties
 
@@ -73,7 +74,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L31)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L32)
 
 ___
 
@@ -83,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L30)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L31)
 
 ___
 
@@ -153,7 +154,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L80)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L81)
 
 ___
 
@@ -195,7 +196,7 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L56)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:57](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L57)
 
 ___
 
@@ -215,7 +216,7 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:64](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L64)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L65)
 
 ___
 
@@ -278,7 +279,7 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:88](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L88)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:97](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L97)
 
 ___
 
@@ -304,4 +305,26 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:72](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L72)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:73](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L73)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+False because the deployed contract uses the legacy reveal tuple.
+
+**`See`**
+
+#### Implementation of
+
+[BitcoinDepositor](../interfaces/BitcoinDepositor.md).[supportsTaprootDeposits](../interfaces/BitcoinDepositor.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L89)

--- a/typescript/api-reference/classes/ArbitrumExtraDataEncoder.md
+++ b/typescript/api-reference/classes/ArbitrumExtraDataEncoder.md
@@ -55,7 +55,7 @@ for reference.
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:142](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L142)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L153)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[src/lib/arbitrum/l2-bitcoin-depositor.ts:128](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L128)
+[src/lib/arbitrum/l2-bitcoin-depositor.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts#L139)

--- a/typescript/api-reference/classes/BaseBitcoinDepositor.md
+++ b/typescript/api-reference/classes/BaseBitcoinDepositor.md
@@ -39,6 +39,7 @@ for reference.
 - [getEvents](BaseBitcoinDepositor.md#getevents)
 - [initializeDeposit](BaseBitcoinDepositor.md#initializedeposit)
 - [setDepositOwner](BaseBitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](BaseBitcoinDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -63,7 +64,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L34)
+[src/lib/base/l2-bitcoin-depositor.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L35)
 
 ## Properties
 
@@ -73,7 +74,7 @@ EthersContractHandle\&lt;L2BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L32)
+[src/lib/base/l2-bitcoin-depositor.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L33)
 
 ___
 
@@ -83,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L31)
+[src/lib/base/l2-bitcoin-depositor.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L32)
 
 ___
 
@@ -153,7 +154,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L81)
+[src/lib/base/l2-bitcoin-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L82)
 
 ___
 
@@ -195,7 +196,7 @@ ___
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:57](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L57)
+[src/lib/base/l2-bitcoin-depositor.ts:58](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L58)
 
 ___
 
@@ -215,7 +216,7 @@ ___
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L65)
+[src/lib/base/l2-bitcoin-depositor.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L66)
 
 ___
 
@@ -278,7 +279,7 @@ ___
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L89)
+[src/lib/base/l2-bitcoin-depositor.ts:98](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L98)
 
 ___
 
@@ -304,4 +305,26 @@ ___
 
 #### Defined in
 
-[src/lib/base/l2-bitcoin-depositor.ts:73](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L73)
+[src/lib/base/l2-bitcoin-depositor.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L74)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+False because the deployed contract uses the legacy reveal tuple.
+
+**`See`**
+
+#### Implementation of
+
+[BitcoinDepositor](../interfaces/BitcoinDepositor.md).[supportsTaprootDeposits](../interfaces/BitcoinDepositor.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/base/l2-bitcoin-depositor.ts:90](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/base/l2-bitcoin-depositor.ts#L90)

--- a/typescript/api-reference/classes/CrossChainDepositor.md
+++ b/typescript/api-reference/classes/CrossChainDepositor.md
@@ -29,6 +29,7 @@ for reference.
 - [extraData](CrossChainDepositor.md#extradata)
 - [getChainIdentifier](CrossChainDepositor.md#getchainidentifier)
 - [revealDeposit](CrossChainDepositor.md#revealdeposit)
+- [supportsTaprootDeposits](CrossChainDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -49,7 +50,7 @@ for reference.
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L33)
+[src/services/deposits/cross-chain.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L35)
 
 ## Properties
 
@@ -59,7 +60,7 @@ for reference.
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L30)
+[src/services/deposits/cross-chain.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L32)
 
 ___
 
@@ -69,7 +70,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L31)
+[src/services/deposits/cross-chain.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L33)
 
 ## Methods
 
@@ -83,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L74)
+[src/services/deposits/cross-chain.ts:98](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L98)
 
 ___
 
@@ -107,7 +108,7 @@ Throws if the destination chain deposit owner cannot be resolved. This
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:63](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L63)
+[src/services/deposits/cross-chain.ts:87](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L87)
 
 ___
 
@@ -135,7 +136,7 @@ The chain-specific identifier of the contract that will be
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L51)
+[src/services/deposits/cross-chain.ts:53](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L53)
 
 ___
 
@@ -169,4 +170,27 @@ Reveals the given deposit depending on the reveal mode.
 
 #### Defined in
 
-[src/services/deposits/cross-chain.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L89)
+[src/services/deposits/cross-chain.ts:113](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L113)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+True when every depositor used by the selected reveal mode
+         explicitly supports Taproot deposits end to end.
+
+**`See`**
+
+#### Implementation of
+
+[DepositorProxy](../interfaces/DepositorProxy.md).[supportsTaprootDeposits](../interfaces/DepositorProxy.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/services/deposits/cross-chain.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/cross-chain.ts#L62)

--- a/typescript/api-reference/classes/Deposit.md
+++ b/typescript/api-reference/classes/Deposit.md
@@ -49,7 +49,7 @@ This component tries to abstract away that complexity.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L66)
+[src/services/deposits/deposit.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L67)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:55](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L55)
+[src/services/deposits/deposit.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L56)
 
 ___
 
@@ -74,7 +74,7 @@ generated deposit address.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:64](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L64)
+[src/services/deposits/deposit.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L65)
 
 ___
 
@@ -86,7 +86,7 @@ Optional depositor proxy used to initiate minting.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L59)
+[src/services/deposits/deposit.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L60)
 
 ___
 
@@ -98,7 +98,7 @@ Bitcoin script corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L47)
+[src/services/deposits/deposit.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L48)
 
 ___
 
@@ -110,7 +110,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L51)
+[src/services/deposits/deposit.ts:52](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L52)
 
 ## Methods
 
@@ -131,7 +131,7 @@ Specific UTXOs targeting this deposit. Empty array in case
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:121](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L121)
+[src/services/deposits/deposit.ts:122](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L122)
 
 ___
 
@@ -147,7 +147,7 @@ Bitcoin address corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:110](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L110)
+[src/services/deposits/deposit.ts:111](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L111)
 
 ___
 
@@ -163,7 +163,7 @@ Receipt corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L103)
+[src/services/deposits/deposit.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L104)
 
 ___
 
@@ -205,9 +205,14 @@ Throws an error if the provided funding outpoint does not
 Throws an error if the funding outpoint was already used to
         initiate minting (both modes).
 
+**`Throws`**
+
+Throws an error if a Taproot deposit uses a depositor proxy that
+        has not explicitly declared Taproot support.
+
 #### Defined in
 
-[src/services/deposits/deposit.ts:150](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L150)
+[src/services/deposits/deposit.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L153)
 
 ___
 
@@ -231,4 +236,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L81)
+[src/services/deposits/deposit.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L82)

--- a/typescript/api-reference/classes/DepositScript.md
+++ b/typescript/api-reference/classes/DepositScript.md
@@ -49,7 +49,7 @@ by the target wallet during the deposit sweep process.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:217](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L217)
+[src/services/deposits/deposit.ts:226](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L226)
 
 ## Properties
 
@@ -62,7 +62,7 @@ and allowing to build a unique deposit script (and address) on Bitcoin chain.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:206](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L206)
+[src/services/deposits/deposit.ts:215](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L215)
 
 ___
 
@@ -74,7 +74,7 @@ Deposit script/address type.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:215](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L215)
+[src/services/deposits/deposit.ts:224](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L224)
 
 ___
 
@@ -87,7 +87,7 @@ should be a witness P2WSH one. If false, legacy P2SH will be used instead.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:211](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L211)
+[src/services/deposits/deposit.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L220)
 
 ## Methods
 
@@ -111,7 +111,7 @@ Bitcoin address corresponding to this deposit script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:366](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L366)
+[src/services/deposits/deposit.ts:375](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L375)
 
 ___
 
@@ -136,7 +136,7 @@ Output script not prepended with length.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L409)
+[src/services/deposits/deposit.ts:418](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L418)
 
 ___
 
@@ -152,7 +152,7 @@ Hashed deposit script as Buffer.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:246](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L246)
+[src/services/deposits/deposit.ts:255](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L255)
 
 ___
 
@@ -168,7 +168,7 @@ Plain-text deposit script as a hex string.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L262)
+[src/services/deposits/deposit.ts:271](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L271)
 
 ___
 
@@ -184,7 +184,7 @@ TapLeaf hash of the Taproot refund script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:335](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L335)
+[src/services/deposits/deposit.ts:344](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L344)
 
 ___
 
@@ -200,7 +200,7 @@ Taproot merkle root for this deposit's script tree.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:342](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L342)
+[src/services/deposits/deposit.ts:351](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L351)
 
 ___
 
@@ -216,7 +216,7 @@ X-only Taproot output key committing to the refund script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:349](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L349)
+[src/services/deposits/deposit.ts:358](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L358)
 
 ___
 
@@ -232,7 +232,7 @@ Tapscript refund leaf for a Taproot-native deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:304](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L304)
+[src/services/deposits/deposit.ts:313](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L313)
 
 ___
 
@@ -253,4 +253,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:236](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L236)
+[src/services/deposits/deposit.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L245)

--- a/typescript/api-reference/classes/DepositsService.md
+++ b/typescript/api-reference/classes/DepositsService.md
@@ -46,7 +46,7 @@ Service exposing features related to tBTC v2 deposits.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:53](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L53)
+[src/services/deposits/deposits-service.ts:54](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L54)
 
 ## Properties
 
@@ -72,7 +72,7 @@ Gets cross-chain contracts for the given supported L2 chain.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:49](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L49)
+[src/services/deposits/deposits-service.ts:50](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L50)
 
 ___
 
@@ -85,7 +85,7 @@ initiated by this service.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L42)
+[src/services/deposits/deposits-service.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L43)
 
 ___
 
@@ -97,7 +97,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:37](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L37)
+[src/services/deposits/deposits-service.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L38)
 
 ___
 
@@ -110,7 +110,7 @@ This is 9 month in seconds assuming 1 month = 30 days
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L29)
+[src/services/deposits/deposits-service.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L30)
 
 ___
 
@@ -122,7 +122,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L33)
+[src/services/deposits/deposits-service.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L34)
 
 ## Methods
 
@@ -145,7 +145,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L256)
+[src/services/deposits/deposits-service.ts:277](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L277)
 
 ___
 
@@ -186,6 +186,8 @@ Throws an error if one of the following occurs:
           deposit script type
         - The cross-chain contracts for the given L2 chain are not
           initialized
+        - The destination-chain or L1 depositor does not explicitly
+          support Taproot deposits end to end
         - The L2 deposit owner cannot be resolved. This typically
           happens if the L2 cross-chain contracts operate with a
           read-only signer whose address cannot be resolved.
@@ -201,7 +203,7 @@ This is actually a call to initiateDepositWithProxy with a built-in
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L234)
+[src/services/deposits/deposits-service.ts:246](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L246)
 
 ___
 
@@ -235,7 +237,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:95](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L95)
+[src/services/deposits/deposits-service.ts:96](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L96)
 
 ___
 
@@ -274,12 +276,14 @@ Throws an error if one of the following occurs:
         - There are no active wallet in the Bridge contract
         - The Bitcoin recovery address does not match the requested
           deposit script type
+        - A Taproot deposit is requested through a depositor proxy that
+          does not explicitly support Taproot deposits end to end
         - The optional extra data is set but is not 32-byte or equals
           to 32 zero bytes.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L179)
+[src/services/deposits/deposits-service.ts:182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L182)
 
 ___
 
@@ -313,7 +317,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:129](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L129)
+[src/services/deposits/deposits-service.ts:130](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L130)
 
 ___
 
@@ -337,7 +341,7 @@ once the loader is ready.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L74)
+[src/services/deposits/deposits-service.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L75)
 
 ___
 
@@ -366,4 +370,4 @@ Typically, there is no need to use this method when DepositsService
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:376](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L376)
+[src/services/deposits/deposits-service.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L397)

--- a/typescript/api-reference/classes/DepositsService.md
+++ b/typescript/api-reference/classes/DepositsService.md
@@ -145,13 +145,13 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:244](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L244)
+[src/services/deposits/deposits-service.ts:256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L256)
 
 ___
 
 ### initiateCrossChainDeposit
 
-▸ **initiateCrossChainDeposit**(`bitcoinRecoveryAddress`, `destinationChainName`): `Promise`\<[`Deposit`](Deposit.md)\>
+▸ **initiateCrossChainDeposit**(`bitcoinRecoveryAddress`, `destinationChainName`, `scriptType?`): `Promise`\<[`Deposit`](Deposit.md)\>
 
 Initiates the tBTC v2 cross-chain deposit process. A cross-chain deposit
 is a deposit that targets an L2 chain other than the L1 chain the tBTC
@@ -166,10 +166,11 @@ must be initialized along with a L2 signer first.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `bitcoinRecoveryAddress` | `string` | P2PKH or P2WPKH Bitcoin address that can be used for emergency recovery of the deposited funds. |
-| `destinationChainName` | [`DestinationChainName`](../README.md#destinationchainname) | Name of the L2 chain the deposit is targeting. |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `bitcoinRecoveryAddress` | `string` | `undefined` | P2PKH or P2WPKH Bitcoin address for legacy deposits, or a P2TR Bitcoin address for Taproot deposits, that can be used for emergency recovery of the deposited funds. |
+| `destinationChainName` | [`DestinationChainName`](../README.md#destinationchainname) | `undefined` | Name of the L2 chain the deposit is targeting. |
+| `scriptType` | [`DepositScriptType`](../README.md#depositscripttype) | `DepositScriptType.P2WSH` | Type of the Bitcoin deposit script. Defaults to P2WSH for backward compatibility. |
 
 #### Returns
 
@@ -181,7 +182,8 @@ Handle to the initiated deposit process.
 
 Throws an error if one of the following occurs:
         - There are no active wallet in the Bridge contract
-        - The Bitcoin recovery address is not a valid P2(W)PKH
+        - The Bitcoin recovery address does not match the requested
+          deposit script type
         - The cross-chain contracts for the given L2 chain are not
           initialized
         - The L2 deposit owner cannot be resolved. This typically
@@ -199,7 +201,7 @@ This is actually a call to initiateDepositWithProxy with a built-in
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:224](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L224)
+[src/services/deposits/deposits-service.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L234)
 
 ___
 
@@ -239,7 +241,7 @@ ___
 
 ### initiateDepositWithProxy
 
-▸ **initiateDepositWithProxy**(`bitcoinRecoveryAddress`, `depositorProxy`, `extraData?`): `Promise`\<[`Deposit`](Deposit.md)\>
+▸ **initiateDepositWithProxy**(`bitcoinRecoveryAddress`, `depositorProxy`, `extraData?`, `scriptType?`): `Promise`\<[`Deposit`](Deposit.md)\>
 
 Initiates the tBTC v2 deposit process using a depositor proxy.
 The depositor proxy initiates minting on behalf of the user (i.e. original
@@ -249,11 +251,12 @@ to another protocols, in an automated way.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `bitcoinRecoveryAddress` | `string` | P2PKH or P2WPKH Bitcoin address that can be used for emergency recovery of the deposited funds. |
-| `depositorProxy` | [`DepositorProxy`](../interfaces/DepositorProxy.md) | Depositor proxy used to initiate the deposit. |
-| `extraData?` | [`Hex`](Hex.md) | Optional 32-byte extra data to be included in the deposit script. Cannot be equal to 32 zero bytes. |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `bitcoinRecoveryAddress` | `string` | `undefined` | P2PKH or P2WPKH Bitcoin address for legacy deposits, or a P2TR Bitcoin address for Taproot deposits, that can be used for emergency recovery of the deposited funds. |
+| `depositorProxy` | [`DepositorProxy`](../interfaces/DepositorProxy.md) | `undefined` | Depositor proxy used to initiate the deposit. |
+| `extraData?` | [`Hex`](Hex.md) | `undefined` | Optional 32-byte extra data to be included in the deposit script. Cannot be equal to 32 zero bytes. |
+| `scriptType` | [`DepositScriptType`](../README.md#depositscripttype) | `DepositScriptType.P2WSH` | Type of the Bitcoin deposit script. Defaults to P2WSH for backward compatibility. |
 
 #### Returns
 
@@ -269,13 +272,14 @@ DepositorProxy
 
 Throws an error if one of the following occurs:
         - There are no active wallet in the Bridge contract
-        - The Bitcoin recovery address is not a valid P2(W)PKH
+        - The Bitcoin recovery address does not match the requested
+          deposit script type
         - The optional extra data is set but is not 32-byte or equals
           to 32 zero bytes.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:175](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L175)
+[src/services/deposits/deposits-service.ts:179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L179)
 
 ___
 
@@ -362,4 +366,4 @@ Typically, there is no need to use this method when DepositsService
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:364](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L364)
+[src/services/deposits/deposits-service.ts:376](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L376)

--- a/typescript/api-reference/classes/EthereumDepositorProxy.md
+++ b/typescript/api-reference/classes/EthereumDepositorProxy.md
@@ -27,6 +27,7 @@ for reference.
 - [getChainIdentifier](EthereumDepositorProxy.md#getchainidentifier)
 - [packRevealDepositParameters](EthereumDepositorProxy.md#packrevealdepositparameters)
 - [revealDeposit](EthereumDepositorProxy.md#revealdeposit)
+- [supportsTaprootDeposits](EthereumDepositorProxy.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -122,7 +123,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/depositor-proxy.ts:44](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L44)
+[src/lib/ethereum/depositor-proxy.ts:54](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L54)
 
 ___
 
@@ -151,4 +152,29 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/depositor-proxy.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L62)
+[src/lib/ethereum/depositor-proxy.ts:72](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L72)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+Legacy Ethereum depositor proxies do not preserve the x-only keys required
+by Taproot deposit reveals. Capable subclasses must override this method.
+
+#### Returns
+
+`boolean`
+
+False by default.
+
+**`See`**
+
+#### Implementation of
+
+[DepositorProxy](../interfaces/DepositorProxy.md).[supportsTaprootDeposits](../interfaces/DepositorProxy.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/ethereum/depositor-proxy.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/depositor-proxy.ts#L38)

--- a/typescript/api-reference/classes/EthereumExtraDataEncoder.md
+++ b/typescript/api-reference/classes/EthereumExtraDataEncoder.md
@@ -55,7 +55,7 @@ for reference.
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:209](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L209)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L220)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L195)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:206](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L206)

--- a/typescript/api-reference/classes/EthereumL1BitcoinDepositor.md
+++ b/typescript/api-reference/classes/EthereumL1BitcoinDepositor.md
@@ -41,6 +41,7 @@ for reference.
 - [getEvents](EthereumL1BitcoinDepositor.md#getevents)
 - [initializeDeposit](EthereumL1BitcoinDepositor.md#initializedeposit)
 - [setDepositOwner](EthereumL1BitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](EthereumL1BitcoinDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -66,7 +67,7 @@ EthersContractHandle\&lt;L1BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L91)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L92)
 
 ## Properties
 
@@ -76,7 +77,7 @@ EthersContractHandle\&lt;L1BitcoinDepositorTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L89)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:90](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L90)
 
 ___
 
@@ -86,7 +87,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:88](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L88)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L89)
 
 ___
 
@@ -156,7 +157,7 @@ L1BitcoinDepositor.extraDataEncoder
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:147](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L147)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:148](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L148)
 
 ___
 
@@ -198,7 +199,7 @@ L1BitcoinDepositor.getChainIdentifier
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L139)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:140](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L140)
 
 ___
 
@@ -218,7 +219,7 @@ L1BitcoinDepositor.getDepositOwner
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:116](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L116)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:117](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L117)
 
 ___
 
@@ -244,7 +245,7 @@ L1BitcoinDepositor.getDepositState
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:132](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L132)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:133](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L133)
 
 ___
 
@@ -307,7 +308,7 @@ L1BitcoinDepositor.initializeDeposit
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L155)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L164)
 
 ___
 
@@ -333,4 +334,26 @@ L1BitcoinDepositor.setDepositOwner
 
 #### Defined in
 
-[src/lib/ethereum/l1-bitcoin-depositor.ts:124](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L124)
+[src/lib/ethereum/l1-bitcoin-depositor.ts:125](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L125)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+False because the deployed contract uses the legacy reveal tuple.
+
+**`See`**
+
+#### Implementation of
+
+L1BitcoinDepositor.supportsTaprootDeposits
+
+#### Defined in
+
+[src/lib/ethereum/l1-bitcoin-depositor.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts#L156)

--- a/typescript/api-reference/classes/SeiBitcoinDepositor.md
+++ b/typescript/api-reference/classes/SeiBitcoinDepositor.md
@@ -38,6 +38,7 @@ provider-aware interface for relayer integration.
 - [initializeDeposit](SeiBitcoinDepositor.md#initializedeposit)
 - [isRetryableError](SeiBitcoinDepositor.md#isretryableerror)
 - [setDepositOwner](SeiBitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](SeiBitcoinDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -65,7 +66,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:88](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L88)
+[src/lib/sei/sei-depositor.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L89)
 
 ## Properties
 
@@ -75,7 +76,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:77](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L77)
+[src/lib/sei/sei-depositor.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L78)
 
 ___
 
@@ -85,7 +86,7 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L76)
+[src/lib/sei/sei-depositor.ts:77](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L77)
 
 ___
 
@@ -95,7 +96,7 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L79)
+[src/lib/sei/sei-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L80)
 
 ___
 
@@ -105,7 +106,7 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L75)
+[src/lib/sei/sei-depositor.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L76)
 
 ___
 
@@ -115,7 +116,7 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L78)
+[src/lib/sei/sei-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L79)
 
 ## Methods
 
@@ -137,7 +138,7 @@ The SeiExtraDataEncoder instance.
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:192](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L192)
+[src/lib/sei/sei-depositor.ts:193](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L193)
 
 ___
 
@@ -161,7 +162,7 @@ Formatted error message
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:423](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L423)
+[src/lib/sei/sei-depositor.ts:434](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L434)
 
 ___
 
@@ -190,7 +191,7 @@ Error if the address is invalid
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:498](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L498)
+[src/lib/sei/sei-depositor.ts:509](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L509)
 
 ___
 
@@ -214,7 +215,7 @@ Always throws since Sei deposits are handled via L1.
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L152)
+[src/lib/sei/sei-depositor.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L153)
 
 ___
 
@@ -232,7 +233,7 @@ The chain name (e.g., "Sei")
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:135](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L135)
+[src/lib/sei/sei-depositor.ts:136](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L136)
 
 ___
 
@@ -254,7 +255,7 @@ The Sei address set as deposit owner, or undefined if not set.
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L163)
+[src/lib/sei/sei-depositor.ts:164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L164)
 
 ___
 
@@ -272,7 +273,7 @@ The Sei provider instance
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:143](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L143)
+[src/lib/sei/sei-depositor.ts:144](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L144)
 
 ___
 
@@ -311,7 +312,7 @@ Error if deposit owner not set or relayer returns unexpected response
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:211](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L211)
+[src/lib/sei/sei-depositor.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L220)
 
 ___
 
@@ -335,7 +336,7 @@ True if the error is retryable
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:395](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L395)
+[src/lib/sei/sei-depositor.ts:406](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L406)
 
 ___
 
@@ -365,4 +366,26 @@ Error if the deposit owner is not a SeiAddress and not undefined/null.
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:173](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L173)
+[src/lib/sei/sei-depositor.ts:174](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L174)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+False until the relayer and L1 depositor support Taproot reveals.
+
+**`See`**
+
+#### Implementation of
+
+[BitcoinDepositor](../interfaces/BitcoinDepositor.md).[supportsTaprootDeposits](../interfaces/BitcoinDepositor.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/sei/sei-depositor.ts:201](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L201)

--- a/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
+++ b/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
@@ -38,6 +38,7 @@ future L2 functionality and relayer integration.
 - [initializeDeposit](StarkNetBitcoinDepositor.md#initializedeposit)
 - [isRetryableError](StarkNetBitcoinDepositor.md#isretryableerror)
 - [setDepositOwner](StarkNetBitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](StarkNetBitcoinDepositor.md#supportstaprootdeposits)
 
 ## Constructors
 
@@ -65,7 +66,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L92)
+[src/lib/starknet/starknet-depositor.ts:93](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L93)
 
 ## Properties
 
@@ -75,7 +76,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
+[src/lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
 
 ___
 
@@ -85,7 +86,7 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
+[src/lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
 
 ___
 
@@ -95,7 +96,7 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:83](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L83)
+[src/lib/starknet/starknet-depositor.ts:84](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L84)
 
 ___
 
@@ -105,7 +106,7 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L79)
+[src/lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
 
 ___
 
@@ -115,7 +116,7 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
+[src/lib/starknet/starknet-depositor.ts:83](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L83)
 
 ## Methods
 
@@ -137,7 +138,7 @@ The StarkNetExtraDataEncoder instance.
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L195)
+[src/lib/starknet/starknet-depositor.ts:196](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L196)
 
 ___
 
@@ -161,7 +162,7 @@ Formatted error message
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:426](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L426)
+[src/lib/starknet/starknet-depositor.ts:437](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L437)
 
 ___
 
@@ -189,7 +190,7 @@ Error if the address is invalid
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L500)
+[src/lib/starknet/starknet-depositor.ts:511](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L511)
 
 ___
 
@@ -213,7 +214,7 @@ Always throws since StarkNet deposits are handled via L1.
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L155)
+[src/lib/starknet/starknet-depositor.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L156)
 
 ___
 
@@ -231,7 +232,7 @@ The chain name (e.g., "StarkNet")
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:138](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L138)
+[src/lib/starknet/starknet-depositor.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L139)
 
 ___
 
@@ -253,7 +254,7 @@ The StarkNet address set as deposit owner, or undefined if not set.
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:166](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L166)
+[src/lib/starknet/starknet-depositor.ts:167](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L167)
 
 ___
 
@@ -271,7 +272,7 @@ The StarkNet provider instance
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L146)
+[src/lib/starknet/starknet-depositor.ts:147](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L147)
 
 ___
 
@@ -310,7 +311,7 @@ Error if deposit owner not set or relayer returns unexpected response
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:214](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L214)
+[src/lib/starknet/starknet-depositor.ts:223](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L223)
 
 ___
 
@@ -334,7 +335,7 @@ True if the error is retryable
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:398](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L398)
+[src/lib/starknet/starknet-depositor.ts:409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L409)
 
 ___
 
@@ -364,4 +365,26 @@ Error if the deposit owner is not a StarkNetAddress and not undefined/null.
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L176)
+[src/lib/starknet/starknet-depositor.ts:177](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L177)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+False until the relayer and L1 depositor support Taproot reveals.
+
+**`See`**
+
+#### Implementation of
+
+[BitcoinDepositor](../interfaces/BitcoinDepositor.md).[supportsTaprootDeposits](../interfaces/BitcoinDepositor.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/starknet/starknet-depositor.ts:204](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L204)

--- a/typescript/api-reference/enums/DepositState.md
+++ b/typescript/api-reference/enums/DepositState.md
@@ -18,7 +18,7 @@ Represents the state of the deposit.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L156)
+[src/lib/contracts/cross-chain.ts:157](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L157)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L154)
+[src/lib/contracts/cross-chain.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L155)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L152)
+[src/lib/contracts/cross-chain.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L153)

--- a/typescript/api-reference/interfaces/BitcoinDepositor.md
+++ b/typescript/api-reference/interfaces/BitcoinDepositor.md
@@ -3,6 +3,12 @@
 Interface for communication with the BitcoinDepositor on-chain contract
 deployed on the given destination chain.
 
+## Hierarchy
+
+- [`TaprootDepositorCapability`](TaprootDepositorCapability.md)
+
+  ↳ **`BitcoinDepositor`**
+
 ## Implemented by
 
 - [`ArbitrumBitcoinDepositor`](../classes/ArbitrumBitcoinDepositor.md)
@@ -19,6 +25,7 @@ deployed on the given destination chain.
 - [getDepositOwner](BitcoinDepositor.md#getdepositowner)
 - [initializeDeposit](BitcoinDepositor.md#initializedeposit)
 - [setDepositOwner](BitcoinDepositor.md#setdepositowner)
+- [supportsTaprootDeposits](BitcoinDepositor.md#supportstaprootdeposits)
 
 ## Methods
 
@@ -35,7 +42,7 @@ encode and decode the extra data included in the cross-chain deposit script.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:99](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L99)
+[src/lib/contracts/cross-chain.ts:100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L100)
 
 ___
 
@@ -52,7 +59,7 @@ Optional method - may not be available for off-chain implementations.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L79)
+[src/lib/contracts/cross-chain.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L80)
 
 ___
 
@@ -71,7 +78,7 @@ The identifier of the deposit owner or undefined if not set.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:86](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L86)
+[src/lib/contracts/cross-chain.ts:87](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L87)
 
 ___
 
@@ -98,7 +105,7 @@ Transaction hash of the reveal deposit transaction or full transaction receipt.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:111](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L111)
+[src/lib/contracts/cross-chain.ts:112](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L112)
 
 ___
 
@@ -121,4 +128,25 @@ issued by this contract.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:93](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L93)
+[src/lib/contracts/cross-chain.ts:94](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L94)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+True only when the complete reveal path preserves both x-only
+         public keys required by a Taproot deposit.
+
+#### Inherited from
+
+[TaprootDepositorCapability](TaprootDepositorCapability.md).[supportsTaprootDeposits](TaprootDepositorCapability.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/contracts/depositor-proxy.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L16)

--- a/typescript/api-reference/interfaces/CrossChainContractsLoader.md
+++ b/typescript/api-reference/interfaces/CrossChainContractsLoader.md
@@ -29,7 +29,7 @@ Loads the chain mapping based on underlying L1 chain.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L42)
+[src/lib/contracts/cross-chain.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L43)
 
 ___
 
@@ -55,4 +55,4 @@ Loads L1-specific TBTC cross-chain contracts for the given destination chain.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L47)
+[src/lib/contracts/cross-chain.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L48)

--- a/typescript/api-reference/interfaces/DepositorProxy.md
+++ b/typescript/api-reference/interfaces/DepositorProxy.md
@@ -8,6 +8,12 @@ another protocols, in an automated way. Depositor proxy is responsible for
 attributing the deposit and minted TBTC tokens to the user (e.g. using the
 optional 32-byte extra data field of the deposit script).
 
+## Hierarchy
+
+- [`TaprootDepositorCapability`](TaprootDepositorCapability.md)
+
+  ↳ **`DepositorProxy`**
+
 ## Implemented by
 
 - [`CrossChainDepositor`](../classes/CrossChainDepositor.md)
@@ -19,6 +25,7 @@ optional 32-byte extra data field of the deposit script).
 
 - [getChainIdentifier](DepositorProxy.md#getchainidentifier)
 - [revealDeposit](DepositorProxy.md#revealdeposit)
+- [supportsTaprootDeposits](DepositorProxy.md#supportstaprootdeposits)
 
 ## Methods
 
@@ -34,7 +41,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[src/lib/contracts/depositor-proxy.ts:20](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L20)
+[src/lib/contracts/depositor-proxy.ts:64](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L64)
 
 ___
 
@@ -61,4 +68,25 @@ Transaction hash of the reveal deposit transaction.
 
 #### Defined in
 
-[src/lib/contracts/depositor-proxy.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L32)
+[src/lib/contracts/depositor-proxy.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L76)
+
+___
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+True only when the complete reveal path preserves both x-only
+         public keys required by a Taproot deposit.
+
+#### Inherited from
+
+[TaprootDepositorCapability](TaprootDepositorCapability.md).[supportsTaprootDeposits](TaprootDepositorCapability.md#supportstaprootdeposits)
+
+#### Defined in
+
+[src/lib/contracts/depositor-proxy.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L16)

--- a/typescript/api-reference/interfaces/DestinationChainTBTCToken.md
+++ b/typescript/api-reference/interfaces/DestinationChainTBTCToken.md
@@ -39,7 +39,7 @@ The balance of the given identifier in 1e18 precision.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L67)
+[src/lib/contracts/cross-chain.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L68)
 
 ___
 
@@ -55,4 +55,4 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L60)
+[src/lib/contracts/cross-chain.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L61)

--- a/typescript/api-reference/interfaces/ExtraDataEncoder.md
+++ b/typescript/api-reference/interfaces/ExtraDataEncoder.md
@@ -40,7 +40,7 @@ Identifier of the deposit owner.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L245)
+[src/lib/contracts/cross-chain.ts:246](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L246)
 
 ___
 
@@ -64,4 +64,4 @@ Encoded extra data.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:238](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L238)
+[src/lib/contracts/cross-chain.ts:239](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L239)

--- a/typescript/api-reference/interfaces/L1BitcoinRedeemer.md
+++ b/typescript/api-reference/interfaces/L1BitcoinRedeemer.md
@@ -28,7 +28,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:205](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L205)
+[src/lib/contracts/cross-chain.ts:206](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L206)
 
 ___
 
@@ -57,4 +57,4 @@ Transaction hash of the approve and call transaction.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:219](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L219)
+[src/lib/contracts/cross-chain.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L220)

--- a/typescript/api-reference/interfaces/L2BitcoinRedeemer.md
+++ b/typescript/api-reference/interfaces/L2BitcoinRedeemer.md
@@ -24,7 +24,7 @@ Gets the chain-specific identifier of this contract.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:127](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L127)
+[src/lib/contracts/cross-chain.ts:128](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L128)
 
 ___
 
@@ -53,4 +53,4 @@ Transaction hash of the approve and call transaction.
 
 #### Defined in
 
-[src/lib/contracts/cross-chain.ts:140](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L140)
+[src/lib/contracts/cross-chain.ts:141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/cross-chain.ts#L141)

--- a/typescript/api-reference/interfaces/SeiBitcoinDepositorConfig.md
+++ b/typescript/api-reference/interfaces/SeiBitcoinDepositorConfig.md
@@ -18,7 +18,7 @@ Configuration for SeiBitcoinDepositor
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L60)
+[src/lib/sei/sei-depositor.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L61)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L62)
+[src/lib/sei/sei-depositor.ts:63](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L63)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/lib/sei/sei-depositor.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L61)
+[src/lib/sei/sei-depositor.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/sei/sei-depositor.ts#L62)

--- a/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
+++ b/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
@@ -18,7 +18,7 @@ Configuration for StarkNetBitcoinDepositor
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L59)
+[src/lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L61)
+[src/lib/starknet/starknet-depositor.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L62)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
+[src/lib/starknet/starknet-depositor.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L61)

--- a/typescript/api-reference/interfaces/TaprootDepositorCapability.md
+++ b/typescript/api-reference/interfaces/TaprootDepositorCapability.md
@@ -1,0 +1,35 @@
+# Interface: TaprootDepositorCapability
+
+Optional capability exposed by deposit handlers that can safely reveal
+Taproot-native deposits end to end.
+
+## Hierarchy
+
+- **`TaprootDepositorCapability`**
+
+  ↳ [`BitcoinDepositor`](BitcoinDepositor.md)
+
+  ↳ [`DepositorProxy`](DepositorProxy.md)
+
+## Table of contents
+
+### Methods
+
+- [supportsTaprootDeposits](TaprootDepositorCapability.md#supportstaprootdeposits)
+
+## Methods
+
+### supportsTaprootDeposits
+
+▸ **supportsTaprootDeposits**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+True only when the complete reveal path preserves both x-only
+         public keys required by a Taproot deposit.
+
+#### Defined in
+
+[src/lib/contracts/depositor-proxy.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/depositor-proxy.ts#L16)

--- a/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts
+++ b/typescript/src/lib/arbitrum/l2-bitcoin-depositor.ts
@@ -10,6 +10,7 @@ import {
   ExtraDataEncoder,
   DepositReceipt,
   BitcoinDepositor,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { EthereumAddress, packRevealDepositParameters } from "../ethereum"
 import { Hex } from "../utils"
@@ -81,6 +82,14 @@ export class ArbitrumBitcoinDepositor
     return this.#extraDataEncoder
   }
 
+  /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False because the deployed contract uses the legacy reveal tuple.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {BitcoinDepositor#initializeDeposit}
@@ -91,6 +100,8 @@ export class ArbitrumBitcoinDepositor
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex | TransactionReceipt> {
+    assertTaprootDepositSupported(this, deposit)
+
     const { fundingTx, reveal } = packRevealDepositParameters(
       depositTx,
       depositOutputIndex,

--- a/typescript/src/lib/base/l2-bitcoin-depositor.ts
+++ b/typescript/src/lib/base/l2-bitcoin-depositor.ts
@@ -10,6 +10,7 @@ import {
   ExtraDataEncoder,
   DepositReceipt,
   BitcoinDepositor,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { EthereumAddress, packRevealDepositParameters } from "../ethereum"
 import { EthereumCrossChainExtraDataEncoder } from "../ethereum/l1-bitcoin-depositor"
@@ -82,6 +83,14 @@ export class BaseBitcoinDepositor
     return this.#extraDataEncoder
   }
 
+  /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False because the deployed contract uses the legacy reveal tuple.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {BitcoinDepositor#initializeDeposit}
@@ -92,6 +101,8 @@ export class BaseBitcoinDepositor
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex | TransactionReceipt> {
+    assertTaprootDepositSupported(this, deposit)
+
     const { fundingTx, reveal } = packRevealDepositParameters(
       depositTx,
       depositOutputIndex,

--- a/typescript/src/lib/contracts/cross-chain.ts
+++ b/typescript/src/lib/contracts/cross-chain.ts
@@ -5,6 +5,7 @@ import { ChainMapping, DestinationChainName } from "./chain"
 import { BitcoinRawTxVectors, BitcoinUtxo } from "../bitcoin"
 import { DepositReceipt } from "./bridge"
 import { Hex } from "../utils"
+import { TaprootDepositorCapability } from "./depositor-proxy"
 
 /**
  * Convenience type aggregating TBTC cross-chain contracts forming a connector
@@ -71,7 +72,7 @@ export interface DestinationChainTBTCToken {
  * Interface for communication with the BitcoinDepositor on-chain contract
  * deployed on the given destination chain.
  */
-export interface BitcoinDepositor {
+export interface BitcoinDepositor extends TaprootDepositorCapability {
   /**
    * Gets the chain-specific identifier of this contract.
    * Optional method - may not be available for off-chain implementations.

--- a/typescript/src/lib/contracts/depositor-proxy.ts
+++ b/typescript/src/lib/contracts/depositor-proxy.ts
@@ -5,6 +5,50 @@ import { DepositReceipt } from "./bridge"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**
+ * Optional capability exposed by deposit handlers that can safely reveal
+ * Taproot-native deposits end to end.
+ */
+export interface TaprootDepositorCapability {
+  /**
+   * @returns True only when the complete reveal path preserves both x-only
+   *          public keys required by a Taproot deposit.
+   */
+  supportsTaprootDeposits?(): boolean
+}
+
+/**
+ * Checks whether a deposit handler explicitly supports Taproot deposits.
+ * Missing capability declarations fail closed for backward compatibility.
+ * @param depositor Deposit handler whose capability should be checked.
+ * @returns True only when Taproot support is explicitly declared.
+ */
+export function supportsTaprootDeposits(
+  depositor: TaprootDepositorCapability
+): boolean {
+  return depositor.supportsTaprootDeposits?.() === true
+}
+
+/**
+ * Rejects a Taproot receipt when the target deposit handler has not explicitly
+ * declared end-to-end Taproot support.
+ * @param depositor Deposit handler whose capability should be checked.
+ * @param deposit Deposit receipt about to be revealed.
+ * @returns {void}
+ */
+export function assertTaprootDepositSupported(
+  depositor: TaprootDepositorCapability,
+  deposit: DepositReceipt
+): void {
+  const hasTaprootKeys =
+    typeof deposit.walletXOnlyPublicKey !== "undefined" ||
+    typeof deposit.refundXOnlyPublicKey !== "undefined"
+
+  if (hasTaprootKeys && !supportsTaprootDeposits(depositor)) {
+    throw new Error("Taproot deposits are not supported by this depositor")
+  }
+}
+
+/**
  * Interface representing a depositor proxy contract. A depositor proxy
  * is used to reveal deposits to the Bridge, on behalf of the user
  * (i.e. original depositor). It receives minted TBTC tokens and can provide
@@ -13,7 +57,7 @@ import { TransactionReceipt } from "@ethersproject/providers"
  * attributing the deposit and minted TBTC tokens to the user (e.g. using the
  * optional 32-byte extra data field of the deposit script).
  */
-export interface DepositorProxy {
+export interface DepositorProxy extends TaprootDepositorCapability {
   /**
    * Gets the chain-specific identifier of this contract.
    */

--- a/typescript/src/lib/ethereum/depositor-proxy.ts
+++ b/typescript/src/lib/ethereum/depositor-proxy.ts
@@ -30,6 +30,16 @@ export abstract class EthereumDepositorProxy implements DepositorProxy {
   }
 
   /**
+   * Legacy Ethereum depositor proxies do not preserve the x-only keys required
+   * by Taproot deposit reveals. Capable subclasses must override this method.
+   * @see {DepositorProxy#supportsTaprootDeposits}
+   * @returns False by default.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
+  /**
    * Packs deposit parameters to match the ABI of the revealDeposit and
    * revealDepositWithExtraData functions of the Ethereum Bridge contract.
    * @param depositTx - Deposit transaction data

--- a/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts
+++ b/typescript/src/lib/ethereum/l1-bitcoin-depositor.ts
@@ -12,6 +12,7 @@ import {
   DepositState,
   L1BitcoinDepositor,
   DestinationChainName,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { EthereumAddress, packRevealDepositParameters } from "./index"
 import { BitcoinRawTxVectors } from "../bitcoin"
@@ -148,6 +149,14 @@ export class EthereumL1BitcoinDepositor
     return this.#extraDataEncoder
   }
 
+  /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False because the deployed contract uses the legacy reveal tuple.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {L1BitcoinDepositor#initializeDeposit}
@@ -158,6 +167,8 @@ export class EthereumL1BitcoinDepositor
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex> {
+    assertTaprootDepositSupported(this, deposit)
+
     const { fundingTx, reveal } = packRevealDepositParameters(
       depositTx,
       depositOutputIndex,

--- a/typescript/src/lib/sei/sei-depositor.ts
+++ b/typescript/src/lib/sei/sei-depositor.ts
@@ -3,6 +3,7 @@ import {
   ChainIdentifier,
   Chains,
   ExtraDataEncoder,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { BitcoinRawTxVectors } from "../bitcoin"
 import { DepositReceipt } from "../contracts/bridge"
@@ -194,6 +195,14 @@ export class SeiBitcoinDepositor implements BitcoinDepositor {
   }
 
   /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False until the relayer and L1 depositor support Taproot reveals.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
+  /**
    * Initializes a cross-chain deposit by calling the external relayer service.
    *
    * This method calls the external service to trigger the deposit transaction
@@ -214,6 +223,8 @@ export class SeiBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex | TransactionReceipt> {
+    assertTaprootDepositSupported(this, deposit)
+
     // Check if deposit owner is set
     if (!this.#depositOwner) {
       throw new Error(

--- a/typescript/src/lib/solana/solana-depositor-interface.ts
+++ b/typescript/src/lib/solana/solana-depositor-interface.ts
@@ -1,5 +1,10 @@
 import axios from "axios"
-import { ChainIdentifier, BitcoinDepositor, DepositReceipt } from "../contracts"
+import {
+  assertTaprootDepositSupported,
+  ChainIdentifier,
+  BitcoinDepositor,
+  DepositReceipt,
+} from "../contracts"
 import { packRevealDepositParameters } from "../ethereum"
 import { BitcoinRawTxVectors } from "../bitcoin"
 import { TransactionReceipt } from "@ethersproject/providers"
@@ -41,6 +46,14 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
     return this.#extraDataEncoder
   }
 
+  /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False until the relayer and L1 depositor support Taproot reveals.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {BitcoinDepositor#initializeDeposit}
@@ -55,6 +68,8 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<TransactionReceipt> {
+    assertTaprootDepositSupported(this, deposit)
+
     const { fundingTx, reveal, extraData } = packRevealDepositParameters(
       depositTx,
       depositOutputIndex,

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -2,6 +2,7 @@ import {
   BitcoinDepositor,
   ChainIdentifier,
   ExtraDataEncoder,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { BitcoinRawTxVectors } from "../bitcoin"
 import { DepositReceipt } from "../contracts/bridge"
@@ -197,6 +198,14 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
   }
 
   /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False until the relayer and L1 depositor support Taproot reveals.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
+  /**
    * Initializes a cross-chain deposit by calling the external relayer service.
    *
    * This method calls the external service to trigger the deposit transaction
@@ -217,6 +226,8 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex | TransactionReceipt> {
+    assertTaprootDepositSupported(this, deposit)
+
     // Check if deposit owner is set
     if (!this.#depositOwner) {
       throw new Error(

--- a/typescript/src/lib/sui/bitcoin-depositor.ts
+++ b/typescript/src/lib/sui/bitcoin-depositor.ts
@@ -4,6 +4,7 @@ import {
   Chains,
   DepositReceipt,
   ExtraDataEncoder,
+  assertTaprootDepositSupported,
 } from "../contracts"
 import { SuiAddress } from "./chain-identifier"
 import { SuiExtraDataEncoder } from "./extra-data-encoder"
@@ -68,6 +69,14 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
     return this.#extraDataEncoder
   }
 
+  /**
+   * @see {BitcoinDepositor#supportsTaprootDeposits}
+   * @returns False because the deployed contract uses the legacy reveal format.
+   */
+  supportsTaprootDeposits(): boolean {
+    return false
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {BitcoinDepositor#initializeDeposit}
@@ -78,6 +87,8 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier // Ignored for SUI - no vault support
   ): Promise<Hex | any> {
+    assertTaprootDepositSupported(this, deposit)
+
     // This method is called by CrossChainDepositor in L2Transaction mode
     // It initiates the deposit on SUI, which triggers the relayer
 

--- a/typescript/src/services/deposits/cross-chain.ts
+++ b/typescript/src/services/deposits/cross-chain.ts
@@ -4,6 +4,8 @@ import {
   DepositorProxy,
   DepositReceipt,
   CrossChainInterfaces,
+  assertTaprootDepositSupported,
+  supportsTaprootDeposits,
 } from "../../lib/contracts"
 import { BitcoinRawTxVectors } from "../../lib/bitcoin"
 import { Hex } from "../../lib/utils"
@@ -53,6 +55,28 @@ export class CrossChainDepositor implements DepositorProxy {
   }
 
   /**
+   * @returns True when every depositor used by the selected reveal mode
+   *          explicitly supports Taproot deposits end to end.
+   * @see {DepositorProxy#supportsTaprootDeposits}
+   */
+  supportsTaprootDeposits(): boolean {
+    const l1SupportsTaproot = supportsTaprootDeposits(
+      this.#crossChainContracts.l1BitcoinDepositor
+    )
+
+    if (this.#revealMode == "L1Transaction") {
+      return l1SupportsTaproot
+    }
+
+    return (
+      l1SupportsTaproot &&
+      supportsTaprootDeposits(
+        this.#crossChainContracts.destinationChainBitcoinDepositor
+      )
+    )
+  }
+
+  /**
    * @returns Extra data for the cross-chain deposit script. Actually, this is
    *          the destination chain deposit owner identifier took from the BitcoinDepositor
    *          contract.
@@ -92,6 +116,8 @@ export class CrossChainDepositor implements DepositorProxy {
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex> {
+    assertTaprootDepositSupported(this, deposit)
+
     let result: Hex | TransactionReceipt | SuiTransactionBlockResponse
 
     switch (this.#revealMode) {

--- a/typescript/src/services/deposits/deposit.ts
+++ b/typescript/src/services/deposits/deposit.ts
@@ -1,4 +1,5 @@
 import {
+  assertTaprootDepositSupported,
   DepositorProxy,
   DepositReceipt,
   TBTCContracts,
@@ -146,10 +147,18 @@ export class Deposit {
    *         provision mode.
    * @throws Throws an error if the funding outpoint was already used to
    *         initiate minting (both modes).
+   * @throws Throws an error if a Taproot deposit uses a depositor proxy that
+   *         has not explicitly declared Taproot support.
    */
   async initiateMinting(
     fundingOutpoint?: BitcoinTxOutpoint
   ): Promise<Hex | TransactionReceipt> {
+    const receipt = this.getReceipt()
+
+    if (typeof this.depositorProxy !== "undefined") {
+      assertTaprootDepositSupported(this.depositorProxy, receipt)
+    }
+
     let resolvedFundingOutpoint: BitcoinTxOutpoint
 
     if (typeof fundingOutpoint !== "undefined") {
@@ -177,7 +186,7 @@ export class Deposit {
       return this.depositorProxy.revealDeposit(
         depositFundingTx,
         outputIndex,
-        this.getReceipt(),
+        receipt,
         tbtcVault.getChainIdentifier()
       )
     }
@@ -185,7 +194,7 @@ export class Deposit {
     return bridge.revealDeposit(
       depositFundingTx,
       outputIndex,
-      this.getReceipt(),
+      receipt,
       tbtcVault.getChainIdentifier()
     )
   }

--- a/typescript/src/services/deposits/deposits-service.ts
+++ b/typescript/src/services/deposits/deposits-service.ts
@@ -159,36 +159,42 @@ export class DepositsService {
    * additional services to the user, such as routing the minted TBTC tokens
    * to another protocols, in an automated way.
    * @see DepositorProxy
-   * @param bitcoinRecoveryAddress P2PKH or P2WPKH Bitcoin address that can
-   *                               be used for emergency recovery of the
-   *                               deposited funds.
+   * @param bitcoinRecoveryAddress P2PKH or P2WPKH Bitcoin address for legacy
+   *                               deposits, or a P2TR Bitcoin address for
+   *                               Taproot deposits, that can be used for
+   *                               emergency recovery of the deposited funds.
    * @param depositorProxy Depositor proxy used to initiate the deposit.
    * @param extraData Optional 32-byte extra data to be included in the
    *                  deposit script. Cannot be equal to 32 zero bytes.
+   * @param scriptType Type of the Bitcoin deposit script. Defaults to P2WSH
+   *                   for backward compatibility.
    * @returns Handle to the initiated deposit process.
    * @throws Throws an error if one of the following occurs:
    *         - There are no active wallet in the Bridge contract
-   *         - The Bitcoin recovery address is not a valid P2(W)PKH
+   *         - The Bitcoin recovery address does not match the requested
+   *           deposit script type
    *         - The optional extra data is set but is not 32-byte or equals
    *           to 32 zero bytes.
    */
   async initiateDepositWithProxy(
     bitcoinRecoveryAddress: string,
     depositorProxy: DepositorProxy,
-    extraData?: Hex
+    extraData?: Hex,
+    scriptType: DepositScriptType = DepositScriptType.P2WSH
   ): Promise<Deposit> {
     const receipt = await this.generateDepositReceipt(
       bitcoinRecoveryAddress,
       depositorProxy.getChainIdentifier(),
       extraData,
-      DepositScriptType.P2WSH
+      scriptType
     )
 
     return Deposit.fromReceipt(
       receipt,
       this.tbtcContracts,
       this.bitcoinClient,
-      depositorProxy
+      depositorProxy,
+      scriptType
     )
   }
 
@@ -204,14 +210,18 @@ export class DepositsService {
    *               PURPOSES AND EXTERNAL APPLICATIONS SHOULD NOT DEPEND ON IT.
    *               CROSS-CHAIN SUPPORT IS NOT FULLY OPERATIONAL YET.
    *
-   * @param bitcoinRecoveryAddress P2PKH or P2WPKH Bitcoin address that can
-   *                               be used for emergency recovery of the
-   *                               deposited funds.
+   * @param bitcoinRecoveryAddress P2PKH or P2WPKH Bitcoin address for legacy
+   *                               deposits, or a P2TR Bitcoin address for
+   *                               Taproot deposits, that can be used for
+   *                               emergency recovery of the deposited funds.
    * @param destinationChainName Name of the L2 chain the deposit is targeting.
+   * @param scriptType Type of the Bitcoin deposit script. Defaults to P2WSH
+   *                   for backward compatibility.
    * @returns Handle to the initiated deposit process.
    * @throws Throws an error if one of the following occurs:
    *         - There are no active wallet in the Bridge contract
-   *         - The Bitcoin recovery address is not a valid P2(W)PKH
+   *         - The Bitcoin recovery address does not match the requested
+   *           deposit script type
    *         - The cross-chain contracts for the given L2 chain are not
    *           initialized
    *         - The L2 deposit owner cannot be resolved. This typically
@@ -223,7 +233,8 @@ export class DepositsService {
    */
   async initiateCrossChainDeposit(
     bitcoinRecoveryAddress: string,
-    destinationChainName: DestinationChainName
+    destinationChainName: DestinationChainName,
+    scriptType: DepositScriptType = DepositScriptType.P2WSH
   ): Promise<Deposit> {
     const crossChainContracts = this.#crossChainContracts(destinationChainName)
     if (!crossChainContracts) {
@@ -237,7 +248,8 @@ export class DepositsService {
     return this.initiateDepositWithProxy(
       bitcoinRecoveryAddress,
       depositorProxy,
-      depositorProxy.extraData()
+      depositorProxy.extraData(),
+      scriptType
     )
   }
 

--- a/typescript/src/services/deposits/deposits-service.ts
+++ b/typescript/src/services/deposits/deposits-service.ts
@@ -4,6 +4,7 @@ import {
   DepositorProxy,
   DepositReceipt,
   DestinationChainName,
+  supportsTaprootDeposits,
   TBTCContracts,
 } from "../../lib/contracts"
 import { WalletIDUtils } from "../../lib/contracts/wallet-id"
@@ -173,6 +174,8 @@ export class DepositsService {
    *         - There are no active wallet in the Bridge contract
    *         - The Bitcoin recovery address does not match the requested
    *           deposit script type
+   *         - A Taproot deposit is requested through a depositor proxy that
+   *           does not explicitly support Taproot deposits end to end
    *         - The optional extra data is set but is not 32-byte or equals
    *           to 32 zero bytes.
    */
@@ -182,6 +185,13 @@ export class DepositsService {
     extraData?: Hex,
     scriptType: DepositScriptType = DepositScriptType.P2WSH
   ): Promise<Deposit> {
+    if (
+      scriptType == DepositScriptType.P2TR &&
+      !supportsTaprootDeposits(depositorProxy)
+    ) {
+      throw new Error("Taproot deposits are not supported by this depositor")
+    }
+
     const receipt = await this.generateDepositReceipt(
       bitcoinRecoveryAddress,
       depositorProxy.getChainIdentifier(),
@@ -224,6 +234,8 @@ export class DepositsService {
    *           deposit script type
    *         - The cross-chain contracts for the given L2 chain are not
    *           initialized
+   *         - The destination-chain or L1 depositor does not explicitly
+   *           support Taproot deposits end to end
    *         - The L2 deposit owner cannot be resolved. This typically
    *           happens if the L2 cross-chain contracts operate with a
    *           read-only signer whose address cannot be resolved.
@@ -244,6 +256,15 @@ export class DepositsService {
     }
 
     const depositorProxy = new CrossChainDepositor(crossChainContracts)
+
+    if (
+      scriptType == DepositScriptType.P2TR &&
+      !supportsTaprootDeposits(depositorProxy)
+    ) {
+      throw new Error(
+        `Taproot deposits are not supported for ${destinationChainName}`
+      )
+    }
 
     return this.initiateDepositWithProxy(
       bitcoinRecoveryAddress,

--- a/typescript/test/lib/arbitrum.test.ts
+++ b/typescript/test/lib/arbitrum.test.ts
@@ -72,6 +72,27 @@ describe("Arbitrum", () => {
         "82883a4c7a8dd73ef165deb402d432613615ced4"
       )
 
+      it("should declare Taproot deposits unsupported", () => {
+        expect(depositorHandle.supportsTaprootDeposits()).to.be.false
+      })
+
+      it("should reject a Taproot receipt before encoding the legacy tuple", async () => {
+        await expect(
+          depositorHandle.initializeDeposit(
+            depositTx,
+            depositOutputIndex,
+            {
+              ...deposit,
+              walletXOnlyPublicKey: Hex.from("11".repeat(32)),
+              refundXOnlyPublicKey: Hex.from("22".repeat(32)),
+            },
+            vault
+          )
+        ).to.be.rejectedWith(
+          "Taproot deposits are not supported by this depositor"
+        )
+      })
+
       context(
         "when L2 deposit owner is properly encoded in the extra data",
         () => {

--- a/typescript/test/lib/base.test.ts
+++ b/typescript/test/lib/base.test.ts
@@ -72,6 +72,27 @@ describe("Base", () => {
         "82883a4c7a8dd73ef165deb402d432613615ced4"
       )
 
+      it("should declare Taproot deposits unsupported", () => {
+        expect(depositorHandle.supportsTaprootDeposits()).to.be.false
+      })
+
+      it("should reject a Taproot receipt before encoding the legacy tuple", async () => {
+        await expect(
+          depositorHandle.initializeDeposit(
+            depositTx,
+            depositOutputIndex,
+            {
+              ...deposit,
+              walletXOnlyPublicKey: Hex.from("11".repeat(32)),
+              refundXOnlyPublicKey: Hex.from("22".repeat(32)),
+            },
+            vault
+          )
+        ).to.be.rejectedWith(
+          "Taproot deposits are not supported by this depositor"
+        )
+      })
+
       context(
         "when L2 deposit owner is properly encoded in the extra data",
         () => {

--- a/typescript/test/lib/ethereum.test.ts
+++ b/typescript/test/lib/ethereum.test.ts
@@ -945,6 +945,27 @@ describe("Ethereum", () => {
         "82883a4c7a8dd73ef165deb402d432613615ced4"
       )
 
+      it("should declare Taproot deposits unsupported", () => {
+        expect(depositorHandle.supportsTaprootDeposits()).to.be.false
+      })
+
+      it("should reject a Taproot receipt before encoding the legacy tuple", async () => {
+        await expect(
+          depositorHandle.initializeDeposit(
+            depositTx,
+            depositOutputIndex,
+            {
+              ...deposit,
+              walletXOnlyPublicKey: Hex.from("11".repeat(32)),
+              refundXOnlyPublicKey: Hex.from("22".repeat(32)),
+            },
+            vault
+          )
+        ).to.be.rejectedWith(
+          "Taproot deposits are not supported by this depositor"
+        )
+      })
+
       context(
         "when L2 deposit owner is properly encoded in the extra data",
         () => {

--- a/typescript/test/lib/sei/sei-depositor.test.ts
+++ b/typescript/test/lib/sei/sei-depositor.test.ts
@@ -3,6 +3,9 @@ import { SeiBitcoinDepositor } from "../../../src/lib/sei/sei-depositor"
 import { SeiAddress } from "../../../src/lib/sei/address"
 import { MockProvider } from "@ethereum-waffle/provider"
 import { EthereumAddress } from "../../../src/lib/ethereum"
+import { DepositReceipt } from "../../../src/lib/contracts"
+import { BitcoinRawTxVectors } from "../../../src/lib/bitcoin"
+import { Hex } from "../../../src/lib/utils"
 
 describe("SeiBitcoinDepositor", () => {
   describe("constructor", () => {
@@ -239,6 +242,41 @@ describe("SeiBitcoinDepositor", () => {
       // Assert
       expect(encoder).to.exist
       expect(encoder.constructor.name).to.equal("SeiExtraDataEncoder")
+    })
+  })
+
+  describe("initializeDeposit", () => {
+    it("should reject Taproot receipts before calling the relayer", async () => {
+      const mockProvider = new MockProvider().getWallets()[0].provider
+      const depositor = new SeiBitcoinDepositor(
+        { chainId: "1328" },
+        "Sei",
+        mockProvider as any
+      )
+      const depositTx: BitcoinRawTxVectors = {
+        version: Hex.from("00000000"),
+        inputs: Hex.from("11111111"),
+        outputs: Hex.from("22222222"),
+        locktime: Hex.from("33333333"),
+      }
+      const deposit: DepositReceipt = {
+        depositor: SeiAddress.from(
+          "0x1234567890123456789012345678901234567890"
+        ),
+        walletPublicKeyHash: Hex.from("11".repeat(20)),
+        refundPublicKeyHash: Hex.from("22".repeat(20)),
+        walletXOnlyPublicKey: Hex.from("33".repeat(32)),
+        refundXOnlyPublicKey: Hex.from("44".repeat(32)),
+        blindingFactor: Hex.from("55".repeat(8)),
+        refundLocktime: Hex.from("66".repeat(4)),
+      }
+
+      expect(depositor.supportsTaprootDeposits()).to.be.false
+      await expect(
+        depositor.initializeDeposit(depositTx, 0, deposit)
+      ).to.be.rejectedWith(
+        "Taproot deposits are not supported by this depositor"
+      )
     })
   })
 })

--- a/typescript/test/lib/solana-depositor-interface.test.ts
+++ b/typescript/test/lib/solana-depositor-interface.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai"
+import { DepositReceipt } from "../../src/lib/contracts"
+import { BitcoinRawTxVectors } from "../../src/lib/bitcoin"
+import { EthereumAddress } from "../../src/lib/ethereum"
+import { SolanaDepositorInterface } from "../../src/lib/solana/solana-depositor-interface"
+import { Hex } from "../../src/lib/utils"
+
+describe("SolanaDepositorInterface", () => {
+  it("should reject Taproot receipts before calling the relayer", async () => {
+    const depositor = new SolanaDepositorInterface()
+    const depositTx: BitcoinRawTxVectors = {
+      version: Hex.from("00000000"),
+      inputs: Hex.from("11111111"),
+      outputs: Hex.from("22222222"),
+      locktime: Hex.from("33333333"),
+    }
+    const deposit: DepositReceipt = {
+      depositor: EthereumAddress.from(
+        "0x1234567890123456789012345678901234567890"
+      ),
+      walletPublicKeyHash: Hex.from("11".repeat(20)),
+      refundPublicKeyHash: Hex.from("22".repeat(20)),
+      walletXOnlyPublicKey: Hex.from("33".repeat(32)),
+      refundXOnlyPublicKey: Hex.from("44".repeat(32)),
+      blindingFactor: Hex.from("55".repeat(8)),
+      refundLocktime: Hex.from("66".repeat(4)),
+    }
+
+    expect(depositor.supportsTaprootDeposits()).to.be.false
+    await expect(
+      depositor.initializeDeposit(depositTx, 0, deposit)
+    ).to.be.rejectedWith("Taproot deposits are not supported by this depositor")
+  })
+})

--- a/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
@@ -28,6 +28,31 @@ describe("StarkNetDepositor - T-001 Implementation", () => {
   })
 
   describe("initializeDeposit", () => {
+    it("should reject Taproot receipts before calling the relayer", async () => {
+      const depositor = new StarkNetDepositor(
+        {
+          chainId: "0x534e5f4d41494e",
+          relayerUrl: "http://test-relayer.local/api/reveal",
+        },
+        "StarkNet",
+        createMockProvider()
+      )
+      const mockReceipt = {
+        ...createMockDeposit(),
+        walletXOnlyPublicKey: Hex.from("11".repeat(32)),
+        refundXOnlyPublicKey: Hex.from("22".repeat(32)),
+      }
+      axios.post = sinon.stub()
+
+      expect(depositor.supportsTaprootDeposits()).to.be.false
+      await expect(
+        depositor.initializeDeposit(createMockDepositTx(), 0, mockReceipt)
+      ).to.be.rejectedWith(
+        "Taproot deposits are not supported by this depositor"
+      )
+      expect((axios.post as sinon.SinonStub).called).to.be.false
+    })
+
     it("should successfully initialize deposit through relayer", async () => {
       // Arrange
       const mockProvider = createMockProvider()

--- a/typescript/test/lib/sui/bitcoin-depositor.test.ts
+++ b/typescript/test/lib/sui/bitcoin-depositor.test.ts
@@ -141,6 +141,22 @@ describe("SUI Bitcoin Depositor", () => {
       }
     })
 
+    it("should reject Taproot receipts before building a SUI transaction", async () => {
+      expect(depositor.supportsTaprootDeposits()).to.be.false
+
+      await expect(
+        depositor.initializeDeposit(depositTx, depositOutputIndex, {
+          ...deposit,
+          walletXOnlyPublicKey: Hex.from("11".repeat(32)),
+          refundXOnlyPublicKey: Hex.from("22".repeat(32)),
+        })
+      ).to.be.rejectedWith(
+        "Taproot deposits are not supported by this depositor"
+      )
+
+      expect(mockClient.signAndExecuteTransaction.called).to.be.false
+    })
+
     it.skip("should initialize deposit successfully", async () => {
       // Skipping: Dynamic import mocking not supported in test environment
       const result = await depositor.initializeDeposit(

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -2434,7 +2434,7 @@ describe("Deposits", () => {
     describe("initiateDepositWithProxy", () => {
       const bitcoinClient = new MockBitcoinClient()
       const tbtcContracts = new MockTBTCContracts()
-      const depositorProxy = new MockDepositorProxy()
+      const depositorProxy = new MockDepositorProxy(true)
       let depositService: DepositsService
 
       beforeEach(async () => {
@@ -2454,6 +2454,24 @@ describe("Deposits", () => {
               depositorProxy
             )
           ).to.be.rejectedWith("Could not get active wallet public key hash")
+        })
+
+        it("should reject unsupported Taproot proxies before reading wallet state", async () => {
+          const unsupportedDepositorProxy: DepositorProxy = {
+            getChainIdentifier: () => depositorProxy.getChainIdentifier(),
+            revealDeposit: depositorProxy.revealDeposit.bind(depositorProxy),
+          }
+
+          await expect(
+            depositService.initiateDepositWithProxy(
+              "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+              unsupportedDepositorProxy,
+              undefined,
+              DepositScriptType.P2TR
+            )
+          ).to.be.rejectedWith(
+            "Taproot deposits are not supported by this depositor"
+          )
         })
       })
 
@@ -2486,6 +2504,24 @@ describe("Deposits", () => {
               )
             ).to.be.rejectedWith(
               "Legacy deposits are not supported for FROST active wallets"
+            )
+          })
+
+          it("should reject Taproot deposits for a proxy without explicit support", async () => {
+            const unsupportedDepositorProxy: DepositorProxy = {
+              getChainIdentifier: () => depositorProxy.getChainIdentifier(),
+              revealDeposit: depositorProxy.revealDeposit.bind(depositorProxy),
+            }
+
+            await expect(
+              depositService.initiateDepositWithProxy(
+                "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+                unsupportedDepositorProxy,
+                undefined,
+                DepositScriptType.P2TR
+              )
+            ).to.be.rejectedWith(
+              "Taproot deposits are not supported by this depositor"
             )
           })
 
@@ -2752,6 +2788,16 @@ describe("Deposits", () => {
               "Cannot resolve destination chain deposit owner"
             )
           })
+
+          it("should reject unsupported Taproot routes before resolving the owner", async () => {
+            await expect(
+              depositService.initiateCrossChainDeposit(
+                "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+                "Base",
+                DepositScriptType.P2TR
+              )
+            ).to.be.rejectedWith("Taproot deposits are not supported for Base")
+          })
         })
 
         context("when L2 deposit owner can be resolved", () => {
@@ -2886,7 +2932,22 @@ describe("Deposits", () => {
                 tbtcContracts.bridge.setActiveWalletID(activeWalletID)
               })
 
-              it("should initiate a Taproot cross-chain deposit", async () => {
+              it("should reject a Taproot cross-chain deposit when the adapters do not support it", async () => {
+                await expect(
+                  depositService.initiateCrossChainDeposit(
+                    "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+                    "Base",
+                    DepositScriptType.P2TR
+                  )
+                ).to.be.rejectedWith(
+                  "Taproot deposits are not supported for Base"
+                )
+              })
+
+              it("should initiate a Taproot cross-chain deposit when both adapters support it", async () => {
+                l2BitcoinDepositor.taprootDepositsSupported = true
+                l1BitcoinDepositor.taprootDepositsSupported = true
+
                 const deposit = await depositService.initiateCrossChainDeposit(
                   "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
                   "Base",
@@ -3709,6 +3770,36 @@ describe("Deposits", () => {
       })
     })
 
+    describe("supportsTaprootDeposits", () => {
+      it("should fail closed when neither adapter declares support", () => {
+        expect(depositor.supportsTaprootDeposits()).to.be.false
+      })
+
+      it("should require both destination-chain and L1 support in L2 mode", () => {
+        l2BitcoinDepositor.taprootDepositsSupported = true
+        expect(depositor.supportsTaprootDeposits()).to.be.false
+
+        l2BitcoinDepositor.taprootDepositsSupported = false
+        l1BitcoinDepositor.taprootDepositsSupported = true
+        expect(depositor.supportsTaprootDeposits()).to.be.false
+
+        l2BitcoinDepositor.taprootDepositsSupported = true
+        expect(depositor.supportsTaprootDeposits()).to.be.true
+      })
+
+      it("should require only L1 support in L1 mode", () => {
+        depositor = new CrossChainDepositor(
+          crossChainContracts,
+          "L1Transaction"
+        )
+
+        expect(depositor.supportsTaprootDeposits()).to.be.false
+
+        l1BitcoinDepositor.taprootDepositsSupported = true
+        expect(depositor.supportsTaprootDeposits()).to.be.true
+      })
+    })
+
     describe("extraData", () => {
       context(
         "when the deposit owner is not set in the L2BitcoinDepositor contract",
@@ -3866,11 +3957,25 @@ describe("Deposits", () => {
       })
 
       context("when the deposit is Taproot-native", () => {
-        beforeEach(async () => {
-          depositor = new CrossChainDepositor(
-            crossChainContracts,
-            "L2Transaction"
+        it("should reject before calling either adapter when support is absent", async () => {
+          await expect(
+            depositor.revealDeposit(
+              depositTx,
+              depositOutputIndex,
+              taprootDeposit,
+              vault
+            )
+          ).to.be.rejectedWith(
+            "Taproot deposits are not supported by this depositor"
           )
+
+          expect(l2BitcoinDepositor.initializeDepositCalls).to.be.empty
+          expect(l1BitcoinDepositor.initializeDepositCalls).to.be.empty
+        })
+
+        it("should forward the x-only keys when both adapters support Taproot", async () => {
+          l2BitcoinDepositor.taprootDepositsSupported = true
+          l1BitcoinDepositor.taprootDepositsSupported = true
 
           await depositor.revealDeposit(
             depositTx,
@@ -3878,9 +3983,7 @@ describe("Deposits", () => {
             taprootDeposit,
             vault
           )
-        })
 
-        it("should forward the x-only keys to the BitcoinDepositor", () => {
           expect(l2BitcoinDepositor.initializeDepositCalls.length).to.be.equal(
             1
           )

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -1957,8 +1957,12 @@ describe("Deposits", () => {
 
           beforeEach(async () => {
             depositorProxy = new MockDepositorProxy()
+            const proxyWithoutTaprootCapability: DepositorProxy = {
+              getChainIdentifier: () => depositorProxy.getChainIdentifier(),
+              revealDeposit: depositorProxy.revealDeposit.bind(depositorProxy),
+            }
             ;({ transaction, tbtcContracts } = await initiateMinting(
-              depositorProxy
+              proxyWithoutTaprootCapability
             ))
           })
 
@@ -1984,6 +1988,8 @@ describe("Deposits", () => {
           let transaction: BitcoinRawTx
           let tbtcContracts: MockTBTCContracts
           let depositorProxy: MockDepositorProxy
+          let bitcoinClient: MockBitcoinClient
+          let depositUtxo: BitcoinUtxo
 
           beforeEach(async () => {
             const fee = BigNumber.from(1520)
@@ -2004,9 +2010,9 @@ describe("Deposits", () => {
             )
 
             transaction = result.rawTransaction
-            const depositUtxo: BitcoinUtxo = result.depositUtxo
+            depositUtxo = result.depositUtxo
 
-            const bitcoinClient: MockBitcoinClient = new MockBitcoinClient()
+            bitcoinClient = new MockBitcoinClient()
             const rawTransactions = new Map<string, BitcoinRawTx>()
             rawTransactions.set(
               depositUtxo.transactionHash.toString(),
@@ -2026,7 +2032,7 @@ describe("Deposits", () => {
               )
             ).initiateMinting(depositUtxo)
 
-            depositorProxy = new MockDepositorProxy()
+            depositorProxy = new MockDepositorProxy(true)
             await (
               await Deposit.fromReceipt(
                 taprootDepositFixture.receipt,
@@ -2073,6 +2079,46 @@ describe("Deposits", () => {
             ).to.be.deep.equal(
               taprootDepositFixture.receipt.refundXOnlyPublicKey
             )
+          })
+
+          it("should reject a restored Taproot deposit for a proxy without explicit support", async () => {
+            const legacyProxy = new MockDepositorProxy(true)
+            const proxyWithoutTaprootCapability: DepositorProxy = {
+              getChainIdentifier: () => legacyProxy.getChainIdentifier(),
+              revealDeposit: legacyProxy.revealDeposit.bind(legacyProxy),
+            }
+            const restoredDeposit = await Deposit.fromReceipt(
+              taprootDepositFixture.receipt,
+              new MockTBTCContracts(),
+              bitcoinClient,
+              proxyWithoutTaprootCapability,
+              DepositScriptType.P2TR
+            )
+
+            await expect(
+              restoredDeposit.initiateMinting(depositUtxo)
+            ).to.be.rejectedWith(
+              "Taproot deposits are not supported by this depositor"
+            )
+            expect(legacyProxy.revealDepositLog.length).to.be.equal(0)
+          })
+
+          it("should reject a restored Taproot deposit for an incapable proxy", async () => {
+            const incapableProxy = new MockDepositorProxy(false)
+            const restoredDeposit = await Deposit.fromReceipt(
+              taprootDepositFixture.receipt,
+              new MockTBTCContracts(),
+              bitcoinClient,
+              incapableProxy,
+              DepositScriptType.P2TR
+            )
+
+            await expect(
+              restoredDeposit.initiateMinting(depositUtxo)
+            ).to.be.rejectedWith(
+              "Taproot deposits are not supported by this depositor"
+            )
+            expect(incapableProxy.revealDepositLog.length).to.be.equal(0)
           })
         })
       })

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -1983,6 +1983,7 @@ describe("Deposits", () => {
         context("when deposit is Taproot-native", () => {
           let transaction: BitcoinRawTx
           let tbtcContracts: MockTBTCContracts
+          let depositorProxy: MockDepositorProxy
 
           beforeEach(async () => {
             const fee = BigNumber.from(1520)
@@ -2024,6 +2025,17 @@ describe("Deposits", () => {
                 DepositScriptType.P2TR
               )
             ).initiateMinting(depositUtxo)
+
+            depositorProxy = new MockDepositorProxy()
+            await (
+              await Deposit.fromReceipt(
+                taprootDepositFixture.receipt,
+                tbtcContracts,
+                bitcoinClient,
+                depositorProxy,
+                DepositScriptType.P2TR
+              )
+            ).initiateMinting(depositUtxo)
           })
 
           it("should reveal the Taproot deposit to the Bridge", () => {
@@ -2037,6 +2049,29 @@ describe("Deposits", () => {
             expect(revealDepositLogEntry.depositOutputIndex).to.be.equal(0)
             expect(revealDepositLogEntry.deposit).to.be.eql(
               taprootDepositFixture.receipt
+            )
+          })
+
+          it("should reveal the Taproot deposit to the DepositorProxy", () => {
+            expect(depositorProxy.revealDepositLog.length).to.be.equal(1)
+
+            const revealDepositLogEntry = depositorProxy.revealDepositLog[0]
+            expect(revealDepositLogEntry.depositTx).to.be.eql(
+              extractBitcoinRawTxVectors(transaction)
+            )
+            expect(revealDepositLogEntry.depositOutputIndex).to.be.equal(0)
+            expect(revealDepositLogEntry.deposit).to.be.eql(
+              taprootDepositFixture.receipt
+            )
+            expect(
+              revealDepositLogEntry.deposit.walletXOnlyPublicKey
+            ).to.be.deep.equal(
+              taprootDepositFixture.receipt.walletXOnlyPublicKey
+            )
+            expect(
+              revealDepositLogEntry.deposit.refundXOnlyPublicKey
+            ).to.be.deep.equal(
+              taprootDepositFixture.receipt.refundXOnlyPublicKey
             )
           })
         })
@@ -2453,6 +2488,29 @@ describe("Deposits", () => {
               "Legacy deposits are not supported for FROST active wallets"
             )
           })
+
+          it("should initiate a Taproot deposit for a proxy", async () => {
+            const deposit = await depositService.initiateDepositWithProxy(
+              "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+              depositorProxy,
+              undefined,
+              DepositScriptType.P2TR
+            )
+
+            const receipt = deposit.getReceipt()
+            expect(receipt.depositor).to.be.deep.equal(
+              depositorProxy.getChainIdentifier()
+            )
+            expect(receipt.walletXOnlyPublicKey).to.be.deep.equal(
+              Hex.from(
+                "2336f65004d8f122f1fe947ebd009a8b4add3a0d937356d568e30f7fcc2e4008"
+              )
+            )
+            expect(receipt.refundXOnlyPublicKey).to.be.deep.equal(
+              taprootDepositFixture.receipt.refundXOnlyPublicKey
+            )
+            expect(await deposit.getBitcoinAddress()).to.match(/^tb1p/)
+          })
         })
 
         context("when recovery address is incorrect", () => {
@@ -2810,6 +2868,50 @@ describe("Deposits", () => {
                     Hex.from("e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0")
                   )
                 })
+              })
+            })
+
+            context("when active wallet is a FROST wallet", () => {
+              const activeWalletPublicKeyHash = Hex.from(
+                "c92a772f11bc97d8938a16a9db435401f4e6a7bc"
+              )
+              const activeWalletID = Hex.from(
+                "2336f65004d8f122f1fe947ebd009a8b4add3a0d937356d568e30f7fcc2e4008"
+              )
+
+              beforeEach(async () => {
+                tbtcContracts.bridge.setActiveWalletPublicKeyHash(
+                  activeWalletPublicKeyHash
+                )
+                tbtcContracts.bridge.setActiveWalletID(activeWalletID)
+              })
+
+              it("should initiate a Taproot cross-chain deposit", async () => {
+                const deposit = await depositService.initiateCrossChainDeposit(
+                  "tb1pzy3rx3z4vemc3xgq42aueh0wluqpzg3ng32kvaugnx4thnxaamlsk2wdrf",
+                  "Base",
+                  DepositScriptType.P2TR
+                )
+
+                const receipt = deposit.getReceipt()
+                expect(receipt.depositor).to.be.equal(
+                  l1BitcoinDepositor.getChainIdentifier()
+                )
+                expect(receipt.walletPublicKeyHash).to.be.deep.equal(
+                  activeWalletPublicKeyHash
+                )
+                expect(receipt.walletXOnlyPublicKey).to.be.deep.equal(
+                  activeWalletID
+                )
+                expect(receipt.refundXOnlyPublicKey).to.be.deep.equal(
+                  taprootDepositFixture.receipt.refundXOnlyPublicKey
+                )
+                expect(receipt.extraData).to.be.eql(
+                  Hex.from(
+                    `000000000000000000000000${l2DepositOwner.identifierHex}`
+                  )
+                )
+                expect(await deposit.getBitcoinAddress()).to.match(/^tb1p/)
               })
             })
           })
@@ -3688,6 +3790,13 @@ describe("Deposits", () => {
           `000000000000000000000000${l2DepositOwner.identifierHex}`
         ),
       }
+      const taprootDeposit: DepositReceipt = {
+        ...deposit,
+        walletXOnlyPublicKey:
+          taprootDepositFixture.receipt.walletXOnlyPublicKey,
+        refundXOnlyPublicKey:
+          taprootDepositFixture.receipt.refundXOnlyPublicKey,
+      }
       const vault: ChainIdentifier = EthereumAddress.from(
         "82883a4c7a8dd73ef165deb402d432613615ced4"
       )
@@ -3753,6 +3862,38 @@ describe("Deposits", () => {
             deposit,
             vault,
           })
+        })
+      })
+
+      context("when the deposit is Taproot-native", () => {
+        beforeEach(async () => {
+          depositor = new CrossChainDepositor(
+            crossChainContracts,
+            "L2Transaction"
+          )
+
+          await depositor.revealDeposit(
+            depositTx,
+            depositOutputIndex,
+            taprootDeposit,
+            vault
+          )
+        })
+
+        it("should forward the x-only keys to the BitcoinDepositor", () => {
+          expect(l2BitcoinDepositor.initializeDepositCalls.length).to.be.equal(
+            1
+          )
+
+          const forwardedDeposit =
+            l2BitcoinDepositor.initializeDepositCalls[0].deposit
+          expect(forwardedDeposit).to.be.eql(taprootDeposit)
+          expect(forwardedDeposit.walletXOnlyPublicKey).to.be.deep.equal(
+            taprootDepositFixture.receipt.walletXOnlyPublicKey
+          )
+          expect(forwardedDeposit.refundXOnlyPublicKey).to.be.deep.equal(
+            taprootDepositFixture.receipt.refundXOnlyPublicKey
+          )
         })
       })
     })

--- a/typescript/test/utils/mock-cross-chain.ts
+++ b/typescript/test/utils/mock-cross-chain.ts
@@ -31,6 +31,7 @@ export class MockBitcoinDepositor implements BitcoinDepositor {
   readonly #encoder: CrossChainExtraDataEncoder
   #depositOwner: ChainIdentifier | undefined
   public readonly initializeDepositCalls: InitializeDepositCall[] = []
+  public taprootDepositsSupported = false
 
   constructor(
     chainIdentifier: ChainIdentifier,
@@ -46,6 +47,10 @@ export class MockBitcoinDepositor implements BitcoinDepositor {
 
   getChainIdentifier(): ChainIdentifier {
     return this.#chainIdentifier
+  }
+
+  supportsTaprootDeposits(): boolean {
+    return this.taprootDepositsSupported
   }
 
   getDepositOwner(): ChainIdentifier | undefined {
@@ -77,6 +82,7 @@ export class MockL1BitcoinDepositor implements L1BitcoinDepositor {
   readonly #chainIdentifier: ChainIdentifier
   readonly #encoder: CrossChainExtraDataEncoder
   public readonly initializeDepositCalls: InitializeDepositCall[] = []
+  public taprootDepositsSupported = false
 
   constructor(
     chainIdentifier: ChainIdentifier,
@@ -104,6 +110,10 @@ export class MockL1BitcoinDepositor implements L1BitcoinDepositor {
 
   getChainIdentifier(): ChainIdentifier {
     return this.#chainIdentifier
+  }
+
+  supportsTaprootDeposits(): boolean {
+    return this.taprootDepositsSupported
   }
 
   initializeDeposit(

--- a/typescript/test/utils/mock-depositor-proxy.ts
+++ b/typescript/test/utils/mock-depositor-proxy.ts
@@ -16,12 +16,18 @@ interface RevealDepositLogEntry {
 export class MockDepositorProxy implements DepositorProxy {
   private _revealDepositLog: RevealDepositLogEntry[] = []
 
+  constructor(public taprootDepositsSupported = false) {}
+
   get revealDepositLog(): RevealDepositLogEntry[] {
     return this._revealDepositLog
   }
 
   getChainIdentifier(): ChainIdentifier {
     return EthereumAddress.from("0xEdA7bE2D82566ce2546b150447b5cb0E4320a1B2")
+  }
+
+  supportsTaprootDeposits(): boolean {
+    return this.taprootDepositsSupported
   }
 
   revealDeposit(


### PR DESCRIPTION
## Summary

Third PR in the #971 remediation stack; depends on #1013 and #1012.

- add an explicit `DepositScriptType` option to proxy and cross-chain deposit APIs
- add an explicit `supportsTaprootDeposits()` capability contract; absence means unsupported
- reject P2TR before receipt construction or address delivery unless the proxy declares end-to-end support
- recheck capability at the shared `Deposit.initiateMinting` reveal boundary so restored P2TR deposits cannot bypass the service guard
- require both destination and L1 depositor capability for L2-mode cross-chain deposits, and L1 capability for L1 mode
- make every shipped legacy adapter report unsupported and reject Taproot receipts before ABI encoding, HTTP calls, or chain transactions
- preserve P2WSH defaults and existing ECDSA behavior

## Security invariant

The SDK must never return a fundable P2TR deposit address or reveal a restored P2TR receipt through a route that can silently discard either x-only reveal key. Capability must be explicitly true across every component used by that route; missing or legacy capability fails closed.

## Behavior preserved

Existing callers remain P2WSH by default. Direct L1 Taproot deposits remain available. Legacy restored receipts can still use proxies without a Taproot capability declaration. A future proxy/cross-chain route can enable P2TR only after its destination contract, L1 depositor, relayer, artifacts, and SDK adapter preserve the complete Taproot reveal and pass an end-to-end staging deposit.

## Validation

- full combined SDK suite: 915 passing, 63 pending
- restored P2TR proxy reveals: missing and false capabilities rejected before proxy invocation; explicit support succeeds
- capability/service matrix: absent, one-sided, both-sided, and L1-only modes covered
- direct pre-side-effect rejection covered for Ethereum L1, Base, Arbitrum, StarkNet, Sui, Sei, and Solana adapters
- legacy P2WSH adapter and restored-proxy regressions: passed
- SDK build/typecheck, ESLint, Prettier, and generated TypeDoc: passed
- combined watchtower suite: 83 passing

## Stack

- Base: #971
- 1/3: #1012
- 2/3: #1013
- This PR: 3/3

## Deployment and runbook

Existing deployed cross-chain routes remain `supportsTaprootDeposits() == false`, so the SDK now rejects P2TR before returning a Bitcoin address instead of risking stranded funds. The mandatory readiness checklist is recorded in `docs/rfc/frost-migration/b1-implementation-plan.md`; concrete relayer/contract ownership is expanded in `c1-companion-services-plan.md`, and both FROST E2E runbooks now state that they validate direct L1 deposits only.
