### PR TITLE
fix(bridge): require P2TR outputs for FROST wallets

### DIFF
--- a/solidity/contracts/bridge/BitcoinTx.sol
+++ b/solidity/contracts/bridge/BitcoinTx.sol
@@ -393,7 +393,13 @@ library BitcoinTx {
         ) = extractWalletScriptKey(output);
 
         if (scriptType != WalletScriptType.P2TR) {
-            return bytes20(walletKey);
+            walletPubKeyHash = bytes20(walletKey);
+            require(
+                self.walletIDByWalletPubKeyHash[walletPubKeyHash] == bytes32(0),
+                "FROST wallet output must be P2TR"
+            );
+
+            return walletPubKeyHash;
         }
 
         walletPubKeyHash = self.walletPubKeyHashByWalletID[walletKey];

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -225,6 +225,9 @@ library Redemption {
         uint256 outputStartingIndex;
         // The number of outputs in the transaction.
         uint256 outputsCount;
+        // True if the wallet uses the FROST signing scheme and can spend only
+        // P2TR change outputs.
+        bool isFrostWallet;
         // P2PKH script for the wallet. Needed to determine the change output.
         bytes32 walletP2PKHScriptKeccak;
         // P2WPKH script for the wallet. Needed to determine the change output.
@@ -828,7 +831,8 @@ library Redemption {
 
         bytes32 walletP2TRScriptKeccak;
         bytes32 walletID = self.walletIDByWalletPubKeyHash[walletPubKeyHash];
-        if (walletID != bytes32(0)) {
+        bool isFrostWallet = walletID != bytes32(0);
+        if (isFrostWallet) {
             // FROST wallets store their x-only Taproot output key as the
             // canonical wallet ID. That key is not derivable from the
             // 20-byte compatibility wallet public key hash, so use the
@@ -846,6 +850,7 @@ library Redemption {
                 RedemptionTxOutputsProcessingInfo(
                     outputStartingIndex,
                     outputsCount,
+                    isFrostWallet,
                     walletP2PKHScriptKeccak,
                     walletP2WPKHScriptKeccak,
                     walletP2TRScriptKeccak
@@ -866,8 +871,8 @@ library Redemption {
     ///        HASH160 over the compressed ECDSA public key) of the wallet which
     ///        performed the redemption transaction.
     /// @param processInfo RedemptionTxOutputsProcessingInfo identifying output
-    ///        starting index, the number of outputs and possible wallet change
-    ///        P2PKH and P2WPKH scripts.
+    ///        starting index, the number of outputs, the wallet scheme, and
+    ///        possible wallet change P2PKH, P2WPKH, and P2TR scripts.
     function processRedemptionTxOutputs(
         BridgeState.Storage storage self,
         bytes memory redemptionTxOutputVector,
@@ -911,9 +916,14 @@ library Redemption {
 
             if (
                 resultInfo.changeValue == 0 &&
-                (outputScriptHash == processInfo.walletP2PKHScriptKeccak ||
-                    outputScriptHash == processInfo.walletP2WPKHScriptKeccak ||
-                    outputScriptHash == processInfo.walletP2TRScriptKeccak) &&
+                (
+                    processInfo.isFrostWallet
+                        ? outputScriptHash == processInfo.walletP2TRScriptKeccak
+                        : outputScriptHash ==
+                            processInfo.walletP2PKHScriptKeccak ||
+                            outputScriptHash ==
+                            processInfo.walletP2WPKHScriptKeccak
+                ) &&
                 outputValue > 0
             ) {
                 // If we entered here, that means the change output with a

--- a/solidity/contracts/test/TestBitcoinTx.sol
+++ b/solidity/contracts/test/TestBitcoinTx.sol
@@ -53,6 +53,13 @@ contract TestBitcoinTx {
         self.walletPubKeyHashByWalletID[walletID] = walletPubKeyHash;
     }
 
+    function setWalletIDForWalletPubKeyHash(
+        bytes20 walletPubKeyHash,
+        bytes32 walletID
+    ) external {
+        self.walletIDByWalletPubKeyHash[walletPubKeyHash] = walletID;
+    }
+
     function deriveWalletPubKeyHashFromXOnly(bytes32 xOnlyKey)
         external
         view

--- a/solidity/test/bridge/BitcoinTx.test.ts
+++ b/solidity/test/bridge/BitcoinTx.test.ts
@@ -147,6 +147,40 @@ describe("BitcoinTx", () => {
       )
     })
 
+    it("rejects P2PKH output locking to a FROST wallet compatibility key", async () => {
+      const frostWalletPubKeyHash =
+        await bitcoinTx.deriveWalletPubKeyHashFromXOnly(xOnlyKey)
+      await bitcoinTx.setWalletIDForWalletPubKeyHash(
+        frostWalletPubKeyHash,
+        xOnlyKey
+      )
+
+      const frostP2PKHOutput =
+        `0x00000000000000001976a914${frostWalletPubKeyHash.substring(2)}` +
+        "88ac"
+
+      await expect(
+        bitcoinTx.extractWalletPubKeyHash(frostP2PKHOutput)
+      ).to.be.revertedWith("FROST wallet output must be P2TR")
+    })
+
+    it("rejects P2WPKH output locking to a FROST wallet compatibility key", async () => {
+      const frostWalletPubKeyHash =
+        await bitcoinTx.deriveWalletPubKeyHashFromXOnly(xOnlyKey)
+      await bitcoinTx.setWalletIDForWalletPubKeyHash(
+        frostWalletPubKeyHash,
+        xOnlyKey
+      )
+
+      const frostP2WPKHOutput = `0x0000000000000000160014${frostWalletPubKeyHash.substring(
+        2
+      )}`
+
+      await expect(
+        bitcoinTx.extractWalletPubKeyHash(frostP2WPKHOutput)
+      ).to.be.revertedWith("FROST wallet output must be P2TR")
+    })
+
     it("rejects P2TR output when extracting wallet public key hash", async () => {
       await expect(bitcoinTx.extractPubKeyHash(p2trOutput)).to.be.revertedWith(
         "P2TR wallet outputs are not enabled"
@@ -166,6 +200,10 @@ describe("BitcoinTx", () => {
       await bitcoinTx.setWalletPubKeyHashForWalletID(
         xOnlyKey,
         mappedWalletPubKeyHash
+      )
+      await bitcoinTx.setWalletIDForWalletPubKeyHash(
+        mappedWalletPubKeyHash,
+        xOnlyKey
       )
 
       expect(await bitcoinTx.extractWalletPubKeyHash(p2trOutput)).to.eq(

--- a/solidity/test/bridge/Bridge.Redemption.test.ts
+++ b/solidity/test/bridge/Bridge.Redemption.test.ts
@@ -1565,6 +1565,39 @@ describe("Bridge - Redemption", () => {
           redemptionAmount + changeValue
         )
       })
+
+      const legacyChangeScripts = [
+        {
+          type: "P2PKH",
+          script: `0x1976a914${walletPubKeyHash.substring(2)}88ac`,
+        },
+        {
+          type: "P2WPKH",
+          script: `0x160014${walletPubKeyHash.substring(2)}`,
+        },
+      ]
+
+      for (const legacyChangeScript of legacyChangeScripts) {
+        it(`should reject a ${legacyChangeScript.type} change output`, async () => {
+          const outputVector = buildOutputVector([
+            {
+              value: changeValue,
+              script: legacyChangeScript.script,
+            },
+            {
+              value: redemptionAmount,
+              script: redeemerOutputScript,
+            },
+          ])
+
+          await expect(
+            bridge.callStatic.processRedemptionTxOutputsForTest(
+              outputVector,
+              walletPubKeyHash
+            )
+          ).to.be.revertedWith("Output is a non-requested redemption")
+        })
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- reject P2PKH and P2WPKH outputs that resolve to a registered FROST compatibility alias
- accept FROST redemption change only as P2TR while preserving legacy change for ECDSA wallets
- add focused regressions for both custody invariants

## Review findings addressed

- Require P2TR for outputs assigned to FROST wallets
- Reject legacy change outputs from FROST wallets

## Verification

- Solidity compile passed; Bridge size: 23.685 KiB
- BitcoinTx + Bridge.Redemption: 222 passing
- Bridge.Deposit: 148 passing
- Bridge.MovingFunds: 181 passing
- Prettier and diff check passed
- Solhint passed with pre-existing ordering warnings only

## Stack

Stack 1 of 4 on top of #971. Merge this PR first.