### PR TITLE
fix(bridge): keep challenged P2TR wallets open

### DIFF
--- a/solidity/contracts/bridge/BridgeLifecycleRouter.sol
+++ b/solidity/contracts/bridge/BridgeLifecycleRouter.sol
@@ -3,12 +3,27 @@
 pragma solidity 0.8.17;
 
 import "./IBridgeLifecycleRouter.sol";
+import "./Wallets.sol";
 
 interface IBridgeFrostLifecycleContext {
     function frostLifecycleContext(bytes20 walletPubKeyHash)
         external
         view
         returns (address frostRegistry, bytes32 walletID);
+
+    function p2trFraudRouter() external view returns (address);
+
+    function wallets(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (Wallets.Wallet memory);
+}
+
+interface IP2TRFraudChallengeCounter {
+    function hasOpenFraudChallengeForWallet(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (bool);
 }
 
 interface IFrostWalletLifecycleRegistry {
@@ -41,6 +56,7 @@ contract BridgeLifecycleRouter is IBridgeLifecycleRouter {
     error FrostWalletRegistryNotSet();
     error FrostWalletIdIsZero();
     error LifecycleOwnerMismatch();
+    error P2TRFraudChallengePending();
 
     address public immutable bridge;
 
@@ -63,6 +79,23 @@ contract BridgeLifecycleRouter is IBridgeLifecycleRouter {
         (IFrostWalletLifecycleRegistry registry, bytes32 walletID) = context(
             walletPubKeyHash
         );
+
+        IBridgeFrostLifecycleContext bridgeContext = IBridgeFrostLifecycleContext(
+                bridge
+            );
+        if (
+            bridgeContext.wallets(walletPubKeyHash).state ==
+            Wallets.WalletState.Closed
+        ) {
+            address p2trRouter = bridgeContext.p2trFraudRouter();
+            if (
+                p2trRouter != address(0) &&
+                IP2TRFraudChallengeCounter(p2trRouter)
+                    .hasOpenFraudChallengeForWallet(walletPubKeyHash)
+            ) {
+                revert P2TRFraudChallengePending();
+            }
+        }
 
         registry.closeWallet(walletID);
     }

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -440,7 +440,6 @@ contract P2TRSignatureFraudRouter {
         );
 
         challenge.resolved = true;
-        _decrementOpenFraudChallengeCount(context.challengeKey);
 
         // The return value is intentionally ignored: a reverting
         // challenger fallback self-griefs the refund but must not block
@@ -457,6 +456,10 @@ contract P2TRSignatureFraudRouter {
             walletMembersIDs,
             challenge.challenger
         );
+
+        // Keep the per-wallet counter as the graceful-closure lock across
+        // the untrusted refund and Bridge slashing callbacks.
+        _decrementOpenFraudChallengeCount(context.challengeKey);
 
         emit P2TRSignatureFraudChallengeDefeatTimedOut(
             payload.walletID,

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -122,6 +122,20 @@ contract P2TRSignatureFraudRouter {
     ///         before retiring the slash-on-timeout callback.
     uint256 public openFraudChallengeCount;
 
+    /// @notice Number of open P2TR fraud challenges attributed to each wallet.
+    ///         BridgeLifecycleRouter uses this counter to keep a FROST wallet
+    ///         in Closing until all of its challenges are resolved.
+    mapping(bytes20 => uint256) public openFraudChallengeCountByWallet;
+
+    /// @notice Number of open migrated challenges whose legacy records do not
+    ///         contain a wallet identity. While non-zero, every FROST wallet is
+    ///         conservatively treated as challenged during graceful closure.
+    uint256 public unattributedOpenFraudChallengeCount;
+
+    /// @dev Wallet attribution for challenges submitted directly to this
+    ///      router. A zero value identifies a migrated legacy challenge.
+    mapping(uint256 => bytes20) internal fraudChallengeWalletPubKeyHash;
+
     enum P2TRFraudAction {
         Submit,
         Defeat,
@@ -243,6 +257,7 @@ contract P2TRSignatureFraudRouter {
             fraudChallenges[challengeKeys[i]] = data[i];
             if (!data[i].resolved) {
                 openFraudChallengeCount++;
+                unattributedOpenFraudChallengeCount++;
             }
             totalDeposit += data[i].depositAmount;
             emit P2TRFraudChallengeMigratedFromBridge(
@@ -252,6 +267,18 @@ contract P2TRSignatureFraudRouter {
             );
         }
         require(msg.value == totalDeposit, "msg.value != total deposit");
+    }
+
+    /// @notice Returns whether graceful closure of the given wallet must wait
+    ///         for an unresolved local or unattributed migrated challenge.
+    function hasOpenFraudChallengeForWallet(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (bool)
+    {
+        return
+            openFraudChallengeCountByWallet[walletPubKeyHash] > 0 ||
+            unattributedOpenFraudChallengeCount > 0;
     }
 
     /// @notice Processes a P2TR signature-fraud challenge lifecycle
@@ -333,7 +360,10 @@ contract P2TRSignatureFraudRouter {
         /* solhint-disable-next-line not-rely-on-time */
         challenge.reportedAt = uint32(block.timestamp);
         challenge.resolved = false;
+        fraudChallengeWalletPubKeyHash[context.challengeKey] = context
+            .walletPubKeyHash;
         openFraudChallengeCount++;
+        openFraudChallengeCountByWallet[context.walletPubKeyHash]++;
 
         emit P2TRSignatureFraudChallengeSubmitted(
             payload.walletID,
@@ -367,7 +397,7 @@ contract P2TRSignatureFraudRouter {
         );
 
         challenge.resolved = true;
-        openFraudChallengeCount--;
+        _decrementOpenFraudChallengeCount(context.challengeKey);
 
         address treasury = b.treasury();
         /* solhint-disable avoid-low-level-calls */
@@ -410,7 +440,7 @@ contract P2TRSignatureFraudRouter {
         );
 
         challenge.resolved = true;
-        openFraudChallengeCount--;
+        _decrementOpenFraudChallengeCount(context.challengeKey);
 
         // The return value is intentionally ignored: a reverting
         // challenger fallback self-griefs the refund but must not block
@@ -493,6 +523,18 @@ contract P2TRSignatureFraudRouter {
             !challenge.resolved,
             "Fraud challenge has already been resolved"
         );
+    }
+
+    function _decrementOpenFraudChallengeCount(uint256 challengeKey) internal {
+        bytes20 walletPubKeyHash = fraudChallengeWalletPubKeyHash[challengeKey];
+
+        openFraudChallengeCount--;
+        if (walletPubKeyHash == bytes20(0)) {
+            unattributedOpenFraudChallengeCount--;
+        } else {
+            openFraudChallengeCountByWallet[walletPubKeyHash]--;
+            delete fraudChallengeWalletPubKeyHash[challengeKey];
+        }
     }
 
     function _isHonestlySpent(IBridgeForP2TRFraud b, uint256 utxoKey)

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -840,15 +840,15 @@ library Wallets {
     /// @notice Called when a wallet which was challenged for a fraud did not
     ///         defeat the challenge before the timeout. Slashes and terminates
     ///         the wallet who failed to defeat the challenge. If the wallet is
-    ///         already terminated, it does nothing.
+    ///         already terminated or closed, it does nothing.
     /// @param walletPubKeyHash 20-byte public key hash of the wallet which was
     ///        supposed to sweep funds.
     /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @param challenger Address of the party which submitted the fraud
     ///        challenge.
     /// @dev Requirements:
-    ///      - The wallet must be in the `Live`, `MovingFunds`, `Closing`
-    ///        or `Terminated` state.
+    ///      - The wallet must be in the `Live`, `MovingFunds`, `Closing`,
+    ///        `Closed`, or `Terminated` state.
     function notifyWalletFraudChallengeDefeatTimeout(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
@@ -888,16 +888,19 @@ library Wallets {
             }
 
             terminateWallet(self, walletPubKeyHash);
-        } else if (walletState == Wallets.WalletState.Terminated) {
-            // This is a special case when the wallet was already terminated
-            // due to a previous deliberate protocol violation. In that
-            // case, this function should be still callable for other fraud
-            // challenges timeouts in order to let the challenger unlock its
-            // ETH deposit back. However, the wallet termination logic is
-            // not called and the challenger is not rewarded.
+        } else if (
+            walletState == Wallets.WalletState.Terminated ||
+            walletState == Wallets.WalletState.Closed
+        ) {
+            // A terminated wallet may have other fraud challenges pending. A
+            // closed wallet may have a legacy challenge that was not covered
+            // by a closure guard before migration. In both cases, registry
+            // lifecycle has already ended, so the wallet cannot be seized or
+            // terminated again. The callback must still succeed so the caller
+            // can release the challenge escrow and accounting lock.
         } else {
             revert(
-                "Wallet must be in Live or MovingFunds or Closing or Terminated state"
+                "Wallet must be in Live or MovingFunds or Closing or Closed or Terminated state"
             );
         }
     }

--- a/solidity/contracts/test/ReentrantP2TRFraudChallenger.sol
+++ b/solidity/contracts/test/ReentrantP2TRFraudChallenger.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+interface IP2TRFraudRouterForReentrancyTest {
+    function processP2TRSignatureFraudChallenge(
+        uint8 action,
+        bytes calldata payload,
+        uint32[] calldata walletMembersIDs
+    ) external payable;
+}
+
+interface IBridgeForP2TRFraudReentrancyTest {
+    function notifyWalletClosingPeriodElapsed(bytes20 walletPubKeyHash)
+        external;
+}
+
+contract ReentrantP2TRFraudChallenger {
+    IP2TRFraudRouterForReentrancyTest public immutable fraudRouter;
+    IBridgeForP2TRFraudReentrancyTest public immutable bridge;
+    bytes20 public immutable walletPubKeyHash;
+
+    event ReentrantClosureAttempt(bool succeeded, bytes4 revertSelector);
+
+    constructor(
+        address _fraudRouter,
+        address _bridge,
+        bytes20 _walletPubKeyHash
+    ) {
+        fraudRouter = IP2TRFraudRouterForReentrancyTest(_fraudRouter);
+        bridge = IBridgeForP2TRFraudReentrancyTest(_bridge);
+        walletPubKeyHash = _walletPubKeyHash;
+    }
+
+    receive() external payable {
+        /* solhint-disable avoid-low-level-calls */
+        (bool succeeded, bytes memory returnData) = address(bridge).call(
+            abi.encodeWithSelector(
+                bridge.notifyWalletClosingPeriodElapsed.selector,
+                walletPubKeyHash
+            )
+        );
+        /* solhint-enable avoid-low-level-calls */
+
+        bytes4 revertSelector;
+        if (returnData.length >= 4) {
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                revertSelector := mload(add(returnData, 32))
+            }
+        }
+
+        emit ReentrantClosureAttempt(succeeded, revertSelector);
+    }
+
+    function submitFraudChallenge(bytes calldata payload) external payable {
+        fraudRouter.processP2TRSignatureFraudChallenge{value: msg.value}(
+            0,
+            payload,
+            new uint32[](0)
+        );
+    }
+}

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -1420,6 +1420,75 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
   })
 
+  it("allows an unattributed migrated challenge for an already-closed wallet to time out and releases the global closure lock", async () => {
+    const payload = vectorPayload(vector)
+    const walletPubKeyHash = await registerClosingFrostWallet(vector, 0)
+    await bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash)
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Closed
+    )
+
+    const unrelatedWalletPubKeyHash = await registerClosingFrostWallet(
+      distinctWalletVector,
+      0
+    )
+    const challengeKey = await buildBridgeChallengeKey(
+      bridge.address,
+      hex(vector.expectedBridgeChallengeIdentityHex)
+    )
+    const migratedChallenge = {
+      challenger: await thirdParty.getAddress(),
+      depositAmount: fraudChallengeDepositAmount,
+      reportedAt: (await lastBlockTime()) - fraudChallengeDefeatTimeout,
+      resolved: false,
+    }
+
+    await p2trFraudRouter
+      .connect(bridgeSigner)
+      .acceptMigration([challengeKey], [migratedChallenge], {
+        value: fraudChallengeDepositAmount,
+      })
+
+    await expectChallengeCounters(walletPubKeyHash, 0, 1, 1)
+    await expectCustomError(
+      bridge.notifyWalletClosingPeriodElapsed(unrelatedWalletPubKeyHash),
+      "P2TRFraudChallengePending"
+    )
+    expect((await bridge.wallets(unrelatedWalletPubKeyHash)).state).to.equal(
+      walletState.Closing
+    )
+
+    const tx = await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Timeout,
+        encodePayload(payload),
+        [1, 2, 3]
+      )
+
+    await expectBalanceDelta(
+      tx,
+      p2trFraudRouter.address,
+      fraudChallengeDepositAmount.mul(-1)
+    )
+    await expectBalanceDelta(tx, thirdParty, fraudChallengeDepositAmount)
+    expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to.be
+      .true
+    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Closed
+    )
+    expect(await frostWalletRegistry.seizeCalled()).to.equal(false)
+
+    await bridge.notifyWalletClosingPeriodElapsed(unrelatedWalletPubKeyHash)
+    expect((await bridge.wallets(unrelatedWalletPubKeyHash)).state).to.equal(
+      walletState.Closed
+    )
+    expect(await frostWalletRegistry.lastClosedWalletID()).to.equal(
+      hex(distinctWalletVector.walletIDHex)
+    )
+  })
+
   it("resolves timeout, refunds deposit, and slashes the P2TR wallet alias", async () => {
     const payload = vectorPayload(vector)
     const walletPubKeyHash = await registerP2TRWallet(payload.walletID)

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -1254,6 +1254,59 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
   })
 
+  it("keeps the challenge active while refunding a contract challenger", async () => {
+    const payload = vectorPayload(vector)
+    const walletPubKeyHash = await registerClosingFrostWallet(
+      vector,
+      Math.floor(fraudChallengeDefeatTimeout / 2)
+    )
+    const ReentrantChallengerFactory = await ethers.getContractFactory(
+      "ReentrantP2TRFraudChallenger"
+    )
+    const reentrantChallenger = await ReentrantChallengerFactory.deploy(
+      p2trFraudRouter.address,
+      bridge.address,
+      walletPubKeyHash
+    )
+    await reentrantChallenger.deployed()
+
+    const challengeKey = await buildBridgeChallengeKey(
+      bridge.address,
+      hex(vector.expectedBridgeChallengeIdentityHex)
+    )
+    await reentrantChallenger.submitFraudChallenge(encodePayload(payload), {
+      value: fraudChallengeDepositAmount,
+    })
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+    await increaseTime(fraudChallengeDefeatTimeout)
+
+    const tx = await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Timeout,
+        encodePayload(payload),
+        [1, 2, 3]
+      )
+
+    await expect(tx)
+      .to.emit(reentrantChallenger, "ReentrantClosureAttempt")
+      .withArgs(
+        false,
+        ethers.utils.id("P2TRFraudChallengePending()").slice(0, 10)
+      )
+    expect(
+      await ethers.provider.getBalance(reentrantChallenger.address)
+    ).to.equal(fraudChallengeDepositAmount)
+    expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to.be
+      .true
+    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Terminated
+    )
+    expect(await frostWalletRegistry.seizeCalled()).to.equal(true)
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
+  })
+
   it("allows FROST wallet closure after its P2TR challenge is defeated", async () => {
     const payload = vectorPayload(vector)
     const remainingClosingTime = Math.floor(fraudChallengeDefeatTimeout / 2)

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -3,14 +3,16 @@
 import fs from "fs"
 import path from "path"
 
-import { BigNumber, ContractTransaction } from "ethers"
+import { BigNumber, ContractTransaction, Signer } from "ethers"
 import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import type {
   Bridge,
+  BridgeLifecycleRouter,
   BridgeStub,
+  FrostWalletRegistryStub,
   IWalletRegistry,
   P2TRSignatureFraudRouter,
 } from "../../typechain"
@@ -78,6 +80,43 @@ const payloadType =
   "tuple(bytes32 walletID,uint32 version,uint32 locktime,tuple(bytes32 txid,uint32 vout,uint32 sequence)[] inputs,tuple(uint64 valueSats,bytes scriptPubKey)[] prevouts,tuple(uint64 valueSats,bytes scriptPubKey)[] outputs,uint32 signedInputIndex,bytes witnessSignature,bytes annex)"
 
 const hex = (value: string): string => `0x${value}`
+
+async function expectCustomError(
+  promise: Promise<unknown>,
+  errorName: string
+): Promise<void> {
+  const expectedSelector = ethers.utils.id(`${errorName}()`).slice(0, 10)
+
+  try {
+    await promise
+  } catch (err) {
+    const errAny = err as {
+      data?: string
+      message?: string
+      error?: { data?: string }
+    }
+    const revertData = errAny.data || errAny.error?.data || ""
+    const errMsg = errAny.message || String(err)
+
+    if (
+      (revertData &&
+        revertData.toLowerCase().startsWith(expectedSelector.toLowerCase())) ||
+      errMsg.toLowerCase().includes(expectedSelector.toLowerCase()) ||
+      errMsg.includes(errorName)
+    ) {
+      return
+    }
+
+    throw new Error(
+      `expected revert with custom error ${errorName} ` +
+        `(selector ${expectedSelector}), got: ${errMsg}`
+    )
+  }
+
+  throw new Error(
+    `expected revert with custom error ${errorName} but tx succeeded`
+  )
+}
 
 const mutateLastByte = (value: string): string => {
   const replacement = value.endsWith("00") ? "01" : "00"
@@ -304,6 +343,9 @@ describe("Bridge - P2TR signature fraud", () => {
   let treasury: SignerWithAddress
   let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
+  let bridgeSigner: Signer
+  let frostWalletRegistry: FrostWalletRegistryStub
+  let lifecycleRouter: BridgeLifecycleRouter
   let p2trFraudRouter: P2TRSignatureFraudRouter
   let fraudChallengeDepositAmount: BigNumber
   let fraudChallengeDefeatTimeout: number
@@ -317,6 +359,32 @@ describe("Bridge - P2TR signature fraud", () => {
     walletRegistry = fixture.walletRegistry
     bridge = fixture.bridge
     p2trFraudRouter = fixture.p2trFraudRouter
+
+    const FrostWalletRegistryStubFactory = await ethers.getContractFactory(
+      "FrostWalletRegistryStub"
+    )
+    frostWalletRegistry =
+      (await FrostWalletRegistryStubFactory.deploy()) as FrostWalletRegistryStub
+    await frostWalletRegistry.deployed()
+
+    const BridgeLifecycleRouterFactory = await ethers.getContractFactory(
+      "BridgeLifecycleRouter"
+    )
+    lifecycleRouter = (await BridgeLifecycleRouterFactory.deploy(
+      bridge.address
+    )) as BridgeLifecycleRouter
+    await lifecycleRouter.deployed()
+
+    await bridge.resetFrostWalletRegistryForTest(frostWalletRegistry.address)
+    await bridge.resetLifecycleRouterForTest(lifecycleRouter.address)
+    await frostWalletRegistry.setLifecycleOwner(lifecycleRouter.address)
+
+    await ethers.provider.send("hardhat_impersonateAccount", [bridge.address])
+    await ethers.provider.send("hardhat_setBalance", [
+      bridge.address,
+      ethers.utils.hexValue(ethers.utils.parseEther("100")),
+    ])
+    bridgeSigner = await ethers.getSigner(bridge.address)
 
     const fraudParameters = await bridge.fraudParameters()
     fraudChallengeDepositAmount = fraudParameters.fraudChallengeDepositAmount
@@ -359,6 +427,36 @@ describe("Bridge - P2TR signature fraud", () => {
     return walletPubKeyHash
   }
 
+  const registerClosingFrostWallet = async (
+    challengeVector: SignatureFraudVector,
+    remainingClosingTime: number
+  ): Promise<string> => {
+    const walletID = hex(challengeVector.walletIDHex)
+
+    await frostWalletRegistry.callBridgeFrostWalletCreatedCallback(
+      bridge.address,
+      walletID
+    )
+
+    const walletPubKeyHash = await bridge.walletPubKeyHashForWalletID(walletID)
+    const { walletClosingPeriod } = await bridge.walletParameters()
+    const now = await lastBlockTime()
+
+    await bridge.setWallet(walletPubKeyHash, {
+      ecdsaWalletID: ethers.constants.HashZero,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: now,
+      movingFundsRequestedAt: 0,
+      closingStartedAt: now - walletClosingPeriod + remainingClosingTime,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Closing,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+
+    return walletPubKeyHash
+  }
+
   const submitChallenge = async (
     payload = vectorPayload(vector),
     challengeVector = vector
@@ -386,6 +484,26 @@ describe("Bridge - P2TR signature fraud", () => {
     return { tx, bridgeChallengeIdentity, challengeKey }
   }
 
+  const expectChallengeCounters = async (
+    walletPubKeyHash: string,
+    expectedWalletCount: number,
+    expectedUnattributedCount: number,
+    expectedTotalCount: number
+  ): Promise<void> => {
+    expect(
+      await p2trFraudRouter.openFraudChallengeCountByWallet(walletPubKeyHash)
+    ).to.equal(expectedWalletCount)
+    expect(
+      await p2trFraudRouter.unattributedOpenFraudChallengeCount()
+    ).to.equal(expectedUnattributedCount)
+    expect(await p2trFraudRouter.openFraudChallengeCount()).to.equal(
+      expectedTotalCount
+    )
+    expect(
+      await p2trFraudRouter.hasOpenFraudChallengeForWallet(walletPubKeyHash)
+    ).to.equal(expectedWalletCount > 0 || expectedUnattributedCount > 0)
+  }
+
   it("submits and stores a P2TR signature-fraud challenge", async () => {
     const payload = vectorPayload(vector)
     const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
@@ -404,6 +522,7 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(fraudChallenge.depositAmount).to.equal(fraudChallengeDepositAmount)
     expect(fraudChallenge.reportedAt).to.equal(await lastBlockTime())
     expect(fraudChallenge.resolved).to.equal(false)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
 
     const event = await findP2TREvent(
       tx,
@@ -989,6 +1108,7 @@ describe("Bridge - P2TR signature fraud", () => {
 
       expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to
         .be.true
+      await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
 
       const event = await findP2TREvent(
         tx,
@@ -1094,6 +1214,159 @@ describe("Bridge - P2TR signature fraud", () => {
     })
   }
 
+  it("blocks FROST wallet closure until its P2TR challenge times out", async () => {
+    const payload = vectorPayload(vector)
+    const remainingClosingTime = Math.floor(fraudChallengeDefeatTimeout / 2)
+    const walletPubKeyHash = await registerClosingFrostWallet(
+      vector,
+      remainingClosingTime
+    )
+    const { challengeKey } = await submitChallenge(payload)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+
+    await increaseTime(remainingClosingTime)
+
+    await expectCustomError(
+      bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash),
+      "P2TRFraudChallengePending"
+    )
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Closing
+    )
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(false)
+
+    await increaseTime(fraudChallengeDefeatTimeout - remainingClosingTime)
+    await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Timeout,
+        encodePayload(payload),
+        [1, 2, 3]
+      )
+
+    expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to.be
+      .true
+    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Terminated
+    )
+    expect(await frostWalletRegistry.seizeCalled()).to.equal(true)
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
+  })
+
+  it("allows FROST wallet closure after its P2TR challenge is defeated", async () => {
+    const payload = vectorPayload(vector)
+    const remainingClosingTime = Math.floor(fraudChallengeDefeatTimeout / 2)
+    const walletPubKeyHash = await registerClosingFrostWallet(
+      vector,
+      remainingClosingTime
+    )
+    await submitChallenge(payload)
+
+    await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
+    await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Defeat,
+        encodePayload(payload),
+        []
+      )
+    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    await increaseTime(remainingClosingTime)
+
+    await bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash)
+
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Closed
+    )
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
+    expect(await frostWalletRegistry.lastClosedWalletID()).to.equal(
+      payload.walletID
+    )
+  })
+
+  it("allows an unrelated FROST wallet to close while a P2TR challenge is open", async () => {
+    const payload = vectorPayload(vector)
+    const challengedWalletPubKeyHash = await registerClosingFrostWallet(
+      vector,
+      Math.floor(fraudChallengeDefeatTimeout / 2)
+    )
+    await submitChallenge(payload)
+    await expectChallengeCounters(challengedWalletPubKeyHash, 1, 0, 1)
+
+    const unrelatedWalletPubKeyHash = await registerClosingFrostWallet(
+      distinctWalletVector,
+      0
+    )
+    await expectChallengeCounters(unrelatedWalletPubKeyHash, 0, 0, 1)
+    await bridge.notifyWalletClosingPeriodElapsed(unrelatedWalletPubKeyHash)
+
+    expect((await bridge.wallets(unrelatedWalletPubKeyHash)).state).to.equal(
+      walletState.Closed
+    )
+    expect((await bridge.wallets(challengedWalletPubKeyHash)).state).to.equal(
+      walletState.Closing
+    )
+    expect(await frostWalletRegistry.lastClosedWalletID()).to.equal(
+      hex(distinctWalletVector.walletIDHex)
+    )
+  })
+
+  it("blocks graceful closure for unattributed migrated challenges without blocking fraud termination", async () => {
+    const payload = vectorPayload(vector)
+    const walletPubKeyHash = await registerClosingFrostWallet(vector, 0)
+    const challengeKey = await buildBridgeChallengeKey(
+      bridge.address,
+      hex(vector.expectedBridgeChallengeIdentityHex)
+    )
+    const secondChallengeKey = challengeKey.add(1)
+    const migratedChallenge = {
+      challenger: await thirdParty.getAddress(),
+      depositAmount: fraudChallengeDepositAmount,
+      reportedAt: (await lastBlockTime()) - fraudChallengeDefeatTimeout,
+      resolved: false,
+    }
+
+    await p2trFraudRouter
+      .connect(bridgeSigner)
+      .acceptMigration(
+        [challengeKey, secondChallengeKey],
+        [migratedChallenge, migratedChallenge],
+        { value: fraudChallengeDepositAmount.mul(2) }
+      )
+
+    await expectChallengeCounters(walletPubKeyHash, 0, 2, 2)
+    expect(
+      await p2trFraudRouter.hasOpenFraudChallengeForWallet(
+        p2trWalletPubKeyHash(hex(distinctWalletVector.walletIDHex))
+      )
+    ).to.equal(true)
+    await expectCustomError(
+      bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash),
+      "P2TRFraudChallengePending"
+    )
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Closing
+    )
+
+    await p2trFraudRouter
+      .connect(thirdParty)
+      .processP2TRSignatureFraudChallenge(
+        p2trFraudAction.Timeout,
+        encodePayload(payload),
+        [1, 2, 3]
+      )
+
+    expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to.be
+      .true
+    await expectChallengeCounters(walletPubKeyHash, 0, 1, 1)
+    expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+      walletState.Terminated
+    )
+    expect(await frostWalletRegistry.seizeCalled()).to.equal(true)
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
+  })
+
   it("resolves timeout, refunds deposit, and slashes the P2TR wallet alias", async () => {
     const payload = vectorPayload(vector)
     const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
@@ -1120,6 +1393,7 @@ describe("Bridge - P2TR signature fraud", () => {
     await expectBalanceDelta(tx, thirdParty, fraudChallengeDepositAmount)
     expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to.be
       .true
+    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
     expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
       walletState.Terminated
     )


### PR DESCRIPTION
## Summary

- track unresolved P2TR fraud challenges by wallet
- block graceful FROST closure while the wallet challenge can still mature
- keep the per-wallet closure lock active through contract-challenger refunds and timeout slashing
- conservatively hold graceful closure for unattributed migrated challenges
- preserve timeout termination, ETH refunds, and unrelated-wallet closure

## Review findings addressed

- Block closure while P2TR challenges can mature
- Keep the challenge counted through the refund callback

The timeout path now clears the challenge counter only after the untrusted refund callback and Bridge slashing complete. A contract challenger therefore cannot reenter the permissionless closing-period notification, move the wallet to Closed, and roll back the later slash.

## Verification

- Pre-fix real-boundary regression: the 100,000-gas receive hook closed the wallet and made timeout slashing revert
- Post-fix reentrant refund regression: passing; callback receives P2TRFraudChallengePending while refund, slashing, termination, and counter cleanup complete
- Focused exploit plus normal closure/refund controls: 3 passing
- Full Bridge.P2TRFrauds suite: 42 passing
- Solidity compile passed
- P2TRSignatureFraudRouter size: 20.969 KiB
- Prettier, ESLint, Solhint, and diff check passed; two pre-existing Solhint ordering warnings only

## Stack

Stack 2 of 4 on top of #1017. Merge #1017 first, then this PR.
