### PR TITLE
fix(sdk): authenticate deposit prevout values

### DIFF
--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -5,7 +5,7 @@ import path from "path"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
-  const { get, deploy } = deployments
+  const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
   console.log("\n========== REBATE DEPLOYMENT STARTING ==========")
@@ -104,34 +104,40 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("✓ RebateStaking deployed at:", rebateStaking.address)
   }
 
-  // Step 2: Use existing libraries for Bridge
-  console.log("\nStep 2: Using existing libraries...")
-
-  const Deposit = await get("Deposit")
-  const Redemption = await get("Redemption")
-
-  console.log("✓ Using existing Deposit library at:", Deposit.address)
-  console.log("✓ Using existing Redemption library at:", Redemption.address)
-
-  // Step 3: Resolve existing libraries and deploy the current Fraud library.
-  // Fraud contains the legacy challenge migration entrypoint used by the
-  // current Bridge implementation. Linking a historical deployment would
-  // leave that selector unavailable.
-  console.log("\nStep 3: Collecting Bridge libraries...")
-
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const Fraud = await deploy("Fraud", {
+  const libraryDeployOptions = {
     from: deployer,
     log: true,
     waitConfirmations: 1,
-  })
-  const MovingFunds = await get("MovingFunds")
+  }
 
-  console.log("✓ Using existing DepositSweep at:", DepositSweep.address)
-  console.log("✓ Using existing Wallets at:", Wallets.address)
+  // Step 2: Deploy the current Deposit and Redemption libraries.
+  // This script builds Bridge from the checked-out source, so every linked
+  // library must come from that same source tree.
+  console.log("\nStep 2: Deploying current Bridge libraries...")
+
+  const Deposit = await deploy("Deposit", libraryDeployOptions)
+  const Redemption = await deploy("Redemption", libraryDeployOptions)
+
+  console.log("✓ Using current Deposit library at:", Deposit.address)
+  console.log("✓ Using current Redemption library at:", Redemption.address)
+
+  // Step 3: Deploy the remaining current Bridge libraries. Wallets uses a
+  // fully-qualified contract name to avoid the Wallets interface/library name
+  // collision. Fraud contains the legacy challenge migration entrypoint.
+  console.log("\nStep 3: Deploying remaining current Bridge libraries...")
+
+  const DepositSweep = await deploy("DepositSweep", libraryDeployOptions)
+  const Wallets = await deploy("Wallets", {
+    contract: "contracts/bridge/Wallets.sol:Wallets",
+    ...libraryDeployOptions,
+  })
+  const Fraud = await deploy("Fraud", libraryDeployOptions)
+  const MovingFunds = await deploy("MovingFunds", libraryDeployOptions)
+
+  console.log("✓ Using current DepositSweep at:", DepositSweep.address)
+  console.log("✓ Using current Wallets at:", Wallets.address)
   console.log("✓ Using current Fraud at:", Fraud.address)
-  console.log("✓ Using existing MovingFunds at:", MovingFunds.address)
+  console.log("✓ Using current MovingFunds at:", MovingFunds.address)
 
   // Step 4: Deploy Bridge implementation
   console.log("\nStep 4: Deploying Bridge implementation...")
