### PR TITLE
fix(bridge): preserve legacy upgrade state

### DIFF
--- a/docs/rfc/frost-migration/d2-2-followups-plan.md
+++ b/docs/rfc/frost-migration/d2-2-followups-plan.md
@@ -7,15 +7,24 @@ slice 1 and slice 3 land as part of PR #971 rather than as standalone
 canonical PRs. Slice 2 and slice 4 remain deferred with their
 operational prerequisites.
 
+> **Security-continuity correction (2026-07-13):** The canonical upgrade
+> retains the authenticated ECDSA creation callback so a DKG initiated before
+> the proxy upgrade can complete afterward. New requests are still FROST-only.
+> Removing this callback is now part of the final registry-drain slice and is
+> safe only after the legacy registry is IDLE and no creation can remain in
+> flight.
+
 ## Context
 
-D-2.1 (PR #445) shipped the structural ECDSA hard retirement:
+D-2.1 (PR #445) originally shipped the structural ECDSA hard retirement:
 
-- `Bridge.__ecdsaWalletCreatedCallback` removed entirely.
+- `Bridge.__ecdsaWalletCreatedCallback` was removed, then restored by the
+  security-continuity correction above.
 - `Wallets.requestNewWallet` Ecdsa-branch reverts
   unconditionally (Codex P1 re-raise).
 - `Bridge.retireEcdsa()` + `EcdsaRetired` event added.
-- `IWalletOwner` interface inheritance dropped.
+- `IWalletOwner` interface inheritance was dropped, then restored with the
+  callback.
 
 It deferred several smaller follow-ups for EIP-170 budget +
 operational-drain reasons. D-2.2 picks those up as a series
@@ -159,12 +168,15 @@ The last ECDSA-related surface on Bridge consists of:
 - `Bridge.__ecdsaWalletHeartbeatFailedCallback` (preserved
   through D-2 because existing ECDSA wallets still need to
   report heartbeat failures via the ECDSA registry).
+- `Bridge.__ecdsaWalletCreatedCallback` (preserved to drain a DKG
+  initiated before the direct proxy upgrade).
 - `notifyWalletHeartbeatFailed` in the Wallets library.
 
 Slice 4 removes all of them. Reclaim: substantial
 (~400-600 bytes) but only safe when:
 
 - All ECDSA wallets have reached Closed/Terminated state.
+- The legacy registry is IDLE and no creation request remains in flight.
 - The ECDSA registry is no longer expected to call into
   Bridge for any purpose.
 

--- a/docs/rfc/frost-migration/d2-ecdsa-hard-retirement-plan.md
+++ b/docs/rfc/frost-migration/d2-ecdsa-hard-retirement-plan.md
@@ -9,6 +9,17 @@ and uses the reclaimed bytecode budget to land the canonical
 `retireEcdsa()` governance setter + supporting surface that was
 deferred from D-1.
 
+> **Security-continuity correction (2026-07-13):** The canonical FROST
+> upgrade retains `__ecdsaWalletCreatedCallback` and `IWalletOwner`
+> compatibility. The deployed Bridge/BridgeGovernance does not expose the
+> pause and scheme-setter ceremony described in the historical runbook below,
+> so a DKG can begin in the last pre-upgrade block. The retained callback is
+> authenticated by the legacy registry, is deliberately not gated by
+> `ecdsaRetired`, and can only drain a request that registry already started;
+> new post-upgrade wallet requests remain FROST-only. Treat the callback-removal
+> and activation-sequence text below as a historical record, not a deployment
+> instruction.
+
 > **NOTE (post-D-2.2 reconciliation, 2026-05-25):** Several
 > claims in the body below are stale relative to the as-shipped
 > contract after PR #447 (D-2.2 slice 1) merged:

--- a/docs/rfc/frost-migration/scheme-preference-and-retirement-rfc.md
+++ b/docs/rfc/frost-migration/scheme-preference-and-retirement-rfc.md
@@ -10,6 +10,16 @@ historical-record cleanup — reconciles the RFC text with the
 deltas that landed during implementation review, so future
 readers cite a consistent design.
 
+> **Security-continuity correction (2026-07-13):** The current canonical
+> upgrade retains `__ecdsaWalletCreatedCallback` with its exact legacy selector
+> and registry authentication. The deployed contracts do not expose the pause
+> and scheme-setter sequence described by the v7 historical reconciliation, so
+> the callback must remain available for a DKG initiated immediately before the
+> proxy upgrade. It is not gated by `ecdsaRetired`; new requests nevertheless
+> remain FROST-only because the post-upgrade request path has no ECDSA dispatch.
+> References below to structural callback removal describe the superseded v7
+> implementation, not the current activation procedure.
+
 ## Revision history
 
 ### v7 — 2026-05-24 (post-implementation reconciliation)

--- a/docs/rfc/frost-migration/wallet-lifecycle-migration-plan.md
+++ b/docs/rfc/frost-migration/wallet-lifecycle-migration-plan.md
@@ -114,16 +114,29 @@ batches. Each batch:
 3. deletes them from Bridge storage before calling the router; and
 4. transfers the aggregate ETH with the records.
 
-The router call is part of the same transaction. A duplicate, resolved record,
-wrong router classification, or receiver failure reverts the deletion and ETH
-movement. Resolved records are intentionally not migrated because their escrow
-has already been paid or routed. Deployment must link the current `Fraud`
-library bytecode; a historical address does not contain the migration selector.
+The router call is part of the same transaction. A duplicate or resolved record,
+an invalid router kind, an unconfigured selected router, or receiver failure
+reverts the deletion and ETH movement. **Router classification does not.** The
+legacy record has no scheme tag, and both routers accept the same record shape,
+so `routerKind` only selects the receiver. A wrong classification succeeds,
+deletes the Bridge record, transfers its escrow, and has no supported on-chain
+rollback or reclassification path. The challenge may become unresolvable;
+routing it to the P2TR router also increments the unattributed global counter
+and can block every graceful FROST wallet closure.
 
-The release record should still include the event-derived challenge inventory,
-the router classification for every unresolved key, the migration transaction
-receipts, and confirmation that both routers report the expected open challenge
-counts afterward.
+Classification is therefore an irreversible off-chain prerequisite. Before
+submitting any batch, the deployment team must bind every unresolved key to its
+scheme-specific submission evidence, independently review the ECDSA/P2TR
+classification manifest, and confirm the governance calldata matches that
+manifest. Do not migrate an ambiguous key. Resolved records are intentionally
+not migrated because their escrow has already been paid or routed. Deployment
+must link the current `Fraud` library bytecode; a historical address does not
+contain the migration selector.
+
+The release record must include the event-derived challenge inventory, the
+approved classification manifest, the exact batch calldata, the migration
+transaction receipts, and confirmation that both routers report the expected
+open challenge counts afterward.
 
 ## Phase B-1 design
 

--- a/docs/rfc/frost-migration/wallet-lifecycle-migration-plan.md
+++ b/docs/rfc/frost-migration/wallet-lifecycle-migration-plan.md
@@ -95,37 +95,35 @@ The authoritative source is the generated storage snapshot, not this
 table. Any future storage-layout doc update must be checked against
 `solidity/test/formal/Bridge.storage-layout.json`.
 
-## Cutover playbook recap (from `Bridge.migrateLegacyFraudChallenges` NatSpec)
+## Legacy fraud challenge cutover
 
-The migration helper for legacy fraud challenges is intentionally
-stubbed in #435 to save ~1.1 KiB of Bridge bytecode. Acceptable only
-under this per-chain operational contract:
+The proxy upgrade atomically removes the permissionless legacy submission
+entrypoint, but a valid historical signature can still be submitted in the
+last pre-upgrade block. The current Bridge therefore retains a governance-only
+`migrateLegacyFraudChallenges` body in the externally linked `Fraud` library.
+The quiet period and off-chain audit remain useful operational checks, but they
+are not relied upon as the security boundary.
 
-1. **Off-chain audit** — enumerate every `FraudChallengeSubmitted` and
-   `P2TRSignatureFraudChallengeSubmitted` event on the target chain;
-   confirm count == 0 OR every emitted submission has a matching
-   `Defeated` / `DefeatTimedOut`. Capture proof in the deployment /
-   governance record.
-2. **Pre-upgrade quiet period** during the governance delay window:
-   no new wallets enabled; maintainers hold off any fraud-eligible
-   signing.
-3. **Atomic cutover** — the same governance proposal that sets the
-   routers (`setEcdsaFraudRouter` + `setP2TRFraudRouter`) activates
-   the upgrade. No in-between window where Bridge accepts fraud
-   calls but routers are not wired.
+After both router addresses are configured, governance must enumerate any
+unresolved legacy records from submission and resolution events, classify each
+key as ECDSA (`routerKind = 0`) or P2TR (`routerKind = 1`), and migrate them in
+batches. Each batch:
 
-If any chain can't satisfy (1) or (2), the migration body MUST be
-added back via a focused upgrade BEFORE the router upgrade activates
-on that chain. Bridge is upgradeable; the function signature, event,
-and `IEcdsaFraudRouterMigration` interface stay in place so the
-follow-up upgrade is a body swap, not an ABI change.
+1. accepts only existing, unresolved records and a configured router;
+2. copies the records and sums their exact escrow;
+3. deletes them from Bridge storage before calling the router; and
+4. transfers the aggregate ETH with the records.
 
-**Chains in scope** at the time of #435: Ethereum L1 (mainnet +
-Sepolia per `contracts/tbtc-v2/deployments/`); no L2/sidechain Bridge
-deployments. Mainnet has never seen an opened fraud challenge;
-Sepolia has never seen one either. Both chains satisfy step (1) with
-count = 0. Release-checklist item: snapshot the audit proof into the
-deployment record before the router upgrade is queued.
+The router call is part of the same transaction. A duplicate, resolved record,
+wrong router classification, or receiver failure reverts the deletion and ETH
+movement. Resolved records are intentionally not migrated because their escrow
+has already been paid or routed. Deployment must link the current `Fraud`
+library bytecode; a historical address does not contain the migration selector.
+
+The release record should still include the event-derived challenge inventory,
+the router classification for every unresolved key, the migration transaction
+receipts, and confirmation that both routers report the expected open challenge
+counts afterward.
 
 ## Phase B-1 design
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -17,13 +17,7 @@ pragma solidity 0.8.17;
 
 import "@keep-network/random-beacon/contracts/Governable.sol";
 import "@keep-network/random-beacon/contracts/ReimbursementPool.sol";
-// D-2 dropped `IWalletOwner` inheritance: the ECDSA wallet
-// registry's `__ecdsaWalletCreatedCallback` callback path is
-// removed entirely (no new ECDSA wallets after D-2 ships). The
-// heartbeat callback is preserved as a standalone external
-// function for existing-wallet lifecycle. Import path retained
-// for the registry contract handle (used via
-// `BridgeState.Storage.ecdsaWalletRegistry`).
+import {IWalletOwner as EcdsaWalletOwner} from "@keep-network/ecdsa/contracts/api/IWalletOwner.sol";
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
@@ -44,15 +38,6 @@ import "./MovingFunds.sol";
 
 import "../bank/IReceiveBalanceApproval.sol";
 import "../bank/Bank.sol";
-
-/// @dev Minimal interface Bridge uses to migrate legacy fraud
-///      challenges into the EcdsaFraudRouter sidecar.
-interface IEcdsaFraudRouterMigration {
-    function acceptMigration(
-        uint256[] calldata challengeKeys,
-        Fraud.FraudChallenge[] calldata data
-    ) external payable;
-}
 
 /// @title Bitcoin Bridge
 /// @notice Bridge manages BTC deposit and redemption flow and is increasing and
@@ -75,7 +60,12 @@ interface IEcdsaFraudRouterMigration {
 /// @dev Bridge is an upgradeable component of the Bank. The order of
 ///      functionalities in this contract is: deposit, sweep, redemption,
 ///      moving funds, wallet lifecycle, frauds, parameters.
-contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
+contract Bridge is
+    Governable,
+    EcdsaWalletOwner,
+    Initializable,
+    IReceiveBalanceApproval
+{
     // Shared custom error for the five initialize() zero-address guards.
     // Converted from individual require strings to a single 4-byte
     // selector to keep the Bridge implementation under the 24 KiB
@@ -90,11 +80,7 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
     using Redemption for BridgeState.Storage;
     using MovingFunds for BridgeState.Storage;
     using Wallets for BridgeState.Storage;
-    // `using Fraud` / `using P2TRSignatureFraudLifecycle` removed --
-    // the ECDSA fraud surface now lives on EcdsaFraudRouter. The
-    // Fraud library import stays only so `BridgeState` can keep its
-    // legacy `fraudChallenges` storage mapping typed against
-    // `Fraud.FraudChallenge` for one-time migration.
+    using Fraud for BridgeState.Storage;
 
     BridgeState.Storage internal self;
 
@@ -1127,10 +1113,9 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
     ///         process is performed asynchronously by the FROST
     ///         wallet registry, which notifies this contract by
     ///         calling `__frostWalletCreatedCallback` on
-    ///         completion. The ECDSA scheme branch unconditionally
-    ///         reverts in D-2; the ECDSA registry's create-side
-    ///         callback was structurally removed and any dispatch
-    ///         attempt to it would strand the registry non-IDLE.
+    ///         completion. New ECDSA dispatch was removed in D-2; the
+    ///         ECDSA callback remains only for requests already in flight at
+    ///         the proxy-upgrade block.
     /// @param activeWalletMainUtxo Data of the active wallet's main UTXO, as
     ///        currently known on the Ethereum chain.
     /// @dev Requirements:
@@ -1156,39 +1141,18 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
         self.requestNewWallet(activeWalletMainUtxo);
     }
 
-    // D-2 removed `__ecdsaWalletCreatedCallback`. The ECDSA
-    // wallet registry's create-side callback into Bridge is
-    // gone; any attempt to invoke the removed selector reverts
-    // at the EVM dispatcher (no matching ABI entry).
-    //
-    // The deadlock vector (dispatch → DKG → late callback into
-    // removed selector → stuck registry → blocked FROST
-    // wallets) is structurally closed by D-2 at TWO layers:
-    //
-    //   1. CODE (load-bearing): `Wallets.requestNewWallet`
-    //      dispatches only to the FROST registry in the
-    //      canonical mirror. The ECDSA branch and scheme setter
-    //      were removed in D-2.2 slice 3, so no dispatch to the
-    //      ECDSA registry can be reached regardless of preserved
-    //      storage flag values.
-    //
-    //   2. OPERATIONS (defense-in-depth): the original D-2
-    //      source runbook called for flipping the scheme to
-    //      Frost before the proxy upgrade. In the canonical
-    //      mirror the setter is gone; FROST activation is
-    //      instead gated by the lifecycle-router/frost-registry
-    //      wiring checks in `Wallets.requestNewWallet`.
-    //
-    // The `retireEcdsa()` flag flip (governance forwarder
-    // added alongside this PR) is an OPTIONAL audit-trail
-    // step and not required for the structural retirement.
-    // See `docs/frost-migration/d2-ecdsa-hard-retirement-plan.md`
-    // §"Activation runbook" for the full sequence.
-    //
-    // Existing ECDSA wallets continue their full lifecycle
-    // (sweeps, redemptions, fraud, moving funds, closing,
-    // termination) — those paths do not depend on this
-    // callback.
+    /// @notice A callback function called by the ECDSA Wallet Registry once a
+    ///         new wallet is created.
+    /// @dev New requests are FROST-only, but this selector must remain until
+    ///      every ECDSA DKG started before the proxy upgrade has completed.
+    ///      The callback is intentionally not gated by `ecdsaRetired`.
+    function __ecdsaWalletCreatedCallback(
+        bytes32 ecdsaWalletID,
+        bytes32 publicKeyX,
+        bytes32 publicKeyY
+    ) external override {
+        self.registerNewWallet(ecdsaWalletID, publicKeyX, publicKeyY);
+    }
 
     /// @notice A callback function that is called by the FROST wallet
     ///         registry once a new FROST/Schnorr-keyed wallet is created.
@@ -1220,7 +1184,7 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
         bytes32,
         bytes32 publicKeyX,
         bytes32 publicKeyY
-    ) external {
+    ) external override {
         self.notifyWalletHeartbeatFailed(publicKeyX, publicKeyY);
     }
 
@@ -2364,11 +2328,9 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
     ///         already blocked structurally, independent of this
     ///         flag: `requestNewWallet` dispatches only to the
     ///         FROST registry (the scheme-dispatch branch was
-    ///         removed in D-2.2 slice 3) and
-    ///         `__ecdsaWalletCreatedCallback` was removed in
-    ///         D-2.1. Because the create path is closed at the
-    ///         EVM dispatcher level, even flipping the flag back
-    ///         (e.g., via a storage poke) cannot reopen it.
+    ///         removed in D-2.2 slice 3). The retained ECDSA callback
+    ///         authenticates the legacy registry and only allows already
+    ///         initiated DKGs to complete; it cannot initiate a new request.
     ///
     ///         Off-chain consumers observe the transition via
     ///         the public `ecdsaRetired()` getter below (NOT
@@ -2514,87 +2476,21 @@ contract Bridge is Governable, Initializable, IReceiveBalanceApproval {
         );
     }
 
