### PR TITLE
fix(frost): bound DKG result retries

### DIFF
--- a/solidity/contracts/frost-registry/FrostWalletRegistry.sol
+++ b/solidity/contracts/frost-registry/FrostWalletRegistry.sol
@@ -441,10 +441,14 @@ contract FrostWalletRegistry is
         dkg.setResultSubmissionTimeout(536);
         dkg.setSubmitterPrecedencePeriodLength(20);
 
-        // Gas parameters were adjusted based on Ethereum state in April 2022.
-        // If the cost of EVM opcodes change over time, these parameters will
-        // have to be updated.
-        _dkgResultSubmissionGas = 290_000;
+        // DKG result submission recreates the 100-member group selected for the
+        // current seed. The reimbursement includes headroom over the measured
+        // cost of that validation against a populated sortition pool.
+        _dkgResultSubmissionGas = 1_500_000;
+
+        // The remaining gas parameters were adjusted based on Ethereum state in
+        // April 2022. If the cost of EVM opcodes changes over time, these
+        // parameters will have to be updated.
         _dkgResultApprovalGasOffset = 72_000;
         _notifyOperatorInactivityGasOffset = 93_000;
         _notifySeedTimeoutGasOffset = 7_250;

--- a/solidity/contracts/frost-registry/libraries/FrostDkg.sol
+++ b/solidity/contracts/frost-registry/libraries/FrostDkg.sol
@@ -232,9 +232,11 @@ library FrostDkg {
     /// @notice Determines the current state of group creation. It doesn't take
     ///         timeouts into consideration. The timeouts should be tracked and
     ///         notified separately.
-    function currentState(
-        Data storage self
-    ) internal view returns (State state) {
+    function currentState(Data storage self)
+        internal
+        view
+        returns (State state)
+    {
         state = State.IDLE;
 
         if (self.sortitionPool.isLocked()) {
@@ -372,10 +374,10 @@ library FrostDkg {
     /// @param result Result to approve. Must match the submitted result stored
     ///        during `submitResult`.
     /// @return misbehavedMembers Identifiers of members who misbehaved during DKG.
-    function approveResult(
-        Data storage self,
-        Result calldata result
-    ) internal returns (uint32[] memory misbehavedMembers) {
+    function approveResult(Data storage self, Result calldata result)
+        internal
+        returns (uint32[] memory misbehavedMembers)
+    {
         require(
             currentState(self) == State.CHALLENGE,
             "Current state is not CHALLENGE"
@@ -433,10 +435,7 @@ library FrostDkg {
     ///        stored during `submitResult`.
     /// @return maliciousResultHash Hash of the malicious result.
     /// @return maliciousSubmitter Identifier of the malicious submitter.
-    function challengeResult(
-        Data storage self,
-        Result calldata result
-    )
+    function challengeResult(Data storage self, Result calldata result)
         internal
         returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
     {
@@ -528,10 +527,11 @@ library FrostDkg {
     /// @param result DKG result.
     /// @return True if the result is valid. If the result is invalid it returns
     ///         false and an error message.
-    function isResultValid(
-        Data storage self,
-        Result calldata result
-    ) internal view returns (bool, string memory) {
+    function isResultValid(Data storage self, Result calldata result)
+        internal
+        view
+        returns (bool, string memory)
+    {
         require(self.startBlock > 0, "DKG has not been started");
 
         return
@@ -545,10 +545,9 @@ library FrostDkg {
     }
 
     /// @notice Set setSeedTimeout parameter.
-    function setSeedTimeout(
-        Data storage self,
-        uint256 newSeedTimeout
-    ) internal {
+    function setSeedTimeout(Data storage self, uint256 newSeedTimeout)
+        internal
+    {
         require(currentState(self) == State.IDLE, "Current state is not IDLE");
 
         require(newSeedTimeout > 0, "New value should be greater than zero");

--- a/solidity/contracts/frost-registry/libraries/FrostDkg.sol
+++ b/solidity/contracts/frost-registry/libraries/FrostDkg.sol
@@ -232,11 +232,9 @@ library FrostDkg {
     /// @notice Determines the current state of group creation. It doesn't take
     ///         timeouts into consideration. The timeouts should be tracked and
     ///         notified separately.
-    function currentState(Data storage self)
-        internal
-        view
-        returns (State state)
-    {
+    function currentState(
+        Data storage self
+    ) internal view returns (State state) {
         state = State.IDLE;
 
         if (self.sortitionPool.isLocked()) {
@@ -374,10 +372,10 @@ library FrostDkg {
     /// @param result Result to approve. Must match the submitted result stored
     ///        during `submitResult`.
     /// @return misbehavedMembers Identifiers of members who misbehaved during DKG.
-    function approveResult(Data storage self, Result calldata result)
-        internal
-        returns (uint32[] memory misbehavedMembers)
-    {
+    function approveResult(
+        Data storage self,
+        Result calldata result
+    ) internal returns (uint32[] memory misbehavedMembers) {
         require(
             currentState(self) == State.CHALLENGE,
             "Current state is not CHALLENGE"
@@ -435,7 +433,10 @@ library FrostDkg {
     ///        stored during `submitResult`.
     /// @return maliciousResultHash Hash of the malicious result.
     /// @return maliciousSubmitter Identifier of the malicious submitter.
-    function challengeResult(Data storage self, Result calldata result)
+    function challengeResult(
+        Data storage self,
+        Result calldata result
+    )
         internal
         returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
     {
@@ -497,9 +498,8 @@ library FrostDkg {
         // Prevent the identified submitter from reacquiring the challenge-state
         // lock in this DKG. Other selected members may still submit before the
         // original fixed deadline.
-        self.challengedSubmitterDkgStartBlocks[
-            maliciousSubmitter
-        ] = self.startBlock;
+        self.challengedSubmitterDkgStartBlocks[maliciousSubmitter] = self
+            .startBlock;
 
         submittedResultCleanup(self);
 
@@ -528,11 +528,10 @@ library FrostDkg {
     /// @param result DKG result.
     /// @return True if the result is valid. If the result is invalid it returns
     ///         false and an error message.
-    function isResultValid(Data storage self, Result calldata result)
-        internal
-        view
-        returns (bool, string memory)
-    {
+    function isResultValid(
+        Data storage self,
+        Result calldata result
+    ) internal view returns (bool, string memory) {
         require(self.startBlock > 0, "DKG has not been started");
 
         return
@@ -546,9 +545,10 @@ library FrostDkg {
     }
 
     /// @notice Set setSeedTimeout parameter.
-    function setSeedTimeout(Data storage self, uint256 newSeedTimeout)
-        internal
-    {
+    function setSeedTimeout(
+        Data storage self,
+        uint256 newSeedTimeout
+    ) internal {
         require(currentState(self) == State.IDLE, "Current state is not IDLE");
 
         require(newSeedTimeout > 0, "New value should be greater than zero");

--- a/solidity/contracts/frost-registry/libraries/FrostDkg.sol
+++ b/solidity/contracts/frost-registry/libraries/FrostDkg.sol
@@ -69,9 +69,9 @@ library FrostDkg {
         uint256 startBlock;
         // Seed used to start DKG.
         uint256 seed;
-        // Time in blocks that should be added to result submission eligibility
-        // delay calculation. Retained for storage and in-flight DKG
-        // compatibility; new challenges do not increase this value.
+        // Time in blocks added to the original result submission deadline. After
+        // a successful challenge it is set to the elapsed time since DKG start,
+        // giving the remaining selected members a full submission window.
         uint256 resultSubmissionStartBlockOffset;
         // Hash of submitted DKG result.
         bytes32 submittedResultHash;
@@ -333,8 +333,10 @@ library FrostDkg {
     /// @notice Checks if DKG timed out. The DKG timeout period includes time required
     ///         for off-chain protocol execution and time for the result publication.
     ///         After this time a result cannot be submitted and DKG can be notified
-    ///         about the timeout. A compatibility offset may already exist for a
-    ///         DKG started before an upgrade, but challenges never increase it.
+    ///         about the timeout. A successful challenge rebases the submission
+    ///         deadline to give the remaining selected members a full retry window.
+    ///         Retries remain bounded because every challenged submitter is
+    ///         quarantined for the current DKG.
     /// @return True if DKG timed out, false otherwise.
     function hasDkgTimedOut(Data storage self) internal view returns (bool) {
         return
@@ -495,10 +497,15 @@ library FrostDkg {
         maliciousSubmitter = result.members[result.submitterMemberIndex - 1];
 
         // Prevent the identified submitter from reacquiring the challenge-state
-        // lock in this DKG. Other selected members may still submit before the
-        // original fixed deadline.
+        // lock in this DKG, including through another selected member index.
         self.challengedSubmitterDkgStartBlocks[maliciousSubmitter] = self
             .startBlock;
+
+        // Give the remaining selected members a full result-submission window,
+        // including when this challenge lands after the previous deadline.
+        // Extensions remain finite because the challenged submitter cannot submit
+        // again in this DKG and there are at most `groupSize` selected IDs.
+        self.resultSubmissionStartBlockOffset = block.number - self.startBlock;
 
         submittedResultCleanup(self);
 

--- a/solidity/contracts/frost-registry/libraries/FrostDkg.sol
+++ b/solidity/contracts/frost-registry/libraries/FrostDkg.sol
@@ -70,8 +70,8 @@ library FrostDkg {
         // Seed used to start DKG.
         uint256 seed;
         // Time in blocks that should be added to result submission eligibility
-        // delay calculation. It is used in case of a challenge to adjust
-        // DKG timeout calculation.
+        // delay calculation. Retained for storage and in-flight DKG
+        // compatibility; new challenges do not increase this value.
         uint256 resultSubmissionStartBlockOffset;
         // Hash of submitted DKG result.
         bytes32 submittedResultHash;
@@ -87,10 +87,14 @@ library FrostDkg {
         // without needing a stored field. (Optimization noted
         // during PR #441 review.)
         address bridge;
+        // Start block of the DKG in which an operator's result was successfully
+        // challenged. Entries do not need to be iterated or deleted when a DKG
+        // completes because every challenged round has a distinct start block.
+        mapping(uint32 => uint256) challengedSubmitterDkgStartBlocks;
         // Reserved storage space in case we need to add more variables.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[37] __gap;
+        uint256[36] __gap;
     }
 
     /// @notice DKG result.
@@ -188,6 +192,9 @@ library FrostDkg {
 
     event DkgSeedTimedOut();
 
+    error InvalidGroupMembers();
+    error SubmitterChallengedForCurrentDkg();
+
     /// @notice Initializes SortitionPool, FrostDkgValidator, and the
     ///         `bridge` digest-binding address. Can be performed
     ///         only once.
@@ -270,8 +277,8 @@ library FrostDkg {
     }
 
     /// @notice Allows to submit a DKG result. The submitted result does not go
-    ///         through a validation and before it gets accepted, it needs to
-    ///         wait through the challenge period during which everyone has
+    ///         through full validation and before it gets accepted, it needs
+    ///         to wait through the challenge period during which everyone has
     ///         a chance to challenge the result as invalid one. Submitter of
     ///         the result needs to be in the sortition pool and if the result
     ///         gets challenged, the submitter will get slashed.
@@ -291,12 +298,23 @@ library FrostDkg {
             sortitionPool.isOperatorInPool(msg.sender),
             "Submitter not in the sortition pool"
         );
+
+        // The caller-authored members array must be the exact group selected
+        // for this seed before it can lock the DKG in the challenge state.
+        if (!self.dkgValidator.validateGroupMembers(result, self.seed)) {
+            revert InvalidGroupMembers();
+        }
+
+        uint32 submitter = result.members[result.submitterMemberIndex - 1];
         require(
-            sortitionPool.getIDOperator(
-                result.members[result.submitterMemberIndex - 1]
-            ) == msg.sender,
+            sortitionPool.getIDOperator(submitter) == msg.sender,
             "Unexpected submitter index"
         );
+        if (
+            self.challengedSubmitterDkgStartBlocks[submitter] == self.startBlock
+        ) {
+            revert SubmitterChallengedForCurrentDkg();
+        }
 
         self.submittedResultHash = keccak256(abi.encode(result));
         self.submittedResultBlock = block.number;
@@ -315,9 +333,8 @@ library FrostDkg {
     /// @notice Checks if DKG timed out. The DKG timeout period includes time required
     ///         for off-chain protocol execution and time for the result publication.
     ///         After this time a result cannot be submitted and DKG can be notified
-    ///         about the timeout. DKG period is adjusted by result submission
-    ///         offset that include blocks that were mined while invalid result
-    ///         has been registered until it got challenged.
+    ///         about the timeout. A compatibility offset may already exist for a
+    ///         DKG started before an upgrade, but challenges never increase it.
     /// @return True if DKG timed out, false otherwise.
     function hasDkgTimedOut(Data storage self) internal view returns (bool) {
         return
@@ -477,9 +494,12 @@ library FrostDkg {
         maliciousResultHash = self.submittedResultHash;
         maliciousSubmitter = result.members[result.submitterMemberIndex - 1];
 
-        // Adjust DKG result submission block start, so submission stage starts
-        // from the beginning.
-        self.resultSubmissionStartBlockOffset = block.number - self.startBlock;
+        // Prevent the identified submitter from reacquiring the challenge-state
+        // lock in this DKG. Other selected members may still submit before the
+        // original fixed deadline.
+        self.challengedSubmitterDkgStartBlocks[
+            maliciousSubmitter
+        ] = self.startBlock;
 
         submittedResultCleanup(self);
 

--- a/solidity/contracts/test/FrostDkgLivenessHarness.sol
+++ b/solidity/contracts/test/FrostDkgLivenessHarness.sol
@@ -35,9 +35,7 @@ contract FrostDkgLivenessHarness {
         dkg.submitResult(result);
     }
 
-    function challengeResult(
-        FrostDkg.Result calldata result
-    )
+    function challengeResult(FrostDkg.Result calldata result)
         external
         returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
     {

--- a/solidity/contracts/test/FrostDkgLivenessHarness.sol
+++ b/solidity/contracts/test/FrostDkgLivenessHarness.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.17;
+
+import "../frost-registry/libraries/FrostDkg.sol";
+import "../frost-registry/FrostDkgValidator.sol";
+import "@keep-network/sortition-pools/contracts/SortitionPool.sol";
+
+/// @notice Test harness exposing the production FrostDkg state transitions.
+contract FrostDkgLivenessHarness {
+    using FrostDkg for FrostDkg.Data;
+
+    FrostDkg.Data private dkg;
+
+    constructor(
+        SortitionPool sortitionPool,
+        FrostDkgValidator validator,
+        address bridge,
+        uint256 challengePeriod,
+        uint256 submissionTimeout
+    ) {
+        dkg.init(sortitionPool, validator, bridge);
+        dkg.parameters.resultChallengePeriodLength = challengePeriod;
+        dkg.parameters.resultSubmissionTimeout = submissionTimeout;
+    }
+
+    function lockState() external {
+        dkg.lockState();
+    }
+
+    function start(uint256 seed) external {
+        dkg.start(seed);
+    }
+
+    function submitResult(FrostDkg.Result calldata result) external {
+        dkg.submitResult(result);
+    }
+
+    function challengeResult(
+        FrostDkg.Result calldata result
+    )
+        external
+        returns (bytes32 maliciousResultHash, uint32 maliciousSubmitter)
+    {
+        return dkg.challengeResult(result);
+    }
+
+    function notifyDkgTimeout() external {
+        dkg.notifyDkgTimeout();
+    }
+
+    function state() external view returns (FrostDkg.State) {
+        return dkg.currentState();
+    }
+
+    function hasDkgTimedOut() external view returns (bool) {
+        return dkg.hasDkgTimedOut();
+    }
+
+    function startBlock() external view returns (uint256) {
+        return dkg.startBlock;
+    }
+
+    function resultSubmissionStartBlockOffset()
+        external
+        view
+        returns (uint256)
+    {
+        return dkg.resultSubmissionStartBlockOffset;
+    }
+
+    function resultSubmissionDeadline() external view returns (uint256) {
+        return
+            dkg.startBlock +
+            dkg.resultSubmissionStartBlockOffset +
+            dkg.parameters.resultSubmissionTimeout;
+    }
+}

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -5,7 +5,7 @@ import path from "path"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
-  const { get, deploy } = deployments
+  const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
   console.log("\n========== REBATE DEPLOYMENT STARTING ==========")
@@ -104,34 +104,40 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("✓ RebateStaking deployed at:", rebateStaking.address)
   }
 
-  // Step 2: Use existing libraries for Bridge
-  console.log("\nStep 2: Using existing libraries...")
-
-  const Deposit = await get("Deposit")
-  const Redemption = await get("Redemption")
-
-  console.log("✓ Using existing Deposit library at:", Deposit.address)
-  console.log("✓ Using existing Redemption library at:", Redemption.address)
-
-  // Step 3: Resolve existing libraries and deploy the current Fraud library.
-  // Fraud contains the legacy challenge migration entrypoint used by the
-  // current Bridge implementation. Linking a historical deployment would
-  // leave that selector unavailable.
-  console.log("\nStep 3: Collecting Bridge libraries...")
-
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const Fraud = await deploy("Fraud", {
+  const libraryDeployOptions = {
     from: deployer,
     log: true,
     waitConfirmations: 1,
-  })
-  const MovingFunds = await get("MovingFunds")
+  }
 
-  console.log("✓ Using existing DepositSweep at:", DepositSweep.address)
-  console.log("✓ Using existing Wallets at:", Wallets.address)
+  // Step 2: Deploy the current Deposit and Redemption libraries.
+  // This script builds Bridge from the checked-out source, so every linked
+  // library must come from that same source tree.
+  console.log("\nStep 2: Deploying current Bridge libraries...")
+
+  const Deposit = await deploy("Deposit", libraryDeployOptions)
+  const Redemption = await deploy("Redemption", libraryDeployOptions)
+
+  console.log("✓ Using current Deposit library at:", Deposit.address)
+  console.log("✓ Using current Redemption library at:", Redemption.address)
+
+  // Step 3: Deploy the remaining current Bridge libraries. Wallets uses a
+  // fully-qualified contract name to avoid the Wallets interface/library name
+  // collision. Fraud contains the legacy challenge migration entrypoint.
+  console.log("\nStep 3: Deploying remaining current Bridge libraries...")
+
+  const DepositSweep = await deploy("DepositSweep", libraryDeployOptions)
+  const Wallets = await deploy("Wallets", {
+    contract: "contracts/bridge/Wallets.sol:Wallets",
+    ...libraryDeployOptions,
+  })
+  const Fraud = await deploy("Fraud", libraryDeployOptions)
+  const MovingFunds = await deploy("MovingFunds", libraryDeployOptions)
+
+  console.log("✓ Using current DepositSweep at:", DepositSweep.address)
+  console.log("✓ Using current Wallets at:", Wallets.address)
   console.log("✓ Using current Fraud at:", Fraud.address)
-  console.log("✓ Using existing MovingFunds at:", MovingFunds.address)
+  console.log("✓ Using current MovingFunds at:", MovingFunds.address)
 
   // Step 4: Deploy Bridge implementation
   console.log("\nStep 4: Deploying Bridge implementation...")
@@ -253,8 +259,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deployedContracts: {
       rebateStaking: rebateStaking.address,
       depositLibrary: Deposit.address,
+      depositSweepLibrary: DepositSweep.address,
       redemptionLibrary: Redemption.address,
+      walletsLibrary: Wallets.address,
       fraudLibrary: Fraud.address,
+      movingFundsLibrary: MovingFunds.address,
       bridgeImplementation: bridgeImplementation.address,
     },
     existingContracts: {
@@ -315,8 +324,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("\nDEPLOYED CONTRACTS:")
   console.log("  RebateStaking:         ", rebateStaking.address)
   console.log("  Deposit Library:       ", Deposit.address)
+  console.log("  DepositSweep Library:  ", DepositSweep.address)
   console.log("  Redemption Library:    ", Redemption.address)
+  console.log("  Wallets Library:       ", Wallets.address)
   console.log("  Fraud Library:         ", Fraud.address)
+  console.log("  MovingFunds Library:   ", MovingFunds.address)
   console.log("  Bridge Implementation: ", bridgeImplementation.address)
 
   console.log("\n================================================")
@@ -354,8 +366,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("Verifying contracts on Etherscan...")
 
     await helpers.etherscan.verify(Deposit)
+    await helpers.etherscan.verify(DepositSweep)
     await helpers.etherscan.verify(Redemption)
+    await helpers.etherscan.verify(Wallets)
     await helpers.etherscan.verify(Fraud)
+    await helpers.etherscan.verify(MovingFunds)
 
     await hre.run("verify", {
       address: rebateProxyDeployment.address,
@@ -387,8 +402,33 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Verify on Tenderly if applicable
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
+      name: "Deposit",
+      address: Deposit.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "DepositSweep",
+      address: DepositSweep.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "Redemption",
+      address: Redemption.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "Wallets",
+      address: Wallets.address,
+    })
+
+    await hre.tenderly.verify({
       name: "Fraud",
       address: Fraud.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "MovingFunds",
+      address: MovingFunds.address,
     })
 
     await hre.tenderly.verify({
@@ -406,5 +446,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployRebateAndPrepareTxs"]
-// Dependencies removed to avoid redeploying existing mainnet contracts
+// Dependencies remain removed so standalone live-network execution does not
+// rerun the full Bridge deployment chain.
 // func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
+++ b/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
@@ -1,27 +1,23 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
-import { DeployFunction } from "hardhat-deploy/types"
+import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
 
-/// Phase C-2.1a upgrade script — deploys fresh `Wallets` and
-/// `Fraud` libraries and re-links Bridge to the new addresses.
+/// Phase C-2.1a upgrade script — deploys the current versions of all
+/// external libraries linked by `Bridge` and upgrades the proxy using
+/// those addresses.
 ///
 /// Why a dedicated script: the standard `80_upgrade_bridge_v2.ts`
-/// pattern explicitly REUSES the pre-existing library
-/// deployments via `deployments.get("Wallets")`. C-2.1a's Wallets
-/// behavior change is the `self.ecdsaWalletCount += 1` increment
-/// in `Wallets.registerNewWallet` — that lives in the `Wallets`
-/// library's bytecode, NOT in Bridge's. Reusing the old library
-/// address would link the new Bridge implementation to old
-/// library code; the counter would stay 0 forever.
-/// (Codex P1 review on PR #442.)
-///
-/// `Fraud` also has current-cycle changes preserving the legacy
-/// fraud-challenge lifecycle across the upgrade, so it must be
-/// deployed from the current source tree. All other linked libraries
-/// (`Deposit`, `DepositSweep`, `Redemption`, `MovingFunds`) are
-/// unchanged, so this script keeps them at their existing addresses.
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+/// pattern explicitly reuses pre-existing library deployments via
+/// `deployments.get`. This script compiles the current `Bridge` source,
+/// so each linked library must be deployed from the same source tree.
+/// Otherwise, the implementation can delegate to stale library bytecode
+/// that lacks the FROST and Taproot behavior exposed by the current Bridge.
+/// `hardhat-deploy` compares deployment bytecode and reuses an existing
+/// address only when it already contains the current library version.
+const func: DeployFunction = async function upgradeBridgeC21Counter(
+  hre: HardhatRuntimeEnvironment
+) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
-  const { get, deploy } = deployments
+  const { get, deploy, log } = deployments
   const { deployer, treasury } = await getNamedAccounts()
 
   const Bank = await get("Bank")
@@ -31,26 +27,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const txProofDifficultyFactor = 6
 
-  // Unchanged libraries — reuse existing addresses.
-  const Deposit = await get("Deposit")
-  const DepositSweep = await get("DepositSweep")
-  const Redemption = await get("Redemption")
-  const MovingFunds = await get("MovingFunds")
+  const deployOptions: DeployOptions = {
+    from: deployer,
+    log: true,
+    waitConfirmations: 1,
+  }
 
-  // Wallets has changed (C-2.1a counter increment) — deploy
-  // a fresh library version. hardhat-deploy will detect the
-  // bytecode hash mismatch and publish a new address.
+  const Deposit = await deploy("Deposit", deployOptions)
+  const DepositSweep = await deploy("DepositSweep", deployOptions)
+  const Redemption = await deploy("Redemption", deployOptions)
   const Wallets = await deploy("Wallets", {
     contract: "contracts/bridge/Wallets.sol:Wallets",
-    from: deployer,
-    log: true,
-    waitConfirmations: 1,
+    ...deployOptions,
   })
-  const Fraud = await deploy("Fraud", {
-    from: deployer,
-    log: true,
-    waitConfirmations: 1,
-  })
+  const Fraud = await deploy("Fraud", deployOptions)
+  const MovingFunds = await deploy("MovingFunds", deployOptions)
 
   const [bridge, proxyDeployment] = await helpers.upgrades.upgradeProxy(
     "Bridge",
@@ -71,8 +62,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Deposit: Deposit.address,
           DepositSweep: DepositSweep.address,
           Redemption: Redemption.address,
-          // Fresh Wallets address — this is what carries the
-          // C-2.1a counter increment.
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
@@ -85,13 +74,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  console.log(
-    `C-2.1a upgrade: fresh Wallets library at ${Wallets.address} and Fraud library at ${Fraud.address} linked to Bridge ${bridge.address}`
+  log(
+    "C-2.1a upgrade: current Bridge libraries linked:\n" +
+      `  Deposit: ${Deposit.address}\n` +
+      `  DepositSweep: ${DepositSweep.address}\n` +
+      `  Redemption: ${Redemption.address}\n` +
+      `  Wallets: ${Wallets.address}\n` +
+      `  Fraud: ${Fraud.address}\n` +
+      `  MovingFunds: ${MovingFunds.address}\n` +
+      `  Bridge: ${bridge.address}`
   )
 
   if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(Deposit)
+    await helpers.etherscan.verify(DepositSweep)
+    await helpers.etherscan.verify(Redemption)
     await helpers.etherscan.verify(Wallets)
     await helpers.etherscan.verify(Fraud)
+    await helpers.etherscan.verify(MovingFunds)
     await hre.run("verify", {
       address: proxyDeployment.address,
       constructorArgsParams: proxyDeployment.args,
@@ -100,12 +100,28 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
+      name: "Deposit",
+      address: Deposit.address,
+    })
+    await hre.tenderly.verify({
+      name: "DepositSweep",
+      address: DepositSweep.address,
+    })
+    await hre.tenderly.verify({
+      name: "Redemption",
+      address: Redemption.address,
+    })
+    await hre.tenderly.verify({
       name: "Wallets",
       address: Wallets.address,
     })
     await hre.tenderly.verify({
       name: "Fraud",
       address: Fraud.address,
+    })
+    await hre.tenderly.verify({
+      name: "MovingFunds",
+      address: MovingFunds.address,
     })
     await hre.tenderly.verify({
       name: "Bridge",
@@ -126,9 +142,7 @@ func.tags = ["UpgradeBridgeC21Counter"]
 // The env-var gate avoids accidental execution during normal
 // fixture-driven deploys (e.g., a `yarn deploy` without tag
 // filtering on a development network would otherwise rerun
-// this upgrade and link fresh libraries on every
-// invocation). It also lets the documented command actually
-// execute — the prior `func.skip = async () => true` was
-// unconditional and made the documented invocation a no-op
-// (Codex P1 review on PR #442).
+// this upgrade on every invocation). It also lets the documented
+// command actually execute — the prior `func.skip = async () => true`
+// was unconditional and made the documented invocation a no-op.
 func.skip = async () => process.env.RUN_UPGRADE_C2_1_COUNTER !== "1"

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -210,8 +210,11 @@ function buildVerificationChecks(addresses: {
   rebateStakingProxy: string
   rebateImpl: string
   depositLib: string
+  depositSweepLib: string
   redemptionLib: string
+  walletsLib: string
   fraudLib: string
+  movingFundsLib: string
 }): VerificationCheck[] {
   return [
     {
@@ -224,11 +227,14 @@ function buildVerificationChecks(addresses: {
       command: `cast code ${addresses.bridgeImpl}`,
       expectedResult:
         "Bytecode should contain embedded library address fragments: " +
-        `${addresses.depositLib.slice(2).toLowerCase()} (Deposit) and ` +
-        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption) and ` +
-        `${addresses.fraudLib.slice(2).toLowerCase()} (Fraud)`,
+        `${addresses.depositLib.slice(2).toLowerCase()} (Deposit), ` +
+        `${addresses.depositSweepLib.slice(2).toLowerCase()} (DepositSweep), ` +
+        `${addresses.redemptionLib.slice(2).toLowerCase()} (Redemption), ` +
+        `${addresses.walletsLib.slice(2).toLowerCase()} (Wallets), ` +
+        `${addresses.fraudLib.slice(2).toLowerCase()} (Fraud), and ` +
+        `${addresses.movingFundsLib.slice(2).toLowerCase()} (MovingFunds)`,
       description:
-        "Bridge implementation bytecode should contain embedded addresses of new Deposit, Redemption, and Fraud libraries",
+        "Bridge implementation bytecode should contain embedded addresses of all six current Bridge libraries",
     },
     {
       command: `cast call ${addresses.bridgeProxy} "deposits(uint256)(bytes32,uint32,uint64,uint32,address,uint32)" <sample_deposit_key>`,
@@ -310,27 +316,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Network: ${hre.network.name}`)
   console.log(`Deployer: ${deployer}`)
 
-  // --- Step 1: Deploy new library versions ---
-  // Deposit has rebate integration changes; Redemption has the balanceOwner
-  // fix; Fraud contains the legacy challenge migration entrypoint. All three
-  // require deployments from the current source before linking Bridge.
-  console.log("\n--- Deploying updated libraries ---")
+  // --- Step 1: Deploy current Bridge library versions ---
+  // The implementation is compiled from the current checkout, so every
+  // external library must be deployed from the same source before linking.
+  console.log("\n--- Deploying current Bridge libraries ---")
   const Deposit = await deploy("Deposit", deployOptions)
+  const DepositSweep = await deploy("DepositSweep", deployOptions)
   const Redemption = await deploy("Redemption", deployOptions)
+  const Wallets = await deploy("Wallets", {
+    contract: "contracts/bridge/Wallets.sol:Wallets",
+    ...deployOptions,
+  })
   const Fraud = await deploy("Fraud", deployOptions)
-
-  // --- Step 2: Resolve unchanged existing libraries ---
-  // These libraries have NOT changed since last deployment and are reused
-  // from existing deployment artifacts.
-  console.log("\n--- Resolving existing libraries ---")
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const MovingFunds = await get("MovingFunds")
-
-  console.log("Existing library addresses:")
-  console.log(`  DepositSweep: ${DepositSweep.address}`)
-  console.log(`  Wallets:      ${Wallets.address}`)
-  console.log(`  MovingFunds:  ${MovingFunds.address}`)
+  const MovingFunds = await deploy("MovingFunds", deployOptions)
 
   // --- Step 3: Deploy Bridge implementation ---
   // Uses a distinct artifact name to avoid overwriting the existing Bridge
@@ -368,8 +366,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`\n${"-".repeat(80)}`)
   console.log("Deployed contract addresses:")
   console.log(`  Deposit library:              ${Deposit.address}`)
+  console.log(`  DepositSweep library:         ${DepositSweep.address}`)
   console.log(`  Redemption library:           ${Redemption.address}`)
+  console.log(`  Wallets library:              ${Wallets.address}`)
   console.log(`  Fraud library:                ${Fraud.address}`)
+  console.log(`  MovingFunds library:          ${MovingFunds.address}`)
   console.log(`  Bridge implementation:        ${bridgeImpl.address}`)
   console.log(`  RebateStaking implementation: ${rebateImpl.address}`)
   console.log("-".repeat(80))
@@ -481,8 +482,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     chainId,
     deployedContracts: {
       Deposit: Deposit.address,
+      DepositSweep: DepositSweep.address,
       Redemption: Redemption.address,
+      Wallets: Wallets.address,
       Fraud: Fraud.address,
+      MovingFunds: MovingFunds.address,
       BridgeTIP109Implementation: bridgeImpl.address,
       RebateStakingTIP109Implementation: rebateImpl.address,
     },
@@ -534,8 +538,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       rebateStakingProxy: RebateStaking.address,
       rebateImpl: rebateImpl.address,
       depositLib: Deposit.address,
+      depositSweepLib: DepositSweep.address,
       redemptionLib: Redemption.address,
+      walletsLib: Wallets.address,
       fraudLib: Fraud.address,
+      movingFundsLib: MovingFunds.address,
     }),
   }
 
@@ -636,14 +643,29 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             label: "Deposit",
           },
           {
+            address: DepositSweep.address,
+            name: "contracts/bridge/DepositSweep.sol:DepositSweep",
+            label: "DepositSweep",
+          },
+          {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
           },
           {
+            address: Wallets.address,
+            name: "contracts/bridge/Wallets.sol:Wallets",
+            label: "Wallets",
+          },
+          {
             address: Fraud.address,
             name: "contracts/bridge/Fraud.sol:Fraud",
             label: "Fraud",
+          },
+          {
+            address: MovingFunds.address,
+            name: "contracts/bridge/MovingFunds.sol:MovingFunds",
+            label: "MovingFunds",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -116,20 +116,29 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Network: ${hre.network.name}`)
   console.log(`Deployer: ${deployer}`)
 
-  // --- Step 1: Reuse existing Deposit library ---
-  // PRs #939/#940 do not touch Deposit.sol. Reuse to save gas.
-  console.log("\n--- Reusing existing Deposit library ---")
-  const Deposit = await get("Deposit")
-  console.log(`  Deposit (existing): ${Deposit.address}`)
-
-  // --- Step 2: Deploy new Redemption and current Fraud libraries ---
-  // Fraud contains the legacy challenge migration entrypoint used by the
-  // current Bridge implementation, so a historical deployment cannot be
-  // reused here.
-  console.log("\n--- Deploying new Redemption and Fraud libraries ---")
+  // --- Step 1: Deploy current Bridge libraries ---
+  // The Bridge implementation must be linked to the bytecode compiled from
+  // this source tree. Historical deployment artifacts may point to earlier
+  // library versions that do not implement the current Bridge behavior.
+  console.log("\n--- Deploying current Bridge libraries ---")
+  const Deposit = await deploy("DepositTIP109Hotfix", {
+    ...deployOptions,
+    contract: "Deposit",
+    skipIfAlreadyDeployed: false,
+  })
+  const DepositSweep = await deploy("DepositSweepTIP109Hotfix", {
+    ...deployOptions,
+    contract: "DepositSweep",
+    skipIfAlreadyDeployed: false,
+  })
   const Redemption = await deploy("RedemptionTIP109Hotfix", {
     ...deployOptions,
     contract: "Redemption",
+    skipIfAlreadyDeployed: false,
+  })
+  const Wallets = await deploy("WalletsTIP109Hotfix", {
+    ...deployOptions,
+    contract: "contracts/bridge/Wallets.sol:Wallets",
     skipIfAlreadyDeployed: false,
   })
   const Fraud = await deploy("FraudTIP109Hotfix", {
@@ -137,15 +146,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     contract: "Fraud",
     skipIfAlreadyDeployed: false,
   })
+  const MovingFunds = await deploy("MovingFundsTIP109Hotfix", {
+    ...deployOptions,
+    contract: "MovingFunds",
+    skipIfAlreadyDeployed: false,
+  })
 
-  // --- Step 3: Resolve unchanged existing libraries ---
-  console.log("\n--- Resolving existing libraries ---")
-  const DepositSweep = await get("DepositSweep")
-  const Wallets = await get("Wallets")
-  const MovingFunds = await get("MovingFunds")
-
-  // --- Step 4: Deploy new Bridge implementation ---
-  // Linked to existing Deposit + new Redemption and Fraud + unchanged libs.
+  // --- Step 2: Deploy new Bridge implementation ---
+  // Linked to all six libraries deployed from the current source tree.
   console.log("\n--- Deploying Bridge implementation ---")
   const bridgeLibraries = {
     Deposit: Deposit.address,
@@ -163,7 +171,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     libraries: bridgeLibraries,
   })
 
-  // --- Step 5: Deploy new RebateStaking implementation (PR #939) ---
+  // --- Step 3: Deploy new RebateStaking implementation (PR #939) ---
   console.log("\n--- Deploying RebateStaking implementation ---")
   const rebateImpl = await deploy("RebateStakingTIP109HotfixImplementation", {
     ...deployOptions,
@@ -174,14 +182,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // --- Deployment Summary ---
   console.log(`\n${"-".repeat(80)}`)
   console.log("Deployed contract addresses:")
-  console.log(`  Deposit library (existing):    ${Deposit.address}`)
+  console.log(`  Deposit library (NEW):         ${Deposit.address}`)
+  console.log(`  DepositSweep library (NEW):    ${DepositSweep.address}`)
   console.log(`  Redemption library (NEW):      ${Redemption.address}`)
+  console.log(`  Wallets library (NEW):         ${Wallets.address}`)
   console.log(`  Fraud library (NEW):           ${Fraud.address}`)
+  console.log(`  MovingFunds library (NEW):     ${MovingFunds.address}`)
   console.log(`  Bridge implementation (NEW):   ${bridgeImpl.address}`)
   console.log(`  RebateStaking impl (NEW):      ${rebateImpl.address}`)
   console.log("-".repeat(80))
 
-  // --- Step 6: Update proxy deployment artifacts ---
+  // --- Step 4: Update proxy deployment artifacts ---
   // Following the pattern from Wormhole V2 upgrade scripts: update the
   // proxy artifact with the new implementation address and ABI so that
   // hardhat-deploy and downstream tooling reflect the upgraded state.
@@ -208,7 +219,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     `  RebateStaking proxy artifact updated (impl → ${rebateImpl.address})`
   )
 
-  // --- Step 7: Discover ProxyAdmin and generate calldata ---
+  // --- Step 5: Discover ProxyAdmin and generate calldata ---
   console.log("\n--- Discovering ProxyAdmin ---")
   const adminData = await ethers.provider.getStorageAt(
     Bridge.address,
@@ -245,7 +256,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`    Proxy: ${Bridge.address}`)
   console.log(`    New impl: ${bridgeImpl.address}`)
 
-  // --- Step 8: Save deployment summary JSON ---
+  // --- Step 6: Save deployment summary JSON ---
   const chainId = await hre.getChainId()
 
   const deploymentSummary = {
@@ -257,13 +268,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       "TIP-109 hotfix: add forceStakeTransfer (PR #939) and " +
       "zero-address redeemer guard (PR #940)",
     deployedContracts: {
+      DepositTIP109Hotfix: Deposit.address,
+      DepositSweepTIP109Hotfix: DepositSweep.address,
       RedemptionTIP109Hotfix: Redemption.address,
+      WalletsTIP109Hotfix: Wallets.address,
       FraudTIP109Hotfix: Fraud.address,
+      MovingFundsTIP109Hotfix: MovingFunds.address,
       BridgeTIP109HotfixImplementation: bridgeImpl.address,
       RebateStakingTIP109HotfixImplementation: rebateImpl.address,
-    },
-    reusedContracts: {
-      Deposit: Deposit.address,
     },
     existingContracts: {
       Bridge: Bridge.address,
@@ -319,7 +331,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`        New impl: ${bridgeImpl.address}`)
   console.log("=".repeat(80))
 
-  // --- Step 9: Verify contracts on Etherscan (v2 API) ---
+  // --- Step 7: Verify contracts on Etherscan (v2 API) ---
   if (hre.network.tags.etherscan) {
     const etherscanApiKey = process.env.ETHERSCAN_API_KEY
     if (!etherscanApiKey) {
@@ -355,14 +367,34 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         const networkChainId = parseInt(await hre.getChainId(), 10)
         const contractsToVerify = [
           {
+            address: Deposit.address,
+            name: "contracts/bridge/Deposit.sol:Deposit",
+            label: "Deposit",
+          },
+          {
+            address: DepositSweep.address,
+            name: "contracts/bridge/DepositSweep.sol:DepositSweep",
+            label: "DepositSweep",
+          },
+          {
             address: Redemption.address,
             name: "contracts/bridge/Redemption.sol:Redemption",
             label: "Redemption",
           },
           {
+            address: Wallets.address,
+            name: "contracts/bridge/Wallets.sol:Wallets",
+            label: "Wallets",
+          },
+          {
             address: Fraud.address,
             name: "contracts/bridge/Fraud.sol:Fraud",
             label: "Fraud",
+          },
+          {
+            address: MovingFunds.address,
+            name: "contracts/bridge/MovingFunds.sol:MovingFunds",
+            label: "MovingFunds",
           },
           {
             address: bridgeImpl.address,

--- a/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
+++ b/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
@@ -14,26 +14,26 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
   const DEPOSIT_ADDRESS = "0x3000000000000000000000000000000000000001"
   const DEPOSIT_SWEEP_ADDRESS = "0x3000000000000000000000000000000000000002"
   const REDEMPTION_ADDRESS = "0x3000000000000000000000000000000000000003"
-  const MOVING_FUNDS_ADDRESS = "0x3000000000000000000000000000000000000004"
-  const WALLETS_ADDRESS = "0x4000000000000000000000000000000000000001"
-  const FRAUD_ADDRESS = "0x4000000000000000000000000000000000000002"
-  const BRIDGE_ADDRESS = "0x5000000000000000000000000000000000000001"
-  const PROXY_ADDRESS = "0x5000000000000000000000000000000000000002"
+  const WALLETS_ADDRESS = "0x3000000000000000000000000000000000000004"
+  const MOVING_FUNDS_ADDRESS = "0x3000000000000000000000000000000000000005"
+  const FRAUD_ADDRESS = "0x3000000000000000000000000000000000000006"
+  const BRIDGE_ADDRESS = "0x4000000000000000000000000000000000000001"
+  const PROXY_ADDRESS = "0x4000000000000000000000000000000000000002"
 
-  const existingDeployments: Record<string, string> = {
+  const dependencyAddresses: Record<string, string> = {
     Bank: BANK_ADDRESS,
     LightRelay: LIGHT_RELAY_ADDRESS,
     WalletRegistry: WALLET_REGISTRY_ADDRESS,
     ReimbursementPool: REIMBURSEMENT_POOL_ADDRESS,
+  }
+
+  const libraryAddresses: Record<string, string> = {
     Deposit: DEPOSIT_ADDRESS,
     DepositSweep: DEPOSIT_SWEEP_ADDRESS,
     Redemption: REDEMPTION_ADDRESS,
-    MovingFunds: MOVING_FUNDS_ADDRESS,
-  }
-
-  const newLibraries: Record<string, string> = {
     Wallets: WALLETS_ADDRESS,
     Fraud: FRAUD_ADDRESS,
+    MovingFunds: MOVING_FUNDS_ADDRESS,
   }
 
   interface DeployCall {
@@ -42,24 +42,26 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
   }
 
   function createMockHre(networkTags: Record<string, boolean> = {}) {
-    const getCalls: string[] = []
     const deployCalls: DeployCall[] = []
+    const getCalls: string[] = []
+    const logCalls: string[] = []
     const upgradeProxyCalls: any[][] = []
     const etherscanVerifyCalls: any[] = []
     const tenderlyVerifyCalls: any[] = []
     const runCalls: Array<{ taskName: string; options: any }> = []
+    const signer = { address: DEPLOYER_ADDRESS }
 
     const mockHre: any = {
       ethers: {
         getSigner: async (address: string) => {
           expect(address).to.equal(DEPLOYER_ADDRESS)
-          return { address }
+          return signer
         },
       },
       deployments: {
         get: async (name: string) => {
           getCalls.push(name)
-          const address = existingDeployments[name]
+          const address = dependencyAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment lookup: ${name}`)
           }
@@ -67,11 +69,14 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
         },
         deploy: async (name: string, options: any) => {
           deployCalls.push({ name, options })
-          const address = newLibraries[name]
+          const address = libraryAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment: ${name}`)
           }
           return { address, newlyDeployed: true }
+        },
+        log: (message: string) => {
+          logCalls.push(message)
         },
       },
       getNamedAccounts: async () => ({
@@ -107,8 +112,9 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
 
     return {
       mockHre,
-      getCalls,
       deployCalls,
+      getCalls,
+      logCalls,
       upgradeProxyCalls,
       etherscanVerifyCalls,
       tenderlyVerifyCalls,
@@ -116,67 +122,71 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
     }
   }
 
-  it("reuses unchanged libraries and deploys and links current Wallets and Fraud", async () => {
-    const { mockHre, getCalls, deployCalls, upgradeProxyCalls } =
+  it("deploys and links the current version of every Bridge library", async () => {
+    const { mockHre, deployCalls, getCalls, logCalls, upgradeProxyCalls } =
       createMockHre()
-    const logCalls: string[] = []
-    const originalLog = console.log
-    console.log = (message?: any) => logCalls.push(String(message))
 
-    try {
-      await func(mockHre)
-    } finally {
-      console.log = originalLog
-    }
+    await func(mockHre)
 
     expect(getCalls).to.deep.equal([
       "Bank",
       "LightRelay",
       "WalletRegistry",
       "ReimbursementPool",
+    ])
+    expect(deployCalls.map(({ name }) => name)).to.deep.equal([
       "Deposit",
       "DepositSweep",
       "Redemption",
-      "MovingFunds",
-    ])
-    expect(deployCalls.map(({ name }) => name)).to.deep.equal([
       "Wallets",
       "Fraud",
+      "MovingFunds",
     ])
     deployCalls.forEach(({ name, options }) => {
       expect(options.from, `${name} deployer`).to.equal(DEPLOYER_ADDRESS)
       expect(options.log, `${name} logging`).to.be.true
       expect(options.waitConfirmations, `${name} confirmations`).to.equal(1)
     })
-    expect(deployCalls[0].options.contract).to.equal(
+    const walletsDeployCall = deployCalls.find(({ name }) => name === "Wallets")
+    expect(walletsDeployCall).to.not.be.undefined
+    expect(walletsDeployCall?.options.contract).to.equal(
       "contracts/bridge/Wallets.sol:Wallets"
     )
 
     expect(upgradeProxyCalls).to.have.lengthOf(1)
-    const [, , options] = upgradeProxyCalls[0]
-    expect(options.factoryOpts.libraries).to.deep.equal({
-      Deposit: DEPOSIT_ADDRESS,
-      DepositSweep: DEPOSIT_SWEEP_ADDRESS,
-      Redemption: REDEMPTION_ADDRESS,
-      Wallets: WALLETS_ADDRESS,
-      Fraud: FRAUD_ADDRESS,
-      MovingFunds: MOVING_FUNDS_ADDRESS,
+    const [proxyDeploymentName, newContractName, options] = upgradeProxyCalls[0]
+    expect(proxyDeploymentName).to.equal("Bridge")
+    expect(newContractName).to.equal("Bridge")
+    expect(options.contractName).to.equal("Bridge")
+    expect(options.initializerArgs).to.deep.equal([
+      BANK_ADDRESS,
+      LIGHT_RELAY_ADDRESS,
+      TREASURY_ADDRESS,
+      WALLET_REGISTRY_ADDRESS,
+      REIMBURSEMENT_POOL_ADDRESS,
+      6,
+    ])
+    expect(options.factoryOpts.signer).to.deep.equal({
+      address: DEPLOYER_ADDRESS,
     })
+    expect(options.factoryOpts.libraries).to.deep.equal(libraryAddresses)
+
     expect(logCalls).to.have.lengthOf(1)
-    expect(logCalls[0]).to.include(`Wallets library at ${WALLETS_ADDRESS}`)
-    expect(logCalls[0]).to.include(`Fraud library at ${FRAUD_ADDRESS}`)
+    Object.entries(libraryAddresses).forEach(([name, address]) => {
+      expect(logCalls[0]).to.include(`${name}: ${address}`)
+    })
+    expect(logCalls[0]).to.include(`Bridge: ${BRIDGE_ADDRESS}`)
   })
 
-  it("verifies both freshly deployed libraries", async () => {
+  it("verifies every deployed library on configured explorers", async () => {
     const { mockHre, etherscanVerifyCalls, tenderlyVerifyCalls, runCalls } =
       createMockHre({ etherscan: true, tenderly: true })
 
     await func(mockHre)
 
-    expect(etherscanVerifyCalls.map(({ address }) => address)).to.deep.equal([
-      WALLETS_ADDRESS,
-      FRAUD_ADDRESS,
-    ])
+    expect(etherscanVerifyCalls.map(({ address }) => address)).to.deep.equal(
+      Object.values(libraryAddresses)
+    )
     expect(runCalls).to.deep.equal([
       {
         taskName: "verify",
@@ -184,8 +194,12 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       },
     ])
     expect(tenderlyVerifyCalls).to.deep.equal([
+      { name: "Deposit", address: DEPOSIT_ADDRESS },
+      { name: "DepositSweep", address: DEPOSIT_SWEEP_ADDRESS },
+      { name: "Redemption", address: REDEMPTION_ADDRESS },
       { name: "Wallets", address: WALLETS_ADDRESS },
       { name: "Fraud", address: FRAUD_ADDRESS },
+      { name: "MovingFunds", address: MOVING_FUNDS_ADDRESS },
       { name: "Bridge", address: BRIDGE_ADDRESS },
     ])
   })

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -35,16 +35,16 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
   // Address maps shared by all mock HRE instances.
   const deployAddressMap: Record<string, string> = {
     Deposit: DEPOSIT_ADDRESS,
+    DepositSweep: DEPOSIT_SWEEP_ADDRESS,
     Redemption: REDEMPTION_ADDRESS,
+    Wallets: WALLETS_ADDRESS,
     Fraud: FRAUD_ADDRESS,
+    MovingFunds: MOVING_FUNDS_ADDRESS,
     BridgeTIP109Implementation: BRIDGE_IMPL_ADDRESS,
     RebateStakingTIP109Implementation: REBATE_IMPL_ADDRESS,
   }
 
   const getAddressMap: Record<string, string> = {
-    DepositSweep: DEPOSIT_SWEEP_ADDRESS,
-    Wallets: WALLETS_ADDRESS,
-    MovingFunds: MOVING_FUNDS_ADDRESS,
     Bridge: BRIDGE_PROXY_ADDRESS,
     RebateStaking: REBATE_STAKING_PROXY_ADDRESS,
     BridgeGovernance: BRIDGE_GOV_ADDRESS,
@@ -211,6 +211,18 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(depositCall!.options.waitConfirmations).to.equal(1)
       })
 
+      it("should deploy DepositSweep library with correct options", async () => {
+        await func(mockHre)
+
+        const depositSweepCall = deployCalls.find(
+          (c) => c.name === "DepositSweep"
+        )
+        expect(depositSweepCall).to.not.be.undefined
+        expect(depositSweepCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(depositSweepCall!.options.log).to.be.true
+        expect(depositSweepCall!.options.waitConfirmations).to.equal(1)
+      })
+
       it("should deploy Redemption library with correct options", async () => {
         await func(mockHre)
 
@@ -219,6 +231,19 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(redemptionCall!.options.from).to.equal(DEPLOYER_ADDRESS)
         expect(redemptionCall!.options.log).to.be.true
         expect(redemptionCall!.options.waitConfirmations).to.equal(1)
+      })
+
+      it("should deploy local Wallets library with correct options", async () => {
+        await func(mockHre)
+
+        const walletsCall = deployCalls.find((c) => c.name === "Wallets")
+        expect(walletsCall).to.not.be.undefined
+        expect(walletsCall!.options.contract).to.equal(
+          "contracts/bridge/Wallets.sol:Wallets"
+        )
+        expect(walletsCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(walletsCall!.options.log).to.be.true
+        expect(walletsCall!.options.waitConfirmations).to.equal(1)
       })
 
       it("should deploy Fraud library with correct options", async () => {
@@ -231,22 +256,41 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(fraudCall!.options.waitConfirmations).to.equal(1)
       })
 
-      it("should resolve existing libraries via deployments.get()", async () => {
+      it("should deploy MovingFunds library with correct options", async () => {
         await func(mockHre)
 
-        const expectedLibraries = ["DepositSweep", "Wallets", "MovingFunds"]
+        const movingFundsCall = deployCalls.find(
+          (c) => c.name === "MovingFunds"
+        )
+        expect(movingFundsCall).to.not.be.undefined
+        expect(movingFundsCall!.options.from).to.equal(DEPLOYER_ADDRESS)
+        expect(movingFundsCall!.options.log).to.be.true
+        expect(movingFundsCall!.options.waitConfirmations).to.equal(1)
+      })
+
+      it("should never resolve Bridge libraries via deployments.get()", async () => {
+        await func(mockHre)
+
+        const bridgeLibraries = [
+          "Deposit",
+          "DepositSweep",
+          "Redemption",
+          "Wallets",
+          "Fraud",
+          "MovingFunds",
+        ]
         const getNames = getCalls.map((c) => c.name)
 
-        expectedLibraries.forEach((lib) => {
-          expect(getNames).to.include(
-            lib,
-            `Expected deployments.get() to be called with "${lib}"`
+        bridgeLibraries.forEach((library) => {
+          expect(getNames).to.not.include(
+            library,
+            `${library} must be deployed from current source`
           )
         })
-        expect(getNames).to.not.include(
-          "Fraud",
-          "Fraud must be deployed from current source, not resolved as an existing library"
-        )
+
+        expect(getNames).to.include("Bridge")
+        expect(getNames).to.include("RebateStaking")
+        expect(getNames).to.include("BridgeGovernance")
       })
 
       it("should deploy Bridge implementation with distinct artifact name", async () => {
@@ -345,13 +389,28 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           ethers.constants.AddressZero
         )
 
+        const depositSweepArtifact = await deployments.get("DepositSweep")
+        expect(depositSweepArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
+
         const redemptionArtifact = await deployments.get("Redemption")
         expect(redemptionArtifact.address).to.not.equal(
           ethers.constants.AddressZero
         )
 
+        const walletsArtifact = await deployments.get("Wallets")
+        expect(walletsArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
+
         const fraudArtifact = await deployments.get("Fraud")
         expect(fraudArtifact.address).to.not.equal(ethers.constants.AddressZero)
+
+        const movingFundsArtifact = await deployments.get("MovingFunds")
+        expect(movingFundsArtifact.address).to.not.equal(
+          ethers.constants.AddressZero
+        )
 
         const bridgeImplArtifact = await deployments.get(
           "BridgeTIP109Implementation"
@@ -382,8 +441,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
 
           // Verify that deployed addresses appear in the console output
           const depositArtifact = await deployments.get("Deposit")
+          const depositSweepArtifact = await deployments.get("DepositSweep")
           const redemptionArtifact = await deployments.get("Redemption")
+          const walletsArtifact = await deployments.get("Wallets")
           const fraudArtifact = await deployments.get("Fraud")
+          const movingFundsArtifact = await deployments.get("MovingFunds")
           const bridgeImplArtifact = await deployments.get(
             "BridgeTIP109Implementation"
           )
@@ -392,8 +454,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           )
 
           expect(allOutput).to.include(depositArtifact.address)
+          expect(allOutput).to.include(depositSweepArtifact.address)
           expect(allOutput).to.include(redemptionArtifact.address)
+          expect(allOutput).to.include(walletsArtifact.address)
           expect(allOutput).to.include(fraudArtifact.address)
+          expect(allOutput).to.include(movingFundsArtifact.address)
           expect(allOutput).to.include(bridgeImplArtifact.address)
           expect(allOutput).to.include(rebateImplArtifact.address)
         } finally {
@@ -714,14 +779,17 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       )
     })
 
-    it("should have deployedContracts with all 5 entries", () => {
+    it("should have deployedContracts with all 8 entries", () => {
       expect(summary).to.not.be.null
       const dc = summary.deployedContracts
 
       const requiredKeys = [
         "Deposit",
+        "DepositSweep",
         "Redemption",
+        "Wallets",
         "Fraud",
+        "MovingFunds",
         "BridgeTIP109Implementation",
         "RebateStakingTIP109Implementation",
       ]
@@ -910,7 +978,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(combined).to.include("56")
       })
 
-      it("should have a bytecode linkage check referencing Deposit, Redemption, and Fraud addresses", () => {
+      it("should have a bytecode linkage check referencing all six library addresses", () => {
         expect(summary).to.not.be.null
 
         const bytecodeCheck = summary.verificationChecks.find(
@@ -928,10 +996,19 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           DEPOSIT_ADDRESS.toLowerCase().slice(2)
         )
         expect(combined.toLowerCase()).to.include(
+          DEPOSIT_SWEEP_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
           REDEMPTION_ADDRESS.toLowerCase().slice(2)
         )
         expect(combined.toLowerCase()).to.include(
+          WALLETS_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
           FRAUD_ADDRESS.toLowerCase().slice(2)
+        )
+        expect(combined.toLowerCase()).to.include(
+          MOVING_FUNDS_ADDRESS.toLowerCase().slice(2)
         )
       })
     })

--- a/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
+++ b/solidity/test/deploy/CurrentFraudLibraryDeployment.test.ts
@@ -10,14 +10,30 @@ describe("active Bridge upgrade scripts", () => {
     "85_deploy_tip109_governance_upgrade.ts",
     "86_deploy_tip109_hotfix.ts",
   ]
+  const bridgeLibraries = [
+    "Deposit",
+    "DepositSweep",
+    "Redemption",
+    "Wallets",
+    "Fraud",
+    "MovingFunds",
+  ]
 
   scripts.forEach((script) => {
-    it(`${script} deploys current Fraud bytecode before linking Bridge`, () => {
+    it(`${script} deploys every current library before linking Bridge`, () => {
       const source = fs.readFileSync(path.join(deployDirectory, script), "utf8")
 
-      expect(source).not.to.match(/get\("Fraud"\)/)
-      expect(source).to.match(/deploy\("Fraud(?:TIP109Hotfix)?"/)
-      expect(source).to.match(/Fraud:\s*Fraud\.address/)
+      bridgeLibraries.forEach((library) => {
+        const deploymentName = script.startsWith("86_")
+          ? `${library}TIP109Hotfix`
+          : library
+
+        expect(source).not.to.match(new RegExp(`get\\("${library}"\\)`))
+        expect(source).to.match(new RegExp(`deploy\\("${deploymentName}"`))
+        expect(source).to.match(
+          new RegExp(`${library}:\\s*${library}\\.address`)
+        )
+      })
     })
   })
 })

--- a/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
+++ b/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
@@ -1,0 +1,267 @@
+import hre, { artifacts, ethers } from "hardhat"
+import { smock } from "@defi-wonderland/smock"
+import chai, { expect } from "chai"
+
+chai.use(smock.matchers)
+
+async function expectCustomError(
+  promise: Promise<unknown>,
+  errorName: string
+): Promise<void> {
+  const expectedSelector = ethers.utils.id(`${errorName}()`).slice(0, 10)
+  try {
+    await promise
+  } catch (err) {
+    const errAny = err as {
+      data?: string
+      message?: string
+      error?: { data?: string }
+    }
+    const revertData = errAny.data || errAny.error?.data || ""
+    const errMsg = errAny.message || String(err)
+
+    if (
+      (revertData &&
+        revertData.toLowerCase().startsWith(expectedSelector.toLowerCase())) ||
+      errMsg.toLowerCase().includes(expectedSelector.toLowerCase()) ||
+      errMsg.includes(errorName)
+    ) {
+      return
+    }
+
+    throw new Error(
+      `expected ${errorName} (${expectedSelector}), got: ${errMsg}`
+    )
+  }
+
+  throw new Error(`expected ${errorName} but transaction succeeded`)
+}
+
+describe("FrostDkg liveness security", () => {
+  const AWAITING_RESULT = 2
+  const CHALLENGE = 3
+  const CHALLENGE_PERIOD = 20
+  const SUBMISSION_TIMEOUT = 40
+  const GROUP_SIZE = 100
+  const MALICIOUS_SELECTED_ID = 1
+  const HONEST_SELECTED_ID = 2
+  const NON_SELECTED_ID = 777
+
+  const selectedMembers = Array.from(
+    { length: GROUP_SIZE },
+    (_, index) => index + 1
+  )
+
+  let maliciousSelected: any
+  let honestSelected: any
+  let nonSelected: any
+  let challenger: any
+  let pool: any
+  let harness: any
+
+  const resultFor = (submitterMemberIndex: number, members: number[]) => ({
+    submitterMemberIndex,
+    xOnlyOutputKey: ethers.utils.id(
+      `frost-dkg-liveness-${submitterMemberIndex}-${members[0]}`
+    ),
+    misbehavedMembersIndices: [],
+    signatures: "0x",
+    signingMembersIndices: [],
+    members,
+    membersHash: ethers.constants.HashZero,
+  })
+
+  beforeEach(async () => {
+    ;[, maliciousSelected, honestSelected, nonSelected, challenger] =
+      await ethers.getSigners()
+
+    pool = await smock.fake(
+      "@keep-network/sortition-pools/contracts/SortitionPool.sol:SortitionPool"
+    )
+
+    pool.isLocked.returns(false)
+    pool.isOperatorInPool
+      .whenCalledWith(maliciousSelected.address)
+      .returns(true)
+    pool.isOperatorInPool.whenCalledWith(honestSelected.address).returns(true)
+    pool.isOperatorInPool.whenCalledWith(nonSelected.address).returns(true)
+    pool.getIDOperator
+      .whenCalledWith(MALICIOUS_SELECTED_ID)
+      .returns(maliciousSelected.address)
+    pool.getIDOperator
+      .whenCalledWith(HONEST_SELECTED_ID)
+      .returns(honestSelected.address)
+    pool.getIDOperator
+      .whenCalledWith(NON_SELECTED_ID)
+      .returns(nonSelected.address)
+    pool.selectGroup.returns(selectedMembers)
+
+    const Validator = await ethers.getContractFactory("FrostDkgValidator")
+    const validator = await Validator.deploy(pool.address)
+    await validator.deployed()
+
+    const Harness = await ethers.getContractFactory("FrostDkgLivenessHarness")
+    harness = await Harness.deploy(
+      pool.address,
+      validator.address,
+      honestSelected.address,
+      CHALLENGE_PERIOD,
+      SUBMISSION_TIMEOUT
+    )
+    await harness.deployed()
+
+    await harness.lockState()
+    pool.isLocked.returns(true)
+    await harness.start(ethers.utils.id("frost-dkg-liveness-seed"))
+    expect(await harness.state()).to.equal(AWAITING_RESULT)
+  })
+
+  it("rejects a current pool operator outside the seed-selected group", async () => {
+    const forgedMembers = [...selectedMembers]
+    forgedMembers[0] = NON_SELECTED_ID
+    const forgedResult = resultFor(1, forgedMembers)
+
+    await expectCustomError(
+      harness.connect(nonSelected).submitResult(forgedResult),
+      "InvalidGroupMembers"
+    )
+
+    expect(await harness.state()).to.equal(AWAITING_RESULT)
+  })
+
+  it("blocks a challenged submitter from repeating while preserving honest resubmission", async () => {
+    const maliciousResult = resultFor(1, selectedMembers)
+
+    await harness.connect(maliciousSelected).submitResult(maliciousResult)
+    expect(await harness.state()).to.equal(CHALLENGE)
+
+    await harness.connect(challenger).challengeResult(maliciousResult)
+    expect(await harness.state()).to.equal(AWAITING_RESULT)
+
+    await expectCustomError(
+      harness.connect(maliciousSelected).submitResult(maliciousResult),
+      "SubmitterChallengedForCurrentDkg"
+    )
+
+    const honestResult = resultFor(2, selectedMembers)
+    await expect(harness.connect(honestSelected).submitResult(honestResult)).to
+      .not.be.reverted
+    expect(await harness.state()).to.equal(CHALLENGE)
+  })
+
+  it("blocks a challenged operator through another selected member index", async () => {
+    const duplicatedMembers = [...selectedMembers]
+    duplicatedMembers[1] = MALICIOUS_SELECTED_ID
+    pool.selectGroup.returns(duplicatedMembers)
+
+    const firstSubmission = resultFor(1, duplicatedMembers)
+    await harness.connect(maliciousSelected).submitResult(firstSubmission)
+    await harness.connect(challenger).challengeResult(firstSubmission)
+
+    const alternateIndexSubmission = resultFor(2, duplicatedMembers)
+    await expectCustomError(
+      harness.connect(maliciousSelected).submitResult(alternateIndexSubmission),
+      "SubmitterChallengedForCurrentDkg"
+    )
+
+    expect(await harness.state()).to.equal(AWAITING_RESULT)
+  })
+
+  it("expires submitter quarantine when a new DKG round starts", async () => {
+    const maliciousResult = resultFor(1, selectedMembers)
+
+    await harness.connect(maliciousSelected).submitResult(maliciousResult)
+    await harness.connect(challenger).challengeResult(maliciousResult)
+
+    const deadline = await harness.resultSubmissionDeadline()
+    const currentBlock = await ethers.provider.getBlockNumber()
+    const blocksPastDeadline = deadline.toNumber() + 1 - currentBlock
+    if (blocksPastDeadline > 0) {
+      await hre.network.provider.send("hardhat_mine", [
+        `0x${blocksPastDeadline.toString(16)}`,
+      ])
+    }
+    await harness.notifyDkgTimeout()
+
+    pool.isLocked.returns(false)
+    await harness.lockState()
+    pool.isLocked.returns(true)
+    await harness.start(ethers.utils.id("frost-dkg-liveness-next-seed"))
+
+    await expect(
+      harness.connect(maliciousSelected).submitResult(maliciousResult)
+    ).to.not.be.reverted
+    expect(await harness.state()).to.equal(CHALLENGE)
+  })
+
+  it("keeps the original deadline and unlocks immediately after the exact timeout boundary", async () => {
+    const originalDeadline = await harness.resultSubmissionDeadline()
+    const maliciousResult = resultFor(1, selectedMembers)
+
+    await harness.connect(maliciousSelected).submitResult(maliciousResult)
+    await harness.connect(challenger).challengeResult(maliciousResult)
+
+    expect(await harness.resultSubmissionStartBlockOffset()).to.equal(0)
+    expect(await harness.resultSubmissionDeadline()).to.equal(originalDeadline)
+
+    const currentBlock = await ethers.provider.getBlockNumber()
+    const blocksToDeadline = originalDeadline.toNumber() - currentBlock
+    if (blocksToDeadline > 0) {
+      await hre.network.provider.send("hardhat_mine", [
+        `0x${blocksToDeadline.toString(16)}`,
+      ])
+    }
+
+    expect(await ethers.provider.getBlockNumber()).to.equal(
+      originalDeadline.toNumber()
+    )
+    expect(await harness.hasDkgTimedOut()).to.equal(false)
+
+    await hre.network.provider.send("hardhat_mine", ["0x1"])
+    expect(await harness.hasDkgTimedOut()).to.equal(true)
+
+    await (await harness.notifyDkgTimeout()).wait()
+    expect(pool.unlock).to.have.been.calledOnce
+  })
+
+  it("keeps selected-group submission within a bounded gas budget", async () => {
+    const selectedResult = resultFor(1, selectedMembers)
+    const receipt = await (
+      await harness.connect(maliciousSelected).submitResult(selectedResult)
+    ).wait()
+
+    expect(receipt.gasUsed).to.be.lt(1_500_000)
+  })
+
+  it("consumes one reserved FrostDkg storage slot for round quarantine", async () => {
+    const buildInfo = await artifacts.getBuildInfo(
+      "contracts/frost-registry/FrostWalletRegistry.sol:FrostWalletRegistry"
+    )
+    expect(buildInfo).to.not.equal(undefined)
+
+    const storageLayout =
+      buildInfo!.output.contracts[
+        "contracts/frost-registry/FrostWalletRegistry.sol"
+      ].FrostWalletRegistry.storageLayout
+    const dkgStorage = storageLayout.storage.find(
+      (entry: { label: string }) => entry.label === "dkg"
+    )
+    const walletsStorage = storageLayout.storage.find(
+      (entry: { label: string }) => entry.label === "wallets"
+    )
+    expect(dkgStorage).to.not.equal(undefined)
+    expect(walletsStorage).to.not.equal(undefined)
+    expect(dkgStorage!.slot).to.equal("151")
+    expect(walletsStorage!.slot).to.equal("202")
+
+    const dkgType = storageLayout.types[dkgStorage!.type]
+    const tail = dkgType.members.slice(-2)
+    expect(tail.map((member: { label: string }) => member.label)).to.deep.equal(
+      ["challengedSubmitterDkgStartBlocks", "__gap"]
+    )
+    expect(tail[0].slot).to.equal("14")
+    expect(tail[1].slot).to.equal("15")
+    expect(storageLayout.types[tail[1].type].label).to.equal("uint256[36]")
+    expect(dkgType.numberOfBytes).to.equal("1632")
+  })
+})

--- a/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
+++ b/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
@@ -158,6 +158,45 @@ describe("FrostDkg liveness security", () => {
     expect(await harness.state()).to.equal(CHALLENGE)
   })
 
+  it("preserves a full retry window after a result is challenged beyond the original deadline", async () => {
+    const originalDeadline = await harness.resultSubmissionDeadline()
+    const originalDeadlineBlock = originalDeadline.toNumber()
+    const currentBlock = await ethers.provider.getBlockNumber()
+    const blocksBeforeDeadline = originalDeadlineBlock - currentBlock - 1
+    if (blocksBeforeDeadline > 0) {
+      await hre.network.provider.send("hardhat_mine", [
+        `0x${blocksBeforeDeadline.toString(16)}`,
+      ])
+    }
+
+    const maliciousResult = resultFor(1, selectedMembers)
+    const submissionReceipt = await (
+      await harness.connect(maliciousSelected).submitResult(maliciousResult)
+    ).wait()
+    expect(submissionReceipt.blockNumber).to.equal(originalDeadlineBlock)
+
+    const challengeReceipt = await (
+      await harness.connect(challenger).challengeResult(maliciousResult)
+    ).wait()
+    expect(challengeReceipt.blockNumber).to.equal(originalDeadlineBlock + 1)
+
+    const retryDeadline = await harness.resultSubmissionDeadline()
+    expect(retryDeadline).to.equal(
+      challengeReceipt.blockNumber + SUBMISSION_TIMEOUT
+    )
+    expect(await harness.hasDkgTimedOut()).to.equal(false)
+
+    await expectCustomError(
+      harness.connect(maliciousSelected).submitResult(maliciousResult),
+      "SubmitterChallengedForCurrentDkg"
+    )
+
+    const honestResult = resultFor(2, selectedMembers)
+    await expect(harness.connect(honestSelected).submitResult(honestResult)).to
+      .not.be.reverted
+    expect(await harness.state()).to.equal(CHALLENGE)
+  })
+
   it("blocks a challenged operator through another selected member index", async () => {
     const duplicatedMembers = [...selectedMembers]
     duplicatedMembers[1] = MALICIOUS_SELECTED_ID
@@ -203,18 +242,25 @@ describe("FrostDkg liveness security", () => {
     expect(await harness.state()).to.equal(CHALLENGE)
   })
 
-  it("keeps the original deadline and unlocks immediately after the exact timeout boundary", async () => {
-    const originalDeadline = await harness.resultSubmissionDeadline()
+  it("expires immediately after the bounded post-challenge retry window", async () => {
     const maliciousResult = resultFor(1, selectedMembers)
 
     await harness.connect(maliciousSelected).submitResult(maliciousResult)
-    await harness.connect(challenger).challengeResult(maliciousResult)
+    const challengeReceipt = await (
+      await harness.connect(challenger).challengeResult(maliciousResult)
+    ).wait()
 
-    expect(await harness.resultSubmissionStartBlockOffset()).to.equal(0)
-    expect(await harness.resultSubmissionDeadline()).to.equal(originalDeadline)
+    const startBlock = await harness.startBlock()
+    expect(await harness.resultSubmissionStartBlockOffset()).to.equal(
+      challengeReceipt.blockNumber - startBlock.toNumber()
+    )
+    const retryDeadline = await harness.resultSubmissionDeadline()
+    expect(retryDeadline).to.equal(
+      challengeReceipt.blockNumber + SUBMISSION_TIMEOUT
+    )
 
     const currentBlock = await ethers.provider.getBlockNumber()
-    const blocksToDeadline = originalDeadline.toNumber() - currentBlock
+    const blocksToDeadline = retryDeadline.toNumber() - currentBlock
     if (blocksToDeadline > 0) {
       await hre.network.provider.send("hardhat_mine", [
         `0x${blocksToDeadline.toString(16)}`,
@@ -222,7 +268,7 @@ describe("FrostDkg liveness security", () => {
     }
 
     expect(await ethers.provider.getBlockNumber()).to.equal(
-      originalDeadline.toNumber()
+      retryDeadline.toNumber()
     )
     expect(await harness.hasDkgTimedOut()).to.equal(false)
 

--- a/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
+++ b/solidity/test/frost-registry/FrostDkg.LivenessSecurity.test.ts
@@ -72,8 +72,17 @@ describe("FrostDkg liveness security", () => {
   })
 
   beforeEach(async () => {
-    ;[, maliciousSelected, honestSelected, nonSelected, challenger] =
-      await ethers.getSigners()
+    const [
+      ,
+      maliciousSigner,
+      honestSigner,
+      nonSelectedSigner,
+      challengeSigner,
+    ] = await ethers.getSigners()
+    maliciousSelected = maliciousSigner
+    honestSelected = honestSigner
+    nonSelected = nonSelectedSigner
+    challenger = challengeSigner
 
     pool = await smock.fake(
       "@keep-network/sortition-pools/contracts/SortitionPool.sol:SortitionPool"
@@ -239,10 +248,10 @@ describe("FrostDkg liveness security", () => {
     )
     expect(buildInfo).to.not.equal(undefined)
 
-    const storageLayout =
+    const { storageLayout } =
       buildInfo!.output.contracts[
         "contracts/frost-registry/FrostWalletRegistry.sol"
-      ].FrostWalletRegistry.storageLayout
+      ].FrostWalletRegistry
     const dkgStorage = storageLayout.storage.find(
       (entry: { label: string }) => entry.label === "dkg"
     )

--- a/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
@@ -257,6 +257,16 @@ describe("FrostWalletRegistry full-cycle DKG happy path (B-1.5 slice 3)", () => 
       groupMembers
     )
 
+    // Submission validates the declared members by recreating the selected
+    // 100-operator group. Keep its fixed approval-time reimbursement at least
+    // as large as the real populated-pool transaction cost.
+    const submitReceipt = await dkgResult.submitDkgResultTx.wait()
+    const gasParameters = await frostWalletRegistry.gasParameters()
+    expect(gasParameters.dkgResultSubmissionGas).to.equal(1_500_000)
+    expect(gasParameters.dkgResultSubmissionGas).to.be.gte(
+      submitReceipt.gasUsed
+    )
+
     expect(await frostWalletRegistry.getWalletCreationState()).to.equal(
       0 /* IDLE */,
       "DKG returned to IDLE after approval"

--- a/solidity/test/frost-registry/FrostWalletRegistry.LivenessSecurity.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.LivenessSecurity.test.ts
@@ -1,0 +1,156 @@
+/* eslint-disable no-underscore-dangle */
+import hre, { ethers } from "hardhat"
+import { smock } from "@defi-wonderland/smock"
+import chai, { expect } from "chai"
+
+import {
+  Operators,
+  signFrostDkgResult,
+} from "../integration/utils/frost-wallet-registry"
+
+chai.use(smock.matchers)
+
+describe("FrostWalletRegistry DKG liveness integration", () => {
+  const GROUP_SIZE = 100
+  const CHALLENGE_PERIOD = 6
+  const selectedMembers = Array.from(
+    { length: GROUP_SIZE },
+    (_, index) => index + 1
+  )
+
+  let walletOwner: any
+  let randomBeacon: any
+
+  afterEach(async () => {
+    if (walletOwner) {
+      await hre.network.provider.send("hardhat_stopImpersonatingAccount", [
+        walletOwner.address,
+      ])
+    }
+    if (randomBeacon) {
+      await hre.network.provider.send("hardhat_stopImpersonatingAccount", [
+        randomBeacon.address,
+      ])
+    }
+  })
+
+  it("preserves a fully valid selected-group submission and approval", async function () {
+    this.timeout(120_000)
+
+    const [deployer, ...availableSigners] = await ethers.getSigners()
+    const operatorSigners = availableSigners.slice(9, 9 + GROUP_SIZE)
+    const operators = new Operators(
+      ...operatorSigners.map((signer, index) => ({
+        id: index + 1,
+        signer,
+        stakingProvider: signer.address,
+      }))
+    )
+
+    const pool = await smock.fake(
+      "@keep-network/sortition-pools/contracts/SortitionPool.sol:SortitionPool"
+    )
+    pool.isLocked.returns(false)
+    pool.isOperatorInPool
+      .whenCalledWith(operatorSigners[0].address)
+      .returns(true)
+    pool.getIDOperator
+      .whenCalledWith(selectedMembers[0])
+      .returns(operatorSigners[0].address)
+    pool.getIDOperators.returns(
+      operatorSigners.slice(0, 51).map((signer) => signer.address)
+    )
+    pool.selectGroup.returns(selectedMembers)
+
+    randomBeacon = await smock.fake("IRandomBeacon")
+    const reimbursementPool = await smock.fake("ReimbursementPool")
+    walletOwner = await smock.fake("IFrostWalletOwner")
+    reimbursementPool.refund.returns()
+
+    const Validator = await ethers.getContractFactory("FrostDkgValidator")
+    const validator = await Validator.deploy(pool.address)
+    await validator.deployed()
+
+    const FrostInactivity = await ethers.getContractFactory("FrostInactivity")
+    const frostInactivity = await FrostInactivity.deploy()
+    await frostInactivity.deployed()
+
+    const Registry = await ethers.getContractFactory("FrostWalletRegistry", {
+      signer: deployer,
+      libraries: { FrostInactivity: frostInactivity.address },
+    })
+    const implementation = await Registry.deploy(pool.address, {
+      gasLimit: 12_000_000,
+    })
+    await implementation.deployed()
+
+    const initializeData = Registry.interface.encodeFunctionData("initialize", [
+      validator.address,
+      randomBeacon.address,
+      reimbursementPool.address,
+      walletOwner.address,
+    ])
+    const Proxy = await ethers.getContractFactory("TransparentUpgradeableProxy")
+    const proxy = await Proxy.deploy(
+      implementation.address,
+      availableSigners[0].address,
+      initializeData,
+      { gasLimit: 12_000_000 }
+    )
+    await proxy.deployed()
+    const registry = Registry.attach(proxy.address)
+
+    await registry.updateLifecycleOwner(deployer.address)
+    await registry.updateDkgParameters(8, CHALLENGE_PERIOD, 50_000, 20, 5)
+
+    for (const address of [walletOwner.address, randomBeacon.address]) {
+      await hre.network.provider.send("hardhat_setBalance", [
+        address,
+        "0x56BC75E2D63100000",
+      ])
+      await hre.network.provider.send("hardhat_impersonateAccount", [address])
+    }
+
+    const walletOwnerSigner = await ethers.getSigner(walletOwner.address)
+    await registry.connect(walletOwnerSigner).requestNewWallet()
+    expect(pool.lock).to.have.been.calledOnce
+
+    pool.isLocked.returns(true)
+    const seed = ethers.BigNumber.from(
+      ethers.utils.id("frost-wallet-registry-liveness-valid-seed")
+    )
+    const randomBeaconSigner = await ethers.getSigner(randomBeacon.address)
+    await registry.connect(randomBeaconSigner).__beaconCallback(seed, 0)
+
+    const xOnlyOutputKey = ethers.utils.id(
+      "frost-wallet-registry-liveness-valid-key"
+    )
+    const result = await signFrostDkgResult(
+      hre,
+      operators,
+      walletOwner.address,
+      registry.address,
+      seed,
+      xOnlyOutputKey,
+      1,
+      [],
+      51
+    )
+
+    const [isValid, validationError] = await registry.isDkgResultValid(result)
+    expect(isValid, validationError).to.equal(true)
+
+    await registry.connect(operatorSigners[0]).submitDkgResult(result)
+    await hre.network.provider.send("hardhat_mine", [
+      `0x${(CHALLENGE_PERIOD + 1).toString(16)}`,
+    ])
+    await registry.connect(operatorSigners[0]).approveDkgResult(result)
+
+    expect(walletOwner.__frostWalletCreatedCallback).to.have.been.calledOnce
+    expect(walletOwner.__frostWalletCreatedCallback).to.have.been.calledWith(
+      xOnlyOutputKey
+    )
+    expect(pool.unlock).to.have.been.calledOnce
+    expect(await registry.isWalletRegistered(xOnlyOutputKey)).to.equal(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the FROST DKG retry-window liveness findings from the Codex Security review of #971.

- require submitted `members` to match the group selected for the active seed before entering the challenge state
- quarantine a successfully challenged submitter for the current DKG round, including alternate duplicate member indices
- give the remaining selected members a full submission window after every justified challenge, including challenges mined after the previous deadline
- bound retry extensions by the finite set of selected operator IDs, each of which can be challenged only once per DKG round
- reimburse the added selected-group validation cost with a 1,500,000-gas submission budget and a populated 100-operator regression

This PR is based on the existing #971 remediation stack tip, #1020.

## Security invariant

No pool operator outside the selected group, and no already-challenged selected operator, can reacquire the challenge-state lock. Every justified challenge gives unchallenged selected members a complete result-submission window. Successful challenge extensions are finite: at most one per unique selected operator ID, and therefore no more than the 100-member group size.

## Verification

- fail-before late-challenge regression reproduced the issue: the old code retained deadline block 44 after a challenge in block 45 instead of opening a retry window through block 85
- focused FROST DKG liveness regressions: 8 passing
- full FROST registry suite: 54 passing
- real populated-pool submission stays within the configured 1,500,000-gas reimbursement budget
- build and strict contract-size gate pass (`FrostWalletRegistry`: 24,534 deployed bytes, 42 bytes below EIP-170)
- storage-layout assertion preserves DKG slot 151 and the following wallet slot 202
- Prettier, Solhint, ESLint (no errors), and `git diff --check` pass

## Residual constraints

An economic actor controlling multiple selected operator IDs may consume one retry window per controlled ID. The extension is nevertheless bounded by the finite selected group, and each challenged ID is quarantined for the rest of the round. The registry remains close to the EIP-170 deployed-code-size limit, with 42 bytes of headroom after this change.