@@ -253,8 +259,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deployedContracts: {
       rebateStaking: rebateStaking.address,
       depositLibrary: Deposit.address,
+      depositSweepLibrary: DepositSweep.address,
       redemptionLibrary: Redemption.address,
+      walletsLibrary: Wallets.address,
       fraudLibrary: Fraud.address,
+      movingFundsLibrary: MovingFunds.address,
       bridgeImplementation: bridgeImplementation.address,
     },
     existingContracts: {
@@ -315,8 +324,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("\nDEPLOYED CONTRACTS:")
   console.log("  RebateStaking:         ", rebateStaking.address)
   console.log("  Deposit Library:       ", Deposit.address)
+  console.log("  DepositSweep Library:  ", DepositSweep.address)
   console.log("  Redemption Library:    ", Redemption.address)
+  console.log("  Wallets Library:       ", Wallets.address)
   console.log("  Fraud Library:         ", Fraud.address)
+  console.log("  MovingFunds Library:   ", MovingFunds.address)
   console.log("  Bridge Implementation: ", bridgeImplementation.address)
 
   console.log("\n================================================")
@@ -354,8 +366,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("Verifying contracts on Etherscan...")
 
     await helpers.etherscan.verify(Deposit)
+    await helpers.etherscan.verify(DepositSweep)
     await helpers.etherscan.verify(Redemption)
+    await helpers.etherscan.verify(Wallets)
     await helpers.etherscan.verify(Fraud)
+    await helpers.etherscan.verify(MovingFunds)
 
     await hre.run("verify", {
       address: rebateProxyDeployment.address,
@@ -387,8 +402,33 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Verify on Tenderly if applicable
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
+      name: "Deposit",
+      address: Deposit.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "DepositSweep",
+      address: DepositSweep.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "Redemption",
+      address: Redemption.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "Wallets",
+      address: Wallets.address,
+    })
+
+    await hre.tenderly.verify({
       name: "Fraud",
       address: Fraud.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "MovingFunds",
+      address: MovingFunds.address,
     })
 
     await hre.tenderly.verify({
@@ -406,5 +446,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployRebateAndPrepareTxs"]
-// Dependencies removed to avoid redeploying existing mainnet contracts
+// Dependencies remain removed so standalone live-network execution does not
+// rerun the full Bridge deployment chain.
 // func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
+++ b/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
@@ -1,27 +1,23 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
-import { DeployFunction } from "hardhat-deploy/types"
+import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
 
-/// Phase C-2.1a upgrade script — deploys fresh `Wallets` and
-/// `Fraud` libraries and re-links Bridge to the new addresses.
+/// Phase C-2.1a upgrade script — deploys the current versions of all
+/// external libraries linked by `Bridge` and upgrades the proxy using
+/// those addresses.
 ///
 /// Why a dedicated script: the standard `80_upgrade_bridge_v2.ts`
-/// pattern explicitly REUSES the pre-existing library
-/// deployments via `deployments.get("Wallets")`. C-2.1a's Wallets
-/// behavior change is the `self.ecdsaWalletCount += 1` increment
-/// in `Wallets.registerNewWallet` — that lives in the `Wallets`
-/// library's bytecode, NOT in Bridge's. Reusing the old library
-/// address would link the new Bridge implementation to old
-/// library code; the counter would stay 0 forever.
-/// (Codex P1 review on PR #442.)
-///
-/// `Fraud` also has current-cycle changes preserving the legacy
-/// fraud-challenge lifecycle across the upgrade, so it must be
-/// deployed from the current source tree. All other linked libraries
-/// (`Deposit`, `DepositSweep`, `Redemption`, `MovingFunds`) are
-/// unchanged, so this script keeps them at their existing addresses.
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+/// pattern explicitly reuses pre-existing library deployments via
+/// `deployments.get`. This script compiles the current `Bridge` source,
+/// so each linked library must be deployed from the same source tree.
+/// Otherwise, the implementation can delegate to stale library bytecode
+/// that lacks the FROST and Taproot behavior exposed by the current Bridge.
+/// `hardhat-deploy` compares deployment bytecode and reuses an existing
+/// address only when it already contains the current library version.
+const func: DeployFunction = async function upgradeBridgeC21Counter(
+  hre: HardhatRuntimeEnvironment
+) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
-  const { get, deploy } = deployments
+  const { get, deploy, log } = deployments
   const { deployer, treasury } = await getNamedAccounts()
 
   const Bank = await get("Bank")
@@ -31,26 +27,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const txProofDifficultyFactor = 6
 
-  // Unchanged libraries — reuse existing addresses.
-  const Deposit = await get("Deposit")
-  const DepositSweep = await get("DepositSweep")
-  const Redemption = await get("Redemption")
-  const MovingFunds = await get("MovingFunds")
+  const deployOptions: DeployOptions = {
+    from: deployer,
+    log: true,
+    waitConfirmations: 1,
+  }
 
-  // Wallets has changed (C-2.1a counter increment) — deploy
-  // a fresh library version. hardhat-deploy will detect the
-  // bytecode hash mismatch and publish a new address.
+  const Deposit = await deploy("Deposit", deployOptions)
+  const DepositSweep = await deploy("DepositSweep", deployOptions)
+  const Redemption = await deploy("Redemption", deployOptions)
   const Wallets = await deploy("Wallets", {
     contract: "contracts/bridge/Wallets.sol:Wallets",
-    from: deployer,
-    log: true,
-    waitConfirmations: 1,
+    ...deployOptions,
   })
-  const Fraud = await deploy("Fraud", {
-    from: deployer,
-    log: true,
-    waitConfirmations: 1,
-  })
+  const Fraud = await deploy("Fraud", deployOptions)
+  const MovingFunds = await deploy("MovingFunds", deployOptions)
 
   const [bridge, proxyDeployment] = await helpers.upgrades.upgradeProxy(
     "Bridge",
@@ -71,8 +62,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Deposit: Deposit.address,
           DepositSweep: DepositSweep.address,
           Redemption: Redemption.address,
-          // Fresh Wallets address — this is what carries the
-          // C-2.1a counter increment.
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
@@ -85,13 +74,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  console.log(
-    `C-2.1a upgrade: fresh Wallets library at ${Wallets.address} and Fraud library at ${Fraud.address} linked to Bridge ${bridge.address}`
+  log(
+    "C-2.1a upgrade: current Bridge libraries linked:\n" +
+      `  Deposit: ${Deposit.address}\n` +
+      `  DepositSweep: ${DepositSweep.address}\n` +
+      `  Redemption: ${Redemption.address}\n` +
+      `  Wallets: ${Wallets.address}\n` +
+      `  Fraud: ${Fraud.address}\n` +
+      `  MovingFunds: ${MovingFunds.address}\n` +
+      `  Bridge: ${bridge.address}`
   )
 
   if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(Deposit)
+    await helpers.etherscan.verify(DepositSweep)
+    await helpers.etherscan.verify(Redemption)
     await helpers.etherscan.verify(Wallets)
     await helpers.etherscan.verify(Fraud)
+    await helpers.etherscan.verify(MovingFunds)
     await hre.run("verify", {
       address: proxyDeployment.address,
       constructorArgsParams: proxyDeployment.args,
@@ -100,12 +100,28 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
+      name: "Deposit",
+      address: Deposit.address,
+    })
+    await hre.tenderly.verify({
+      name: "DepositSweep",
+      address: DepositSweep.address,
+    })
+    await hre.tenderly.verify({
+      name: "Redemption",
+      address: Redemption.address,
+    })
+    await hre.tenderly.verify({
       name: "Wallets",
       address: Wallets.address,
     })
     await hre.tenderly.verify({
       name: "Fraud",
       address: Fraud.address,
+    })
+    await hre.tenderly.verify({
+      name: "MovingFunds",
+      address: MovingFunds.address,
     })
     await hre.tenderly.verify({
       name: "Bridge",
@@ -126,9 +142,7 @@ func.tags = ["UpgradeBridgeC21Counter"]
 // The env-var gate avoids accidental execution during normal
 // fixture-driven deploys (e.g., a `yarn deploy` without tag
 // filtering on a development network would otherwise rerun
-// this upgrade and link fresh libraries on every
-// invocation). It also lets the documented command actually
-// execute — the prior `func.skip = async () => true` was
-// unconditional and made the documented invocation a no-op
-// (Codex P1 review on PR #442).
+// this upgrade on every invocation). It also lets the documented
+// command actually execute — the prior `func.skip = async () => true`
+// was unconditional and made the documented invocation a no-op.
 func.skip = async () => process.env.RUN_UPGRADE_C2_1_COUNTER !== "1"

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -210,8 +210,11 @@ function buildVerificationChecks(addresses: {
   rebateStakingProxy: string
   rebateImpl: string
   depositLib: string
+  depositSweepLib: string
   redemptionLib: string
+  walletsLib: string
   fraudLib: string
+  movingFundsLib: string
 }): VerificationCheck[] {
   return [
     {
@@ -224,11 +227,14 @@ function buildVerificationChecks(addresses: {
       command: `cast code ${addresses.bridgeImpl}`,
       expectedResult:
         "Bytecode should contain embedded library address fragments: " +
-        `${addresses.depositLib.slice(2).toLowerCase()} (Deposit) and ` +
-        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption) and ` +
-        `${addresses.fraudLib.slice(2).toLowerCase()} (Fraud)`,
+        `${addresses.depositLib.slice(2).toLowerCase()} (Deposit), ` +
+        `${addresses.depositSweepLib.slice(2).toLowerCase()} (DepositSweep), ` +
+        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption), ` +
+        `${addresses.walletsLib.slice(2).toLowerCase()} (Wallets), ` +
+        `${addresses.fraudLib.slice(2).toLowerCase()} (Fraud), and ` +
+        `${addresses.movingFundsLib.slice(2).toLowerCase()} (MovingFunds)`,
       description:
-        "Bridge implementation bytecode should contain embedded addresses of new Deposit, Redemption, and Fraud libraries",
+        "Bridge implementation bytecode should contain embedded addresses of all six current Bridge libraries",
     },
     {
       command: `cast call ${addresses.bridgeProxy} "deposits(uint256)(bytes32,uint32,uint64,uint32,address,uint32)" <sample_deposit_key>`,
@@ -310,27 +316,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Network: ${hre.network.name}`)
   console.log(`Deployer: ${deployer}`)
 
-  // --- Step 1: Deploy new library versions ---
-  // Deposit has rebate integration changes; Redemption has the balanceOwner
-  // fix; Fraud contains the legacy challenge migration entrypoint. All three
-  // require deployments from the current source before linking Bridge.
-  console.log("\n--- Deploying updated libraries ---")
+  // --- Step 1: Deploy current Bridge library versions ---
+  // The implementation is compiled from the current checkout, so every
+  // external library must be deployed from the same source before linking.
+  console.log("\n--- Deploying current Bridge libraries ---")
   const Deposit = await deploy("Deposit", deployOptions)
+  const DepositSweep = await deploy("DepositSweep", deployOptions)
   const Redemption = await deploy("Redemption", deployOptions)
+  const Wallets = await deploy("Wallets", {
+    contract: "contracts/bridge/Wallets.sol:Wallets",
+    ...deployOptions,
+  })
   const Fraud = await deploy("Fraud", deployOptions)
-
-  // --- Step 2: Resolve unchanged existing libraries ---
-  // These libraries have NOT changed since last deployment and are reused
-  // from existing deployment artifacts.
-  console.log("\n--- Resolving existing libraries ---")
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const MovingFunds = await get("MovingFunds")
-
-  console.log("Existing library addresses:")
-  console.log(`  DepositSweep: ${DepositSweep.address}`)
-  console.log(`  Wallets:      ${Wallets.address}`)
-  console.log(`  MovingFunds:  ${MovingFunds.address}`)
+  const MovingFunds = await deploy("MovingFunds", deployOptions)
 
   // --- Step 3: Deploy Bridge implementation ---
   // Uses a distinct artifact name to avoid overwriting the existing Bridge
@@ -368,8 +366,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`\n${"-".repeat(80)}`)
   console.log("Deployed contract addresses:")
   console.log(`  Deposit library:              ${Deposit.address}`)
+  console.log(`  DepositSweep library:         ${DepositSweep.address}`)
   console.log(`  Redemption library:           ${Redemption.address}`)
+  console.log(`  Wallets library:              ${Wallets.address}`)
   console.log(`  Fraud library:                ${Fraud.address}`)
+  console.log(`  MovingFunds library:          ${MovingFunds.address}`)
   console.log(`  Bridge implementation:        ${bridgeImpl.address}`)
   console.log(`  RebateStaking implementation: ${rebateImpl.address}`)
   console.log("-".repeat(80))
@@ -481,8 +482,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     chainId,
     deployedContracts: {
       Deposit: Deposit.address,
+      DepositSweep: DepositSweep.address,
       Redemption: Redemption.address,
+      Wallets: Wallets.address,
       Fraud: Fraud.address,
+      MovingFunds: MovingFunds.address,
       BridgeTIP109Implementation: bridgeImpl.address,
       RebateStakingTIP109Implementation: rebateImpl.address,
     },
@@ -534,8 +538,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       rebateStakingProxy: RebateStaking.address,
       rebateImpl: rebateImpl.address,
       depositLib: Deposit.address,
+      depositSweepLib: DepositSweep.address,
       redemptionLib: Redemption.address,
+      walletsLib: Wallets.address,
       fraudLib: Fraud.address,
+      movingFundsLib: MovingFunds.address,
     }),
   }
 
@@ -636,14 +643,29 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             label: "Deposit",
           },
           {
+            address: DepositSweep.address,
+            name: "contracts/bridge/DepositSweep.sol:DepositSweep",
+            label: "DepositSweep",
+          },
+          {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
           },
           {
+            address: Wallets.address,
+            name: "contracts/bridge/Wallets.sol:Wallets",
+            label: "Wallets",
+          },
+          {
             address: Fraud.address,
             name: "contracts/bridge/Fraud.sol:Fraud",
             label: "Fraud",
+          },
+          {
+            address: MovingFunds.address,
+            name: "contracts/bridge/MovingFunds.sol:MovingFunds",
+            label: "MovingFunds",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -116,20 +116,29 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Network: ${hre.network.name}`)
   console.log(`Deployer: ${deployer}`)
 
-  // --- Step 1: Reuse existing Deposit library ---
-  // PRs #939/#940 do not touch Deposit.sol. Reuse to save gas.
-  console.log("\n--- Reusing existing Deposit library ---")
-  const Deposit = await get("Deposit")
-  console.log(`  Deposit (existing): ${Deposit.address}`)
-
-  // --- Step 2: Deploy new Redemption and current Fraud libraries ---
-  // Fraud contains the legacy challenge migration entrypoint used by the
-  // current Bridge implementation, so a historical deployment cannot be
-  // reused here.
-  console.log("\n--- Deploying new Redemption and Fraud libraries ---")
+  // --- Step 1: Deploy current Bridge libraries ---
+  // The Bridge implementation must be linked to the bytecode compiled from
+  // this source tree. Historical deployment artifacts may point to earlier
+  // library versions that do not implement the current Bridge behavior.
+  console.log("\n--- Deploying current Bridge libraries ---")
+  const Deposit = await deploy("DepositTIP109Hotfix", {
+    ...deployOptions,
+    contract: "Deposit",
+    skipIfAlreadyDeployed: false,
+  })
+  const DepositSweep = await deploy("DepositSweepTIP109Hotfix", {
+    ...deployOptions,
+    contract: "DepositSweep",
+    skipIfAlreadyDeployed: false,
+  })
   const Redemption = await deploy("RedemptionTIP109Hotfix", {
     ...deployOptions,
     contract: "Redemption",
+    skipIfAlreadyDeployed: false,
+  })
+  const Wallets = await deploy("WalletsTIP109Hotfix", {
+    ...deployOptions,
+    contract: "contracts/bridge/Wallets.sol:Wallets",
     skipIfAlreadyDeployed: false,
   })
   const Fraud = await deploy("FraudTIP109Hotfix", {
@@ -137,15 +146,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     contract: "Fraud",
     skipIfAlreadyDeployed: false,
   })
+  const MovingFunds = await deploy("MovingFundsTIP109Hotfix", {
+    ...deployOptions,
+    contract: "MovingFunds",
+    skipIfAlreadyDeployed: false,
+  })
 
-  // --- Step 3: Resolve unchanged existing libraries ---
-  console.log("\n--- Resolving existing libraries ---")
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const MovingFunds = await get("MovingFunds")
-
-  // --- Step 4: Deploy new Bridge implementation ---
-  // Linked to existing Deposit + new Redemption and Fraud + unchanged libs.
+  // --- Step 2: Deploy new Bridge implementation ---
+  // Linked to all six libraries deployed from the current source tree.
   console.log("\n--- Deploying Bridge implementation ---")
   const bridgeLibraries = {
     Deposit: Deposit.address,
@@ -163,7 +171,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     libraries: bridgeLibraries,
   })
 
-  // --- Step 5: Deploy new RebateStaking implementation (PR #939) ---
+  // --- Step 3: Deploy new RebateStaking implementation (PR #939) ---
   console.log("\n--- Deploying RebateStaking implementation ---")
   const rebateImpl = await deploy("RebateStakingTIP109HotfixImplementation", {
     ...deployOptions,
@@ -174,14 +182,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // --- Deployment Summary ---
   console.log(`\n${"-".repeat(80)}`)
   console.log("Deployed contract addresses:")
-  console.log(`  Deposit library (existing):    ${Deposit.address}`)
+  console.log(`  Deposit library (NEW):         ${Deposit.address}`)
+  console.log(`  DepositSweep library (NEW):    ${DepositSweep.address}`)
   console.log(`  Redemption library (NEW):      ${Redemption.address}`)
+  console.log(`  Wallets library (NEW):         ${Wallets.address}`)
   console.log(`  Fraud library (NEW):           ${Fraud.address}`)
+  console.log(`  MovingFunds library (NEW):     ${MovingFunds.address}`)
   console.log(`  Bridge implementation (NEW):   ${bridgeImpl.address}`)
   console.log(`  RebateStaking impl (NEW):      ${rebateImpl.address}`)
   console.log("-".repeat(80))
 
-  // --- Step 6: Update proxy deployment artifacts ---
+  // --- Step 4: Update proxy deployment artifacts ---
   // Following the pattern from Wormhole V2 upgrade scripts: update the
   // proxy artifact with the new implementation address and ABI so that
   // hardhat-deploy and downstream tooling reflect the upgraded state.
@@ -208,7 +219,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     `  RebateStaking proxy artifact updated (impl → ${rebateImpl.address})`
   )
 
-  // --- Step 7: Discover ProxyAdmin and generate calldata ---
+  // --- Step 5: Discover ProxyAdmin and generate calldata ---
   console.log("\n--- Discovering ProxyAdmin ---")
   const adminData = await ethers.provider.getStorageAt(
     Bridge.address,
@@ -245,7 +256,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`    Proxy: ${Bridge.address}`)
   console.log(`    New impl: ${bridgeImpl.address}`)
 
-  // --- Step 8: Save deployment summary JSON ---
+  // --- Step 6: Save deployment summary JSON ---
   const chainId = await hre.getChainId()
 
   const deploymentSummary = {
@@ -257,13 +268,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       "TIP-109 hotfix: add forceStakeTransfer (PR #939) and " +
       "zero-address redeemer guard (PR #940)",
     deployedContracts: {
+      DepositTIP109Hotfix: Deposit.address,
+      DepositSweepTIP109Hotfix: DepositSweep.address,
       RedemptionTIP109Hotfix: Redemption.address,
+      WalletsTIP109Hotfix: Wallets.address,
       FraudTIP109Hotfix: Fraud.address,
+      MovingFundsTIP109Hotfix: MovingFunds.address,
       BridgeTIP109HotfixImplementation: bridgeImpl.address,
       RebateStakingTIP109HotfixImplementation: rebateImpl.address,
-    },
-    reusedContracts: {
-      Deposit: Deposit.address,
     },
     existingContracts: {
       Bridge: Bridge.address,
@@ -319,7 +331,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`        New impl: ${bridgeImpl.address}`)
   console.log("=".repeat(80))
 
-  // --- Step 9: Verify contracts on Etherscan (v2 API) ---
+  // --- Step 7: Verify contracts on Etherscan (v2 API) ---
   if (hre.network.tags.etherscan) {
     const etherscanApiKey = process.env.ETHERSCAN_API_KEY
     if (!etherscanApiKey) {
@@ -355,14 +367,34 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         const networkChainId = parseInt(await hre.getChainId(), 10)
         const contractsToVerify = [
           {
+            address: Deposit.address,
+            name: "contracts/bridge/Deposit.sol:Deposit",
+            label: "Deposit",
+          },
+          {
+            address: DepositSweep.address,
+            name: "contracts/bridge/DepositSweep.sol:DepositSweep",
+            label: "DepositSweep",
+          },
+          {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
           },
           {
+            address: Wallets.address,
+            name: "contracts/bridge/Wallets.sol:Wallets",
+            label: "Wallets",
+          },
+          {
             address: Fraud.address,
             name: "contracts/bridge/Fraud.sol:Fraud",
             label: "Fraud",
+          },
+          {
+            address: MovingFunds.address,
+            name: "contracts/bridge/MovingFunds.sol:MovingFunds",
+            label: "MovingFunds",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
+++ b/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
@@ -14,26 +14,26 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
   const DEPOSIT_ADDRESS = "0x3000000000000000000000000000000000000001"
   const DEPOSIT_SWEEP_ADDRESS = "0x3000000000000000000000000000000000000002"
   const REDEMPTION_ADDRESS = "0x3000000000000000000000000000000000000003"
-  const MOVING_FUNDS_ADDRESS = "0x3000000000000000000000000000000000000004"
-  const WALLETS_ADDRESS = "0x4000000000000000000000000000000000000001"
-  const FRAUD_ADDRESS = "0x4000000000000000000000000000000000000002"
-  const BRIDGE_ADDRESS = "0x5000000000000000000000000000000000000001"
-  const PROXY_ADDRESS = "0x5000000000000000000000000000000000000002"
+  const WALLETS_ADDRESS = "0x3000000000000000000000000000000000000004"
+  const MOVING_FUNDS_ADDRESS = "0x3000000000000000000000000000000000000005"
+  const FRAUD_ADDRESS = "0x3000000000000000000000000000000000000006"
+  const BRIDGE_ADDRESS = "0x4000000000000000000000000000000000000001"
+  const PROXY_ADDRESS = "0x4000000000000000000000000000000000000002"
 
-  const existingDeployments: Record<string, string> = {
+  const dependencyAddresses: Record<string, string> = {
     Bank: BANK_ADDRESS,
     LightRelay: LIGHT_RELAY_ADDRESS,
     WalletRegistry: WALLET_REGISTRY_ADDRESS,
     ReimbursementPool: REIMBURSEMENT_POOL_ADDRESS,
+  }
+
+  const libraryAddresses: Record<string, string> = {
     Deposit: DEPOSIT_ADDRESS,
     DepositSweep: DEPOSIT_SWEEP_ADDRESS,
     Redemption: REDEMPTION_ADDRESS,
-    MovingFunds: MOVING_FUNDS_ADDRESS,
-  }
-
-  const newLibraries: Record<string, string> = {
     Wallets: WALLETS_ADDRESS,
     Fraud: FRAUD_ADDRESS,
+    MovingFunds: MOVING_FUNDS_ADDRESS,
   }
 
   interface DeployCall {
@@ -42,24 +42,26 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
   }
 
   function createMockHre(networkTags: Record<string, boolean> = {}) {
-    const getCalls: string[] = []
     const deployCalls: DeployCall[] = []
+    const getCalls: string[] = []
+    const logCalls: string[] = []
     const upgradeProxyCalls: any[][] = []
     const etherscanVerifyCalls: any[] = []
     const tenderlyVerifyCalls: any[] = []
     const runCalls: Array<{ taskName: string; options: any }> = []
+    const signer = { address: DEPLOYER_ADDRESS }
 
     const mockHre: any = {
       ethers: {
         getSigner: async (address: string) => {
           expect(address).to.equal(DEPLOYER_ADDRESS)
-          return { address }
+          return signer
         },
       },
       deployments: {
         get: async (name: string) => {
           getCalls.push(name)
-          const address = existingDeployments[name]
+          const address = dependencyAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment lookup: ${name}`)
           }
@@ -67,11 +69,14 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
         },
         deploy: async (name: string, options: any) => {
           deployCalls.push({ name, options })
-          const address = newLibraries[name]
+          const address = libraryAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment: ${name}`)
           }
           return { address, newlyDeployed: true }
+        },
+        log: (message: string) => {
+          logCalls.push(message)
         },
       },
       getNamedAccounts: async () => ({
@@ -107,8 +112,9 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
 
     return {
       mockHre,
-      getCalls,
       deployCalls,
+      getCalls,
+      logCalls,
       upgradeProxyCalls,
       etherscanVerifyCalls,
       tenderlyVerifyCalls,
@@ -116,67 +122,71 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
     }
   }
 
-  it("reuses unchanged libraries and deploys and links current Wallets and Fraud", async () => {
-    const { mockHre, getCalls, deployCalls, upgradeProxyCalls } =
+  it("deploys and links the current version of every Bridge library", async () => {
+    const { mockHre, deployCalls, getCalls, logCalls, upgradeProxyCalls } =
       createMockHre()
-    const logCalls: string[] = []
-    const originalLog = console.log
-    console.log = (message?: any) => logCalls.push(String(message))
 
-    try {
-      await func(mockHre)
-    } finally {
-      console.log = originalLog
-    }
+    await func(mockHre)
 
     expect(getCalls).to.deep.equal([
       "Bank",
       "LightRelay",
       "WalletRegistry",
       "ReimbursementPool",
+    ])
+    expect(deployCalls.map(({ name }) => name)).to.deep.equal([
       "Deposit",
       "DepositSweep",
       "Redemption",
-      "MovingFunds",
-    ])
-    expect(deployCalls.map(({ name }) => name)).to.deep.equal([
       "Wallets",
       "Fraud",
+      "MovingFunds",
     ])
     deployCalls.forEach(({ name, options }) => {
       expect(options.from, `${name} deployer`).to.equal(DEPLOYER_ADDRESS)
       expect(options.log, `${name} logging`).to.be.true
       expect(options.waitConfirmations, `${name} confirmations`).to.equal(1)
     })
-    expect(deployCalls[0].options.contract).to.equal(
+    const walletsDeployCall = deployCalls.find(({ name }) => name === "Wallets")
+    expect(walletsDeployCall).to.not.be.undefined
+    expect(walletsDeployCall?.options.contract).to.equal(
       "contracts/bridge/Wallets.sol:Wallets"
     )
 
     expect(upgradeProxyCalls).to.have.lengthOf(1)
-    const [, , options] = upgradeProxyCalls[0]
-    expect(options.factoryOpts.libraries).to.deep.equal({
-      Deposit: DEPOSIT_ADDRESS,
-      DepositSweep: DEPOSIT_SWEEP_ADDRESS,
-      Redemption: REDEMPTION_ADDRESS,
-      Wallets: WALLETS_ADDRESS,
-      Fraud: FRAUD_ADDRESS,
-      MovingFunds: MOVING_FUNDS_ADDRESS,
+    const [proxyDeploymentName, newContractName, options] = upgradeProxyCalls[0]
+    expect(proxyDeploymentName).to.equal("Bridge")
+    expect(newContractName).to.equal("Bridge")
+    expect(options.contractName).to.equal("Bridge")
+    expect(options.initializerArgs).to.deep.equal([
+      BANK_ADDRESS,
+      LIGHT_RELAY_ADDRESS,
+      TREASURY_ADDRESS,
+      WALLET_REGISTRY_ADDRESS,
+      REIMBURSEMENT_POOL_ADDRESS,
+      6,
+    ])
+    expect(options.factoryOpts.signer).to.deep.equal({
+      address: DEPLOYER_ADDRESS,
     })
+    expect(options.factoryOpts.libraries).to.deep.equal(libraryAddresses)
+
     expect(logCalls).to.have.lengthOf(1)
-    expect(logCalls[0]).to.include(`Wallets library at ${WALLETS_ADDRESS}`)
-    expect(logCalls[0]).to.include(`Fraud library at ${FRAUD_ADDRESS}`)
+    Object.entries(libraryAddresses).forEach(([name, address]) => {
+      expect(logCalls[0]).to.include(`${name}: ${address}`)
+    })
+    expect(logCalls[0]).to.include(`Bridge: ${BRIDGE_ADDRESS}`)
   })
 
-  it("verifies both freshly deployed libraries", async () => {
+  it("verifies every deployed library on configured explorers", async () => {
     const { mockHre, etherscanVerifyCalls, tenderlyVerifyCalls, runCalls } =
       createMockHre({ etherscan: true, tenderly: true })
 
     await func(mockHre)
 
-    expect(etherscanVerifyCalls.map(({ address }) => address)).to.deep.equal([
-      WALLETS_ADDRESS,
-      FRAUD_ADDRESS,
-    ])
+    expect(etherscanVerifyCalls.map(({ address }) => address)).to.deep.equal(
+      Object.values(libraryAddresses)
+    )
     expect(runCalls).to.deep.equal([
       {
         taskName: "verify",
@@ -184,8 +194,12 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       },
     ])
     expect(tenderlyVerifyCalls).to.deep.equal([
+      { name: "Deposit", address: DEPOSIT_ADDRESS },
+      { name: "DepositSweep", address: DEPOSIT_SWEEP_ADDRESS },
+      { name: "Redemption", address: REDEMPTION_ADDRESS },
       { name: "Wallets", address: WALLETS_ADDRESS },
       { name: "Fraud", address: FRAUD_ADDRESS },
+      { name: "MovingFunds", address: MOVING_FUNDS_ADDRESS },
       { name: "Bridge", address: BRIDGE_ADDRESS },
     ])
   })

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -35,16 +35,16 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
   // Address maps shared by all mock HRE instances.
   const deployAddressMap: Record<string, string> = {
     Deposit: DEPOSIT_ADDRESS,
+    DepositSweep: DEPOSIT_SWEEP_ADDRESS,
     Redemption: REDEMPTION_ADDRESS,
+    Wallets: WALLETS_ADDRESS,
     Fraud: FRAUD_ADDRESS,
+    MovingFunds: MOVING_FUNDS_ADDRESS,
     BridgeTIP109Implementation: BRIDGE_IMPL_ADDRESS,
     RebateStakingTIP109Implementation: REBATE_IMPL_ADDRESS,
   }
 
   const getAddressMap: Record<string, string> = {
-    DepositSweep: DEPOSIT_SWEEP_ADDRESS,
-    Wallets: WALLETS_ADDRESS,
-    MovingFunds: MOVING_FUNDS_ADDRESS,
     Bridge: BRIDGE_PROXY_ADDRESS,
     RebateStaking: REBATE_STAKING_PROXY_ADDRESS,
     BridgeGovernance: BRIDGE_GOV_ADDRESS,
@@ -211,6 +211,18 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(depositCall!.options.waitConfirmations).to.equal(1)
       })
 
+      it("should deploy DepositSweep library with correct options", async () => {
+        await func(mockHre)
+
+        const depositSweepCall = deployCalls.find(
+          (c) => c.name === "DepositSweep"
+        )
+        expect(depositSweepCall).to.not.be.undefined
+        expect(depositSweepCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(depositSweepCall!.options.log).to.be.true
+        expect(depositSweepCall!.options.waitConfirmations).to.equal(1)
+      })
+
       it("should deploy Redemption library with correct options", async () => {
         await func(mockHre)
 
@@ -219,6 +231,19 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(redemptionCall!.options.from).to.equal(DEPLOYER_ADDRESS)
         expect(redemptionCall!.options.log).to.be.true
         expect(redemptionCall!.options.waitConfirmations).to.equal(1)
+      })
+
+      it("should deploy local Wallets library with correct options", async () => {
+        await func(mockHre)
+
+        const walletsCall = deployCalls.find((c) => c.name === "Wallets")
+        expect(walletsCall).to.not.be.undefined
+        expect(walletsCall!.options.contract).to.equal(
+          "contracts/bridge/Wallets.sol:Wallets"
+        )
+        expect(walletsCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(walletsCall!.options.log).to.be.true
+        expect(walletsCall!.options.waitConfirmations).to.equal(1)
       })
 
       it("should deploy Fraud library with correct options", async () => {
@@ -231,22 +256,41 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(fraudCall!.options.waitConfirmations).to.equal(1)
       })
 
-      it("should resolve existing libraries via deployments.get()", async () => {
+      it("should deploy MovingFunds library with correct options", async () => {
         await func(mockHre)
 
-        const expectedLibraries = ["DepositSweep", "Wallets", "MovingFunds"]
+        const movingFundsCall = deployCalls.find(
+          (c) => c.name === "MovingFunds"
+        )
+        expect(movingFundsCall).to.not.be.undefined
+        expect(movingFundsCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(movingFundsCall!.options.log).to.be.true
+        expect(movingFundsCall!.options.waitConfirmations).to.equal(1)
+      })
+
+      it("should never resolve Bridge libraries via deployments.get()", async () => {
+        await func(mockHre)
+
+        const bridgeLibraries = [
+          "Deposit",
+          "DepositSweep",
+          "Redemption",
+          "Wallets",
+          "Fraud",
+          "MovingFunds",
+        ]
         const getNames = getCalls.map((c) => c.name)
 
-        expectedLibraries.forEach((lib) => {
-          expect(getNames).to.include(
-            lib,
-            `Expected deployments.get() to be called with "${lib}"`
+        bridgeLibraries.forEach((library) => {
+          expect(getNames).to.not.include(
+            library,
+            `${library} must be deployed from current source`
           )
         })
-        expect(getNames).to.not.include(
-          "Fraud",
-          "Fraud must be deployed from current source, not resolved as an existing library"
-        )
+
+        expect(getNames).to.include("Bridge")
+        expect(getNames).to.include("RebateStaking")
+        expect(getNames).to.include("BridgeGovernance")
       })
 
       it("should deploy Bridge implementation with distinct artifact name", async () => {
@@ -345,13 +389,28 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           ethers.constants.AddressZero
         )
 
+        const depositSweepArtifact = await deployments.get("DepositSweep")
+        expect(depositSweepArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
+
         const redemptionArtifact = await deployments.get("Redemption")
         expect(redemptionArtifact.address).to.not.equal(
           ethers.constants.AddressZero
         )
 
+        const walletsArtifact = await deployments.get("Wallets")
+        expect(walletsArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
+
         const fraudArtifact = await deployments.get("Fraud")
         expect(fraudArtifact.address).to.not.equal(ethers.constants.AddressZero)
+
+        const movingFundsArtifact = await deployments.get("MovingFunds")
+        expect(movingFundsArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
 
         const bridgeImplArtifact = await deployments.get(
           "BridgeTIP109Implementation"
@@ -382,8 +441,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
 
           // Verify that deployed addresses appear in the console output
           const depositArtifact = await deployments.get("Deposit")
+          const depositSweepArtifact = await deployments.get("DepositSweep")
           const redemptionArtifact = await deployments.get("Redemption")
+          const walletsArtifact = await deployments.get("Wallets")
           const fraudArtifact = await deployments.get("Fraud")
+          const movingFundsArtifact = await deployments.get("MovingFunds")
           const bridgeImplArtifact = await deployments.get(
             "BridgeTIP109Implementation"
           )
@@ -392,8 +454,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           )
 
           expect(allOutput).to.include(depositArtifact.address)
+          expect(allOutput).to.include(depositSweepArtifact.address)
           expect(allOutput).to.include(redemptionArtifact.address)
+          expect(allOutput).to.include(walletsArtifact.address)
           expect(allOutput).to.include(fraudArtifact.address)
+          expect(allOutput).to.include(movingFundsArtifact.address)
           expect(allOutput).to.include(bridgeImplArtifact.address)
           expect(allOutput).to.include(rebateImplArtifact.address)
         } finally {
@@ -714,14 +779,17 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       )
     })
 
-    it("should have deployedContracts with all 5 entries", () => {
+    it("should have deployedContracts with all 8 entries", () => {
       expect(summary).to.not.be.null
       const dc = summary.deployedContracts
 
       const requiredKeys = [
         "Deposit",
+        "DepositSweep",
         "Redemption",
+        "Wallets",
         "Fraud",
+        "MovingFunds",
         "BridgeTIP109Implementation",
         "RebateStakingTIP109Implementation",
       ]
@@ -910,7 +978,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(combined).to.include("56")
       })
 
-      it("should have a bytecode linkage check referencing Deposit, Redemption, and Fraud addresses", () => {
+      it("should have a bytecode linkage check referencing all six library addresses", () => {
         expect(summary).to.not.be.null
 
         const bytecodeCheck = summary.verificationChecks.find(
@@ -928,10 +996,19 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           DEPOSIT_ADDRESS.toLowerCase().slice(2)
         )
         expect(combined.toLowerCase()).to.include(
+          DEPOSIT_SWEEP_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
           REDEMPTION_ADDRESS.toLowerCase().slice(2)
         )
         expect(combined.toLowerCase()).to.include(
+          WALLETS_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
           FRAUD_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
+          MOVING_FUNDS_ADDRESS.toLowerCase().slice(2)
         )
       })
     })

--- a/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
+++ b/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
@@ -10,14 +10,30 @@ describe("active Bridge upgrade scripts", () => {
     "85_deploy_tip109_governance_upgrade.ts",
     "86_deploy_tip109_hotfix.ts",
   ]
+  const bridgeLibraries = [
+    "Deposit",
+    "DepositSweep",
+    "Redemption",
+    "Wallets",
+    "Fraud",
+    "MovingFunds",
+  ]
 
   scripts.forEach((script) => {
-    it(`${script} deploys current Fraud bytecode before linking Bridge`, () => {
+    it(`${script} deploys every current library before linking Bridge`, () => {
       const source = fs.readFileSync(path.join(deployDirectory, script), "utf8")
 
-      expect(source).not.to.match(/get\("Fraud"\)/)
-      expect(source).to.match(/deploy\("Fraud(?:TIP109Hotfix)?"/)
-      expect(source).to.match(/Fraud:\s*Fraud\.address/)
+      bridgeLibraries.forEach((library) => {
+        const deploymentName = script.startsWith("86_")
+          ? `${library}TIP109Hotfix`
+          : library
+
+        expect(source).not.to.match(new RegExp(`get\\("${library}"\\)`))
+        expect(source).to.match(new RegExp(`deploy\\("${deploymentName}"`))
+        expect(source).to.match(
+          new RegExp(`${library}:\\s*${library}\\.address`)
+        )
+      })
     })
   })
 })

--- a/typescript/api-reference/classes/DepositFunding.md
+++ b/typescript/api-reference/classes/DepositFunding.md
@@ -41,7 +41,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[src/services/deposits/funding.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L30)
+[src/services/deposits/funding.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L31)
 
 ## Properties
 
@@ -51,7 +51,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[src/services/deposits/funding.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L28)
+[src/services/deposits/funding.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L29)
 
 ## Methods
 
@@ -101,7 +101,7 @@ When the sum of the selected UTXOs is insufficient to cover
 
 #### Defined in
 
-[src/services/deposits/funding.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L62)
+[src/services/deposits/funding.ts:63](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L63)
 
 ___
 
@@ -151,7 +151,7 @@ When the sum of the selected UTXOs is insufficient to cover
 
 #### Defined in
 
-[src/services/deposits/funding.ts:200](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L200)
+[src/services/deposits/funding.ts:201](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L201)
 
 ___
 
@@ -171,4 +171,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/funding.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L34)
+[src/services/deposits/funding.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/funding.ts#L35)

--- a/typescript/api-reference/classes/DepositRefund.md
+++ b/typescript/api-reference/classes/DepositRefund.md
@@ -48,7 +48,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L41)
+[src/services/deposits/refund.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L42)
 
 ## Properties
 
@@ -58,7 +58,7 @@ the given tBTC v2 deposit script.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:39](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L39)
+[src/services/deposits/refund.ts:40](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L40)
 
 ## Methods
 
@@ -88,7 +88,7 @@ The outcome consisting of:
 
 #### Defined in
 
-[src/services/deposits/refund.ts:115](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L115)
+[src/services/deposits/refund.ts:116](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L116)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/refund.ts:306](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L306)
+[src/services/deposits/refund.ts:307](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L307)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/refund.ts:292](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L292)
+[src/services/deposits/refund.ts:293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L293)
 
 ___
 
@@ -182,7 +182,7 @@ Error if there are discrepancies in values or key formats.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:204](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L204)
+[src/services/deposits/refund.ts:205](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L205)
 
 ___
 
@@ -206,7 +206,7 @@ A Promise resolving to the assembled tapscript and signer.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:229](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L229)
+[src/services/deposits/refund.ts:230](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L230)
 
 ___
 
@@ -232,7 +232,7 @@ An empty promise upon successful signing.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L343)
+[src/services/deposits/refund.ts:344](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L344)
 
 ___
 
@@ -260,7 +260,7 @@ An empty promise upon successful signing.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:420](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L420)
+[src/services/deposits/refund.ts:421](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L421)
 
 ___
 
@@ -287,7 +287,7 @@ An empty promise upon successful signing.
 
 #### Defined in
 
-[src/services/deposits/refund.ts:380](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L380)
+[src/services/deposits/refund.ts:381](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L381)
 
 ___
 
@@ -324,7 +324,7 @@ This function should be called by the refunder after `refundLocktime`
 
 #### Defined in
 
-[src/services/deposits/refund.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L67)
+[src/services/deposits/refund.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L68)
 
 ___
 
@@ -344,4 +344,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/refund.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L45)
+[src/services/deposits/refund.ts:46](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/refund.ts#L46)

--- a/typescript/src/services/deposits/funding.ts
+++ b/typescript/src/services/deposits/funding.ts
@@ -11,8 +11,9 @@ import {
   toBitcoinJsLibNetwork,
 } from "../../lib/bitcoin"
 import { BigNumber } from "ethers"
-import { Psbt, Transaction } from "bitcoinjs-lib"
+import { Psbt } from "bitcoinjs-lib"
 import { Hex } from "../../lib/utils"
+import { resolveBitcoinUtxo, validateTransactionFee } from "./utxo"
 
 /**
  * Component allowing to craft and submit the Bitcoin funding transaction using
@@ -85,9 +86,8 @@ export class DepositFunding {
     let skippedUnsupportedUtxos = 0
 
     for (const utxo of inputUtxos) {
-      const previousOutput = Transaction.fromHex(utxo.transactionHex).outs[
-        utxo.outputIndex
-      ]
+      const { output: previousOutput, value: authoritativeValue } =
+        resolveBitcoinUtxo(utxo)
       const previousOutputValue = previousOutput.value
       const previousOutputScript = previousOutput.script
 
@@ -101,7 +101,7 @@ export class DepositFunding {
           },
         })
 
-        totalInputValue = totalInputValue.add(utxo.value)
+        totalInputValue = totalInputValue.add(authoritativeValue)
         if (totalInputValue.gte(totalExpenses)) {
           break
         }
@@ -114,7 +114,7 @@ export class DepositFunding {
           nonWitnessUtxo: Buffer.from(utxo.transactionHex, "hex"),
         })
 
-        totalInputValue = totalInputValue.add(utxo.value)
+        totalInputValue = totalInputValue.add(authoritativeValue)
         if (totalInputValue.gte(totalExpenses)) {
           break
         }
@@ -158,6 +158,7 @@ export class DepositFunding {
     psbt.finalizeAllInputs()
 
     const transaction = psbt.extractTransaction()
+    validateTransactionFee(transaction, totalInputValue, fee)
     const transactionHash = BitcoinTxHash.from(transaction.getId())
 
     return {

--- a/typescript/src/services/deposits/refund.ts
+++ b/typescript/src/services/deposits/refund.ts
@@ -22,6 +22,7 @@ import {
   Stack,
 } from "bitcoinjs-lib"
 import * as secp256k1 from "@bitcoinerlab/secp256k1"
+import { resolveBitcoinUtxo, validateTransactionFee } from "./utxo"
 
 const TAPROOT_SIGHASH_DEFAULT = 0
 
@@ -129,7 +130,9 @@ export class DepositRefund {
       bitcoinNetwork
     )
 
-    const outputValue = utxo.value.sub(fee)
+    const { output: previousOutput, value: authoritativeValue } =
+      resolveBitcoinUtxo(utxo)
+    const outputValue = authoritativeValue.sub(fee)
 
     const transaction = new Transaction()
 
@@ -154,9 +157,6 @@ export class DepositRefund {
     transaction.ins[0].sequence = 0xfffffffe
 
     // Sign the input
-    const previousOutput = Transaction.fromHex(utxo.transactionHex).outs[
-      utxo.outputIndex
-    ]
     const previousOutputValue = previousOutput.value
     const previousOutputScript = Hex.from(previousOutput.script)
 
@@ -184,6 +184,7 @@ export class DepositRefund {
       throw new Error("Unsupported UTXO script type")
     }
 
+    validateTransactionFee(transaction, authoritativeValue, fee)
     const transactionHash = BitcoinTxHash.from(transaction.getId())
 
     return {

--- a/typescript/src/services/deposits/utxo.ts
+++ b/typescript/src/services/deposits/utxo.ts
@@ -1,0 +1,65 @@
+import { BigNumber } from "ethers"
+import { Transaction } from "bitcoinjs-lib"
+import { BitcoinRawTx, BitcoinUtxo } from "../../lib/bitcoin"
+
+export type ResolvedBitcoinUtxo = {
+  transaction: Transaction
+  output: Transaction["outs"][number]
+  value: BigNumber
+}
+
+/**
+ * Resolves a UTXO against its raw transaction and rejects inconsistent
+ * provider metadata before the output is used for signing or accounting.
+ * @param utxo UTXO metadata paired with its raw transaction.
+ * @returns The authenticated transaction output and its authoritative value.
+ */
+export function resolveBitcoinUtxo(
+  utxo: BitcoinUtxo & BitcoinRawTx
+): ResolvedBitcoinUtxo {
+  const transaction = Transaction.fromHex(utxo.transactionHex)
+
+  if (transaction.getId() !== utxo.transactionHash.toString()) {
+    throw new Error("Raw transaction does not match UTXO transaction hash")
+  }
+
+  if (
+    !Number.isInteger(utxo.outputIndex) ||
+    utxo.outputIndex < 0 ||
+    utxo.outputIndex >= transaction.outs.length
+  ) {
+    throw new Error("UTXO output index is out of range")
+  }
+
+  const output = transaction.outs[utxo.outputIndex]
+  const value = BigNumber.from(output.value)
+
+  if (!value.eq(utxo.value)) {
+    throw new Error("UTXO value does not match raw previous transaction")
+  }
+
+  return { transaction, output, value }
+}
+
+/**
+ * Ensures the final transaction pays exactly the fee requested by the caller.
+ * @param transaction Final transaction to validate.
+ * @param totalInputValue Sum of its authenticated input values.
+ * @param requestedFee Absolute fee requested by the caller.
+ * @returns Void if the transaction pays the requested fee.
+ */
+export function validateTransactionFee(
+  transaction: Transaction,
+  totalInputValue: BigNumber,
+  requestedFee: BigNumber
+): void {
+  const totalOutputValue = transaction.outs.reduce(
+    (sum, output) => sum.add(output.value),
+    BigNumber.from(0)
+  )
+  const actualFee = totalInputValue.sub(totalOutputValue)
+
+  if (!actualFee.eq(requestedFee)) {
+    throw new Error("Transaction fee does not match the requested fee")
+  }
+}

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -47,6 +47,7 @@ import {
   depositRefundOfWitnessDepositAndWitnessRefunderAddress,
   refunderPrivateKey,
 } from "../data/deposit-refund"
+import { validateTransactionFee } from "../../src/services/deposits/utxo"
 
 chai.use(chaiAsPromised)
 import { MockDepositorProxy } from "../utils/mock-depositor-proxy"
@@ -448,6 +449,32 @@ describe("Deposits", () => {
     }
   }
 
+  describe("deposit transaction fee validation", () => {
+    const transaction = new Transaction()
+    transaction.addInput(Buffer.alloc(32), 0)
+    transaction.addOutput(Buffer.from([0x51]), 9000)
+
+    it("should accept the exact requested absolute fee", () => {
+      expect(() =>
+        validateTransactionFee(
+          transaction,
+          BigNumber.from(10000),
+          BigNumber.from(1000)
+        )
+      ).not.to.throw()
+    })
+
+    it("should reject any other absolute fee", () => {
+      expect(() =>
+        validateTransactionFee(
+          transaction,
+          BigNumber.from(10000),
+          BigNumber.from(999)
+        )
+      ).to.throw("Transaction fee does not match the requested fee")
+    })
+  })
+
   describe("DepositFunding", () => {
     describe("submitTransaction", () => {
       let bitcoinClient: MockBitcoinClient
@@ -554,6 +581,97 @@ describe("Deposits", () => {
             expect(input.index).to.be.equal(inputUtxo.outputIndex)
             expect(input.script.length).to.be.greaterThan(0)
             expect(input.witness.length).to.be.equal(0)
+          })
+
+          it("should preserve the requested absolute fee", () => {
+            const transaction = Transaction.fromHex(
+              bitcoinClient.broadcastLog[0].transactionHex
+            )
+            const previousOutput = Transaction.fromHex(inputUtxo.transactionHex)
+              .outs[inputUtxo.outputIndex]
+            const totalOutputValue = transaction.outs.reduce(
+              (sum, output) => sum.add(output.value),
+              BigNumber.from(0)
+            )
+
+            expect(
+              BigNumber.from(previousOutput.value)
+                .sub(totalOutputValue)
+                .toString()
+            ).to.be.equal("1520")
+          })
+        })
+
+        context("when P2PKH UTXO metadata is inconsistent", () => {
+          const actualValue = BigNumber.from(100000)
+          const fee = BigNumber.from(1000)
+          const amount = BigNumber.from(40000)
+          let authenticUtxo: BitcoinUtxo & BitcoinRawTx
+          let depositFunding: DepositFunding
+
+          beforeEach(() => {
+            authenticUtxo = createTestnetP2PKHUtxo(actualValue)
+            depositFunding = DepositFunding.fromScript(
+              DepositScript.fromReceipt(depositFixture.receipt, true)
+            )
+          })
+
+          const submit = async (utxo: BitcoinUtxo) => {
+            bitcoinClient.rawTransactions = new Map<string, BitcoinRawTx>([
+              [
+                utxo.transactionHash.toString(),
+                { transactionHex: authenticUtxo.transactionHex },
+              ],
+            ])
+
+            return depositFunding.submitTransaction(
+              amount,
+              [utxo],
+              fee,
+              testnetPrivateKey,
+              bitcoinClient
+            )
+          }
+
+          it("should reject understated metadata without broadcasting", async () => {
+            await expect(
+              submit({ ...authenticUtxo, value: BigNumber.from(50000) })
+            ).to.be.rejectedWith(
+              "UTXO value does not match raw previous transaction"
+            )
+
+            expect(bitcoinClient.broadcastLog).to.be.empty
+          })
+
+          it("should reject overstated metadata without broadcasting", async () => {
+            await expect(
+              submit({ ...authenticUtxo, value: BigNumber.from(150000) })
+            ).to.be.rejectedWith(
+              "UTXO value does not match raw previous transaction"
+            )
+
+            expect(bitcoinClient.broadcastLog).to.be.empty
+          })
+
+          it("should reject a raw transaction with the wrong transaction ID", async () => {
+            await expect(
+              submit({
+                ...authenticUtxo,
+                transactionHash: BitcoinTxHash.from("11".repeat(32)),
+              })
+            ).to.be.rejectedWith(
+              "Raw transaction does not match UTXO transaction hash"
+            )
+
+            expect(bitcoinClient.broadcastLog).to.be.empty
+          })
+
+          it("should reject an out-of-range output index", async () => {
+            await expect(
+              submit({ ...authenticUtxo, outputIndex: 1 })
+            ).to.be.rejectedWith("UTXO output index is out of range")
+
+            expect(bitcoinClient.broadcastLog).to.be.empty
           })
         })
 
@@ -3655,6 +3773,16 @@ describe("Deposits", () => {
                     signature
                   )
                 ).to.be.true
+
+                const totalOutputValue = refundTransaction.outs.reduce(
+                  (sum, output) => sum.add(output.value),
+                  BigNumber.from(0)
+                )
+                expect(
+                  BigNumber.from(previousOutput.value)
+                    .sub(totalOutputValue)
+                    .toString()
+                ).to.be.equal(fee.toString())
               }
 
               beforeEach(async () => {
@@ -3696,6 +3824,127 @@ describe("Deposits", () => {
                     ).getId()
                   )
                 )
+              })
+            })
+
+            context("when P2TR refund UTXO metadata is inconsistent", () => {
+              const actualValue = BigNumber.from(100000)
+              let authenticUtxo: BitcoinUtxo & BitcoinRawTx
+              let depositRefund: DepositRefund
+
+              beforeEach(async () => {
+                const refunderKeyPair = BitcoinPrivateKeyUtils.createKeyPair(
+                  refunderPrivateKey,
+                  BitcoinNetwork.Testnet
+                )
+                const refundXOnlyPublicKey = Hex.from(
+                  Buffer.from(refunderKeyPair.publicKey).subarray(1)
+                )
+                const depositReceipt: DepositReceipt = {
+                  ...taprootDepositFixture.receipt,
+                  refundPublicKeyHash:
+                    BitcoinAddressConverter.taprootOutputKeyToWalletPublicKeyHash(
+                      refundXOnlyPublicKey
+                    ),
+                  refundXOnlyPublicKey,
+                }
+                const depositScript = DepositScript.fromReceipt(
+                  depositReceipt,
+                  DepositScriptType.P2TR
+                )
+                const fundingTransaction = new Transaction()
+                fundingTransaction.version = 1
+                fundingTransaction.addInput(Buffer.alloc(32), 0)
+                fundingTransaction.addOutput(
+                  await depositScript.deriveOutputScript(
+                    BitcoinNetwork.Testnet
+                  ),
+                  actualValue.toNumber()
+                )
+
+                authenticUtxo = {
+                  transactionHash: BitcoinTxHash.from(
+                    fundingTransaction.getId()
+                  ),
+                  outputIndex: 0,
+                  value: actualValue,
+                  transactionHex: fundingTransaction.toHex(),
+                }
+                depositRefund = DepositRefund.fromScript(depositScript)
+              })
+
+              const submit = async (utxo: BitcoinUtxo) => {
+                bitcoinClient.rawTransactions = new Map<string, BitcoinRawTx>([
+                  [
+                    utxo.transactionHash.toString(),
+                    { transactionHex: authenticUtxo.transactionHex },
+                  ],
+                ])
+
+                return depositRefund.submitTransaction(
+                  bitcoinClient,
+                  fee,
+                  utxo,
+                  depositRefundOfWitnessDepositAndWitnessRefunderAddress.refunderAddress,
+                  refunderPrivateKey
+                )
+              }
+
+              it("should broadcast a matching UTXO with the requested fee", async () => {
+                await submit(authenticUtxo)
+
+                expect(bitcoinClient.broadcastLog).to.have.length(1)
+                const refundTransaction = Transaction.fromHex(
+                  bitcoinClient.broadcastLog[0].transactionHex
+                )
+                const totalOutputValue = refundTransaction.outs.reduce(
+                  (sum, output) => sum.add(output.value),
+                  BigNumber.from(0)
+                )
+                expect(actualValue.sub(totalOutputValue).toString()).to.equal(
+                  fee.toString()
+                )
+              })
+
+              it("should reject understated metadata without broadcasting", async () => {
+                await expect(
+                  submit({ ...authenticUtxo, value: BigNumber.from(2000) })
+                ).to.be.rejectedWith(
+                  "UTXO value does not match raw previous transaction"
+                )
+
+                expect(bitcoinClient.broadcastLog).to.be.empty
+              })
+
+              it("should reject overstated metadata without broadcasting", async () => {
+                await expect(
+                  submit({ ...authenticUtxo, value: BigNumber.from(150000) })
+                ).to.be.rejectedWith(
+                  "UTXO value does not match raw previous transaction"
+                )
+
+                expect(bitcoinClient.broadcastLog).to.be.empty
+              })
+
+              it("should reject a raw transaction with the wrong transaction ID", async () => {
+                await expect(
+                  submit({
+                    ...authenticUtxo,
+                    transactionHash: BitcoinTxHash.from("11".repeat(32)),
+                  })
+                ).to.be.rejectedWith(
+                  "Raw transaction does not match UTXO transaction hash"
+                )
+
+                expect(bitcoinClient.broadcastLog).to.be.empty
+              })
+
+              it("should reject an out-of-range output index", async () => {
+                await expect(
+                  submit({ ...authenticUtxo, outputIndex: 1 })
+                ).to.be.rejectedWith("UTXO output index is out of range")
+
+                expect(bitcoinClient.broadcastLog).to.be.empty
               })
             })
           }


### PR DESCRIPTION
## Stack

This PR is stacked on #1020 and should merge after it.

## Security fix

Closes two Codex Security findings in PR #971:

- untrusted P2PKH UTXO metadata could turn principal into miner fee
- understated Taproot refund metadata could turn principal into miner fee

The SDK now resolves every supplied UTXO against its raw previous transaction, rejects txid, output-index, or value mismatches, uses the parsed value for accounting and signing, and checks that the final serialized transaction pays exactly the requested absolute fee.

## Verification

- targeted security regressions: 14 passing
- full deposits suite: 146 passing
- full TypeScript suite: 927 passing, 63 pending
- TypeScript no-emit check: passed
- package build: passed
- ESLint and Prettier: passed
- original mismatch PoCs now reject before signing or broadcast

Matching P2PKH, P2WPKH, P2SH, P2WSH, and P2TR flows retain their existing APIs and behavior.