-    /// @notice One-time governance helper to transfer legacy ECDSA
-    ///         fraud challenges from Bridge storage to the
-    ///         EcdsaFraudRouter sidecar. Sends the aggregate escrowed
-    ///         ETH along with the challenge records.
+    /// @notice Governance helper transferring unresolved legacy fraud
+    ///         challenges and their aggregate ETH escrow to a router sidecar.
     /// @param challengeKeys Identifiers of legacy challenges (from
     ///        `BridgeState.fraudChallenges`) to migrate.
     /// @dev Requirements:
     ///      - Caller must be governance,
-    ///      - EcdsaFraudRouter must be set,
-    ///      - Each key must reference a challenge that exists in
-    ///        Bridge storage and has not already been migrated.
-    ///
-    ///      Operationally, governance is expected to drain/resolve as
-    ///      many active challenges as possible before invoking this
-    ///      helper, then run this once for any residual entries.
+    ///      - `routerKind` must be 0 (ECDSA) or 1 (P2TR),
+    ///      - The selected router must be set,
+    ///      - Every key must reference an unresolved legacy challenge.
     function migrateLegacyFraudChallenges(
         uint8 routerKind,
         uint256[] calldata challengeKeys
     ) external onlyGovernance {
-        // Deliberately stubbed in this PR. Removing the loop body
-        // saves ~1.1 KiB on Bridge, which is currently pressed
-        // against EIP-170 by the addition of the P2TR fraud router
-        // surface.
-        //
-        // The acceptable use of this stub is gated by a per-chain
-        // cutover playbook that must hold for EVERY chain the Bridge
-        // is deployed to BEFORE the upgrade that adds the router
-        // setters is queued:
-        //
-        //   1. Off-chain audit: enumerate every FraudChallengeSubmitted
-        //      and P2TRSignatureFraudChallengeSubmitted event ever
-        //      emitted on the target chain. Confirm the count is zero
-        //      OR confirm every emitted challenge has a matching
-        //      FraudChallengeDefeated / FraudChallengeDefeatTimedOut
-        //      (and the same for the P2TR pair). Snapshot the proof
-        //      into the deployment record.
-        //
-        //   2. Pre-upgrade quiet period: during the governance delay
-        //      window before this upgrade activates, governance MUST
-        //      not enable any new wallet (so no new fraud-able UTXOs
-        //      get unlocked); existing wallet maintainers MUST hold
-        //      off any fraud-eligible signing. The quiet period gives
-        //      the audit in step (1) durable validity.
-        //
-        //   3. Atomic cutover: the same governance proposal that
-        //      sets the routers (via setEcdsaFraudRouter +
-        //      setP2TRFraudRouter) is the proposal that activates
-        //      this upgrade. There is no in-between window where
-        //      Bridge accepts fraud calls but the routers are not
-        //      yet wired.
-        //
-        // If any chain cannot satisfy the audit OR the quiet period,
-        // the migration body MUST be added in a focused upgrade
-        // before the router upgrade activates on that chain. Bridge
-        // is upgradeable; the function signature, event, and
-        // `IEcdsaFraudRouterMigration` interface stay in place here
-        // so that follow-up upgrade is a body swap and not an ABI
-        // change.
-        //
-        // Chains in scope at the time of this PR: Ethereum L1
-        // (Sepolia + mainnet); no L2/sidechain Bridge deployments.
-        // Mainnet has never seen an opened fraud challenge; Sepolia
-        // has never seen one either. Both chains pass step (1) with
-        // count = 0.
-        routerKind;
-        challengeKeys;
-        // Custom error keeps the stub small at runtime; the rich
-        // diagnostic was previously a string revert that cost
-        // ~70 extra bytes in deployed bytecode. Behavior is
-        // unchanged for callers (the helper is unimplemented and
-        // governance MUST swap the body in via a focused upgrade
-        // if any chain fails the audit-or-quiet-period test in
-        // the cutover playbook above).
-        revert MigrateLegacyFraudChallengesNotImplemented();
+        self.migrateLegacyFraudChallenges(routerKind, challengeKeys);
     }
-
-    /// @notice The migrateLegacyFraudChallenges helper is
-    ///         deliberately stubbed in this PR (see the NatSpec
-    ///         block on the function itself). Custom error to
-    ///         keep the deployed bytecode small.
-    error MigrateLegacyFraudChallengesNotImplemented();
 
     /// @notice Sets the P2TRSignatureFraudRouter sidecar address.
     /// @dev Same one-time-setter pattern as `setEcdsaFraudRouter`.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1903,14 +1903,24 @@ contract Bridge is
         return self.liveWalletsCount;
     }
 
-    // fraudChallenges getter: moved off Bridge -- ECDSA challenges
-    // live on EcdsaFraudRouter, P2TR challenges live on
-    // P2TRSignatureFraudRouter. The legacy
-    // `BridgeState.fraudChallenges` mapping remains in storage to
-    // support one-time migration of pre-cutover entries via
-    // migrateLegacyFraudChallenges (routerKind 0 = ECDSA, 1 = P2TR),
-    // but no read accessor is exposed -- consumers should call the
-    // routers' `fraudChallenges` views directly.
+    /// @notice Returns whether a fraud challenge key is reserved by a
+    ///         pre-cutover record still held in Bridge storage.
+    /// @dev Both unresolved and resolved records reserve their key. This keeps
+    ///      the extracted routers from accepting public evidence under the
+    ///      same key before an unresolved record and its escrow are migrated,
+    ///      or replaying evidence that the legacy Bridge already resolved.
+    ///      During migration, Bridge deletes the legacy record and seeds the
+    ///      router record atomically, so the key is never available between
+    ///      those state transitions. This selector must remain callable while
+    ///      the immutable fraud routers accept submissions; removing it would
+    ///      fail closed and reject every future challenge.
+    function legacyFraudChallengeExists(uint256 challengeKey)
+        external
+        view
+        returns (bool)
+    {
+        return self.fraudChallenges[challengeKey].reportedAt != 0;
+    }
 
     /// @notice Collection of all moved funds sweep requests indexed by
     ///         `keccak256(movingFundsTxHash | movingFundsOutputIndex)`.

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1854,14 +1854,9 @@ contract BridgeGovernance is Ownable {
     ///        classification is required since the legacy Bridge
     ///        mapping was shared between the two lifecycles.
     /// @param challengeKeys Legacy challenge keys to migrate.
-    /// @dev The target `Bridge.migrateLegacyFraudChallenges` helper is
-    ///      intentionally non-operational in the current Bridge
-    ///      implementation: its body is stubbed out and it always
-    ///      reverts with `MigrateLegacyFraudChallengesNotImplemented`.
-    ///      Calls through this forwarder therefore revert until a
-    ///      future Bridge upgrade swaps in the migration body. The
-    ///      forwarder is kept in place so the governance ABI stays
-    ///      stable across that upgrade (a body swap, not an ABI change).
+    /// @dev Bridge accepts only unresolved records, deletes them before the
+    ///      router call, and transfers the exact aggregate escrow. A router
+    ///      failure reverts the complete migration atomically.
     function migrateLegacyFraudChallenges(
         uint8 routerKind,
         uint256[] calldata challengeKeys
@@ -1910,15 +1905,10 @@ contract BridgeGovernance is Ownable {
     ///         getter (NOT via an event: D-2.2 dropped the
     ///         `emit EcdsaRetired()` in `Bridge.retireEcdsa()`
     ///         to fit the getter under EIP-170).
-    /// @dev The load-bearing pre-upgrade step on existing
-    ///      mainnet deployments is
-    ///      `BridgeGovernance.setNewWalletScheme(Frost)` (the
-    ///      method above, already in the deployed
-    ///      BridgeGovernance from C-2). With scheme = Frost,
-    ///      no ECDSA dispatch ever reaches the registry, so
-    ///      the deadlock vector against the removed
-    ///      `__ecdsaWalletCreatedCallback` is structurally
-    ///      closed without ever calling `retireEcdsa()`.
+    /// @dev New requests are FROST-only after the Bridge upgrade. The Bridge
+    ///      intentionally retains the authenticated ECDSA creation callback
+    ///      so a request started before that upgrade can complete even if this
+    ///      audit-trail flag has already been set.
     ///
     ///      `retireEcdsa()` is a NEW function shipping in this
     ///      PR's source. Calling it on mainnet requires

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -437,8 +437,9 @@ library BridgeState {
         // ECDSA wallet creation is already blocked structurally,
         // because that function dispatches only to the FROST
         // registry (the scheme-dispatch branch was removed in
-        // D-2.2 slice 3) and `__ecdsaWalletCreatedCallback` was
-        // removed in D-2.1. The originally planned D-1 read-side
+        // D-2.2 slice 3). The authenticated ECDSA callback is retained
+        // solely to drain DKGs initiated before the upgrade and is
+        // deliberately not gated by this flag. The originally planned D-1 read-side
         // guard (rejecting ECDSA-routed requests) and the
         // pre-existing IDLE precheck it depended on were both
         // dropped when the scheme dispatch was removed, so no such

--- a/solidity/contracts/bridge/EcdsaFraudRouter.sol
+++ b/solidity/contracts/bridge/EcdsaFraudRouter.sol
@@ -221,16 +221,10 @@ contract EcdsaFraudRouter {
                 fraudChallenges[challengeKeys[i]].reportedAt == 0,
                 "Challenge already migrated"
             );
-            if (!data[i].resolved) {
-                require(
-                    data[i].reportedAt > 0,
-                    "Unresolved challenge not reported"
-                );
-            }
+            require(data[i].reportedAt > 0, "Challenge not reported");
+            require(!data[i].resolved, "Challenge already resolved");
             fraudChallenges[challengeKeys[i]] = data[i];
-            if (!data[i].resolved) {
-                openFraudChallengeCount++;
-            }
+            openFraudChallengeCount++;
             totalDeposit += data[i].depositAmount;
             emit FraudChallengeMigratedFromBridge(
                 challengeKeys[i],

--- a/solidity/contracts/bridge/EcdsaFraudRouter.sol
+++ b/solidity/contracts/bridge/EcdsaFraudRouter.sol
@@ -65,6 +65,11 @@ interface IBridgeForFraud {
         view
         returns (MovingFunds.MovedFundsSweepRequest memory);
 
+    function legacyFraudChallengeExists(uint256 challengeKey)
+        external
+        view
+        returns (bool);
+
     /// @notice Privileged callback the router invokes from the timeout
     ///         path. Bridge gates this with `onlyEcdsaFraudRouter`.
     function slashWalletForFraud(
@@ -304,6 +309,10 @@ contract EcdsaFraudRouter {
 
         Fraud.FraudChallenge storage challenge = fraudChallenges[challengeKey];
         require(challenge.reportedAt == 0, "Fraud challenge already exists");
+        require(
+            !b.legacyFraudChallengeExists(challengeKey),
+            "Legacy fraud challenge exists"
+        );
 
         challenge.challenger = msg.sender;
         challenge.depositAmount = msg.value;

--- a/solidity/contracts/bridge/Fraud.sol
+++ b/solidity/contracts/bridge/Fraud.sol
@@ -18,6 +18,8 @@ pragma solidity 0.8.17;
 import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
 import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
 
+import "./BridgeState.sol";
+
 /// @title Bridge fraud helpers
 /// @notice The ECDSA fraud lifecycle (submit / defeat / timeout) was
 ///         extracted out of this library into the `EcdsaFraudRouter`
@@ -57,6 +59,83 @@ library Fraud {
         // This struct doesn't contain `__gap` property as the structure is stored
         // in a mapping, mappings store values in different slots and they are
         // not contiguous with other values.
+    }
+
+    event LegacyFraudChallengeMigrated(
+        uint8 indexed routerKind,
+        uint256 indexed challengeKey,
+        address indexed challenger,
+        uint256 depositAmount
+    );
+
+    error InvalidLegacyFraudRouterKind();
+    error LegacyFraudRouterNotSet();
+    error LegacyFraudChallengeDoesNotExist();
+    error LegacyFraudChallengeAlreadyResolved();
+
+    /// @notice Moves unresolved fraud challenges and their exact ETH escrow
+    ///         from legacy Bridge storage into one of the fraud routers.
+    /// @dev This function is external so the migration loop stays in linked
+    ///      library bytecode instead of the size-constrained Bridge runtime.
+    ///      Records are deleted before the router interaction. Any router
+    ///      failure reverts the entire delegatecall, restoring both storage
+    ///      and escrow atomically.
+    function migrateLegacyFraudChallenges(
+        BridgeState.Storage storage self,
+        uint8 routerKind,
+        uint256[] calldata challengeKeys
+    ) external {
+        address router;
+
+        if (routerKind == 0) {
+            router = self.ecdsaFraudRouter;
+        } else if (routerKind == 1) {
+            router = self.p2trFraudRouter;
+        } else {
+            revert InvalidLegacyFraudRouterKind();
+        }
+
+        if (router == address(0)) {
+            revert LegacyFraudRouterNotSet();
+        }
+
+        FraudChallenge[] memory challenges = new FraudChallenge[](
+            challengeKeys.length
+        );
+        uint256 totalDeposit;
+
+        for (uint256 i = 0; i < challengeKeys.length; i++) {
+            uint256 challengeKey = challengeKeys[i];
+            FraudChallenge storage challenge = self.fraudChallenges[
+                challengeKey
+            ];
+
+            if (challenge.reportedAt == 0) {
+                revert LegacyFraudChallengeDoesNotExist();
+            }
+            if (challenge.resolved) {
+                revert LegacyFraudChallengeAlreadyResolved();
+            }
+
+            challenges[i] = challenge;
+            totalDeposit += challenge.depositAmount;
+
+            address challenger = challenge.challenger;
+            uint256 depositAmount = challenge.depositAmount;
+            delete self.fraudChallenges[challengeKey];
+
+            emit LegacyFraudChallengeMigrated(
+                routerKind,
+                challengeKey,
+                challenger,
+                depositAmount
+            );
+        }
+
+        IFraudRouterMigration(router).acceptMigration{value: totalDeposit}(
+            challengeKeys,
+            challenges
+        );
     }
 
     /// @notice Extracts the UTXO keys from the given preimage used during
@@ -202,4 +281,12 @@ library Fraud {
         uint32 sighashTypeLE = uint32(sighashTypeBytes);
         return sighashTypeLE.reverseUint32();
     }
+}
+
+/// @dev Common migration receiver implemented by both fraud router sidecars.
+interface IFraudRouterMigration {
+    function acceptMigration(
+        uint256[] calldata challengeKeys,
+        Fraud.FraudChallenge[] calldata data
+    ) external payable;
 }

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -248,17 +248,11 @@ contract P2TRSignatureFraudRouter {
                 fraudChallenges[challengeKeys[i]].reportedAt == 0,
                 "Challenge already migrated"
             );
-            if (!data[i].resolved) {
-                require(
-                    data[i].reportedAt > 0,
-                    "Unresolved challenge not reported"
-                );
-            }
+            require(data[i].reportedAt > 0, "Challenge not reported");
+            require(!data[i].resolved, "Challenge already resolved");
             fraudChallenges[challengeKeys[i]] = data[i];
-            if (!data[i].resolved) {
-                openFraudChallengeCount++;
-                unattributedOpenFraudChallengeCount++;
-            }
+            openFraudChallengeCount++;
+            unattributedOpenFraudChallengeCount++;
             totalDeposit += data[i].depositAmount;
             emit P2TRFraudChallengeMigratedFromBridge(
                 challengeKeys[i],

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -58,6 +58,11 @@ interface IBridgeForP2TRFraud {
         view
         returns (MovingFunds.MovedFundsSweepRequest memory);
 
+    function legacyFraudChallengeExists(uint256 challengeKey)
+        external
+        view
+        returns (bool);
+
     /// @notice Privileged callback the P2TR router invokes from the
     ///         timeout path. Bridge gates this with
     ///         `onlyP2TRFraudRouter`.
@@ -339,6 +344,10 @@ contract P2TRSignatureFraudRouter {
             context.challengeKey
         ];
         require(challenge.reportedAt == 0, "Fraud challenge already exists");
+        require(
+            !b.legacyFraudChallengeExists(context.challengeKey),
+            "Legacy fraud challenge exists"
+        );
 
         require(
             CheckBitcoinP2TRSignatureFraud.checkSignature(

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -348,9 +348,21 @@ library Wallets {
         /* solhint-disable-next-line not-rely-on-time */
         wallet.createdAt = uint32(block.timestamp);
 
-        // Set the freshly created wallet as the new active wallet.
-        self.activeWalletPubKeyHash = walletPubKeyHash;
-        self.activeWalletID = walletID;
+        // A callback for an ECDSA DKG started before the FROST upgrade may
+        // arrive after a newer FROST wallet has already been registered. The
+        // callback must still succeed so the legacy registry can complete its
+        // DKG, but it must not route new deposits away from that FROST wallet.
+        // Preserve the legacy replacement behavior when there is no active
+        // wallet or the current active wallet is itself ECDSA-keyed.
+        bytes20 activeWalletPubKeyHash = self.activeWalletPubKeyHash;
+        if (
+            activeWalletPubKeyHash == bytes20(0) ||
+            self.registeredWallets[activeWalletPubKeyHash].ecdsaWalletID !=
+            bytes32(0)
+        ) {
+            self.activeWalletPubKeyHash = walletPubKeyHash;
+            self.activeWalletID = walletID;
+        }
         self.walletPubKeyHashByWalletID[walletID] = walletPubKeyHash;
 
         self.liveWalletsCount++;

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.17;
 import "../bridge/BitcoinTx.sol";
 import "../bridge/Bridge.sol";
 import "../bridge/EcdsaLib.sol";
+import "../bridge/Fraud.sol";
 import "../bridge/MovingFunds.sol";
 import "../bridge/RebateStaking.sol";
 import "../bridge/Redemption.sol";
@@ -134,6 +135,33 @@ contract BridgeStub is Bridge {
 
     function resetLifecycleRouterForTest(address lifecycleRouter) external {
         self.lifecycleRouter = lifecycleRouter;
+    }
+
+    function resetEcdsaFraudRouterForTest(address router) external {
+        self.ecdsaFraudRouter = router;
+    }
+
+    function resetP2TRFraudRouterForTest(address router) external {
+        self.p2trFraudRouter = router;
+    }
+
+    function setLegacyFraudChallengeForTest(
+        uint256 challengeKey,
+        Fraud.FraudChallenge calldata challenge
+    ) external payable {
+        require(
+            msg.value == challenge.depositAmount,
+            "msg.value != challenge deposit"
+        );
+        self.fraudChallenges[challengeKey] = challenge;
+    }
+
+    function legacyFraudChallengeForTest(uint256 challengeKey)
+        external
+        view
+        returns (Fraud.FraudChallenge memory)
+    {
+        return self.fraudChallenges[challengeKey];
     }
 
     function setDepositDustThreshold(uint64 _depositDustThreshold) external {
@@ -299,17 +327,15 @@ contract BridgeStub is Bridge {
         self.ecdsaRetired = retired;
     }
 
-    /// @notice Test-only ECDSA wallet creation helper. Replaces
-    ///         the production `__ecdsaWalletCreatedCallback`
-    ///         that D-2 removed from Bridge. Replicates the
+    /// @notice Test-only ECDSA wallet creation helper. Replicates the
     ///         body of `Wallets.registerNewWallet` minus the
     ///         `msg.sender == ecdsaWalletRegistry` access
     ///         check so test fixtures can create ECDSA wallets
     ///         for downstream-flow testing (redemptions,
     ///         deposits, fraud, etc.) without needing to
     ///         impersonate the registry.
-    /// @dev Mainnet path is gone; this duplicated body lives
-    ///      in the test-only stub. If the library's
+    /// @dev This helper only bypasses production registry authentication.
+    ///      If the library's
     ///      `registerNewWallet` changes in a future PR, this
     ///      helper should be updated to match.
     function __ecdsaWalletCreatedCallbackForTest(

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -364,8 +364,15 @@ contract BridgeStub is Bridge {
         /* solhint-disable-next-line not-rely-on-time */
         wallet.createdAt = uint32(block.timestamp);
 
-        self.activeWalletPubKeyHash = walletPubKeyHash;
-        self.activeWalletID = walletID;
+        bytes20 activeWalletPubKeyHash = self.activeWalletPubKeyHash;
+        if (
+            activeWalletPubKeyHash == bytes20(0) ||
+            self.registeredWallets[activeWalletPubKeyHash].ecdsaWalletID !=
+            bytes32(0)
+        ) {
+            self.activeWalletPubKeyHash = walletPubKeyHash;
+            self.activeWalletID = walletID;
+        }
         self.walletPubKeyHashByWalletID[walletID] = walletPubKeyHash;
 
         self.liveWalletsCount++;

--- a/solidity/deploy/06_deploy_bridge.ts
+++ b/solidity/deploy/06_deploy_bridge.ts
@@ -37,14 +37,10 @@ const func: DeployFunction = async function deployBridge(
     contract: "contracts/bridge/Wallets.sol:Wallets",
     ...deployOptions,
   })
-  // Fraud and P2TRSignatureFraudLifecycle are no longer linked into
-  // Bridge -- the ECDSA fraud lifecycle moved to the EcdsaFraudRouter
-  // sidecar. Fraud retains a few `internal pure` helpers + the
-  // FraudChallenge struct (for the legacy storage mapping kept on
-  // Bridge until one-time migration completes), but internal-only
-  // libraries are inlined and need no separate deployment.
-  // EcdsaFraudRouter is deployed as a regular contract via its own
-  // deploy script.
+  // The migration loop is externalized into Fraud to keep the Bridge
+  // implementation below EIP-170 while preserving an atomic migration of
+  // pre-upgrade challenges and their escrow.
+  const Fraud = await deploy("Fraud", deployOptions)
   const MovingFunds = await deploy("MovingFunds", deployOptions)
 
   const [bridge, proxyDeployment] = await helpers.upgrades.deployProxy(
@@ -67,6 +63,7 @@ const func: DeployFunction = async function deployBridge(
           DepositSweep: DepositSweep.address,
           Redemption: Redemption.address,
           Wallets: Wallets.address,
+          Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
         },
       },
@@ -86,6 +83,7 @@ const func: DeployFunction = async function deployBridge(
     await helpers.etherscan.verify(DepositSweep)
     await helpers.etherscan.verify(Redemption)
     await helpers.etherscan.verify(Wallets)
+    await helpers.etherscan.verify(Fraud)
     await helpers.etherscan.verify(MovingFunds)
 
     // We use `verify` instead of `verify:verify` as the `verify` task is defined

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -5,7 +5,7 @@ import path from "path"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
-  const { get } = deployments
+  const { get, deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
   console.log("\n========== REBATE DEPLOYMENT STARTING ==========")
@@ -13,7 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("Deployer:", deployer)
   console.log("=================================================\n")
 
-  // Verify we're using existing mainnet deployments - do NOT redeploy!
+  // Verify the existing mainnet infrastructure before deploying upgrade
+  // components.
   console.log("Verifying existing mainnet infrastructure...")
   try {
     const Bridge = await deployments.get("Bridge")
@@ -112,17 +113,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("✓ Using existing Deposit library at:", Deposit.address)
   console.log("✓ Using existing Redemption library at:", Redemption.address)
 
-  // Step 3: Get existing libraries for Bridge upgrade
-  console.log("\nStep 3: Collecting existing libraries...")
+  // Step 3: Resolve existing libraries and deploy the current Fraud library.
+  // Fraud contains the legacy challenge migration entrypoint used by the
+  // current Bridge implementation. Linking a historical deployment would
+  // leave that selector unavailable.
+  console.log("\nStep 3: Collecting Bridge libraries...")
 
   const DepositSweep = await get("DepositSweep")
   const Wallets = await get("Wallets")
-  const Fraud = await get("Fraud")
+  const Fraud = await deploy("Fraud", {
+    from: deployer,
+    log: true,
+    waitConfirmations: 1,
+  })
   const MovingFunds = await get("MovingFunds")
 
   console.log("✓ Using existing DepositSweep at:", DepositSweep.address)
   console.log("✓ Using existing Wallets at:", Wallets.address)
-  console.log("✓ Using existing Fraud at:", Fraud.address)
+  console.log("✓ Using current Fraud at:", Fraud.address)
   console.log("✓ Using existing MovingFunds at:", MovingFunds.address)
 
   // Step 4: Deploy Bridge implementation
@@ -246,6 +254,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       rebateStaking: rebateStaking.address,
       depositLibrary: Deposit.address,
       redemptionLibrary: Redemption.address,
+      fraudLibrary: Fraud.address,
       bridgeImplementation: bridgeImplementation.address,
     },
     existingContracts: {
@@ -307,6 +316,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("  RebateStaking:         ", rebateStaking.address)
   console.log("  Deposit Library:       ", Deposit.address)
   console.log("  Redemption Library:    ", Redemption.address)
+  console.log("  Fraud Library:         ", Fraud.address)
   console.log("  Bridge Implementation: ", bridgeImplementation.address)
 
   console.log("\n================================================")
@@ -345,6 +355,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     await helpers.etherscan.verify(Deposit)
     await helpers.etherscan.verify(Redemption)
+    await helpers.etherscan.verify(Fraud)
 
     await hre.run("verify", {
       address: rebateProxyDeployment.address,
@@ -375,6 +386,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Verify on Tenderly if applicable
   if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "Fraud",
+      address: Fraud.address,
+    })
+
     await hre.tenderly.verify({
       name: "RebateStaking",
       address: rebateStaking.address,

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -117,12 +117,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const DepositSweep = await get("DepositSweep")
   const Wallets = await get("Wallets")
+  const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
-  // Fraud and P2TRSignatureFraudLifecycle are no longer linked into
-  // Bridge -- ECDSA fraud surface moved to EcdsaFraudRouter sidecar.
 
   console.log("✓ Using existing DepositSweep at:", DepositSweep.address)
   console.log("✓ Using existing Wallets at:", Wallets.address)
+  console.log("✓ Using existing Fraud at:", Fraud.address)
   console.log("✓ Using existing MovingFunds at:", MovingFunds.address)
 
   // Step 4: Deploy Bridge implementation
@@ -143,6 +143,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       DepositSweep: DepositSweep.address,
       Redemption: Redemption.address,
       Wallets: Wallets.address,
+      Fraud: Fraud.address,
       MovingFunds: MovingFunds.address,
     },
   })
@@ -360,6 +361,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           DepositSweep: DepositSweep.address,
           Redemption: Redemption.address,
           Wallets: Wallets.address,
+          Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
         },
       })

--- a/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
+++ b/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
@@ -1,13 +1,12 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
-/// Phase C-2.1a upgrade script — deploys a fresh `Wallets`
-/// library (the only one with FROST-related code changes this
-/// cycle) and re-links Bridge to the new address.
+/// Phase C-2.1a upgrade script — deploys fresh `Wallets` and
+/// `Fraud` libraries and re-links Bridge to the new addresses.
 ///
 /// Why a dedicated script: the standard `80_upgrade_bridge_v2.ts`
 /// pattern explicitly REUSES the pre-existing library
-/// deployments via `deployments.get("Wallets")`. C-2.1a's only
+/// deployments via `deployments.get("Wallets")`. C-2.1a's Wallets
 /// behavior change is the `self.ecdsaWalletCount += 1` increment
 /// in `Wallets.registerNewWallet` — that lives in the `Wallets`
 /// library's bytecode, NOT in Bridge's. Reusing the old library
@@ -15,9 +14,11 @@ import { DeployFunction } from "hardhat-deploy/types"
 /// library code; the counter would stay 0 forever.
 /// (Codex P1 review on PR #442.)
 ///
-/// All other linked libraries (`Deposit`, `DepositSweep`,
-/// `Redemption`, `MovingFunds`) are unchanged, so this script
-/// keeps them at their existing addresses.
+/// `Fraud` also has current-cycle changes preserving the legacy
+/// fraud-challenge lifecycle across the upgrade, so it must be
+/// deployed from the current source tree. All other linked libraries
+/// (`Deposit`, `DepositSweep`, `Redemption`, `MovingFunds`) are
+/// unchanged, so this script keeps them at their existing addresses.
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
   const { get, deploy } = deployments
@@ -45,6 +46,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
     waitConfirmations: 1,
   })
+  const Fraud = await deploy("Fraud", {
+    from: deployer,
+    log: true,
+    waitConfirmations: 1,
+  })
 
   const [bridge, proxyDeployment] = await helpers.upgrades.upgradeProxy(
     "Bridge",
@@ -68,6 +74,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           // Fresh Wallets address — this is what carries the
           // C-2.1a counter increment.
           Wallets: Wallets.address,
+          Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
         },
       },
@@ -79,11 +86,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   )
 
   console.log(
-    `C-2.1a upgrade: fresh Wallets library at ${Wallets.address} linked to Bridge ${bridge.address}`
+    `C-2.1a upgrade: fresh Wallets library at ${Wallets.address} and Fraud library at ${Fraud.address} linked to Bridge ${bridge.address}`
   )
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(Wallets)
+    await helpers.etherscan.verify(Fraud)
     await hre.run("verify", {
       address: proxyDeployment.address,
       constructorArgsParams: proxyDeployment.args,
@@ -94,6 +102,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await hre.tenderly.verify({
       name: "Wallets",
       address: Wallets.address,
+    })
+    await hre.tenderly.verify({
+      name: "Fraud",
+      address: Fraud.address,
     })
     await hre.tenderly.verify({
       name: "Bridge",
@@ -114,7 +126,7 @@ func.tags = ["UpgradeBridgeC21Counter"]
 // The env-var gate avoids accidental execution during normal
 // fixture-driven deploys (e.g., a `yarn deploy` without tag
 // filtering on a development network would otherwise rerun
-// this upgrade and link a fresh Wallets library on every
+// this upgrade and link fresh libraries on every
 // invocation). It also lets the documented command actually
 // execute — the prior `func.skip = async () => true` was
 // unconditional and made the documented invocation a no-op

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -211,6 +211,7 @@ function buildVerificationChecks(addresses: {
   rebateImpl: string
   depositLib: string
   redemptionLib: string
+  fraudLib: string
 }): VerificationCheck[] {
   return [
     {
@@ -224,9 +225,10 @@ function buildVerificationChecks(addresses: {
       expectedResult:
         "Bytecode should contain embedded library address fragments: " +
         `${addresses.depositLib.slice(2).toLowerCase()} (Deposit) and ` +
-        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption)`,
+        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption) and ` +
+        `${addresses.fraudLib.slice(2).toLowerCase()} (Fraud)`,
       description:
-        "Bridge implementation bytecode should contain embedded addresses of new Deposit and Redemption libraries",
+        "Bridge implementation bytecode should contain embedded addresses of new Deposit, Redemption, and Fraud libraries",
     },
     {
       command: `cast call ${addresses.bridgeProxy} "deposits(uint256)(bytes32,uint32,uint64,uint32,address,uint32)" <sample_deposit_key>`,
@@ -310,10 +312,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // --- Step 1: Deploy new library versions ---
   // Deposit has rebate integration changes; Redemption has the balanceOwner
-  // fix. Both require fresh deployments.
+  // fix; Fraud contains the legacy challenge migration entrypoint. All three
+  // require deployments from the current source before linking Bridge.
   console.log("\n--- Deploying updated libraries ---")
   const Deposit = await deploy("Deposit", deployOptions)
   const Redemption = await deploy("Redemption", deployOptions)
+  const Fraud = await deploy("Fraud", deployOptions)
 
   // --- Step 2: Resolve unchanged existing libraries ---
   // These libraries have NOT changed since last deployment and are reused
@@ -321,13 +325,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("\n--- Resolving existing libraries ---")
   const DepositSweep = await get("DepositSweep")
   const Wallets = await get("Wallets")
-  const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
 
   console.log("Existing library addresses:")
   console.log(`  DepositSweep: ${DepositSweep.address}`)
   console.log(`  Wallets:      ${Wallets.address}`)
-  console.log(`  Fraud:        ${Fraud.address}`)
   console.log(`  MovingFunds:  ${MovingFunds.address}`)
 
   // --- Step 3: Deploy Bridge implementation ---
@@ -367,6 +369,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("Deployed contract addresses:")
   console.log(`  Deposit library:              ${Deposit.address}`)
   console.log(`  Redemption library:           ${Redemption.address}`)
+  console.log(`  Fraud library:                ${Fraud.address}`)
   console.log(`  Bridge implementation:        ${bridgeImpl.address}`)
   console.log(`  RebateStaking implementation: ${rebateImpl.address}`)
   console.log("-".repeat(80))
@@ -479,6 +482,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deployedContracts: {
       Deposit: Deposit.address,
       Redemption: Redemption.address,
+      Fraud: Fraud.address,
       BridgeTIP109Implementation: bridgeImpl.address,
       RebateStakingTIP109Implementation: rebateImpl.address,
     },
@@ -531,6 +535,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       rebateImpl: rebateImpl.address,
       depositLib: Deposit.address,
       redemptionLib: Redemption.address,
+      fraudLib: Fraud.address,
     }),
   }
 
@@ -634,6 +639,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
+          },
+          {
+            address: Fraud.address,
+            name: "contracts/bridge/Fraud.sol:Fraud",
+            label: "Fraud",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -321,29 +321,26 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("\n--- Resolving existing libraries ---")
   const DepositSweep = await get("DepositSweep")
   const Wallets = await get("Wallets")
-  // Fraud library is no longer linked into Bridge — the ECDSA fraud
-  // lifecycle moved to the EcdsaFraudRouter sidecar in the FROST
-  // extraction (round-1 strip removed the Fraud library deployment from
-  // 06_deploy_bridge.ts). No "Fraud" deployment artifact exists; the
-  // Bridge implementation links 5 libraries, not 6.
+  const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
 
   console.log("Existing library addresses:")
   console.log(`  DepositSweep: ${DepositSweep.address}`)
   console.log(`  Wallets:      ${Wallets.address}`)
+  console.log(`  Fraud:        ${Fraud.address}`)
   console.log(`  MovingFunds:  ${MovingFunds.address}`)
 
   // --- Step 3: Deploy Bridge implementation ---
   // Uses a distinct artifact name to avoid overwriting the existing Bridge
   // proxy artifact managed by hardhat-deploy. The Bridge contract links
-  // 5 libraries at deployment time (Fraud moved to EcdsaFraudRouter
-  // sidecar — see round-1 covenant-debt strip on PR #971).
+  // all 6 libraries required by the current implementation.
   console.log("\n--- Deploying Bridge implementation ---")
   const bridgeLibraries = {
     Deposit: Deposit.address,
     DepositSweep: DepositSweep.address,
     Redemption: Redemption.address,
     Wallets: Wallets.address,
+    Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
   }
 

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -122,11 +122,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Deposit = await get("Deposit")
   console.log(`  Deposit (existing): ${Deposit.address}`)
 
-  // --- Step 2: Deploy new Redemption library (PR #940) ---
-  console.log("\n--- Deploying new Redemption library ---")
+  // --- Step 2: Deploy new Redemption and current Fraud libraries ---
+  // Fraud contains the legacy challenge migration entrypoint used by the
+  // current Bridge implementation, so a historical deployment cannot be
+  // reused here.
+  console.log("\n--- Deploying new Redemption and Fraud libraries ---")
   const Redemption = await deploy("RedemptionTIP109Hotfix", {
     ...deployOptions,
     contract: "Redemption",
+    skipIfAlreadyDeployed: false,
+  })
+  const Fraud = await deploy("FraudTIP109Hotfix", {
+    ...deployOptions,
+    contract: "Fraud",
     skipIfAlreadyDeployed: false,
   })
 
@@ -134,11 +142,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("\n--- Resolving existing libraries ---")
   const DepositSweep = await get("DepositSweep")
   const Wallets = await get("Wallets")
-  const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
 
   // --- Step 4: Deploy new Bridge implementation ---
-  // Linked to existing Deposit + new Redemption + unchanged libs.
+  // Linked to existing Deposit + new Redemption and Fraud + unchanged libs.
   console.log("\n--- Deploying Bridge implementation ---")
   const bridgeLibraries = {
     Deposit: Deposit.address,
@@ -169,6 +176,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("Deployed contract addresses:")
   console.log(`  Deposit library (existing):    ${Deposit.address}`)
   console.log(`  Redemption library (NEW):      ${Redemption.address}`)
+  console.log(`  Fraud library (NEW):           ${Fraud.address}`)
   console.log(`  Bridge implementation (NEW):   ${bridgeImpl.address}`)
   console.log(`  RebateStaking impl (NEW):      ${rebateImpl.address}`)
   console.log("-".repeat(80))
@@ -250,6 +258,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       "zero-address redeemer guard (PR #940)",
     deployedContracts: {
       RedemptionTIP109Hotfix: Redemption.address,
+      FraudTIP109Hotfix: Fraud.address,
       BridgeTIP109HotfixImplementation: bridgeImpl.address,
       RebateStakingTIP109HotfixImplementation: rebateImpl.address,
     },
@@ -349,6 +358,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
+          },
+          {
+            address: Fraud.address,
+            name: "contracts/bridge/Fraud.sol:Fraud",
+            label: "Fraud",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/test/bridge/Bridge.D1EcdsaRetirement.test.ts
+++ b/solidity/test/bridge/Bridge.D1EcdsaRetirement.test.ts
@@ -41,10 +41,9 @@ const { createSnapshot, restoreSnapshot } = helpers.snapshot
 // invariant: `requestNewWallet` reverts identically whether the
 // flag is set or not (FROST-only dispatch, unwired registry).
 //
-// ECDSA wallet creation is instead blocked structurally: the
-// scheme branch is gone (D-2.2 slice 3) and
-// `Bridge.__ecdsaWalletCreatedCallback` was removed entirely in
-// D-2 — so there is no late-callback drain path left to test.
+// New ECDSA requests are blocked structurally because the scheme
+// branch is gone. The authenticated callback remains deliberately
+// ungated so a DKG started before the proxy upgrade can still finish.
 describe("Bridge - ECDSA retirement (informational flag + D-2 setter)", () => {
   let governance: SignerWithAddress
   let thirdParty: SignerWithAddress
@@ -123,13 +122,40 @@ describe("Bridge - ECDSA retirement (informational flag + D-2 setter)", () => {
     })
   })
 
-  // D-2 removed `Bridge.__ecdsaWalletCreatedCallback`
-  // entirely — the late-callback drain test from D-1 no
-  // longer applies (there is no callback to drain). The
-  // ABI-removal regression is covered indirectly: any test
-  // attempting to call `bridge.__ecdsaWalletCreatedCallback`
-  // now hits a TypeError on the typechain proxy because the
-  // function is not in the ABI.
+  describe("legacy ECDSA creation callback continuity", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("preserves the production callback selector", async () => {
+      expect(
+        bridge.interface.getSighash(
+          "__ecdsaWalletCreatedCallback(bytes32,bytes32,bytes32)"
+        )
+      ).to.equal("0xa8fa0f42")
+    })
+
+    it("accepts a registry callback after ecdsaRetired is set", async () => {
+      await bridgeGovernance.connect(governance).retireEcdsa()
+
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.publicKeyX,
+          ecdsaWalletTestData.publicKeyY
+        )
+
+      expect(await bridge.ecdsaRetired()).to.equal(true)
+      expect(
+        (await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)).state
+      ).to.equal(1)
+    })
+  })
 
   describe("retireEcdsa (D-2 canonical setter)", () => {
     before(async () => {

--- a/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
+++ b/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
@@ -449,6 +449,117 @@ describe("Bridge - FROST Wallet Registration", () => {
     })
   })
 
+  describe("late ECDSA callback after FROST activation", () => {
+    let frostWalletPubKeyHash: string
+    let lateEcdsaCallbackTx: ContractTransaction
+
+    before(async () => {
+      await createSnapshot()
+      await bridge.resetFrostWalletRegistryForTest(frostRegistry.address)
+
+      await frostRegistry.callBridgeFrostWalletCreatedCallback(
+        bridge.address,
+        frostXOnlyOutputKey
+      )
+      frostWalletPubKeyHash = await bridge.walletPubKeyHashForWalletID(
+        frostXOnlyOutputKey
+      )
+
+      lateEcdsaCallbackTx = await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.publicKeyX,
+          ecdsaWalletTestData.publicKeyY
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should preserve the newer FROST wallet as active", async () => {
+      expect(await bridge.activeWalletPubKeyHash()).to.equal(
+        frostWalletPubKeyHash
+      )
+      expect(await bridge.activeWalletID()).to.equal(frostXOnlyOutputKey)
+    })
+
+    it("should still register the in-flight ECDSA wallet", async () => {
+      const wallet = await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)
+      const legacyWalletID = ethers.utils.hexZeroPad(
+        ecdsaWalletTestData.pubKeyHash160,
+        32
+      )
+
+      expect(wallet.ecdsaWalletID).to.equal(ecdsaWalletTestData.walletID)
+      expect(wallet.state).to.equal(walletState.Live)
+      expect(await bridge.walletPubKeyHashForWalletID(legacyWalletID)).to.equal(
+        ecdsaWalletTestData.pubKeyHash160
+      )
+      expect(await bridge.liveWalletsCount()).to.equal(2)
+      await expect(lateEcdsaCallbackTx)
+        .to.emit(bridge, "NewWalletRegisteredV2")
+        .withArgs(
+          legacyWalletID,
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.pubKeyHash160
+        )
+    })
+  })
+
+  describe("ECDSA callback with an active ECDSA wallet", () => {
+    const previousEcdsaWalletID =
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    // Valid secp256k1 public key for private key 1.
+    const previousPublicKeyX =
+      "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    const previousPublicKeyY =
+      "0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    let previousWalletPubKeyHash: string
+
+    before(async () => {
+      await createSnapshot()
+
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          previousEcdsaWalletID,
+          previousPublicKeyX,
+          previousPublicKeyY
+        )
+      previousWalletPubKeyHash = await bridge.activeWalletPubKeyHash()
+
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.publicKeyX,
+          ecdsaWalletTestData.publicKeyY
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should preserve legacy ECDSA active-wallet replacement", async () => {
+      expect(
+        (await bridge.wallets(previousWalletPubKeyHash)).ecdsaWalletID
+      ).to.equal(previousEcdsaWalletID)
+      expect(await bridge.activeWalletPubKeyHash()).to.equal(
+        ecdsaWalletTestData.pubKeyHash160
+      )
+      expect(await bridge.activeWalletPubKeyHash()).to.not.equal(
+        previousWalletPubKeyHash
+      )
+      expect(await bridge.activeWalletID()).to.equal(
+        ethers.utils.hexZeroPad(ecdsaWalletTestData.pubKeyHash160, 32)
+      )
+      expect(await bridge.liveWalletsCount()).to.equal(2)
+    })
+  })
+
   describe("ECDSA-ID-non-zero guard (via test-stub helper)", () => {
     // The ECDSA wallet creation path now reserves bytes32(0) as
     // the on-chain marker for FROST wallets. Before D-2 the

--- a/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
+++ b/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
@@ -452,13 +452,10 @@ describe("Bridge - FROST Wallet Registration", () => {
   describe("ECDSA-ID-non-zero guard (via test-stub helper)", () => {
     // The ECDSA wallet creation path now reserves bytes32(0) as
     // the on-chain marker for FROST wallets. Before D-2 the
-    // Bridge enforced this at the registration boundary via
-    // `__ecdsaWalletCreatedCallback`; D-2 removed that
-    // callback entirely (no new ECDSA wallets ever again), so
-    // this test now validates the same guard via the
-    // `BridgeStub.__ecdsaWalletCreatedCallbackForTest` helper
-    // — which mirrors the `Wallets.registerNewWallet` body
-    // including the `EcdsaWalletIdIsZero` custom error.
+    // Bridge enforces this at the authenticated production
+    // `__ecdsaWalletCreatedCallback`. This isolated boundary test uses the
+    // BridgeStub helper to bypass registry authentication while preserving the
+    // `Wallets.registerNewWallet` body and `EcdsaWalletIdIsZero` error.
     it("should revert with EcdsaWalletIdIsZero", async () =>
       expectCustomError(
         bridge.__ecdsaWalletCreatedCallbackForTest(

--- a/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
+++ b/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
@@ -1,0 +1,253 @@
+import { ethers, helpers, waffle } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { expect } from "chai"
+import type {
+  Bridge,
+  BridgeGovernance,
+  BridgeStub,
+  EcdsaFraudRouter,
+  P2TRSignatureFraudRouter,
+} from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+describe("Bridge - legacy fraud challenge migration", () => {
+  let deployer: SignerWithAddress
+  let governance: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let bridge: Bridge & BridgeStub
+  let bridgeGovernance: BridgeGovernance
+  let ecdsaFraudRouter: EcdsaFraudRouter
+  let p2trFraudRouter: P2TRSignatureFraudRouter
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      deployer,
+      governance,
+      thirdParty,
+      bridge,
+      bridgeGovernance,
+      ecdsaFraudRouter,
+      p2trFraudRouter,
+    } = await waffle.loadFixture(bridgeFixture))
+  })
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  async function seedChallenge(
+    challengeKey: number,
+    depositAmount: ReturnType<typeof ethers.utils.parseEther>,
+    resolved = false,
+    reportedAt = 1_700_000_000
+  ): Promise<void> {
+    await bridge.setLegacyFraudChallengeForTest(
+      challengeKey,
+      {
+        challenger: thirdParty.address,
+        depositAmount,
+        reportedAt,
+        resolved,
+      },
+      { value: depositAmount }
+    )
+  }
+
+  it("migrates an ECDSA batch and transfers the exact aggregate escrow", async () => {
+    const keys = [101, 102]
+    const deposits = [
+      ethers.utils.parseEther("0.4"),
+      ethers.utils.parseEther("0.7"),
+    ]
+    const totalDeposit = deposits[0].add(deposits[1])
+
+    await seedChallenge(keys[0], deposits[0])
+    await seedChallenge(keys[1], deposits[1])
+
+    const bridgeBalanceBefore = await ethers.provider.getBalance(bridge.address)
+    const routerBalanceBefore = await ethers.provider.getBalance(
+      ecdsaFraudRouter.address
+    )
+
+    const tx = await bridgeGovernance
+      .connect(governance)
+      .migrateLegacyFraudChallenges(0, keys)
+
+    await expect(tx)
+      .to.emit(bridge, "LegacyFraudChallengeMigrated")
+      .withArgs(0, keys[0], thirdParty.address, deposits[0])
+    await expect(tx)
+      .to.emit(bridge, "LegacyFraudChallengeMigrated")
+      .withArgs(0, keys[1], thirdParty.address, deposits[1])
+
+    expect(await ethers.provider.getBalance(bridge.address)).to.equal(
+      bridgeBalanceBefore.sub(totalDeposit)
+    )
+    expect(await ethers.provider.getBalance(ecdsaFraudRouter.address)).to.equal(
+      routerBalanceBefore.add(totalDeposit)
+    )
+    expect(await ecdsaFraudRouter.openFraudChallengeCount()).to.equal(2)
+
+    for (let i = 0; i < keys.length; i++) {
+      const legacy = await bridge.legacyFraudChallengeForTest(keys[i])
+      expect(legacy.reportedAt).to.equal(0)
+
+      const migrated = await ecdsaFraudRouter.fraudChallenges(keys[i])
+      expect(migrated.challenger).to.equal(thirdParty.address)
+      expect(migrated.depositAmount).to.equal(deposits[i])
+      expect(migrated.reportedAt).to.equal(1_700_000_000)
+      expect(migrated.resolved).to.equal(false)
+    }
+  })
+
+  it("routes P2TR records only to the P2TR router", async () => {
+    const key = 201
+    const deposit = ethers.utils.parseEther("0.25")
+    await seedChallenge(key, deposit)
+
+    await bridgeGovernance
+      .connect(governance)
+      .migrateLegacyFraudChallenges(1, [key])
+
+    expect((await p2trFraudRouter.fraudChallenges(key)).depositAmount).to.equal(
+      deposit
+    )
+    expect((await ecdsaFraudRouter.fraudChallenges(key)).reportedAt).to.equal(0)
+  })
+
+  it("rejects calls through BridgeGovernance from a non-owner", async () => {
+    await expect(
+      bridgeGovernance.connect(thirdParty).migrateLegacyFraudChallenges(0, [])
+    ).to.be.revertedWith("Ownable: caller is not the owner")
+  })
+
+  it("rejects direct calls to Bridge from a non-governance address", async () => {
+    await expect(
+      bridge.connect(thirdParty).migrateLegacyFraudChallenges(0, [])
+    ).to.be.revertedWith("Caller is not the governance")
+  })
+
+  it("rejects an unsupported router kind without consuming the record", async () => {
+    const key = 301
+    const deposit = ethers.utils.parseEther("0.1")
+    await seedChallenge(key, deposit)
+
+    await expect(
+      bridgeGovernance
+        .connect(governance)
+        .migrateLegacyFraudChallenges(2, [key])
+    ).to.be.reverted
+
+    expect(
+      (await bridge.legacyFraudChallengeForTest(key)).depositAmount
+    ).to.equal(deposit)
+  })
+
+  it("rejects an unwired router without consuming the record", async () => {
+    const key = 302
+    const deposit = ethers.utils.parseEther("0.1")
+    await seedChallenge(key, deposit)
+    await bridge.resetEcdsaFraudRouterForTest(ethers.constants.AddressZero)
+
+    await expect(
+      bridgeGovernance
+        .connect(governance)
+        .migrateLegacyFraudChallenges(0, [key])
+    ).to.be.reverted
+
+    expect(
+      (await bridge.legacyFraudChallengeForTest(key)).depositAmount
+    ).to.equal(deposit)
+  })
+
+  it("rejects a nonexistent legacy challenge", async () => {
+    await expect(
+      bridgeGovernance
+        .connect(governance)
+        .migrateLegacyFraudChallenges(0, [401])
+    ).to.be.reverted
+  })
+
+  it("rejects a resolved legacy challenge and leaves its escrow intact", async () => {
+    const key = 402
+    const deposit = ethers.utils.parseEther("0.15")
+    await seedChallenge(key, deposit, true)
+    const bridgeBalanceBefore = await ethers.provider.getBalance(bridge.address)
+
+    await expect(
+      bridgeGovernance
+        .connect(governance)
+        .migrateLegacyFraudChallenges(0, [key])
+    ).to.be.reverted
+
+    expect((await bridge.legacyFraudChallengeForTest(key)).resolved).to.equal(
+      true
+    )
+    expect(await ethers.provider.getBalance(bridge.address)).to.equal(
+      bridgeBalanceBefore
+    )
+  })
+
+  it("rolls deletion and escrow transfer back when the router rejects", async () => {
+    const key = 501
+    const initialDeposit = ethers.utils.parseEther("0.1")
+    await seedChallenge(key, initialDeposit)
+    await bridgeGovernance
+      .connect(governance)
+      .migrateLegacyFraudChallenges(0, [key])
+
+    const secondDeposit = ethers.utils.parseEther("0.2")
+    await seedChallenge(key, secondDeposit)
+    const bridgeBalanceBefore = await ethers.provider.getBalance(bridge.address)
+    const routerBalanceBefore = await ethers.provider.getBalance(
+      ecdsaFraudRouter.address
+    )
+
+    await expect(
+      bridgeGovernance
+        .connect(governance)
+        .migrateLegacyFraudChallenges(0, [key])
+    ).to.be.revertedWith("Challenge already migrated")
+
+    expect(
+      (await bridge.legacyFraudChallengeForTest(key)).depositAmount
+    ).to.equal(secondDeposit)
+    expect(await ethers.provider.getBalance(bridge.address)).to.equal(
+      bridgeBalanceBefore
+    )
+    expect(await ethers.provider.getBalance(ecdsaFraudRouter.address)).to.equal(
+      routerBalanceBefore
+    )
+  })
+
+  for (const routerName of ["EcdsaFraudRouter", "P2TRSignatureFraudRouter"]) {
+    it(`${routerName} rejects resolved migration records`, async () => {
+      const factory = await ethers.getContractFactory(routerName, deployer)
+      const router = await factory.deploy(thirdParty.address)
+      await router.deployed()
+      const deposit = ethers.utils.parseEther("0.1")
+
+      await expect(
+        router.connect(thirdParty).acceptMigration(
+          [601],
+          [
+            {
+              challenger: thirdParty.address,
+              depositAmount: deposit,
+              reportedAt: 1_700_000_000,
+              resolved: true,
+            },
+          ],
+          { value: deposit }
+        )
+      ).to.be.revertedWith("Challenge already resolved")
+    })
+  }
+})

--- a/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
+++ b/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
@@ -1,5 +1,6 @@
 import { ethers, helpers, waffle } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { BigNumberish } from "ethers"
 import { expect } from "chai"
 import type {
   Bridge,
@@ -9,6 +10,11 @@ import type {
   P2TRSignatureFraudRouter,
 } from "../../typechain"
 import bridgeFixture from "../fixtures/bridge"
+import {
+  nonWitnessSignSingleInputTx,
+  wallet as fraudWallet,
+} from "../data/fraud"
+import { constants, walletState } from "../fixtures"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
@@ -43,7 +49,7 @@ describe("Bridge - legacy fraud challenge migration", () => {
   })
 
   async function seedChallenge(
-    challengeKey: number,
+    challengeKey: BigNumberish,
     depositAmount: ReturnType<typeof ethers.utils.parseEther>,
     resolved = false,
     reportedAt = 1_700_000_000
@@ -105,6 +111,140 @@ describe("Bridge - legacy fraud challenge migration", () => {
       expect(migrated.reportedAt).to.equal(1_700_000_000)
       expect(migrated.resolved).to.equal(false)
     }
+  })
+
+  it("blocks public evidence from pre-seeding an ECDSA migration key", async () => {
+    const data = nonWitnessSignSingleInputTx
+    const key = ethers.BigNumber.from(
+      ethers.utils.solidityKeccak256(
+        ["bytes", "bytes32"],
+        [fraudWallet.publicKey, data.sighash]
+      )
+    )
+
+    await bridge.setWallet(fraudWallet.pubKeyHash160, {
+      ecdsaWalletID: fraudWallet.ecdsaWalletID,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: 1_700_000_000,
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+    await seedChallenge(key, constants.fraudChallengeDepositAmount)
+
+    await expect(
+      ecdsaFraudRouter
+        .connect(deployer)
+        .submitFraudChallenge(
+          fraudWallet.publicKey,
+          data.preimageSha256,
+          data.signature,
+          { value: constants.fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Legacy fraud challenge exists")
+
+    expect(await ecdsaFraudRouter.openFraudChallengeCount()).to.equal(0)
+    expect((await ecdsaFraudRouter.fraudChallenges(key)).reportedAt).to.equal(0)
+    expect(await ethers.provider.getBalance(ecdsaFraudRouter.address)).to.equal(
+      0
+    )
+    expect(await bridge.legacyFraudChallengeExists(key)).to.equal(true)
+
+    await bridgeGovernance
+      .connect(governance)
+      .migrateLegacyFraudChallenges(0, [key])
+
+    const migrated = await ecdsaFraudRouter.fraudChallenges(key)
+    expect(migrated.challenger).to.equal(thirdParty.address)
+    expect(migrated.depositAmount).to.equal(
+      constants.fraudChallengeDepositAmount
+    )
+    expect(await bridge.legacyFraudChallengeExists(key)).to.equal(false)
+  })
+
+  it("allows a fresh ECDSA key while a different legacy key awaits migration", async () => {
+    const data = nonWitnessSignSingleInputTx
+
+    await bridge.setWallet(fraudWallet.pubKeyHash160, {
+      ecdsaWalletID: fraudWallet.ecdsaWalletID,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: 1_700_000_000,
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+    await seedChallenge(
+      ethers.constants.MaxUint256,
+      ethers.utils.parseEther("0.1")
+    )
+
+    await ecdsaFraudRouter
+      .connect(deployer)
+      .submitFraudChallenge(
+        fraudWallet.publicKey,
+        data.preimageSha256,
+        data.signature,
+        { value: constants.fraudChallengeDepositAmount }
+      )
+
+    expect(
+      (
+        await ecdsaFraudRouter.fraudChallenges(
+          ethers.BigNumber.from(
+            ethers.utils.solidityKeccak256(
+              ["bytes", "bytes32"],
+              [fraudWallet.publicKey, data.sighash]
+            )
+          )
+        )
+      ).challenger
+    ).to.equal(deployer.address)
+    expect(
+      (await bridge.legacyFraudChallengeForTest(ethers.constants.MaxUint256))
+        .reportedAt
+    ).to.equal(1_700_000_000)
+  })
+
+  it("keeps a resolved legacy ECDSA key reserved against replay", async () => {
+    const data = nonWitnessSignSingleInputTx
+    const key = ethers.BigNumber.from(
+      ethers.utils.solidityKeccak256(
+        ["bytes", "bytes32"],
+        [fraudWallet.publicKey, data.sighash]
+      )
+    )
+
+    await bridge.setWallet(fraudWallet.pubKeyHash160, {
+      ecdsaWalletID: fraudWallet.ecdsaWalletID,
+      mainUtxoHash: ethers.constants.HashZero,
+      pendingRedemptionsValue: 0,
+      createdAt: 1_700_000_000,
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+    })
+    await seedChallenge(key, constants.fraudChallengeDepositAmount, true)
+
+    expect(await bridge.legacyFraudChallengeExists(key)).to.equal(true)
+    await expect(
+      ecdsaFraudRouter
+        .connect(deployer)
+        .submitFraudChallenge(
+          fraudWallet.publicKey,
+          data.preimageSha256,
+          data.signature,
+          { value: constants.fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Legacy fraud challenge exists")
+    expect(await ecdsaFraudRouter.openFraudChallengeCount()).to.equal(0)
   })
 
   it("routes P2TR records only to the P2TR router", async () => {

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -10,6 +10,7 @@ import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import type {
   Bridge,
+  BridgeGovernance,
   BridgeLifecycleRouter,
   BridgeStub,
   FrostWalletRegistryStub,
@@ -340,9 +341,11 @@ describe("Bridge - P2TR signature fraud", () => {
   }
 
   let thirdParty: SignerWithAddress
+  let governance: SignerWithAddress
   let treasury: SignerWithAddress
   let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
+  let bridgeGovernance: BridgeGovernance
   let bridgeSigner: Signer
   let frostWalletRegistry: FrostWalletRegistryStub
   let lifecycleRouter: BridgeLifecycleRouter
@@ -355,9 +358,11 @@ describe("Bridge - P2TR signature fraud", () => {
   before(async () => {
     const fixture = await waffle.loadFixture(bridgeFixture)
     thirdParty = fixture.thirdParty
+    governance = fixture.governance
     treasury = fixture.treasury
     walletRegistry = fixture.walletRegistry
     bridge = fixture.bridge
+    bridgeGovernance = fixture.bridgeGovernance
     p2trFraudRouter = fixture.p2trFraudRouter
 
     const FrostWalletRegistryStubFactory = await ethers.getContractFactory(
@@ -753,6 +758,61 @@ describe("Bridge - P2TR signature fraud", () => {
           { value: fraudChallengeDepositAmount }
         )
     ).to.be.revertedWith("Fraud challenge already exists")
+  })
+
+  it("blocks public evidence from pre-seeding a legacy P2TR migration key", async () => {
+    const payload = vectorPayload(vector)
+    await registerP2TRWallet(payload.walletID)
+    const challengeKey = await buildBridgeChallengeKey(
+      bridge.address,
+      hex(vector.expectedBridgeChallengeIdentityHex)
+    )
+    await bridge.setLegacyFraudChallengeForTest(
+      challengeKey,
+      {
+        challenger: treasury.address,
+        depositAmount: fraudChallengeDepositAmount,
+        reportedAt: 1_700_000_000,
+        resolved: false,
+      },
+      { value: fraudChallengeDepositAmount }
+    )
+
+    await expect(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Submit,
+          encodePayload(payload),
+          [],
+          { value: fraudChallengeDepositAmount }
+        )
+    ).to.be.revertedWith("Legacy fraud challenge exists")
+
+    expect(
+      (await p2trFraudRouter.fraudChallenges(challengeKey)).reportedAt
+    ).to.equal(0)
+    expect(await p2trFraudRouter.openFraudChallengeCount()).to.equal(0)
+    expect(await ethers.provider.getBalance(p2trFraudRouter.address)).to.equal(
+      0
+    )
+    expect(
+      (await bridge.legacyFraudChallengeForTest(challengeKey)).challenger
+    ).to.equal(treasury.address)
+
+    await bridgeGovernance
+      .connect(governance)
+      .migrateLegacyFraudChallenges(1, [challengeKey])
+
+    const migrated = await p2trFraudRouter.fraudChallenges(challengeKey)
+    expect(migrated.challenger).to.equal(treasury.address)
+    expect(migrated.depositAmount).to.equal(fraudChallengeDepositAmount)
+    expect(
+      (await bridge.legacyFraudChallengeForTest(challengeKey)).reportedAt
+    ).to.equal(0)
+    expect(await bridge.legacyFraudChallengeExists(challengeKey)).to.equal(
+      false
+    )
   })
 
   it("rejects P2TR challenges for unknown wallets before storage", async () => {

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -409,8 +409,8 @@ describe("Bridge - Wallets", () => {
       // The Bridge no longer gates FROST wallet creation on the LEGACY ECDSA
       // wallet registry's DKG state. That gate read
       // `ecdsaWalletRegistry.getWalletCreationState() == IDLE`; with ECDSA wallet
-      // creation retired (its created-callback removed), a stuck ECDSA DKG could
-      // never return to IDLE and would permanently block FROST wallet creation.
+      // creation retired, a stuck ECDSA DKG must not permanently block FROST
+      // wallet creation. The callback remains only to drain pre-upgrade DKGs.
       // The "one creation at a time" guarantee is now enforced by the FROST
       // registry itself — FrostWalletRegistry.requestNewWallet() calls
       // dkg.lockState(), which reverts ("Current state is not IDLE") unless the
@@ -420,28 +420,20 @@ describe("Bridge - Wallets", () => {
     })
   })
 
-  // D-2 removed `__ecdsaWalletCreatedCallback` from Bridge.
-  // Tests that previously exercised the callback now route
-  // through the `BridgeStub.__ecdsaWalletCreatedCallbackForTest`
-  // helper, which mirrors the body of the pre-removal callback
-  // minus the `msg.sender == ecdsaWalletRegistry` access check
-  // (no longer relevant — the production callback is gone).
-  // The "called by a third party should revert" case is no
-  // longer applicable: calling a removed selector reverts with
-  // no data at the EVM dispatcher; there is no
-  // registry-vs-third-party distinction to assert.
-  describe("__ecdsaWalletCreatedCallback (test-stub helper)", () => {
+  describe("__ecdsaWalletCreatedCallback", () => {
     context("when called with a valid ECDSA Wallet details", async () => {
       let tx: ContractTransaction
 
       before(async () => {
         await createSnapshot()
 
-        tx = await bridge.__ecdsaWalletCreatedCallbackForTest(
-          ecdsaWalletTestData.walletID,
-          ecdsaWalletTestData.publicKeyX,
-          ecdsaWalletTestData.publicKeyY
-        )
+        tx = await bridge
+          .connect(walletRegistry.wallet)
+          .__ecdsaWalletCreatedCallback(
+            ecdsaWalletTestData.walletID,
+            ecdsaWalletTestData.publicKeyX,
+            ecdsaWalletTestData.publicKeyY
+          )
       })
 
       after(async () => {
@@ -544,11 +536,13 @@ describe("Bridge - Wallets", () => {
         before(async () => {
           await createSnapshot()
 
-          tx = await bridge.__ecdsaWalletCreatedCallbackForTest(
-            registryWalletID,
-            ecdsaWalletTestData.publicKeyX,
-            ecdsaWalletTestData.publicKeyY
-          )
+          tx = await bridge
+            .connect(walletRegistry.wallet)
+            .__ecdsaWalletCreatedCallback(
+              registryWalletID,
+              ecdsaWalletTestData.publicKeyX,
+              ecdsaWalletTestData.publicKeyY
+            )
         })
 
         after(async () => {
@@ -598,11 +592,13 @@ describe("Bridge - Wallets", () => {
         before(async () => {
           await createSnapshot()
 
-          await bridge.__ecdsaWalletCreatedCallbackForTest(
-            ecdsaWalletTestData.walletID,
-            ecdsaWalletTestData.publicKeyX,
-            ecdsaWalletTestData.publicKeyY
-          )
+          await bridge
+            .connect(walletRegistry.wallet)
+            .__ecdsaWalletCreatedCallback(
+              ecdsaWalletTestData.walletID,
+              ecdsaWalletTestData.publicKeyX,
+              ecdsaWalletTestData.publicKeyY
+            )
         })
 
         after(async () => {
@@ -669,8 +665,9 @@ describe("Bridge - Wallets", () => {
             it(
               test.expectedError ? "should revert" : "should not revert",
               async () => {
-                const tx: Promise<ContractTransaction> =
-                  bridge.__ecdsaWalletCreatedCallbackForTest(
+                const tx: Promise<ContractTransaction> = bridge
+                  .connect(walletRegistry.wallet)
+                  .__ecdsaWalletCreatedCallback(
                     test.walletID,
                     test.publicKeyX,
                     test.publicKeyY
@@ -687,6 +684,20 @@ describe("Bridge - Wallets", () => {
         })
       }
     )
+
+    context("when called by a third party", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge
+            .connect(thirdParty)
+            .__ecdsaWalletCreatedCallback(
+              ecdsaWalletTestData.walletID,
+              ecdsaWalletTestData.publicKeyX,
+              ecdsaWalletTestData.publicKeyY
+            )
+        ).to.be.revertedWith("Caller is not the ECDSA Wallet Registry")
+      })
+    })
   })
 
   describe("activeWalletID", () => {

--- a/solidity/test/bridge/EcdsaFraudRouter.test.ts
+++ b/solidity/test/bridge/EcdsaFraudRouter.test.ts
@@ -236,7 +236,7 @@ describe("EcdsaFraudRouter", () => {
         ],
         { value: fraudChallengeDepositAmount }
       )
-    ).to.be.revertedWith("Unresolved challenge not reported")
+    ).to.be.revertedWith("Challenge not reported")
   })
 
   it("rejects FROST wallets even when they are not the active wallet", async () => {

--- a/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
+++ b/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai"
+import func from "../../deploy/84_upgrade_bridge_c2_1_counter"
+
+describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
+  const DEPLOYER_ADDRESS = "0x1000000000000000000000000000000000000001"
+  const TREASURY_ADDRESS = "0x1000000000000000000000000000000000000002"
+  const BANK_ADDRESS = "0x2000000000000000000000000000000000000001"
+  const LIGHT_RELAY_ADDRESS = "0x2000000000000000000000000000000000000002"
+  const WALLET_REGISTRY_ADDRESS = "0x2000000000000000000000000000000000000003"
+  const REIMBURSEMENT_POOL_ADDRESS =
+    "0x2000000000000000000000000000000000000004"
+  const DEPOSIT_ADDRESS = "0x3000000000000000000000000000000000000001"
+  const DEPOSIT_SWEEP_ADDRESS = "0x3000000000000000000000000000000000000002"
+  const REDEMPTION_ADDRESS = "0x3000000000000000000000000000000000000003"
+  const MOVING_FUNDS_ADDRESS = "0x3000000000000000000000000000000000000004"
+  const WALLETS_ADDRESS = "0x4000000000000000000000000000000000000001"
+  const FRAUD_ADDRESS = "0x4000000000000000000000000000000000000002"
+  const BRIDGE_ADDRESS = "0x5000000000000000000000000000000000000001"
+  const PROXY_ADDRESS = "0x5000000000000000000000000000000000000002"
+
+  const existingDeployments: Record<string, string> = {
+    Bank: BANK_ADDRESS,
+    LightRelay: LIGHT_RELAY_ADDRESS,
+    WalletRegistry: WALLET_REGISTRY_ADDRESS,
+    ReimbursementPool: REIMBURSEMENT_POOL_ADDRESS,
+    Deposit: DEPOSIT_ADDRESS,
+    DepositSweep: DEPOSIT_SWEEP_ADDRESS,
+    Redemption: REDEMPTION_ADDRESS,
+    MovingFunds: MOVING_FUNDS_ADDRESS,
+  }
+
+  const newLibraries: Record<string, string> = {
+    Wallets: WALLETS_ADDRESS,
+    Fraud: FRAUD_ADDRESS,
+  }
+
+  interface DeployCall {
+    name: string
+    options: any
+  }
+
+  function createMockHre(networkTags: Record<string, boolean> = {}) {
+    const getCalls: string[] = []
+    const deployCalls: DeployCall[] = []
+    const upgradeProxyCalls: any[][] = []
+    const etherscanVerifyCalls: any[] = []
+    const tenderlyVerifyCalls: any[] = []
+    const runCalls: Array<{ taskName: string; options: any }> = []
+
+    const mockHre: any = {
+      ethers: {
+        getSigner: async (address: string) => {
+          expect(address).to.equal(DEPLOYER_ADDRESS)
+          return { address }
+        },
+      },
+      deployments: {
+        get: async (name: string) => {
+          getCalls.push(name)
+          const address = existingDeployments[name]
+          if (!address) {
+            throw new Error(`Unexpected deployment lookup: ${name}`)
+          }
+          return { address }
+        },
+        deploy: async (name: string, options: any) => {
+          deployCalls.push({ name, options })
+          const address = newLibraries[name]
+          if (!address) {
+            throw new Error(`Unexpected deployment: ${name}`)
+          }
+          return { address, newlyDeployed: true }
+        },
+      },
+      getNamedAccounts: async () => ({
+        deployer: DEPLOYER_ADDRESS,
+        treasury: TREASURY_ADDRESS,
+      }),
+      helpers: {
+        upgrades: {
+          upgradeProxy: async (...args: any[]) => {
+            upgradeProxyCalls.push(args)
+            return [
+              { address: BRIDGE_ADDRESS },
+              { address: PROXY_ADDRESS, args: [] },
+            ]
+          },
+        },
+        etherscan: {
+          verify: async (deployment: any) => {
+            etherscanVerifyCalls.push(deployment)
+          },
+        },
+      },
+      network: { tags: networkTags },
+      tenderly: {
+        verify: async (deployment: any) => {
+          tenderlyVerifyCalls.push(deployment)
+        },
+      },
+      run: async (taskName: string, options: any) => {
+        runCalls.push({ taskName, options })
+      },
+    }
+
+    return {
+      mockHre,
+      getCalls,
+      deployCalls,
+      upgradeProxyCalls,
+      etherscanVerifyCalls,
+      tenderlyVerifyCalls,
+      runCalls,
+    }
+  }
+
+  it("reuses unchanged libraries and deploys and links current Wallets and Fraud", async () => {
+    const { mockHre, getCalls, deployCalls, upgradeProxyCalls } =
+      createMockHre()
+    const logCalls: string[] = []
+    const originalLog = console.log
+    console.log = (message?: any) => logCalls.push(String(message))
+
+    try {
+      await func(mockHre)
+    } finally {
+      console.log = originalLog
+    }
+
+    expect(getCalls).to.deep.equal([
+      "Bank",
+      "LightRelay",
+      "WalletRegistry",
+      "ReimbursementPool",
+      "Deposit",
+      "DepositSweep",
+      "Redemption",
+      "MovingFunds",
+    ])
+    expect(deployCalls.map(({ name }) => name)).to.deep.equal([
+      "Wallets",
+      "Fraud",
+    ])
+    deployCalls.forEach(({ name, options }) => {
+      expect(options.from, `${name} deployer`).to.equal(DEPLOYER_ADDRESS)
+      expect(options.log, `${name} logging`).to.be.true
+      expect(options.waitConfirmations, `${name} confirmations`).to.equal(1)
+    })
+    expect(deployCalls[0].options.contract).to.equal(
+      "contracts/bridge/Wallets.sol:Wallets"
+    )
+
+    expect(upgradeProxyCalls).to.have.lengthOf(1)
+    const [, , options] = upgradeProxyCalls[0]
+    expect(options.factoryOpts.libraries).to.deep.equal({
+      Deposit: DEPOSIT_ADDRESS,
+      DepositSweep: DEPOSIT_SWEEP_ADDRESS,
+      Redemption: REDEMPTION_ADDRESS,
+      Wallets: WALLETS_ADDRESS,
+      Fraud: FRAUD_ADDRESS,
+      MovingFunds: MOVING_FUNDS_ADDRESS,
+    })
+    expect(logCalls).to.have.lengthOf(1)
+    expect(logCalls[0]).to.include(`Wallets library at ${WALLETS_ADDRESS}`)
+    expect(logCalls[0]).to.include(`Fraud library at ${FRAUD_ADDRESS}`)
+  })
+
+  it("verifies both freshly deployed libraries", async () => {
+    const { mockHre, etherscanVerifyCalls, tenderlyVerifyCalls, runCalls } =
+      createMockHre({ etherscan: true, tenderly: true })
+
+    await func(mockHre)
+
+    expect(etherscanVerifyCalls.map(({ address }) => address)).to.deep.equal([
+      WALLETS_ADDRESS,
+      FRAUD_ADDRESS,
+    ])
+    expect(runCalls).to.deep.equal([
+      {
+        taskName: "verify",
+        options: { address: PROXY_ADDRESS, constructorArgsParams: [] },
+      },
+    ])
+    expect(tenderlyVerifyCalls).to.deep.equal([
+      { name: "Wallets", address: WALLETS_ADDRESS },
+      { name: "Fraud", address: FRAUD_ADDRESS },
+      { name: "Bridge", address: BRIDGE_ADDRESS },
+    ])
+  })
+})

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -224,11 +224,12 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       it("should resolve existing libraries via deployments.get()", async () => {
         await func(mockHre)
 
-        // Fraud is no longer linked into Bridge — moved to
-        // EcdsaFraudRouter sidecar by round-1 of the FROST extraction.
-        // Round 19 dropped the `get("Fraud")` call from the deploy script;
-        // updating the expected list here to match.
-        const expectedLibraries = ["DepositSweep", "Wallets", "MovingFunds"]
+        const expectedLibraries = [
+          "DepositSweep",
+          "Wallets",
+          "Fraud",
+          "MovingFunds",
+        ]
         const getNames = getCalls.map((c) => c.name)
 
         expectedLibraries.forEach((lib) => {
@@ -256,7 +257,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(directBridgeCall).to.be.undefined
       })
 
-      it("should define all 5 required libraries for Bridge implementation deployment", async () => {
+      it("should define all 6 required libraries for Bridge implementation deployment", async () => {
         await func(mockHre)
 
         const bridgeCall = deployCalls.find(
@@ -267,19 +268,16 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         const { libraries } = bridgeCall!.options
         expect(libraries).to.not.be.undefined
 
-        // 5 libraries, not 6: Fraud was extracted to the
-        // EcdsaFraudRouter sidecar by round-1 of the FROST extraction
-        // (06_deploy_bridge.ts and 85_deploy_tip109_governance_upgrade.ts
-        // updated in round 19 to drop the Fraud library link).
         const expectedLibKeys = [
           "Deposit",
           "DepositSweep",
           "Redemption",
           "Wallets",
+          "Fraud",
           "MovingFunds",
         ]
         const actualKeys = Object.keys(libraries)
-        expect(actualKeys).to.have.lengthOf(5)
+        expect(actualKeys).to.have.lengthOf(6)
 
         expectedLibKeys.forEach((key) => {
           expect(libraries).to.have.property(key)
@@ -291,6 +289,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(libraries.DepositSweep).to.equal(DEPOSIT_SWEEP_ADDRESS)
         expect(libraries.Redemption).to.equal(REDEMPTION_ADDRESS)
         expect(libraries.Wallets).to.equal(WALLETS_ADDRESS)
+        expect(libraries.Fraud).to.equal(FRAUD_ADDRESS)
         expect(libraries.MovingFunds).to.equal(MOVING_FUNDS_ADDRESS)
       })
 
@@ -739,20 +738,18 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       })
     })
 
-    it("should have libraries with all 5 entries", () => {
-      // 5 libraries after FROST extraction: Fraud moved to
-      // EcdsaFraudRouter sidecar (round 1 strip + round 19 deploy
-      // script update).
+    it("should have libraries with all 6 entries", () => {
       expect(summary).to.not.be.null
       const libs = summary.libraries
 
-      expect(Object.keys(libs)).to.have.lengthOf(5)
+      expect(Object.keys(libs)).to.have.lengthOf(6)
 
       const requiredKeys = [
         "Deposit",
         "DepositSweep",
         "Redemption",
         "Wallets",
+        "Fraud",
         "MovingFunds",
       ]
 

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -36,6 +36,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
   const deployAddressMap: Record<string, string> = {
     Deposit: DEPOSIT_ADDRESS,
     Redemption: REDEMPTION_ADDRESS,
+    Fraud: FRAUD_ADDRESS,
     BridgeTIP109Implementation: BRIDGE_IMPL_ADDRESS,
     RebateStakingTIP109Implementation: REBATE_IMPL_ADDRESS,
   }
@@ -43,7 +44,6 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
   const getAddressMap: Record<string, string> = {
     DepositSweep: DEPOSIT_SWEEP_ADDRESS,
     Wallets: WALLETS_ADDRESS,
-    Fraud: FRAUD_ADDRESS,
     MovingFunds: MOVING_FUNDS_ADDRESS,
     Bridge: BRIDGE_PROXY_ADDRESS,
     RebateStaking: REBATE_STAKING_PROXY_ADDRESS,
@@ -221,15 +221,20 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(redemptionCall!.options.waitConfirmations).to.equal(1)
       })
 
+      it("should deploy Fraud library with correct options", async () => {
+        await func(mockHre)
+
+        const fraudCall = deployCalls.find((c) => c.name === "Fraud")
+        expect(fraudCall).to.not.be.undefined
+        expect(fraudCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(fraudCall!.options.log).to.be.true
+        expect(fraudCall!.options.waitConfirmations).to.equal(1)
+      })
+
       it("should resolve existing libraries via deployments.get()", async () => {
         await func(mockHre)
 
-        const expectedLibraries = [
-          "DepositSweep",
-          "Wallets",
-          "Fraud",
-          "MovingFunds",
-        ]
+        const expectedLibraries = ["DepositSweep", "Wallets", "MovingFunds"]
         const getNames = getCalls.map((c) => c.name)
 
         expectedLibraries.forEach((lib) => {
@@ -238,6 +243,10 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
             `Expected deployments.get() to be called with "${lib}"`
           )
         })
+        expect(getNames).to.not.include(
+          "Fraud",
+          "Fraud must be deployed from current source, not resolved as an existing library"
+        )
       })
 
       it("should deploy Bridge implementation with distinct artifact name", async () => {
@@ -341,6 +350,9 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           ethers.constants.AddressZero
         )
 
+        const fraudArtifact = await deployments.get("Fraud")
+        expect(fraudArtifact.address).to.not.equal(ethers.constants.AddressZero)
+
         const bridgeImplArtifact = await deployments.get(
           "BridgeTIP109Implementation"
         )
@@ -371,6 +383,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           // Verify that deployed addresses appear in the console output
           const depositArtifact = await deployments.get("Deposit")
           const redemptionArtifact = await deployments.get("Redemption")
+          const fraudArtifact = await deployments.get("Fraud")
           const bridgeImplArtifact = await deployments.get(
             "BridgeTIP109Implementation"
           )
@@ -380,6 +393,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
 
           expect(allOutput).to.include(depositArtifact.address)
           expect(allOutput).to.include(redemptionArtifact.address)
+          expect(allOutput).to.include(fraudArtifact.address)
           expect(allOutput).to.include(bridgeImplArtifact.address)
           expect(allOutput).to.include(rebateImplArtifact.address)
         } finally {
@@ -700,13 +714,14 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       )
     })
 
-    it("should have deployedContracts with all 4 entries", () => {
+    it("should have deployedContracts with all 5 entries", () => {
       expect(summary).to.not.be.null
       const dc = summary.deployedContracts
 
       const requiredKeys = [
         "Deposit",
         "Redemption",
+        "Fraud",
         "BridgeTIP109Implementation",
         "RebateStakingTIP109Implementation",
       ]
@@ -895,7 +910,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(combined).to.include("56")
       })
 
-      it("should have a bytecode linkage check referencing Deposit and Redemption addresses", () => {
+      it("should have a bytecode linkage check referencing Deposit, Redemption, and Fraud addresses", () => {
         expect(summary).to.not.be.null
 
         const bytecodeCheck = summary.verificationChecks.find(
@@ -908,13 +923,15 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         ).to.not.be.undefined
 
         const combined = `${bytecodeCheck.command} ${bytecodeCheck.expectedResult}`
-        // The check should reference the deployed Deposit and Redemption
-        // library addresses (from deployAddressMap in mock)
+        // The check should reference all freshly deployed library addresses.
         expect(combined.toLowerCase()).to.include(
           DEPOSIT_ADDRESS.toLowerCase().slice(2)
         )
         expect(combined.toLowerCase()).to.include(
           REDEMPTION_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
+          FRAUD_ADDRESS.toLowerCase().slice(2)
         )
       })
     })

--- a/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
+++ b/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai"
+import fs from "fs"
+import path from "path"
+
+describe("active Bridge upgrade scripts", () => {
+  const deployDirectory = path.resolve(__dirname, "../../deploy")
+  const scripts = [
+    "82_deploy_rebate_and_prepare_txs.ts",
+    "84_upgrade_bridge_c2_1_counter.ts",
+    "85_deploy_tip109_governance_upgrade.ts",
+    "86_deploy_tip109_hotfix.ts",
+  ]
+
+  scripts.forEach((script) => {
+    it(`${script} deploys current Fraud bytecode before linking Bridge`, () => {
+      const source = fs.readFileSync(path.join(deployDirectory, script), "utf8")
+
+      expect(source).not.to.match(/get\("Fraud"\)/)
+      expect(source).to.match(/deploy\("Fraud(?:TIP109Hotfix)?"/)
+      expect(source).to.match(/Fraud:\s*Fraud\.address/)
+    })
+  })
+})

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -278,14 +278,9 @@ export default async function bridgeFixture(): Promise<{
           Redemption: (await helpers.contracts.getContract("Redemption"))
             .address,
           Wallets: (await helpers.contracts.getContract("Wallets")).address,
+          Fraud: (await helpers.contracts.getContract("Fraud")).address,
           MovingFunds: (await helpers.contracts.getContract("MovingFunds"))
             .address,
-          // Fraud / P2TRSignatureFraudLifecycle removed -- ECDSA
-          // fraud surface moved to EcdsaFraudRouter, P2TR signature-
-          // fraud surface moved to P2TRSignatureFraudRouter. The
-          // Fraud library retains only internal pure helpers (inlined)
-          // and the FraudChallenge struct for the legacy mapping; it
-          // is no longer an external library link target on Bridge.
         },
       },
       proxyOpts: {

--- a/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
@@ -429,9 +429,21 @@ describe("FrostWalletRegistry DKG edge cases (B-1.5 slice 4)", () => {
       )
     }
 
-    // Non-misbehaved operators stay eligible.
+    // Group selection samples with replacement, so an operator at an
+    // unmarked position can also occupy a marked position. Pick an operator
+    // ID that does not occur at any misbehaved position.
+    const misbehavedOperatorIdSet = new Set(
+      misbehavedOperatorIds.map((operatorId) => operatorId.toString())
+    )
+    const nonMisbehavedOperatorId = dkgResult.members.find(
+      (operatorId) => !misbehavedOperatorIdSet.has(operatorId.toString())
+    )
+    if (nonMisbehavedOperatorId === undefined) {
+      throw new Error("DKG result contains no non-misbehaved operator")
+    }
+
     const nonMisbehavedAddr = (
-      await frostSortitionPool.getIDOperators([dkgResult.members[0]])
+      await frostSortitionPool.getIDOperators([nonMisbehavedOperatorId])
     )[0]
     expect(
       await frostSortitionPool.isEligibleForRewards(nonMisbehavedAddr)


### PR DESCRIPTION
## Summary

- retain the authenticated ECDSA wallet-created callback so DKGs started before the proxy upgrade can finish afterward
- keep a newer active FROST wallet authoritative when that legacy callback arrives late
- keep new wallet requests FROST-only and preserve selector 0xa8fa0f42
- replace the legacy fraud migration stub with an external-library implementation that migrates unresolved records and exact escrow atomically
- reserve every legacy fraud-challenge key in Bridge until its record is atomically migrated, blocking permissionless router pre-seeding
- reject resolved or malformed records at both router receivers
- deploy the current Fraud artifact in every active Bridge assembly path before linking the migration entrypoint
- add the required Fraud link to the documented C-2.1 upgrade and record/verify the deployed address
- correct activation runbooks that referenced unavailable pause and scheme-setter controls
- stabilize the FROST DKG edge-case test for duplicate operator selections

## Review findings addressed

- Preserve the ECDSA callback across the direct upgrade
- Preserve the newer FROST wallet on a late ECDSA callback
- Disable legacy fraud submissions before removing resolvers
- Block router pre-seeding before migrating escrow
- Deploy the current Fraud library before linking upgrades
- Add the Fraud link to the C-2.1 upgrade path

The proxy upgrade atomically removes legacy fraud submission. Any challenge submitted in the final pre-upgrade block remains recoverable through the governance migration path, so correctness no longer depends on an unenforceable quiet period.

The ECDSA and P2TR routers now query Bridge for the canonical challenge key before recording a submission. A legacy record reserves that key whether unresolved or already resolved. Migration deletes the Bridge record and seeds the router in one transaction, so the key is never exposed between states; unrelated fresh keys remain available throughout batched migration. A patched router staged before the Bridge upgrade fails closed because the old Bridge lacks the reservation getter. Any previously staged router built from vulnerable bytecode must not be wired.

The retained ECDSA callback still completes registration, mapping, events, and counters so the legacy registry can drain an in-flight DKG. It now skips only the active-wallet hash/ID replacement when the current active record carries the FROST marker. No-active and active-ECDSA replacement behavior remains unchanged.

Scripts 82, 84, 85, and 86 deploy Fraud from the current source tree instead of resolving a historical deployment. A cross-script regression rejects any active path that returns to get(Fraud).

## Verification

- Pre-fix ECDSA and P2TR pre-seeding regressions reproduced: 0 passing / 2 failing because both replay submissions succeeded
- Post-fix focused replay/migration controls: 6 passing, covering both routers, resolved keys, unrelated fresh keys, rollback, and preserved challenger/escrow
- Independent migration, P2TR lifecycle, and storage-layout second pass: 59 passing
- Full legacy migration suite: 14 passing
- ECDSA fraud router plus full P2TR fraud suite: 54 passing
- Pre-fix production-callback regression reproduced the overwrite: 1 passing / 1 failing
- Post-fix late-callback regression: 2 passing
- No-active ECDSA activation control: 9 passing
- Active-ECDSA replacement control: 1 passing
- Bridge.FrostWalletRegistration + Bridge.Wallets + Bridge.D1EcdsaRetirement: 134 passing
- Aligned BridgeStub mirror: full Bridge.FrostWalletRegistration suite, 30 passing
- Inherited P2TR refund-reentrancy regression: passing after rebase
- Deployment-script regressions: 46 passing; full Hardhat deployment dry-run passed
- Bridge storage-layout invariant: 2 passing
- Solidity build passed; Bridge runtime 23.958 KiB with 618-byte EIP-170 headroom
- Exact Fraud external link present in Bridge bytecode
- Prettier, ESLint, Solhint, and diff check passed; pre-existing warning classes only

## Stack

Stack 3 of 4 on top of #1018. Merge #1017, then #1018, then this PR.
