### PR TITLE
fix(sdk): authenticate deposit custody inputs

### DIFF
--- a/solidity/contracts/bridge/P2TRFraudEvidenceProtocol.sol
+++ b/solidity/contracts/bridge/P2TRFraudEvidenceProtocol.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+/// @notice Minimal handshake required before Bridge may activate FROST custody.
+interface IP2TRFraudEvidenceProtocol {
+    function bridge() external view returns (address);
+
+    function evidenceProtocolID() external view returns (bytes32);
+}
+
+/// @notice Version identifiers and strict handshake for P2TR signature-fraud
+///         evidence protocols.
+/// @dev BOUNDED_V1 reconstructs full BIP-341 sighashes subject to finite
+///      transaction-shape limits. It is useful for verification and testing,
+///      but cannot safely protect FROST custody because a valid Bitcoin
+///      transaction can exceed those limits. COMPLETE_V2 is reserved for a
+///      future, reviewed protocol that can adjudicate every valid wallet spend
+///      shape and correlate an accepted spend with the exact BIP-341
+///      authorization being challenged. That correlation must authenticate
+///      witness data through a wtxid proof anchored in the BIP-141 witness
+///      commitment, and separately authenticate authoritative prevout
+///      values/scripts through trusted Bridge state or Bitcoin UTXO evidence.
+///      It must also bind the signed outpoint to the wallet and map every
+///      accepted representation/sighash mode to the challenged authorization.
+///      A txid alone is insufficient because it commits neither witness/annex
+///      data nor the prevout data used by the Taproot sighash.
+///
+///      The protocol ID is a compatibility handshake, not a security
+///      certification. Governance must separately review the router bytecode,
+///      immutability, and evidence construction before activating custody.
+library P2TRFraudEvidenceProtocol {
+    bytes32 internal constant BOUNDED_V1 =
+        keccak256("tbtc/p2tr-signature-fraud/evidence/bounded-v1");
+    bytes32 internal constant COMPLETE_V2 =
+        keccak256("tbtc/p2tr-signature-fraud/evidence/complete-v2");
+
+    error P2TRFraudEvidenceUnavailable();
+
+    /// @notice Requires an exact COMPLETE_V2 handshake bound to the expected
+    ///         Bridge address.
+    /// @dev Absent, reverting, malformed, wrong-Bridge, and bounded routers all
+    ///      fail closed with the same error. Exact 32-byte ABI words are
+    ///      required so fallback data cannot accidentally satisfy the check.
+    function requireCompleteRouter(address router, address expectedBridge)
+        internal
+        view
+    {
+        if (router == address(0)) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        (bool bridgeCallSucceeded, bytes memory bridgeResult) = router
+            .staticcall(
+                abi.encodeWithSelector(
+                    IP2TRFraudEvidenceProtocol.bridge.selector
+                )
+            );
+        if (!bridgeCallSucceeded || bridgeResult.length != 32) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        bytes32 encodedBridge = abi.decode(bridgeResult, (bytes32));
+        if (
+            uint256(encodedBridge) >> 160 != 0 ||
+            address(uint160(uint256(encodedBridge))) != expectedBridge
+        ) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        (bool protocolCallSucceeded, bytes memory protocolResult) = router
+            .staticcall(
+                abi.encodeWithSelector(
+                    IP2TRFraudEvidenceProtocol.evidenceProtocolID.selector
+                )
+            );
+        if (!protocolCallSucceeded || protocolResult.length != 32) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        if (abi.decode(protocolResult, (bytes32)) != COMPLETE_V2) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+    }
+}

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -6,8 +6,8 @@ import "./CheckBitcoinBIP341Sighash.sol";
 import "./CheckBitcoinP2TRSignatureFraud.sol";
 import "./Deposit.sol";
 import "./Fraud.sol";
-import "./MovingFunds.sol";
 import "./P2TRSignatureFraud.sol";
+import "./P2TRFraudEvidenceProtocol.sol";
 import "./Wallets.sol";
 
 /// @notice State the P2TR fraud router needs to read from Bridge while
@@ -41,22 +41,10 @@ interface IBridgeForP2TRFraud {
 
     function treasury() external view returns (address);
 
-    function deposits(uint256 depositKey)
-        external
-        view
-        returns (Deposit.DepositRequest memory);
-
     function taprootDepositOutputKeyCommitment(uint256 depositKey)
         external
         view
         returns (bytes32);
-
-    function spentMainUTXOs(uint256 utxoKey) external view returns (bool);
-
-    function movedFundsSweepRequests(uint256 requestKey)
-        external
-        view
-        returns (MovingFunds.MovedFundsSweepRequest memory);
 
     function legacyFraudChallengeExists(uint256 challengeKey)
         external
@@ -228,6 +216,14 @@ contract P2TRSignatureFraudRouter {
         bridge = _bridge;
     }
 
+    /// @notice Identifies the evidence protocol implemented by this router.
+    /// @dev BOUNDED_V1 deliberately must not activate FROST custody. Its finite
+    ///      shape limits leave valid, larger Bitcoin transactions outside the
+    ///      on-chain adjudication boundary.
+    function evidenceProtocolID() public pure virtual returns (bytes32) {
+        return P2TRFraudEvidenceProtocol.BOUNDED_V1;
+    }
+
     /// @notice Accepts ETH + challenge records for legacy P2TR fraud
     ///         challenges migrated from Bridge.
     /// @dev Same contract as ECDSA router's `acceptMigration`. Called
@@ -244,6 +240,7 @@ contract P2TRSignatureFraudRouter {
         uint256[] calldata challengeKeys,
         Fraud.FraudChallenge[] calldata data
     ) external payable {
+        _requireCompleteEvidenceProtocol();
         require(msg.sender == bridge, "Caller is not Bridge");
         require(challengeKeys.length == data.length, "Length mismatch");
 
@@ -292,6 +289,8 @@ contract P2TRSignatureFraudRouter {
         bytes calldata payload,
         uint32[] calldata walletMembersIDs
     ) external payable {
+        _requireCompleteEvidenceProtocol();
+
         require(
             payload.length <= P2TRSignatureFraudMaxPayloadBytes,
             "P2TR payload too large"
@@ -377,44 +376,21 @@ contract P2TRSignatureFraudRouter {
         );
     }
 
+    function _requireCompleteEvidenceProtocol() internal view {
+        if (evidenceProtocolID() != P2TRFraudEvidenceProtocol.COMPLETE_V2) {
+            revert P2TRFraudEvidenceProtocol.P2TRFraudEvidenceUnavailable();
+        }
+    }
+
     function _defeat(
-        CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload
-            memory payload
+        CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload memory
     ) internal {
-        IBridgeForP2TRFraud b = IBridgeForP2TRFraud(bridge);
-
-        _validatePayloadShape(payload);
-
-        ChallengeContext memory context = _computeChallengeContext(
-            _resolveWalletPubKeyHash(b, payload.walletID),
-            payload
-        );
-
-        Fraud.FraudChallenge storage challenge = _unresolvedChallenge(
-            context.challengeKey
-        );
-
-        require(
-            _isHonestlySpent(b, _signedInputUtxoKey(payload)),
-            "Spent UTXO not found among correctly spent UTXOs"
-        );
-
-        challenge.resolved = true;
-        _decrementOpenFraudChallengeCount(context.challengeKey);
-
-        address treasury = b.treasury();
-        /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls,unchecked-lowlevel,arbitrary-send-eth
-        treasury.call{gas: 100000, value: challenge.depositAmount}("");
-        /* solhint-enable avoid-low-level-calls */
-
-        emit P2TRSignatureFraudChallengeDefeated(
-            payload.walletID,
-            context.walletPubKeyHash,
-            context.bridgeChallengeIdentity,
-            context.challengeKey,
-            context.sighash
-        );
+        // BOUNDED_V1 cannot prove that an accepted Bitcoin authorization is
+        // identical to the challenged BIP-341 authorization. A Bitcoin txid
+        // does not commit witness/annex data or the prevout values and scripts
+        // used by the sighash. Keep defeat fail-closed until COMPLETE_V2
+        // supplies authenticated, authorization-complete evidence.
+        revert P2TRFraudEvidenceProtocol.P2TRFraudEvidenceUnavailable();
     }
 
     function _notifyTimeout(
@@ -541,18 +517,6 @@ contract P2TRSignatureFraudRouter {
             openFraudChallengeCountByWallet[walletPubKeyHash]--;
             delete fraudChallengeWalletPubKeyHash[challengeKey];
         }
-    }
-
-    function _isHonestlySpent(IBridgeForP2TRFraud b, uint256 utxoKey)
-        internal
-        view
-        returns (bool)
-    {
-        return
-            b.deposits(utxoKey).sweptAt > 0 ||
-            b.spentMainUTXOs(utxoKey) ||
-            b.movedFundsSweepRequests(utxoKey).state ==
-            MovingFunds.MovedFundsSweepRequestState.Processed;
     }
 
     /// @dev Deposit inputs verify against their tweaked output key only after

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -22,6 +22,7 @@ import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./BridgeState.sol";
 import "./IBridgeLifecycleRouter.sol";
+import "./P2TRFraudEvidenceProtocol.sol";
 
 /// @notice Minimal interface for the FROST wallet registry's wallet
 ///         creation entry point and lifecycle-owner handshake. The
@@ -270,6 +271,7 @@ library Wallets {
         if (frostWalletRegistry == address(0)) {
             revert FrostWalletRegistryNotSet();
         }
+        requireCompleteP2TRFraudEvidence(self);
         address lifecycleRouter = self.lifecycleRouter;
         if (lifecycleRouter == address(0)) {
             revert LifecycleRouterNotSet();
@@ -437,6 +439,7 @@ library Wallets {
         if (msg.sender != frostWalletRegistry) {
             revert CallerIsNotFrostWalletRegistry();
         }
+        requireCompleteP2TRFraudEvidence(self);
         // Gate FROST wallet creation on both ends of the lifecycle
         // path being wired up. Without a lifecycle router, the
         // wallet's eventual closeWallet/seize/isWalletMember would
@@ -499,6 +502,22 @@ library Wallets {
             xOnlyOutputKey
         );
         emit NewWalletRegisteredV2(walletID, bytes32(0), walletPubKeyHash);
+    }
+
+    /// @notice Requires a complete P2TR fraud-evidence protocol bound to this
+    ///         Bridge before FROST custody can begin.
+    /// @dev Low-level calls deliberately normalize absent, reverting, and
+    ///      malformed implementations to one fail-closed custom error. Exact
+    ///      32-byte ABI words are required so a fallback cannot accidentally
+    ///      satisfy the handshake with trailing or truncated data.
+    function requireCompleteP2TRFraudEvidence(BridgeState.Storage storage self)
+        internal
+        view
+    {
+        P2TRFraudEvidenceProtocol.requireCompleteRouter(
+            self.p2trFraudRouter,
+            address(this)
+        );
     }
 
     /// @notice Derives canonical wallet ID for legacy ECDSA wallets.

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -145,6 +145,22 @@ contract BridgeStub is Bridge {
         self.p2trFraudRouter = router;
     }
 
+    function emitNewFrostWalletRegisteredForTest() external {
+        emit Wallets.NewFrostWalletRegistered(
+            bytes32(uint256(1)),
+            bytes20(uint160(1)),
+            bytes32(uint256(1))
+        );
+    }
+
+    function emitZeroEcdsaWalletRegisteredV2ForTest() external {
+        emit Wallets.NewWalletRegisteredV2(
+            bytes32(uint256(1)),
+            bytes32(0),
+            bytes20(uint160(1))
+        );
+    }
+
     function setLegacyFraudChallengeForTest(
         uint256 challengeKey,
         Fraud.FraudChallenge calldata challenge

--- a/solidity/contracts/test/P2TRFraudEvidenceProtocolStub.sol
+++ b/solidity/contracts/test/P2TRFraudEvidenceProtocolStub.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import "../bridge/P2TRFraudEvidenceProtocol.sol";
+import "../bridge/P2TRSignatureFraudRouter.sol";
+
+/// @notice Handshake-only test stub advertising the reserved future protocol.
+/// @dev This is not a functional COMPLETE_V2 implementation and must never be
+///      deployed as custody protection. It only lets tests exercise Bridge's
+///      strict request/callback compatibility gate.
+contract HandshakeOnlyCompleteP2TRSignatureFraudRouterStub is
+    P2TRSignatureFraudRouter
+{
+    constructor(address bridgeAddress)
+        P2TRSignatureFraudRouter(bridgeAddress)
+    {}
+
+    function evidenceProtocolID() public pure override returns (bytes32) {
+        return P2TRFraudEvidenceProtocol.COMPLETE_V2;
+    }
+}
+
+/// @notice Configurable handshake stub for activation-gate tests.
+contract P2TRFraudEvidenceProtocolStub {
+    address public immutable bridge;
+    bytes32 public immutable evidenceProtocolID;
+
+    constructor(address bridgeAddress, bytes32 protocolID) {
+        bridge = bridgeAddress;
+        evidenceProtocolID = protocolID;
+    }
+}
+
+/// @notice Returns a truncated protocol word to prove strict ABI validation.
+contract MalformedP2TRFraudEvidenceProtocolStub {
+    address public immutable bridge;
+
+    constructor(address bridgeAddress) {
+        bridge = bridgeAddress;
+    }
+
+    function evidenceProtocolID() external pure {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0, 0)
+            return(0, 31)
+        }
+    }
+}

--- a/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
+++ b/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
@@ -1,32 +1,241 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
+import { utils } from "ethers"
 
-// Returns a signer for `address` only when that account is configured for the
-// current network. Used to decide whether a governance-gated call can be sent by
-// this deployment, or must instead be emitted as calldata for manual governance
-// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
-// signer in production). Mirrors 48_deploy_frost_wallet_registry.
-async function getConfiguredSigner(
+export const BOUNDED_V1_PROTOCOL_ID = utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+)
+export const COMPLETE_V2_PROTOCOL_ID = utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/complete-v2"
+)
+
+const FROST_REGISTRATION_SCAN_PAGE_SIZE = 10000
+
+// Formal storage layout for Bridge at this upgrade boundary:
+// Bridge.self starts at absolute slot 51. Within BridgeState.Storage,
+// frostWalletRegistry is relative slot 32 and p2trFraudRouter is relative slot
+// 34. Reading the proxy slots directly works before the candidate getters are
+// installed and proves both reserved fields are exactly zero.
+export const BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT = 51 + 32
+export const BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT = 51 + 34
+
+export interface FrostCustodyPreflightReceipt {
+  schemaVersion: "tbtc/frost-custody-preflight/v1"
+  networkName: string
+  chainId: string
+  bridge: string
+  snapshotBlockNumber: number
+  snapshotBlockHash: string
+  scanFromBlock: 0
+  scanToBlock: number
+  registrationsFound: 0
+  frostWalletRegistry: string
+  configuredP2TRFraudRouter: string
+  configuredRouterStatus: "unset"
+  frostWalletRegistryStorageSlot: number
+  p2trFraudRouterStorageSlot: number
+  storageLayoutEvidence: "test/formal/Bridge.storage-layout.json"
+}
+
+const requireExactResultLength = (
+  result: string,
+  bytes: number,
+  description: string
+): void => {
+  if (!/^0x[0-9a-fA-F]*$/.test(result) || result.length !== 2 + bytes * 2) {
+    throw new Error(
+      `FROST custody preflight failed: malformed ${description} result`
+    )
+  }
+}
+
+const readBridgePreflightState = async (
   hre: HardhatRuntimeEnvironment,
-  address: string
-) {
-  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
-    (account) => account.toLowerCase()
-  )
+  bridgeAddress: string,
+  snapshotBlockNumber: number
+): Promise<{
+  frostWalletRegistry: string
+  configuredP2TRFraudRouter: string
+  configuredRouterStatus: "unset"
+}> => {
+  const { ethers } = hre
 
-  if (!configuredAccounts.includes(address.toLowerCase())) {
-    return undefined
+  const frostWalletRegistryWord = await ethers.provider.getStorageAt(
+    bridgeAddress,
+    BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+    snapshotBlockNumber
+  )
+  requireExactResultLength(
+    frostWalletRegistryWord,
+    32,
+    `Bridge storage slot ${BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT}`
+  )
+  if (frostWalletRegistryWord !== ethers.constants.HashZero) {
+    throw new Error(
+      `FROST custody preflight failed: Bridge frost registry storage slot ${BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT} is non-zero (${frostWalletRegistryWord})`
+    )
   }
 
-  return hre.ethers.getSigner(address)
+  const p2trFraudRouterWord = await ethers.provider.getStorageAt(
+    bridgeAddress,
+    BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+    snapshotBlockNumber
+  )
+  requireExactResultLength(
+    p2trFraudRouterWord,
+    32,
+    `Bridge storage slot ${BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT}`
+  )
+  if (p2trFraudRouterWord !== ethers.constants.HashZero) {
+    throw new Error(
+      `FROST custody preflight failed: Bridge P2TR router storage slot ${BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT} is non-zero (${p2trFraudRouterWord})`
+    )
+  }
+
+  return {
+    frostWalletRegistry: ethers.constants.AddressZero,
+    configuredP2TRFraudRouter: ethers.constants.AddressZero,
+    configuredRouterStatus: "unset",
+  }
 }
+
+const assertNoFrostRegistrationHistory = async (
+  hre: HardhatRuntimeEnvironment,
+  bridgeAddress: string,
+  snapshotBlockNumber: number
+): Promise<void> => {
+  const { ethers } = hre
+  const newFrostWalletRegisteredTopic = ethers.utils.id(
+    "NewFrostWalletRegistered(bytes32,bytes20,bytes32)"
+  )
+  const newWalletRegisteredV2Topic = ethers.utils.id(
+    "NewWalletRegisteredV2(bytes32,bytes32,bytes20)"
+  )
+
+  for (
+    let fromBlock = 0;
+    fromBlock <= snapshotBlockNumber;
+    fromBlock += FROST_REGISTRATION_SCAN_PAGE_SIZE
+  ) {
+    const toBlock = Math.min(
+      snapshotBlockNumber,
+      fromBlock + FROST_REGISTRATION_SCAN_PAGE_SIZE - 1
+    )
+
+    // Both queries are required. NewFrostWalletRegistered covers the current
+    // callback, while the zero-ECDSA V2 marker covers intermediate deployments.
+    // Any provider or decoding failure propagates and aborts the deployment.
+    // eslint-disable-next-line no-await-in-loop
+    const newFrostWalletLogs = await ethers.provider.getLogs({
+      address: bridgeAddress,
+      fromBlock,
+      toBlock,
+      topics: [newFrostWalletRegisteredTopic],
+    })
+    // eslint-disable-next-line no-await-in-loop
+    const zeroEcdsaWalletV2Logs = await ethers.provider.getLogs({
+      address: bridgeAddress,
+      fromBlock,
+      toBlock,
+      topics: [newWalletRegisteredV2Topic, null, ethers.constants.HashZero],
+    })
+
+    if (newFrostWalletLogs.length > 0 || zeroEcdsaWalletV2Logs.length > 0) {
+      const firstLog = newFrostWalletLogs[0] ?? zeroEcdsaWalletV2Logs[0]
+      throw new Error(
+        `FROST custody preflight failed: prior FROST wallet registration at block ${firstLog.blockNumber}`
+      )
+    }
+  }
+}
+
+export const runFrostCustodyPreflight = async (
+  hre: HardhatRuntimeEnvironment,
+  bridgeAddress: string
+): Promise<FrostCustodyPreflightReceipt> => {
+  const snapshotBlockNumber = await hre.ethers.provider.getBlockNumber()
+  const snapshotBlock = await hre.ethers.provider.getBlock(snapshotBlockNumber)
+  if (!snapshotBlock?.hash) {
+    throw new Error(
+      "FROST custody preflight failed: snapshot block has no hash"
+    )
+  }
+
+  const bridgeState = await readBridgePreflightState(
+    hre,
+    bridgeAddress,
+    snapshotBlockNumber
+  )
+  await assertNoFrostRegistrationHistory(
+    hre,
+    bridgeAddress,
+    snapshotBlockNumber
+  )
+
+  const canonicalSnapshot = await hre.ethers.provider.getBlock(
+    snapshotBlockNumber
+  )
+  if (
+    !canonicalSnapshot?.hash ||
+    canonicalSnapshot.hash.toLowerCase() !== snapshotBlock.hash.toLowerCase()
+  ) {
+    throw new Error("FROST custody preflight failed: snapshot block reorged")
+  }
+
+  return {
+    schemaVersion: "tbtc/frost-custody-preflight/v1",
+    networkName: hre.network.name,
+    chainId: await hre.getChainId(),
+    bridge: bridgeAddress,
+    snapshotBlockNumber,
+    snapshotBlockHash: snapshotBlock.hash,
+    scanFromBlock: 0,
+    scanToBlock: snapshotBlockNumber,
+    registrationsFound: 0,
+    frostWalletRegistry: bridgeState.frostWalletRegistry,
+    configuredP2TRFraudRouter: bridgeState.configuredP2TRFraudRouter,
+    configuredRouterStatus: bridgeState.configuredRouterStatus,
+    frostWalletRegistryStorageSlot: BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+    p2trFraudRouterStorageSlot: BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+    storageLayoutEvidence: "test/formal/Bridge.storage-layout.json",
+  }
+}
+
+export const abortLiveBridgeUpgradeWithoutVettedCompleteV2 = async (
+  hre: HardhatRuntimeEnvironment,
+  upgradePath: string
+): Promise<never> => {
+  const Bridge = await hre.deployments.get("Bridge")
+  const receipt = await runFrostCustodyPreflight(hre, Bridge.address)
+
+  // Machine-readable, write-free receipt for operator review. The script
+  // throws immediately afterward, so no deployment or governance calldata is
+  // produced on live/custom networks.
+  console.log(`FROST_CUSTODY_PREFLIGHT_RECEIPT=${JSON.stringify(receipt)}`)
+
+  throw new Error(
+    `NO-GO ${upgradePath}: zero-FROST preflight passed at ${receipt.snapshotBlockNumber}/${receipt.snapshotBlockHash}, ` +
+      "but no vetted immutable COMPLETE_V2 evidence router exists. Do not deploy an implementation, execute a proxy upgrade, or emit governance calldata. " +
+      "The eventual governance operation must atomically validate the vetted router before enabling FROST-only replacement-wallet creation."
+  )
+}
+
+export const isEphemeralLocalNetwork = (networkName: string): boolean =>
+  ["hardhat", "development", "system_tests"].includes(networkName)
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { deployments, helpers, getNamedAccounts, ethers } = hre
-  const { deploy } = deployments
+  const { deploy, save } = deployments
   const { deployer } = await getNamedAccounts()
 
   const Bridge = await deployments.get("Bridge")
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "45_deploy_p2tr_signature_fraud_router"
+    )
+  }
+  const preflightReceipt = await runFrostCustodyPreflight(hre, Bridge.address)
 
   // P2TRSignatureFraudRouter is a plain (non-upgradeable) contract
   // that pins the Bridge address at construction. Sister sidecar to
@@ -38,190 +247,50 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
-  // Wire the router onto the Bridge via the one-time governance setter
-  // `Bridge.setP2TRFraudRouter`. Until this lands, `Bridge.p2trFraudRouter()`
-  // stays `address(0)`, `slashWalletForP2TRFraud` (the router's only privileged
-  // Bridge entry point, gated by `onlyP2TRFraudRouter`) is unreachable, and all
-  // P2TR fraud slashing is dead -- the router is deployed-but-dead until this
-  // call runs. The setter is one-time (reverts `P2TRFraudRouterAlreadySet()`
-  // once set), so this wiring is idempotent and must skip cleanly on re-runs.
-  //
-  // This mirrors the `setFrostWalletRegistry` wiring in
-  // 48_deploy_frost_wallet_registry: read the current Bridge value, send the
-  // setter when the deployer/governance owner is a configured signer, else emit
-  // the exact governance calldata for manual execution, and verify idempotently.
-  const bridgeContract = await ethers.getContractAt("Bridge", Bridge.address)
-  const bridgeGovernance = await ethers.getContractAt(
-    "BridgeGovernance",
-    (
-      await deployments.get("BridgeGovernance")
-    ).address
+  const routerContract = await ethers.getContractAt(
+    "P2TRSignatureFraudRouter",
+    p2trFraudRouter.address
+  )
+  if (
+    (await routerContract.bridge()).toLowerCase() !==
+    Bridge.address.toLowerCase()
+  ) {
+    throw new Error("P2TRSignatureFraudRouter is bound to the wrong Bridge")
+  }
+  if (
+    (await routerContract.evidenceProtocolID()).toLowerCase() !==
+    BOUNDED_V1_PROTOCOL_ID.toLowerCase()
+  ) {
+    throw new Error("Unexpected P2TR fraud evidence protocol ID")
+  }
+
+  // Re-read both reserved slots after the deployment transaction. Governance
+  // ordering requires them to remain zero until an independently reviewed,
+  // immutable COMPLETE_V2 router is available.
+  await readBridgePreflightState(
+    hre,
+    Bridge.address,
+    await ethers.provider.getBlockNumber()
   )
 
-  // Route the setter based on the current `Bridge.governance()`. On a fresh
-  // deploy chain (test/local) `21_transfer_bridge_governance.ts` runs last
-  // (`runAtTheEnd = true`), so this script executes while `Bridge.governance`
-  // is still the `deployer` named account -- the only address that passes
-  // `Bridge.onlyGovernance` in that window (routing through `BridgeGovernance`
-  // there would revert with "Caller is not the governance"). Once governance
-  // has been transferred, `Bridge.governance` is the `BridgeGovernance`
-  // contract and the setter must be routed through its `onlyOwner` wrapper
-  // (production deploys substitute the governance multisig signer there).
-  const currentBridgeGovernance = await bridgeContract.governance()
-  const governanceIsDeployer =
-    currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
-  const ALREADY_SET_SELECTOR = ethers.utils
-    .id("P2TRFraudRouterAlreadySet()")
-    .slice(0, 10)
+  await save("P2TRSignatureFraudRouter", {
+    ...p2trFraudRouter,
+    linkedData: {
+      ...(p2trFraudRouter.linkedData ?? {}),
+      frostCustodyPreflight: preflightReceipt,
+    },
+  })
 
-  // Idempotency pre-check via the public getter. `setP2TRFraudRouter` is a
-  // one-shot setter, so a re-run must skip cleanly on EVERY governance
-  // configuration -- including a multisig owner that is not a configured
-  // signer, where the wiring is emitted as calldata (not sent) and the
-  // AlreadySet revert path is never reached.
-  //
-  // When preparing the atomic upgrade of an EXISTING Bridge, the proxy is
-  // still on the pre-upgrade implementation, which has no `p2trFraudRouter()`
-  // selector until the governance proposal executes -- so this read reverts
-  // with a CALL_EXCEPTION (the eth_call returns no data to decode). A plain
-  // getter cannot revert for any other reason, so tolerate ONLY that case:
-  // treat the router as unwired and fall through to emit the setter calldata
-  // the operator needs for the upgrade/wiring proposal, rather than aborting
-  // before that branch is reached. Any other error (e.g. an RPC failure)
-  // rethrows so it is not silently swallowed (cf. the blanket-catch regression
-  // fixed in 48_deploy_frost_wallet_registry).
-  let currentP2TRFraudRouter: string
-  let bridgeExposesGetter = true
-  try {
-    currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
-  } catch (err) {
-    if ((err as { code?: string }).code !== "CALL_EXCEPTION") {
-      throw err
-    }
-    console.log(
-      "Bridge.p2trFraudRouter() reverted (no such selector on the current " +
-        "Bridge implementation -- pre-upgrade proxy); treating the router as " +
-        "unwired and emitting wiring for the upgrade proposal"
-    )
-    currentP2TRFraudRouter = ethers.constants.AddressZero
-    bridgeExposesGetter = false
-  }
-
-  if (
-    currentP2TRFraudRouter.toLowerCase() ===
-    p2trFraudRouter.address.toLowerCase()
-  ) {
-    console.log(
-      `P2TRSignatureFraudRouter already wired on this Bridge at ${p2trFraudRouter.address}; skipping`
-    )
-  } else if (currentP2TRFraudRouter !== ethers.constants.AddressZero) {
-    throw new Error(
-      "Bridge is already wired to a different P2TRSignatureFraudRouter " +
-        `(${currentP2TRFraudRouter}); refusing to wire ` +
-        `${p2trFraudRouter.address}`
-    )
-  } else {
-    // Resolve the authorized caller. In the governance-wrapper case the setter
-    // is `BridgeGovernance.onlyOwner`, so the call must come from the wrapper
-    // owner -- which post-handoff is the governance multisig, not `deployer`.
-    // When that owner is not a configured signer, emit the calldata for manual
-    // governance execution and skip (mainnet) rather than sending from
-    // `deployer` and reverting.
-    const setterContract = governanceIsDeployer
-      ? bridgeContract
-      : bridgeGovernance
-    const setterCaller = governanceIsDeployer
-      ? deployer
-      : await bridgeGovernance.owner()
-    // A pre-upgrade Bridge has no `setP2TRFraudRouter` selector yet, so the
-    // transaction cannot be sent regardless of who is a configured signer.
-    // Force the calldata-emission path in that case (leave the signer
-    // unresolved) rather than attempting -- and reverting -- the send.
-    const setterSigner = bridgeExposesGetter
-      ? await getConfiguredSigner(hre, setterCaller)
-      : undefined
-
-    if (!setterSigner) {
-      const calldata = setterContract.interface.encodeFunctionData(
-        "setP2TRFraudRouter",
-        [p2trFraudRouter.address]
-      )
-      const reason = !bridgeExposesGetter
-        ? `the Bridge at ${Bridge.address} does not yet expose ` +
-          "setP2TRFraudRouter (pre-upgrade implementation); wire it as part " +
-          "of the upgrade proposal"
-        : `${setterCaller} is not a configured signer for network ${hre.network.name}`
-      const message =
-        `P2TRSignatureFraudRouter wiring must be executed by governance -- ${reason}. ` +
-        "Submit this call from governance:\n" +
-        `  target: ${setterContract.address}\n` +
-        `  data:   ${calldata}`
-
-      // A pre-upgrade Bridge genuinely cannot be wired now on ANY network, so
-      // emit the calldata and continue. Otherwise keep the existing guard:
-      // skip on mainnet (a non-signer governance owner is expected there) and
-      // error elsewhere so an unexpected non-signer is surfaced.
-      if (!bridgeExposesGetter || hre.network.name === "mainnet") {
-        console.log(`${message}\nskipping for manual governance execution`)
-      } else {
-        throw new Error(message)
-      }
-    } else {
-      try {
-        const tx = await setterContract
-          .connect(setterSigner)
-          .setP2TRFraudRouter(p2trFraudRouter.address)
-        await tx.wait(1)
-        console.log(
-          `wired P2TRSignatureFraudRouter at ${
-            p2trFraudRouter.address
-          } onto Bridge ${
-            governanceIsDeployer
-              ? "directly (governance is still deployer)"
-              : "via BridgeGovernance"
-          }`
-        )
-      } catch (err) {
-        // Tolerate only a concurrent deployment that wired the SAME router
-        // between the pre-check read above and this call (AlreadySet revert).
-        const errAny = err as {
-          data?: string
-          error?: { data?: string }
-          message?: string
-        }
-        const revertData =
-          errAny.data || errAny.error?.data || errAny.message || ""
-        if (
-          typeof revertData === "string" &&
-          revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
-        ) {
-          console.log(
-            "P2TRSignatureFraudRouter already wired on this Bridge; skipping"
-          )
-        } else {
-          console.error(
-            "setP2TRFraudRouter call reverted with an unexpected error;",
-            "deploy aborted so the operator can investigate:",
-            errAny.message || err
-          )
-          throw err
-        }
-      }
-
-      // Idempotent post-check: assert the on-chain value now reflects this
-      // router. Only meaningful when the setter was actually sent; the
-      // calldata-emit path skips before reaching here. Also catches a
-      // concurrent deploy that wired a DIFFERENT router (AlreadySet caught
-      // above) between the pre-check and this send.
-      const wiredRouter = await bridgeContract.p2trFraudRouter()
-      if (wiredRouter.toLowerCase() !== p2trFraudRouter.address.toLowerCase()) {
-        throw new Error(
-          "Bridge.p2trFraudRouter mismatch after deploy: " +
-            `expected ${p2trFraudRouter.address}, got ${wiredRouter}`
-        )
-      }
-    }
-  }
+  // NO-GO: BOUNDED_V1 cannot adjudicate every valid Bitcoin transaction
+  // shape, so wiring it would make an unchallengeable FROST spend possible.
+  // Do not call the one-shot setter and do not emit governance calldata. The
+  // slot must remain available for a future COMPLETE_V2 implementation.
+  console.log(
+    `NO-GO: deployed bounded P2TR fraud router ${p2trFraudRouter.address}; ` +
+      "leaving Bridge.p2trFraudRouter unset. Zero-FROST receipt: " +
+      `${preflightReceipt.snapshotBlockNumber}/${preflightReceipt.snapshotBlockHash}. ` +
+      "Do not upgrade this Bridge until a vetted immutable COMPLETE_V2 router exists."
+  )
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(p2trFraudRouter)
@@ -238,4 +307,4 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 export default func
 
 func.tags = ["P2TRSignatureFraudRouter"]
-func.dependencies = ["Bridge", "BridgeGovernance"]
+func.dependencies = ["FrostCustodyNoGo", "Bridge", "BridgeGovernance"]

--- a/solidity/deploy/47_assert_frost_custody_no_go.ts
+++ b/solidity/deploy/47_assert_frost_custody_no_go.ts
@@ -1,0 +1,23 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
+
+/// @notice Write-free guard placed first in every FROST deployment dependency
+///         chain. Live/custom networks fail before FROST dependencies deploy.
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  if (isEphemeralLocalNetwork(hre.network.name)) {
+    return
+  }
+
+  await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+    hre,
+    "47_assert_frost_custody_no_go"
+  )
+}
+
+export default func
+
+func.tags = ["FrostCustodyNoGo"]

--- a/solidity/deploy/48_deploy_frost_wallet_registry.ts
+++ b/solidity/deploy/48_deploy_frost_wallet_registry.ts
@@ -1,5 +1,9 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 // Returns a signer for `address` only when that account is configured for the
 // current network. Used to decide whether a governance-gated call can be sent by
@@ -24,6 +28,13 @@ async function getConfiguredSigner(
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "48_deploy_frost_wallet_registry"
+    )
+  }
 
   const FrostSortitionPool = await deployments.get("FrostSortitionPool")
   const ReimbursementPool = await deployments.get("ReimbursementPool")
@@ -354,6 +365,7 @@ export default func
 
 func.tags = ["FrostWalletRegistry"]
 func.dependencies = [
+  "FrostCustodyNoGo",
   "Bridge",
   "BridgeGovernance",
   "FrostSortitionPool",

--- a/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
+++ b/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
@@ -16,11 +16,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, deployments, getNamedAccounts } = hre
   const { get } = deployments
   const { deployer, treasury } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "80_upgrade_bridge_v2_DEPRECATED"
+    )
+  }
 
   const Bank = await deployments.get("Bank")
   const LightRelay = await deployments.get("LightRelay")
@@ -147,6 +158,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["UpgradeBridge"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Set UPGRADE_BRIDGE=true when running an upgrade.
 // yarn deploy --tags UpgradeBridge --network <NETWORK>
 func.skip = async () => process.env.UPGRADE_BRIDGE !== "true"

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -2,11 +2,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "82_deploy_rebate_and_prepare_txs"
+    )
+  }
 
   console.log("\n========== REBATE DEPLOYMENT STARTING ==========")
   console.log("Network:", hre.network.name)
@@ -446,6 +457,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployRebateAndPrepareTxs"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Dependencies remain removed so standalone live-network execution does not
-// rerun the full Bridge deployment chain.
+// rerun the full Bridge deployment chain. The write-free NO-GO dependency is
+// the sole exception and aborts non-ephemeral networks before this function.
 // func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
+++ b/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
@@ -1,5 +1,9 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 /// Phase C-2.1a upgrade script — deploys the current versions of all
 /// external libraries linked by `Bridge` and upgrades the proxy using
@@ -19,6 +23,13 @@ const func: DeployFunction = async function upgradeBridgeC21Counter(
   const { ethers, helpers, deployments, getNamedAccounts } = hre
   const { get, deploy, log } = deployments
   const { deployer, treasury } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "84_upgrade_bridge_c2_1_counter"
+    )
+  }
 
   const Bank = await get("Bank")
   const LightRelay = await get("LightRelay")
@@ -133,6 +144,7 @@ const func: DeployFunction = async function upgradeBridgeC21Counter(
 export default func
 
 func.tags = ["UpgradeBridgeC21Counter"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Off by default. To run, set the environment variable
 // `RUN_UPGRADE_C2_1_COUNTER=1` and invoke:
 //

--- a/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
+++ b/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
@@ -19,11 +19,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, deployments, getNamedAccounts, upgrades } = hre
   const { get, log } = deployments
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "84_upgrade_bridge_repair_rebate_staking_DEPRECATED"
+    )
+  }
 
   const repairTarget =
     process.env.REBATE_STAKING_REPAIR_TARGET ?? ethers.constants.AddressZero
@@ -151,4 +162,5 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["RepairBridgeRebateStaking"]
+func.dependencies = ["FrostCustodyNoGo"]
 func.skip = async () => process.env.REPAIR_BRIDGE_REBATE_STAKING !== "true"

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -4,6 +4,10 @@ import https from "https"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
 import { utils } from "ethers"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 // EIP-1967 transparent proxy admin storage slot. Defined by the standard
 // at https://eips.ethereum.org/EIPS/eip-1967#admin-address and used to
@@ -303,6 +307,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy, get } = deployments
   const { deployer } = await getNamedAccounts()
   const { ethers } = hre
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "85_deploy_tip109_governance_upgrade"
+    )
+  }
 
   const deployOptions: DeployOptions = {
     from: deployer,
@@ -707,6 +718,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployTIP109GovernanceUpgrade"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Set DEPLOY_TIP109=true when running the deployment.
 // yarn deploy --tags DeployTIP109GovernanceUpgrade --network <NETWORK>
 func.skip = async () => process.env.DEPLOY_TIP109 !== "true"

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -11,6 +11,10 @@ import {
   KNOWN_TIMELOCK,
   KNOWN_COUNCIL_SAFE,
 } from "./85_deploy_tip109_governance_upgrade"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const PROXY_ADMIN_ABI = [
   "function upgrade(address proxy, address implementation)",
@@ -91,6 +95,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy, get, save } = deployments
   const { deployer } = await getNamedAccounts()
   const { ethers } = hre
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "86_deploy_tip109_hotfix"
+    )
+  }
 
   // Patch ethers.js v5 Formatter to handle empty-string `to` field returned
   // by some RPC providers for contract-creation transactions. Without this
@@ -434,4 +445,5 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployTIP109Hotfix"]
+func.dependencies = ["FrostCustodyNoGo"]
 func.skip = async () => process.env.DEPLOY_TIP109_HOTFIX !== "true"

--- a/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
+++ b/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
@@ -28,6 +28,44 @@ const { lastBlockTime } = helpers.time
 // must be structurally distinguishable from a left-padded legacy alias.
 const frostXOnlyOutputKey =
   "0xb1de1afa17e1cbb20d8a4f8e54f8a55fbf5c8d2da9e1c6c4d1f0c7b3a2e5d4c8"
+const boundedEvidenceProtocolID = ethers.utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+)
+const completeEvidenceProtocolID = ethers.utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/complete-v2"
+)
+
+async function deployBoundedP2TRFraudRouter(
+  bridgeAddress: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory("P2TRSignatureFraudRouter")
+  const router = await factory.deploy(bridgeAddress)
+  await router.deployed()
+  return router.address
+}
+
+async function deployEvidenceProtocolStub(
+  bridgeAddress: string,
+  protocolID: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory(
+    "P2TRFraudEvidenceProtocolStub"
+  )
+  const router = await factory.deploy(bridgeAddress, protocolID)
+  await router.deployed()
+  return router.address
+}
+
+async function deployMalformedEvidenceProtocolStub(
+  bridgeAddress: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory(
+    "MalformedP2TRFraudEvidenceProtocolStub"
+  )
+  const router = await factory.deploy(bridgeAddress)
+  await router.deployed()
+  return router.address
+}
 
 // Local helper: assert a transaction reverts with a specific no-arg
 // custom error. The project's test toolchain (hardhat-waffle 2.x +
@@ -70,6 +108,24 @@ async function expectCustomError(
   throw new Error(
     `expected revert with custom error ${errorName} but tx succeeded`
   )
+}
+
+async function expectFrostActivationRejectedWithoutStateChanges(
+  bridge: Bridge & BridgeStub,
+  action: () => Promise<unknown>
+): Promise<void> {
+  const activeWalletPubKeyHash = await bridge.activeWalletPubKeyHash()
+  const activeWalletID = await bridge.activeWalletID()
+  const liveWalletsCount = await bridge.liveWalletsCount()
+
+  await expectCustomError(action(), "P2TRFraudEvidenceUnavailable")
+
+  expect(await bridge.activeWalletPubKeyHash()).to.equal(activeWalletPubKeyHash)
+  expect(await bridge.activeWalletID()).to.equal(activeWalletID)
+  expect(await bridge.liveWalletsCount()).to.equal(liveWalletsCount)
+  expect(
+    await bridge.walletPubKeyHashForWalletID(frostXOnlyOutputKey)
+  ).to.equal(ethers.constants.AddressZero)
 }
 
 describe("Bridge - FROST Wallet Registration", () => {
@@ -215,6 +271,57 @@ describe("Bridge - FROST Wallet Registration", () => {
       await restoreSnapshot()
     })
 
+    it("should fail closed before DKG when the router is unset without changing state", async () => {
+      await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject the bounded V1 router before DKG", async () => {
+      const routerAddress = await deployBoundedP2TRFraudRouter(bridge.address)
+      const router = await ethers.getContractAt(
+        "P2TRSignatureFraudRouter",
+        routerAddress
+      )
+      expect(await router.evidenceProtocolID()).to.equal(
+        boundedEvidenceProtocolID
+      )
+      await bridge.resetP2TRFraudRouterForTest(routerAddress)
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject malformed protocol data before DKG", async () => {
+      await bridge.resetP2TRFraudRouterForTest(
+        await deployMalformedEvidenceProtocolStub(bridge.address)
+      )
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject a complete protocol bound to another Bridge before DKG", async () => {
+      await bridge.resetP2TRFraudRouterForTest(
+        await deployEvidenceProtocolStub(
+          thirdParty.address,
+          completeEvidenceProtocolID
+        )
+      )
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
     it("should fail before DKG when lifecycle router is unset", async () => {
       await bridge.resetLifecycleRouterForTest(ethers.constants.AddressZero)
       await frostRegistry.setLifecycleOwner(thirdParty.address)
@@ -238,6 +345,14 @@ describe("Bridge - FROST Wallet Registration", () => {
 
     it("should dispatch when registry lifecycle owner matches Bridge lifecycle router", async () => {
       await frostRegistry.setLifecycleOwner(thirdParty.address)
+
+      const router = await ethers.getContractAt(
+        "P2TRSignatureFraudRouter",
+        await bridge.p2trFraudRouter()
+      )
+      expect(await router.evidenceProtocolID()).to.equal(
+        completeEvidenceProtocolID
+      )
 
       await expect(
         bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
@@ -280,6 +395,63 @@ describe("Bridge - FROST Wallet Registration", () => {
               .__frostWalletCreatedCallback(frostXOnlyOutputKey),
             "CallerIsNotFrostWalletRegistry"
           ))
+      })
+
+      context("when complete P2TR fraud evidence is unavailable", () => {
+        beforeEach(async () => {
+          await createSnapshot()
+        })
+
+        afterEach(async () => {
+          await restoreSnapshot()
+        })
+
+        const callRegistration = async () =>
+          frostRegistry.callBridgeFrostWalletCreatedCallback(
+            bridge.address,
+            frostXOnlyOutputKey
+          )
+
+        it("should reject an unset router without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject bounded V1 without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployBoundedP2TRFraudRouter(bridge.address)
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject malformed protocol data without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployMalformedEvidenceProtocolStub(bridge.address)
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject a protocol bound to another Bridge without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployEvidenceProtocolStub(
+              thirdParty.address,
+              completeEvidenceProtocolID
+            )
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
       })
 
       context(
@@ -339,6 +511,13 @@ describe("Bridge - FROST Wallet Registration", () => {
 
         before(async () => {
           await createSnapshot()
+          const router = await ethers.getContractAt(
+            "P2TRSignatureFraudRouter",
+            await bridge.p2trFraudRouter()
+          )
+          expect(await router.evidenceProtocolID()).to.equal(
+            completeEvidenceProtocolID
+          )
           tx = await frostRegistry.callBridgeFrostWalletCreatedCallback(
             bridge.address,
             frostXOnlyOutputKey
@@ -626,6 +805,30 @@ describe("Bridge - FROST Wallet Registration", () => {
           ecdsaWalletTestData.walletID,
           ecdsaWalletTestData.pubKeyHash160
         )
+    })
+  })
+
+  describe("ECDSA registration while P2TR evidence is unavailable", () => {
+    before(async () => {
+      await createSnapshot()
+      await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.publicKeyX,
+          ecdsaWalletTestData.publicKeyY
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should preserve the legacy ECDSA callback path", async () => {
+      const wallet = await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)
+      expect(wallet.ecdsaWalletID).to.equal(ecdsaWalletTestData.walletID)
+      expect(wallet.state).to.equal(walletState.Live)
     })
   })
 

--- a/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
+++ b/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
@@ -18,6 +18,28 @@ import { constants, walletState } from "../fixtures"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
+const expectCustomError = async (
+  promise: Promise<unknown>,
+  errorName: string
+): Promise<void> => {
+  const selector = ethers.utils.id(`${errorName}()`).slice(0, 10)
+
+  try {
+    await promise
+    expect.fail(`expected ${errorName}`)
+  } catch (error) {
+    const errorData = error as {
+      data?: string
+      error?: { data?: string }
+      message?: string
+    }
+    const data = errorData.data ?? errorData.error?.data ?? ""
+    expect(`${data} ${errorData.message ?? ""}`.toLowerCase()).to.include(
+      selector.toLowerCase()
+    )
+  }
+}
+
 describe("Bridge - legacy fraud challenge migration", () => {
   let deployer: SignerWithAddress
   let governance: SignerWithAddress
@@ -260,7 +282,7 @@ describe("Bridge - legacy fraud challenge migration", () => {
     expect(await ecdsaFraudRouter.openFraudChallengeCount()).to.equal(0)
   })
 
-  it("routes P2TR records only to the P2TR router", async () => {
+  it("routes P2TR records only to the handshake-only P2TR test stub", async () => {
     const key = 201
     const deposit = ethers.utils.parseEther("0.25")
     await seedChallenge(key, deposit)
@@ -380,7 +402,10 @@ describe("Bridge - legacy fraud challenge migration", () => {
     )
   })
 
-  for (const routerName of ["EcdsaFraudRouter", "P2TRSignatureFraudRouter"]) {
+  for (const routerName of [
+    "EcdsaFraudRouter",
+    "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+  ]) {
     it(`${routerName} rejects resolved migration records`, async () => {
       const factory = await ethers.getContractFactory(routerName, deployer)
       const router = await factory.deploy(thirdParty.address)
@@ -403,4 +428,20 @@ describe("Bridge - legacy fraud challenge migration", () => {
       ).to.be.revertedWith("Challenge already resolved")
     })
   }
+
+  it("keeps production BOUNDED_V1 migration dormant", async () => {
+    const factory = await ethers.getContractFactory(
+      "P2TRSignatureFraudRouter",
+      deployer
+    )
+    const router = await factory.deploy(thirdParty.address)
+    await router.deployed()
+
+    await expectCustomError(
+      router.connect(thirdParty).acceptMigration([], []),
+      "P2TRFraudEvidenceUnavailable"
+    )
+    expect(await router.openFraudChallengeCount()).to.equal(0)
+    expect(await ethers.provider.getBalance(router.address)).to.equal(0)
+  })
 })

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -36,6 +36,7 @@ type PrevoutVector = {
 
 type SignatureFraudVector = {
   id: string
+  annexHex?: string
   walletIDHex: string
   unsignedTransactionHex: string
   signedInputIndex: number
@@ -333,6 +334,7 @@ async function expectBalanceDelta(
 
 describe("Bridge - P2TR signature fraud", () => {
   const vectorCorpus = loadVectorCorpus()
+  const fullSighashVectorCorpus = loadVectorCorpus(fullSighashVectorCorpusPath)
   const vector = vectorCorpus.cases[0]
   const multiInputVector = vectorCorpus.cases.find(
     ({ id }) => id === "bip341-keypath-sighash-default-multi-input-multi-output"
@@ -340,9 +342,15 @@ describe("Bridge - P2TR signature fraud", () => {
   const distinctWalletVector = vectorCorpus.cases.find(
     ({ walletIDHex }) => walletIDHex !== vector.walletIDHex
   )
-  const sighashNoneVector = loadVectorCorpus(
-    fullSighashVectorCorpusPath
-  ).cases.find(({ id }) => id === "bip341-keypath-none-multi")!
+  const sighashNoneVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-none-multi"
+  )!
+  const annexVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-default-with-annex"
+  )!
+  const noAnnexVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-default-multi"
+  )!
   if (!distinctWalletVector) {
     throw new Error("P2TR fraud vector corpus needs two distinct wallets")
   }
@@ -515,6 +523,49 @@ describe("Bridge - P2TR signature fraud", () => {
       await p2trFraudRouter.hasOpenFraudChallengeForWallet(walletPubKeyHash)
     ).to.equal(expectedWalletCount > 0 || expectedUnattributedCount > 0)
   }
+
+  it("keeps the production BOUNDED_V1 lifecycle and migration completely dormant", async () => {
+    const factory = await ethers.getContractFactory("P2TRSignatureFraudRouter")
+    const boundedRouter = (await factory.deploy(
+      bridge.address
+    )) as P2TRSignatureFraudRouter
+    await boundedRouter.deployed()
+
+    expect(await boundedRouter.evidenceProtocolID()).to.equal(
+      ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes(
+          "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+        )
+      )
+    )
+
+    const encodedPayload = encodePayload(vectorPayload(vector))
+    for (const action of [
+      p2trFraudAction.Submit,
+      p2trFraudAction.Defeat,
+      p2trFraudAction.Timeout,
+    ]) {
+      await expectCustomError(
+        boundedRouter
+          .connect(thirdParty)
+          .processP2TRSignatureFraudChallenge(action, encodedPayload, [], {
+            value:
+              action === p2trFraudAction.Submit
+                ? fraudChallengeDepositAmount
+                : 0,
+          }),
+        "P2TRFraudEvidenceUnavailable"
+      )
+    }
+
+    await expectCustomError(
+      boundedRouter.connect(thirdParty).acceptMigration([], []),
+      "P2TRFraudEvidenceUnavailable"
+    )
+
+    expect(await boundedRouter.openFraudChallengeCount()).to.equal(0)
+    expect(await ethers.provider.getBalance(boundedRouter.address)).to.equal(0)
+  })
 
   it("submits and stores a P2TR signature-fraud challenge", async () => {
     const payload = vectorPayload(vector)
@@ -791,6 +842,30 @@ describe("Bridge - P2TR signature fraud", () => {
           { value: fraudChallengeDepositAmount }
         )
     ).to.be.revertedWith("Fraud challenge already exists")
+  })
+
+  it("treats the same txid with different annex authorization as distinct evidence", async () => {
+    expect(annexVector.unsignedTransactionHex).to.equal(
+      noAnnexVector.unsignedTransactionHex
+    )
+
+    const noAnnexPayload = vectorPayload(noAnnexVector)
+    const annexPayload = vectorPayload(annexVector, {
+      annexHex: hex(annexVector.annexHex!),
+    })
+    const walletPubKeyHash = await registerP2TRWallet(noAnnexPayload.walletID)
+
+    const first = await submitChallenge(noAnnexPayload, noAnnexVector)
+    const second = await submitChallenge(annexPayload, annexVector)
+
+    expect(first.challengeKey).to.not.equal(second.challengeKey)
+    expect(
+      (await p2trFraudRouter.fraudChallenges(first.challengeKey)).reportedAt
+    ).to.be.greaterThan(0)
+    expect(
+      (await p2trFraudRouter.fraudChallenges(second.challengeKey)).reportedAt
+    ).to.be.greaterThan(0)
+    await expectChallengeCounters(walletPubKeyHash, 2, 0, 2)
   })
 
   it("blocks public evidence from pre-seeding a legacy P2TR migration key", async () => {
@@ -1173,58 +1248,71 @@ describe("Bridge - P2TR signature fraud", () => {
   ]
 
   for (const scenario of honestSpendDefeatScenarios) {
-    it(`defeats a P2TR challenge after the signed input is a ${scenario.name}`, async () => {
+    it(`keeps authorization-incomplete defeat fail-closed after the signed input is a ${scenario.name}`, async () => {
       const payload = vectorPayload(vector)
       const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
-      const { challengeKey, bridgeChallengeIdentity } = await submitChallenge(
-        payload
-      )
+      const { challengeKey } = await submitChallenge(payload)
 
       await scenario.markHonestSpend(payload, walletPubKeyHash)
 
-      const tx = await p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Defeat,
-          encodePayload(payload),
-          []
-        )
-
-      await expectBalanceDelta(tx, treasury, fraudChallengeDepositAmount)
-
-      expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to
-        .be.true
-      await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
-
-      const event = await findP2TREvent(
-        tx,
-        p2trFraudRouter.address,
-        "P2TRSignatureFraudChallengeDefeated"
+      await expectCustomError(
+        p2trFraudRouter
+          .connect(thirdParty)
+          .processP2TRSignatureFraudChallenge(
+            p2trFraudAction.Defeat,
+            encodePayload(payload),
+            []
+          ),
+        "P2TRFraudEvidenceUnavailable"
       )
-      expect(event.args.walletID).to.equal(payload.walletID)
-      expect(event.args.walletPubKeyHash).to.equal(walletPubKeyHash)
-      expect(event.args.bridgeChallengeIdentity).to.equal(
-        bridgeChallengeIdentity
-      )
-      expect(event.args.challengeKey).to.equal(challengeKey)
-      expect(event.args.sighash).to.equal(hex(vector.expectedBip341SighashHex))
+
+      expect(
+        (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+      ).to.equal(false)
+      await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
     })
   }
 
-  it("rejects P2TR defeat before the signed input is proven honestly spent", async () => {
-    const payload = vectorPayload(vector)
-    await registerP2TRWallet(payload.walletID)
-    await submitChallenge(payload)
+  it("keeps defeat fail-closed for a valid annex authorization", async () => {
+    const payload = vectorPayload(annexVector, {
+      annexHex: hex(annexVector.annexHex!),
+    })
+    const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
+    const { challengeKey } = await submitChallenge(payload, annexVector)
 
-    await expect(
+    await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
+
+    expect(
+      (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+    ).to.equal(false)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+  })
+
+  it("rejects P2TR defeat before the signed input is proven honestly spent", async () => {
+    const payload = vectorPayload(vector)
+    await registerP2TRWallet(payload.walletID)
+    await submitChallenge(payload)
+
+    await expectCustomError(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Defeat,
+          encodePayload(payload),
+          []
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
   })
 
   it("rejects P2TR defeat when only a different outpoint is proven honestly spent", async () => {
@@ -1240,15 +1328,16 @@ describe("Bridge - P2TR signature fraud", () => {
       },
     ])
 
-    await expect(
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
   })
 
   const movedFundsNonDefeatScenarios: {
@@ -1288,15 +1377,16 @@ describe("Bridge - P2TR signature fraud", () => {
 
       await scenario.markMovedFundsRequest(payload, walletPubKeyHash)
 
-      await expect(
+      await expectCustomError(
         p2trFraudRouter
           .connect(thirdParty)
           .processP2TRSignatureFraudChallenge(
             p2trFraudAction.Defeat,
             encodePayload(payload),
             []
-          )
-      ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+          ),
+        "P2TRFraudEvidenceUnavailable"
+      )
     })
   }
 
@@ -1393,35 +1483,42 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
   })
 
-  it("allows FROST wallet closure after its P2TR challenge is defeated", async () => {
+  it("does not let an outpoint-only honest-spend marker defeat a challenge", async () => {
     const payload = vectorPayload(vector)
     const remainingClosingTime = Math.floor(fraudChallengeDefeatTimeout / 2)
     const walletPubKeyHash = await registerClosingFrostWallet(
       vector,
       remainingClosingTime
     )
-    await submitChallenge(payload)
+    const { challengeKey } = await submitChallenge(payload)
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-    await p2trFraudRouter
-      .connect(thirdParty)
-      .processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodePayload(payload),
-        []
-      )
-    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    await expectCustomError(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Defeat,
+          encodePayload(payload),
+          []
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
+    expect(
+      (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+    ).to.equal(false)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+
     await increaseTime(remainingClosingTime)
 
-    await bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash)
+    await expectCustomError(
+      bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash),
+      "P2TRFraudChallengePending"
+    )
 
     expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
-      walletState.Closed
+      walletState.Closing
     )
-    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
-    expect(await frostWalletRegistry.lastClosedWalletID()).to.equal(
-      payload.walletID
-    )
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(false)
   })
 
   it("allows an unrelated FROST wallet to close while a P2TR challenge is open", async () => {
@@ -1625,43 +1722,6 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(event.args.sighash).to.equal(hex(vector.expectedBip341SighashHex))
   })
 
-  it("rejects later P2TR timeout or defeat after an honest-spend defeat", async () => {
-    const payload = vectorPayload(vector)
-    await registerP2TRWallet(payload.walletID)
-    await submitChallenge(payload)
-
-    await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-    await p2trFraudRouter
-      .connect(thirdParty)
-      .processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodePayload(payload),
-        []
-      )
-
-    await increaseTime(fraudChallengeDefeatTimeout)
-
-    await expect(
-      p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Timeout,
-          encodePayload(payload),
-          [1, 2, 3]
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
-
-    await expect(
-      p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Defeat,
-          encodePayload(payload),
-          []
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
-  })
-
   it("rejects later P2TR defeat or repeated timeout after timeout resolution", async () => {
     const payload = vectorPayload(vector)
     await registerP2TRWallet(payload.walletID)
@@ -1678,15 +1738,16 @@ describe("Bridge - P2TR signature fraud", () => {
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
 
-    await expect(
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
 
     await expect(
       p2trFraudRouter
@@ -1713,17 +1774,9 @@ describe("Bridge - P2TR signature fraud", () => {
         { value: fraudChallengeDepositAmount }
       )
 
-    const { challengeKey } = await submitChallenge(payload)
+    await submitChallenge(payload)
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-
-    const defeatGas = await p2trFraudRouter
-      .connect(thirdParty)
-      .estimateGas.processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodedPayload,
-        []
-      )
 
     await increaseTime(fraudChallengeDefeatTimeout)
 
@@ -1738,12 +1791,9 @@ describe("Bridge - P2TR signature fraud", () => {
     // eslint-disable-next-line no-console
     console.log(`p2tr_submitChallenge_gas=${submitGas.toString()}`)
     // eslint-disable-next-line no-console
-    console.log(`p2tr_defeatChallenge_gas=${defeatGas.toString()}`)
-    // eslint-disable-next-line no-console
     console.log(`p2tr_timeoutChallenge_gas=${timeoutGas.toString()}`)
 
     expect(submitGas.toNumber()).to.be.lessThan(6000000)
-    expect(defeatGas.toNumber()).to.be.lessThan(1000000)
     expect(timeoutGas.toNumber()).to.be.lessThan(1500000)
   })
 

--- a/solidity/test/deploy/45_deploy_p2tr_signature_fraud_router.test.ts
+++ b/solidity/test/deploy/45_deploy_p2tr_signature_fraud_router.test.ts
@@ -1,0 +1,378 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai"
+import hre, { deployments, ethers } from "hardhat"
+import fs from "fs"
+import path from "path"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { BridgeStub, P2TRSignatureFraudRouter } from "../../typechain"
+import type { FrostCustodyPreflightReceipt } from "../../deploy/45_deploy_p2tr_signature_fraud_router"
+import deployP2TRFraudRouter, {
+  BOUNDED_V1_PROTOCOL_ID,
+  BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+  BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+  runFrostCustodyPreflight,
+} from "../../deploy/45_deploy_p2tr_signature_fraud_router"
+import deployFrostWalletRegistry from "../../deploy/48_deploy_frost_wallet_registry"
+import deployRebateAndPrepareTxs from "../../deploy/82_deploy_rebate_and_prepare_txs"
+import deployTIP109GovernanceUpgrade from "../../deploy/85_deploy_tip109_governance_upgrade"
+import deployTIP109Hotfix from "../../deploy/86_deploy_tip109_hotfix"
+
+const expectPreflightFailure = async (
+  promise: Promise<unknown>,
+  message: string
+): Promise<void> => {
+  try {
+    await promise
+    expect.fail("expected FROST custody preflight to fail")
+  } catch (error) {
+    expect((error as Error).message).to.include(message)
+  }
+}
+
+const createPreflightMockHre = (
+  providerOverrides: Record<string, (...args: any[]) => Promise<any>>
+): HardhatRuntimeEnvironment => {
+  const sourceProvider = ethers.provider
+
+  return {
+    ...hre,
+    getChainId: hre.getChainId.bind(hre),
+    ethers: {
+      constants: ethers.constants,
+      utils: ethers.utils,
+      provider: {
+        getBlockNumber: sourceProvider.getBlockNumber.bind(sourceProvider),
+        getBlock: sourceProvider.getBlock.bind(sourceProvider),
+        getStorageAt: sourceProvider.getStorageAt.bind(sourceProvider),
+        getLogs: sourceProvider.getLogs.bind(sourceProvider),
+        ...providerOverrides,
+      },
+    },
+  } as unknown as HardhatRuntimeEnvironment
+}
+
+const createLiveMockHre = (): {
+  hre: HardhatRuntimeEnvironment
+  deployCalls: string[]
+  saveCalls: string[]
+} => {
+  const deployCalls: string[] = []
+  const saveCalls: string[] = []
+  const bridgeAddress = "0x1000000000000000000000000000000000000001"
+  const blockHash = `0x${"ab".repeat(32)}`
+
+  const mock = {
+    network: { name: "sepolia", tags: {} },
+    deployments: {
+      get: async (name: string) => {
+        if (name !== "Bridge") {
+          throw new Error(`unexpected deployment lookup: ${name}`)
+        }
+        return { address: bridgeAddress }
+      },
+      deploy: async (name: string) => {
+        deployCalls.push(name)
+        return { address: bridgeAddress }
+      },
+      save: async (name: string) => {
+        saveCalls.push(name)
+      },
+    },
+    getNamedAccounts: async () => ({
+      deployer: "0x2000000000000000000000000000000000000002",
+    }),
+    getChainId: async () => "11155111",
+    ethers: {
+      ...ethers,
+      constants: ethers.constants,
+      utils: ethers.utils,
+      provider: {
+        getBlockNumber: async () => 100,
+        getBlock: async () => ({ hash: blockHash }),
+        getStorageAt: async () => ethers.constants.HashZero,
+        getLogs: async () => [],
+      },
+    },
+    helpers: {},
+    artifacts: {},
+  } as unknown as HardhatRuntimeEnvironment
+
+  return { hre: mock, deployCalls, saveCalls }
+}
+
+describe("deploy/45 P2TR fraud evidence NO-GO", () => {
+  let bridge: BridgeStub
+
+  beforeEach(async () => {
+    await deployments.fixture()
+    const Bridge = await deployments.get("Bridge")
+    bridge = (await ethers.getContractAt(
+      "BridgeStub",
+      Bridge.address
+    )) as BridgeStub
+    await bridge.resetFrostWalletRegistryForTest(ethers.constants.AddressZero)
+    await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+  })
+
+  it("derives the raw preflight slots from the committed formal layout", () => {
+    const layout = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, "../formal/Bridge.storage-layout.json"),
+        "utf8"
+      )
+    ) as {
+      storage: { label: string; slot: string; type: string }[]
+      types: Record<string, { members?: { label: string; slot: string }[] }>
+    }
+    const self = layout.storage.find(({ label }) => label === "self")!
+    const members = layout.types[self.type].members!
+    const frostRegistry = members.find(
+      ({ label }) => label === "frostWalletRegistry"
+    )!
+    const p2trRouter = members.find(({ label }) => label === "p2trFraudRouter")!
+
+    expect(self.slot).to.equal("51")
+    expect(frostRegistry.slot).to.equal("32")
+    expect(p2trRouter.slot).to.equal("34")
+    expect(Number(self.slot) + Number(frostRegistry.slot)).to.equal(
+      BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT
+    )
+    expect(Number(self.slot) + Number(p2trRouter.slot)).to.equal(
+      BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT
+    )
+  })
+
+  it("keeps the bounded router unwired and persists a pinned zero-state receipt", async () => {
+    const Bridge = await deployments.get("Bridge")
+    const routerDeployment = await deployments.get("P2TRSignatureFraudRouter")
+    const router = (await ethers.getContractAt(
+      "P2TRSignatureFraudRouter",
+      routerDeployment.address
+    )) as P2TRSignatureFraudRouter
+    const receipt = routerDeployment.linkedData
+      ?.frostCustodyPreflight as FrostCustodyPreflightReceipt
+
+    expect(await bridge.p2trFraudRouter()).to.equal(
+      ethers.constants.AddressZero
+    )
+    expect(await router.bridge()).to.equal(Bridge.address)
+    expect(await router.evidenceProtocolID()).to.equal(BOUNDED_V1_PROTOCOL_ID)
+
+    expect(receipt.schemaVersion).to.equal("tbtc/frost-custody-preflight/v1")
+    expect(receipt.networkName).to.equal("hardhat")
+    expect(receipt.chainId).to.equal("31337")
+    expect(receipt.bridge).to.equal(Bridge.address)
+    expect(receipt.scanFromBlock).to.equal(0)
+    expect(receipt.scanToBlock).to.equal(receipt.snapshotBlockNumber)
+    expect(receipt.registrationsFound).to.equal(0)
+    expect(receipt.frostWalletRegistry).to.equal(ethers.constants.AddressZero)
+    expect(receipt.configuredP2TRFraudRouter).to.equal(
+      ethers.constants.AddressZero
+    )
+    expect(receipt.configuredRouterStatus).to.equal("unset")
+    expect(receipt.frostWalletRegistryStorageSlot).to.equal(
+      BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT
+    )
+    expect(receipt.p2trFraudRouterStorageSlot).to.equal(
+      BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT
+    )
+    expect(receipt.storageLayoutEvidence).to.equal(
+      "test/formal/Bridge.storage-layout.json"
+    )
+
+    const snapshotBlock = await ethers.provider.getBlock(
+      receipt.snapshotBlockNumber
+    )
+    expect(snapshotBlock.hash).to.equal(receipt.snapshotBlockHash)
+    expect(
+      await ethers.provider.getStorageAt(
+        Bridge.address,
+        BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+        receipt.snapshotBlockNumber
+      )
+    ).to.equal(ethers.constants.HashZero)
+    expect(
+      await ethers.provider.getStorageAt(
+        Bridge.address,
+        BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+        receipt.snapshotBlockNumber
+      )
+    ).to.equal(ethers.constants.HashZero)
+  })
+
+  it("fails on a non-zero FROST registry storage word", async () => {
+    await bridge.resetFrostWalletRegistryForTest(
+      (
+        await ethers.getSigners()
+      )[1].address
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "frost registry storage slot"
+    )
+  })
+
+  it("fails on a non-zero P2TR router storage word", async () => {
+    await bridge.resetP2TRFraudRouterForTest(
+      (
+        await ethers.getSigners()
+      )[1].address
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "P2TR router storage slot"
+    )
+  })
+
+  it("fails when NewFrostWalletRegistered exists in history", async () => {
+    await bridge.emitNewFrostWalletRegisteredForTest()
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "prior FROST wallet registration"
+    )
+  })
+
+  it("fails when the zero-ECDSA NewWalletRegisteredV2 marker exists", async () => {
+    await bridge.emitZeroEcdsaWalletRegisteredV2ForTest()
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "prior FROST wallet registration"
+    )
+  })
+
+  it("fails closed on malformed or unavailable raw storage reads", async () => {
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({ getStorageAt: async () => "0x00" }),
+        bridge.address
+      ),
+      "malformed Bridge storage slot"
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getStorageAt: async () => {
+            throw new Error("storage RPC unavailable")
+          },
+        }),
+        bridge.address
+      ),
+      "storage RPC unavailable"
+    )
+  })
+
+  it("fails closed when either registration log query fails", async () => {
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getLogs: async () => {
+            throw new Error("NewFrostWalletRegistered RPC unavailable")
+          },
+        }),
+        bridge.address
+      ),
+      "NewFrostWalletRegistered RPC unavailable"
+    )
+
+    let queryCount = 0
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getLogs: async () => {
+            queryCount += 1
+            if (queryCount === 2) {
+              throw new Error("NewWalletRegisteredV2 RPC unavailable")
+            }
+            return []
+          },
+        }),
+        bridge.address
+      ),
+      "NewWalletRegisteredV2 RPC unavailable"
+    )
+  })
+
+  it("fails closed when the pinned snapshot hash changes", async () => {
+    const getBlock = ethers.provider.getBlock.bind(ethers.provider)
+    let readCount = 0
+    const reorgedHre = createPreflightMockHre({
+      getBlock: async (...args: unknown[]) => {
+        const block = await getBlock(...(args as [number]))
+        readCount += 1
+        return readCount === 1
+          ? block
+          : { ...block, hash: `0x${"cd".repeat(32)}` }
+      },
+    })
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(reorgedHre, bridge.address),
+      "snapshot block reorged"
+    )
+  })
+
+  for (const [upgradePath, deployFunction] of [
+    ["45_deploy_p2tr_signature_fraud_router", deployP2TRFraudRouter],
+    ["48_deploy_frost_wallet_registry", deployFrostWalletRegistry],
+    ["82_deploy_rebate_and_prepare_txs", deployRebateAndPrepareTxs],
+    ["85_deploy_tip109_governance_upgrade", deployTIP109GovernanceUpgrade],
+    ["86_deploy_tip109_hotfix", deployTIP109Hotfix],
+  ] as const) {
+    it(`aborts live ${upgradePath} before writes or calldata output`, async () => {
+      const mock = createLiveMockHre()
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => logs.push(args.join(" "))
+
+      try {
+        await expectPreflightFailure(
+          deployFunction(mock.hre),
+          `NO-GO ${upgradePath}`
+        )
+      } finally {
+        console.log = originalLog
+      }
+
+      expect(mock.deployCalls).to.deep.equal([])
+      expect(mock.saveCalls).to.deep.equal([])
+      expect(logs).to.have.lengthOf(1)
+      expect(logs[0]).to.match(/^FROST_CUSTODY_PREFLIGHT_RECEIPT=/)
+      expect(logs[0]).not.to.include("calldata")
+      expect(logs[0]).not.to.include("SUMMARY")
+    })
+  }
+
+  it("runs the write-free NO-GO dependency first on every active path", () => {
+    for (const deployFunction of [
+      deployP2TRFraudRouter,
+      deployFrostWalletRegistry,
+      deployRebateAndPrepareTxs,
+      deployTIP109GovernanceUpgrade,
+      deployTIP109Hotfix,
+    ]) {
+      expect(deployFunction.dependencies?.[0]).to.equal("FrostCustodyNoGo")
+    }
+  })
+
+  it("default-denies every non-ephemeral network and returns NO-GO", async () => {
+    expect(isEphemeralLocalNetwork("hardhat")).to.equal(true)
+    expect(isEphemeralLocalNetwork("development")).to.equal(true)
+    expect(isEphemeralLocalNetwork("system_tests")).to.equal(true)
+    expect(isEphemeralLocalNetwork("sepolia")).to.equal(false)
+    expect(isEphemeralLocalNetwork("mainnet")).to.equal(false)
+    expect(isEphemeralLocalNetwork("custom-live-network")).to.equal(false)
+
+    await expectPreflightFailure(
+      abortLiveBridgeUpgradeWithoutVettedCompleteV2(hre, "test-upgrade"),
+      "NO-GO test-upgrade"
+    )
+  })
+})

--- a/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
+++ b/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { expect } from "chai"
+import { constants, utils } from "ethers"
 import func from "../../deploy/84_upgrade_bridge_c2_1_counter"
 
 describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
@@ -41,7 +42,10 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
     options: any
   }
 
-  function createMockHre(networkTags: Record<string, boolean> = {}) {
+  function createMockHre(
+    networkTags: Record<string, boolean> = {},
+    networkName = "hardhat"
+  ) {
     const deployCalls: DeployCall[] = []
     const getCalls: string[] = []
     const logCalls: string[] = []
@@ -53,6 +57,14 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
 
     const mockHre: any = {
       ethers: {
+        constants,
+        utils,
+        provider: {
+          getBlockNumber: async () => 100,
+          getBlock: async () => ({ hash: `0x${"ab".repeat(32)}` }),
+          getStorageAt: async () => constants.HashZero,
+          getLogs: async () => [],
+        },
         getSigner: async (address: string) => {
           expect(address).to.equal(DEPLOYER_ADDRESS)
           return signer
@@ -61,6 +73,9 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       deployments: {
         get: async (name: string) => {
           getCalls.push(name)
+          if (name === "Bridge") {
+            return { address: BRIDGE_ADDRESS }
+          }
           const address = dependencyAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment lookup: ${name}`)
@@ -83,6 +98,7 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
         deployer: DEPLOYER_ADDRESS,
         treasury: TREASURY_ADDRESS,
       }),
+      getChainId: async () => "11155111",
       helpers: {
         upgrades: {
           upgradeProxy: async (...args: any[]) => {
@@ -99,7 +115,7 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
           },
         },
       },
-      network: { tags: networkTags },
+      network: { name: networkName, tags: networkTags },
       tenderly: {
         verify: async (deployment: any) => {
           tenderlyVerifyCalls.push(deployment)
@@ -202,5 +218,24 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       { name: "MovingFunds", address: MOVING_FUNDS_ADDRESS },
       { name: "Bridge", address: BRIDGE_ADDRESS },
     ])
+  })
+
+  it("aborts a live-network upgrade before deployment or proxy mutation", async () => {
+    const { mockHre, deployCalls, upgradeProxyCalls } = createMockHre(
+      {},
+      "sepolia"
+    )
+
+    try {
+      await func(mockHre)
+      expect.fail("expected live Bridge upgrade NO-GO")
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        "NO-GO 84_upgrade_bridge_c2_1_counter"
+      )
+    }
+
+    expect(deployCalls).to.deep.equal([])
+    expect(upgradeProxyCalls).to.deep.equal([])
   })
 })

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -209,9 +209,10 @@ export default async function bridgeFixture(): Promise<{
   // Deploy + wire the two fraud router sidecars. EcdsaFraudRouter
   // hosts the ECDSA fraud lifecycle (was inlined on Bridge);
   // P2TRSignatureFraudRouter is the sister sidecar for the P2TR
-  // signature-fraud lifecycle. Both routers are pinned to the
-  // Bridge address at construction and wired via the one-time
-  // setters on Bridge.
+  // signature-fraud lifecycle. Production BOUNDED_V1 is intentionally
+  // not wired because it cannot activate FROST custody. Tests use an
+  // explicit handshake-only COMPLETE_V2 stub. It is not evidence that a
+  // production COMPLETE_V2 implementation exists.
   const existingEcdsaFraudRouter = await bridge.ecdsaFraudRouter()
   let ecdsaFraudRouter: EcdsaFraudRouter
   if (existingEcdsaFraudRouter === ethers.constants.AddressZero) {
@@ -237,7 +238,7 @@ export default async function bridgeFixture(): Promise<{
   let p2trFraudRouter: P2TRSignatureFraudRouter
   if (existingP2TRFraudRouter === ethers.constants.AddressZero) {
     const P2TRFraudRouterFactory = await ethers.getContractFactory(
-      "P2TRSignatureFraudRouter",
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
       deployer
     )
     p2trFraudRouter = (await P2TRFraudRouterFactory.deploy(

--- a/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
@@ -86,6 +86,21 @@ describe("FrostWalletRegistry DKG edge cases (B-1.5 slice 4)", () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ deployer, bridge } = await waffle.loadFixture(bridgeFixture))
 
+    // This suite deliberately exercises the registry -> Bridge FROST callback.
+    // Install the handshake-only COMPLETE_V2 test stub explicitly so the test
+    // never depends on whichever bounded production router another full-suite
+    // fixture left in Bridge storage. The stub is not a functional fraud router
+    // and is never used by deployment code.
+    const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+      deployer
+    )
+    const completeP2TRFraudRouter = await CompleteP2TRFraudRouterFactory.deploy(
+      bridge.address
+    )
+    await completeP2TRFraudRouter.deployed()
+    await bridge.resetP2TRFraudRouterForTest(completeP2TRFraudRouter.address)
+
     const t = await deployments.get("T")
     randomBeacon = await smock.fake<IRandomBeacon>("IRandomBeacon")
 

--- a/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
@@ -58,6 +58,21 @@ describe("FrostWalletRegistry full-cycle DKG happy path (B-1.5 slice 3)", () => 
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ deployer, bridge } = await waffle.loadFixture(bridgeFixture))
 
+    // This suite deliberately exercises the registry -> Bridge FROST callback.
+    // Install the handshake-only COMPLETE_V2 test stub explicitly so the test
+    // never depends on whichever bounded production router another full-suite
+    // fixture left in Bridge storage. The stub is not a functional fraud router
+    // and is never used by deployment code.
+    const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+      deployer
+    )
+    const completeP2TRFraudRouter = await CompleteP2TRFraudRouterFactory.deploy(
+      bridge.address
+    )
+    await completeP2TRFraudRouter.deployed()
+    await bridge.resetP2TRFraudRouterForTest(completeP2TRFraudRouter.address)
+
     const t = await deployments.get("T")
 
     randomBeacon = await smock.fake<IRandomBeacon>("IRandomBeacon")

--- a/solidity/test/integration/utils/fixture.ts
+++ b/solidity/test/integration/utils/fixture.ts
@@ -128,9 +128,10 @@ export const fixture = deployments.createFixture(
     // the unit-test bridgeFixture). The deploy scripts at
     // deploy/44_deploy_ecdsa_fraud_router.ts and
     // deploy/45_deploy_p2tr_signature_fraud_router.ts run during
-    // deployments.fixture() above; this block calls the one-time
-    // governance setters so the routers are usable for integration
-    // tests that exercise fraud paths through MaintainerProxy.
+    // deployments.fixture() above. Production BOUNDED_V1 deliberately stays
+    // unwired; integration tests substitute a handshake-only COMPLETE_V2 stub.
+    // The stub is not evidence that a production COMPLETE_V2 implementation
+    // exists.
     const existingEcdsaFraudRouter = await bridge.ecdsaFraudRouter()
     let ecdsaFraudRouter: EcdsaFraudRouter
     if (existingEcdsaFraudRouter === ethers.constants.AddressZero) {
@@ -150,10 +151,14 @@ export const fixture = deployments.createFixture(
     const existingP2TRFraudRouter = await bridge.p2trFraudRouter()
     let p2trFraudRouter: P2TRSignatureFraudRouter
     if (existingP2TRFraudRouter === ethers.constants.AddressZero) {
-      p2trFraudRouter =
-        await helpers.contracts.getContract<P2TRSignatureFraudRouter>(
-          "P2TRSignatureFraudRouter"
-        )
+      const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+        "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+        deployer
+      )
+      p2trFraudRouter = (await CompleteP2TRFraudRouterFactory.deploy(
+        bridge.address
+      )) as P2TRSignatureFraudRouter
+      await p2trFraudRouter.deployed()
       await bridgeGovernance
         .connect(governance)
         .setP2TRFraudRouter(p2trFraudRouter.address)

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -66,12 +66,23 @@ Here is a short example demonstrating SDK usage:
 ```typescript
 // Import SDK entrypoint component.
 import { TBTC } from "@keep-network/tbtc-v2.ts"
+import { providers } from "ethers"
 
-// Create an instance of ethers signer.
+// Create an instance of an ethers signer backed by the primary provider.
 const signer = (...)
 
-// Initialize the SDK.
-const sdk = await TBTC.initializeMainnet(signer)
+// Use a second provider operated in a different trust domain. Both providers
+// must support the Ethereum `finalized` block tag.
+const canonicalProvider = new providers.JsonRpcProvider(...)
+
+// Initialize the SDK with the finalized-state quorum required for deposits.
+const sdk = await TBTC.initializeMainnet(signer, {
+  sourceTrustDomainID: "primary-provider-operator",
+  canonicalProvider: {
+    trustDomainID: "independent-provider-operator",
+    provider: canonicalProvider,
+  },
+})
 
 // Access SDK features.
 sdk.deposits.(...)
@@ -83,6 +94,33 @@ sdk.tbtcContracts.(...)
 // Access Bitcoin client directly.
 sdk.bitcoinClient.(...)
 ```
+
+Deposit creation fails closed unless the two providers have different
+non-empty trust-domain IDs and are different provider instances on the same
+Ethereum chain. The SDK reads the active wallet hash, canonical wallet ID, and
+both forward and reverse identity mappings at each provider's own authenticated
+finalized head, then requires both fully bound identities to match. This rejects
+a stale provider that reports a genuine but retired wallet and prevents a
+compromised provider from downgrading a FROST wallet to a legacy deposit script.
+Trust-domain IDs are operator assertions: integrations must use providers with
+genuinely independent infrastructure, administration, and upstream failure
+domains. Wrapping one provider object or using two URLs operated by the same
+organization does not provide an independent quorum.
+
+Applications enabling cross-chain support pass the quorum as the third
+argument: `TBTC.initializeMainnet(signer, true, quorum)`. Ordinary contract
+reads remain available without a quorum, but `initiateDeposit`,
+`initiateTaprootDeposit`, proxy deposits, and cross-chain deposits will reject
+before deriving a custody address.
+
+This is a coordinated activation requirement for every SDK deposit path. The
+Bridge deployment must expose `activeWalletID`, `walletID`, and
+`walletPubKeyHashForWalletID` before applications enable this SDK version, and
+applications must configure both finalized-capable providers at the same time.
+If either the selectors or quorum configuration are missing, deposits stop
+before producing an address; there is no legacy fallback. Rollouts should verify
+the upgraded Bridge selectors and both provider trust domains before directing
+users to the new client.
 
 ## Contributing
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -68,6 +68,7 @@
 
 ### Interfaces
 
+- [ActiveWalletIdentity](interfaces/ActiveWalletIdentity.md)
 - [BitcoinClient](interfaces/BitcoinClient.md)
 - [BitcoinDepositor](interfaces/BitcoinDepositor.md)
 - [BitcoinHeader](interfaces/BitcoinHeader.md)
@@ -87,6 +88,9 @@
 - [DepositorProxy](interfaces/DepositorProxy.md)
 - [DestinationChainTBTCToken](interfaces/DestinationChainTBTCToken.md)
 - [ElectrumCredentials](interfaces/ElectrumCredentials.md)
+- [EthereumActiveWalletIdentityQuorum](interfaces/EthereumActiveWalletIdentityQuorum.md)
+- [EthereumBridgeConfig](interfaces/EthereumBridgeConfig.md)
+- [EthereumCanonicalActiveWalletIdentityProvider](interfaces/EthereumCanonicalActiveWalletIdentityProvider.md)
 - [EthereumContractConfig](interfaces/EthereumContractConfig.md)
 - [ExtraDataEncoder](interfaces/ExtraDataEncoder.md)
 - [L1BitcoinRedeemer](interfaces/L1BitcoinRedeemer.md)
@@ -446,7 +450,7 @@ Represents an event emitted on deposit reveal to the on-chain bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:403](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L403)
+[src/lib/contracts/bridge.ts:427](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L427)
 
 ___
 
@@ -456,7 +460,7 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:32](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L32)
+[src/services/deposits/deposit.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L33)
 
 ___
 
@@ -466,9 +470,9 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L23)
+[src/services/deposits/deposit.ts:24](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L24)
 
-[src/services/deposits/deposit.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L29)
+[src/services/deposits/deposit.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L30)
 
 ___
 
@@ -716,7 +720,7 @@ Represents an event emitted when new wallet is registered on the on-chain bridge
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:581](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L581)
+[src/lib/contracts/bridge.ts:605](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L605)
 
 ___
 
@@ -1866,7 +1870,7 @@ Represents an event emitted on redemption request.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:464](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L464)
+[src/lib/contracts/bridge.ts:488](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L488)
 
 ___
 
@@ -1984,7 +1988,7 @@ information required to build a unique P2TR deposit address on Bitcoin chain.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:309](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L309)
+[src/lib/contracts/bridge.ts:333](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L333)
 
 ___
 
@@ -1997,7 +2001,7 @@ bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L413)
+[src/lib/contracts/bridge.ts:437](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L437)
 
 ## Variables
 
@@ -2304,9 +2308,9 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L23)
+[src/services/deposits/deposit.ts:24](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L24)
 
-[src/services/deposits/deposit.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L29)
+[src/services/deposits/deposit.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L30)
 
 ___
 
@@ -3578,7 +3582,7 @@ ___
 
 ### loadEthereumCoreContracts
 
-▸ **loadEthereumCoreContracts**(`signer`, `chainId`): `Promise`\<[`TBTCContracts`](README.md#tbtccontracts)\>
+▸ **loadEthereumCoreContracts**(`signer`, `chainId`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTCContracts`](README.md#tbtccontracts)\>
 
 Loads Ethereum implementation of tBTC core contracts for the given Ethereum
 chain ID and attaches the given signer there.
@@ -3589,6 +3593,7 @@ chain ID and attaches the given signer there.
 | :------ | :------ | :------ |
 | `signer` | [`EthereumSigner`](README.md#ethereumsigner) | Signer that should be attached to tBTC contracts. |
 | `chainId` | [`Ethereum`](enums/Chains.Ethereum.md) | Ethereum chain ID. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](interfaces/EthereumActiveWalletIdentityQuorum.md) | Independent finalized-state provider required before the SDK can create a deposit address. |
 
 #### Returns
 
@@ -3603,7 +3608,7 @@ Throws an error if the signer's Ethereum chain ID is other than
 
 #### Defined in
 
-[src/lib/ethereum/index.ts:74](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L74)
+[src/lib/ethereum/index.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/index.ts#L76)
 
 ___
 
@@ -3731,7 +3736,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1327](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1327)
+[src/lib/ethereum/bridge.ts:1614](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1614)
 
 ___
 
@@ -4177,7 +4182,7 @@ This function does not validate the depositor's identifier as its
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:321](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L321)
+[src/lib/contracts/bridge.ts:345](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L345)
 
 ___
 

--- a/typescript/api-reference/classes/Deposit.md
+++ b/typescript/api-reference/classes/Deposit.md
@@ -49,7 +49,7 @@ This component tries to abstract away that complexity.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L67)
+[src/services/deposits/deposit.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L68)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L56)
+[src/services/deposits/deposit.ts:57](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L57)
 
 ___
 
@@ -74,7 +74,7 @@ generated deposit address.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L65)
+[src/services/deposits/deposit.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L66)
 
 ___
 
@@ -86,7 +86,7 @@ Optional depositor proxy used to initiate minting.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L60)
+[src/services/deposits/deposit.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L61)
 
 ___
 
@@ -98,7 +98,7 @@ Bitcoin script corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L48)
+[src/services/deposits/deposit.ts:49](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L49)
 
 ___
 
@@ -110,7 +110,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:52](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L52)
+[src/services/deposits/deposit.ts:53](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L53)
 
 ## Methods
 
@@ -131,7 +131,7 @@ Specific UTXOs targeting this deposit. Empty array in case
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:122](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L122)
+[src/services/deposits/deposit.ts:123](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L123)
 
 ___
 
@@ -147,7 +147,7 @@ Bitcoin address corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:111](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L111)
+[src/services/deposits/deposit.ts:112](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L112)
 
 ___
 
@@ -163,7 +163,7 @@ Receipt corresponding to this deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L104)
+[src/services/deposits/deposit.ts:105](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L105)
 
 ___
 
@@ -212,7 +212,7 @@ Throws an error if a Taproot deposit uses a depositor proxy that
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L153)
+[src/services/deposits/deposit.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L154)
 
 ___
 
@@ -236,4 +236,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L82)
+[src/services/deposits/deposit.ts:83](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L83)

--- a/typescript/api-reference/classes/DepositScript.md
+++ b/typescript/api-reference/classes/DepositScript.md
@@ -49,7 +49,7 @@ by the target wallet during the deposit sweep process.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:226](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L226)
+[src/services/deposits/deposit.ts:240](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L240)
 
 ## Properties
 
@@ -62,7 +62,7 @@ and allowing to build a unique deposit script (and address) on Bitcoin chain.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:215](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L215)
+[src/services/deposits/deposit.ts:229](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L229)
 
 ___
 
@@ -74,7 +74,7 @@ Deposit script/address type.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:224](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L224)
+[src/services/deposits/deposit.ts:238](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L238)
 
 ___
 
@@ -87,7 +87,7 @@ should be a witness P2WSH one. If false, legacy P2SH will be used instead.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L220)
+[src/services/deposits/deposit.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L234)
 
 ## Methods
 
@@ -111,7 +111,7 @@ Bitcoin address corresponding to this deposit script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:375](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L375)
+[src/services/deposits/deposit.ts:389](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L389)
 
 ___
 
@@ -136,7 +136,7 @@ Output script not prepended with length.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:418](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L418)
+[src/services/deposits/deposit.ts:432](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L432)
 
 ___
 
@@ -152,7 +152,7 @@ Hashed deposit script as Buffer.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:255](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L255)
+[src/services/deposits/deposit.ts:269](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L269)
 
 ___
 
@@ -168,7 +168,7 @@ Plain-text deposit script as a hex string.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:271](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L271)
+[src/services/deposits/deposit.ts:285](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L285)
 
 ___
 
@@ -184,7 +184,7 @@ TapLeaf hash of the Taproot refund script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:344](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L344)
+[src/services/deposits/deposit.ts:358](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L358)
 
 ___
 
@@ -200,7 +200,7 @@ Taproot merkle root for this deposit's script tree.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:351](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L351)
+[src/services/deposits/deposit.ts:365](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L365)
 
 ___
 
@@ -216,7 +216,7 @@ X-only Taproot output key committing to the refund script.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:358](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L358)
+[src/services/deposits/deposit.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L372)
 
 ___
 
@@ -232,7 +232,7 @@ Tapscript refund leaf for a Taproot-native deposit.
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:313](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L313)
+[src/services/deposits/deposit.ts:327](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L327)
 
 ___
 
@@ -253,4 +253,4 @@ ___
 
 #### Defined in
 
-[src/services/deposits/deposit.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L245)
+[src/services/deposits/deposit.ts:259](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposit.ts#L259)

--- a/typescript/api-reference/classes/DepositsService.md
+++ b/typescript/api-reference/classes/DepositsService.md
@@ -46,7 +46,7 @@ Service exposing features related to tBTC v2 deposits.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:54](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L54)
+[src/services/deposits/deposits-service.ts:55](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L55)
 
 ## Properties
 
@@ -72,7 +72,7 @@ Gets cross-chain contracts for the given supported L2 chain.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:50](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L50)
+[src/services/deposits/deposits-service.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L51)
 
 ___
 
@@ -85,7 +85,7 @@ initiated by this service.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L43)
+[src/services/deposits/deposits-service.ts:44](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L44)
 
 ___
 
@@ -97,7 +97,7 @@ Bitcoin client handle.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L38)
+[src/services/deposits/deposits-service.ts:39](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L39)
 
 ___
 
@@ -110,7 +110,7 @@ This is 9 month in seconds assuming 1 month = 30 days
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:30](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L30)
+[src/services/deposits/deposits-service.ts:31](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L31)
 
 ___
 
@@ -122,7 +122,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L34)
+[src/services/deposits/deposits-service.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L35)
 
 ## Methods
 
@@ -145,7 +145,7 @@ Handle to tBTC contracts.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:277](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L277)
+[src/services/deposits/deposits-service.ts:278](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L278)
 
 ___
 
@@ -203,7 +203,7 @@ This is actually a call to initiateDepositWithProxy with a built-in
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:246](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L246)
+[src/services/deposits/deposits-service.ts:247](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L247)
 
 ___
 
@@ -237,7 +237,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:96](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L96)
+[src/services/deposits/deposits-service.ts:97](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L97)
 
 ___
 
@@ -283,7 +283,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L182)
+[src/services/deposits/deposits-service.ts:183](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L183)
 
 ___
 
@@ -317,7 +317,7 @@ Throws an error if one of the following occurs:
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:130](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L130)
+[src/services/deposits/deposits-service.ts:131](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L131)
 
 ___
 
@@ -341,7 +341,7 @@ once the loader is ready.
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:75](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L75)
+[src/services/deposits/deposits-service.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L76)
 
 ___
 
@@ -370,4 +370,4 @@ Typically, there is no need to use this method when DepositsService
 
 #### Defined in
 
-[src/services/deposits/deposits-service.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L397)
+[src/services/deposits/deposits-service.ts:411](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/deposits/deposits-service.ts#L411)

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -27,12 +27,15 @@ for reference.
 - [\_deployedAtBlockNumber](EthereumBridge.md#_deployedatblocknumber)
 - [\_instance](EthereumBridge.md#_instance)
 - [\_totalRetryAttempts](EthereumBridge.md#_totalretryattempts)
+- [activeWalletIdentityQuorum](EthereumBridge.md#activewalletidentityquorum)
 
 ### Methods
 
 - [activeWalletID](EthereumBridge.md#activewalletid)
+- [activeWalletIdentity](EthereumBridge.md#activewalletidentity)
 - [activeWalletPublicKey](EthereumBridge.md#activewalletpublickey)
 - [activeWalletPublicKeyHash](EthereumBridge.md#activewalletpublickeyhash)
+- [authenticateFinalizedBlock](EthereumBridge.md#authenticatefinalizedblock)
 - [bridgeV2CompatibilityContract](EthereumBridge.md#bridgev2compatibilitycontract)
 - [buildUtxoHash](EthereumBridge.md#buildutxohash)
 - [deposits](EthereumBridge.md#deposits)
@@ -40,6 +43,7 @@ for reference.
 - [getChainIdentifier](EthereumBridge.md#getchainidentifier)
 - [getDepositRevealedEvents](EthereumBridge.md#getdepositrevealedevents)
 - [getEvents](EthereumBridge.md#getevents)
+- [getFinalizedBlock](EthereumBridge.md#getfinalizedblock)
 - [getNewWalletRegisteredEvents](EthereumBridge.md#getnewwalletregisteredevents)
 - [getRedemptionRequestedEvents](EthereumBridge.md#getredemptionrequestedevents)
 - [getTaprootDepositRevealedEvents](EthereumBridge.md#gettaprootdepositrevealedevents)
@@ -49,6 +53,7 @@ for reference.
 - [parseWalletDetails](EthereumBridge.md#parsewalletdetails)
 - [pendingRedemptions](EthereumBridge.md#pendingredemptions)
 - [pendingRedemptionsByWalletPKH](EthereumBridge.md#pendingredemptionsbywalletpkh)
+- [readActiveWalletIdentityAt](EthereumBridge.md#readactivewalletidentityat)
 - [requestRedemption](EthereumBridge.md#requestredemption)
 - [resolveWalletPublicKey](EthereumBridge.md#resolvewalletpublickey)
 - [revealDeposit](EthereumBridge.md#revealdeposit)
@@ -68,6 +73,7 @@ for reference.
 - [compareEventsByChainOrder](EthereumBridge.md#compareeventsbychainorder)
 - [ensureBridgeV2CompatibilityFallback](EthereumBridge.md#ensurebridgev2compatibilityfallback)
 - [isMissingBridgeV2CompatibilityMethodError](EthereumBridge.md#ismissingbridgev2compatibilitymethoderror)
+- [normalizeTrustDomainID](EthereumBridge.md#normalizetrustdomainid)
 - [parseLegacyNewWalletRegisteredEvent](EthereumBridge.md#parselegacynewwalletregisteredevent)
 - [parseV2NewWalletRegisteredEvent](EthereumBridge.md#parsev2newwalletregisteredevent)
 - [walletRegistrationFilterArgs](EthereumBridge.md#walletregistrationfilterargs)
@@ -82,7 +88,7 @@ for reference.
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `config` | [`EthereumContractConfig`](../interfaces/EthereumContractConfig.md) | `undefined` |
+| `config` | [`EthereumBridgeConfig`](../interfaces/EthereumBridgeConfig.md) | `undefined` |
 | `chainId` | [`Ethereum`](../enums/Chains.Ethereum.md) | `Chains.Ethereum.Local` |
 
 #### Returns
@@ -95,7 +101,7 @@ EthersContractHandle\&lt;BridgeTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:205](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L205)
+[src/lib/ethereum/bridge.ts:249](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L249)
 
 ## Properties
 
@@ -147,6 +153,16 @@ EthersContractHandle.\_totalRetryAttempts
 
 [src/lib/ethereum/adapter.ts:84](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L84)
 
+___
+
+### activeWalletIdentityQuorum
+
+• `Private` `Optional` `Readonly` **activeWalletIdentityQuorum**: [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md)
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:117](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L117)
+
 ## Methods
 
 ### activeWalletID
@@ -165,7 +181,27 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:808](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L808)
+[src/lib/ethereum/bridge.ts:1138](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1138)
+
+___
+
+### activeWalletIdentity
+
+▸ **activeWalletIdentity**(): `Promise`\<`undefined` \| [`ActiveWalletIdentity`](../interfaces/ActiveWalletIdentity.md)\>
+
+#### Returns
+
+`Promise`\<`undefined` \| [`ActiveWalletIdentity`](../interfaces/ActiveWalletIdentity.md)\>
+
+**`See`**
+
+#### Implementation of
+
+[Bridge](../interfaces/Bridge.md).[activeWalletIdentity](../interfaces/Bridge.md#activewalletidentity)
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:1014](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1014)
 
 ___
 
@@ -185,7 +221,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:792](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L792)
+[src/lib/ethereum/bridge.ts:1122](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1122)
 
 ___
 
@@ -205,13 +241,43 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:771](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L771)
+[src/lib/ethereum/bridge.ts:1101](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1101)
+
+___
+
+### authenticateFinalizedBlock
+
+▸ **authenticateFinalizedBlock**(`provider`, `finalizedBlock`, `label`): `Promise`\<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `provider` | `Provider` |
+| `finalizedBlock` | `Object` |
+| `finalizedBlock.hash` | `string` |
+| `finalizedBlock.number` | `number` |
+| `label` | `string` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:898](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L898)
 
 ___
 
 ### bridgeV2CompatibilityContract
 
-▸ **bridgeV2CompatibilityContract**(): `Contract`
+▸ **bridgeV2CompatibilityContract**(`provider?`): `Contract`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `provider?` | `Provider` |
 
 #### Returns
 
@@ -219,7 +285,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:240](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L240)
+[src/lib/ethereum/bridge.ts:328](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L328)
 
 ___
 
@@ -248,7 +314,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1257](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1257)
+[src/lib/ethereum/bridge.ts:1544](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1544)
 
 ___
 
@@ -275,7 +341,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:679](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L679)
+[src/lib/ethereum/bridge.ts:769](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L769)
 
 ___
 
@@ -317,7 +383,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:232](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L232)
+[src/lib/ethereum/bridge.ts:320](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L320)
 
 ___
 
@@ -344,7 +410,7 @@ Bridge.getDepositRevealedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:252](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L252)
+[src/lib/ethereum/bridge.ts:342](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L342)
 
 ___
 
@@ -382,6 +448,27 @@ EthersContractHandle.getEvents
 
 ___
 
+### getFinalizedBlock
+
+▸ **getFinalizedBlock**(`provider`, `label`): `Promise`\<\{ `hash`: `string` ; `number`: `number`  }\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `provider` | `Provider` |
+| `label` | `string` |
+
+#### Returns
+
+`Promise`\<\{ `hash`: `string` ; `number`: `number`  }\>
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:857](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L857)
+
+___
+
 ### getNewWalletRegisteredEvents
 
 ▸ **getNewWalletRegisteredEvents**(`options?`, `...filterArgs`): `Promise`\<[`NewWalletRegisteredEvent`](../README.md#newwalletregisteredevent)[]\>
@@ -405,7 +492,7 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:899](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L899)
+[src/lib/ethereum/bridge.ts:1186](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1186)
 
 ___
 
@@ -432,7 +519,7 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1274](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1274)
+[src/lib/ethereum/bridge.ts:1561](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1561)
 
 ___
 
@@ -459,7 +546,7 @@ Bridge.getTaprootDepositRevealedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:289](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L289)
+[src/lib/ethereum/bridge.ts:379](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L379)
 
 ___
 
@@ -479,7 +566,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:873](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L873)
+[src/lib/ethereum/bridge.ts:1160](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1160)
 
 ___
 
@@ -503,7 +590,7 @@ Parsed deposit request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:748](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L748)
+[src/lib/ethereum/bridge.ts:838](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L838)
 
 ___
 
@@ -528,7 +615,7 @@ Parsed redemption request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:435](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L435)
+[src/lib/ethereum/bridge.ts:525](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L525)
 
 ___
 
@@ -554,7 +641,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1221](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1221)
+[src/lib/ethereum/bridge.ts:1508](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1508)
 
 ___
 
@@ -581,7 +668,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:338](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L338)
+[src/lib/ethereum/bridge.ts:428](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L428)
 
 ___
 
@@ -608,7 +695,29 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:354](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L354)
+[src/lib/ethereum/bridge.ts:444](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L444)
+
+___
+
+### readActiveWalletIdentityAt
+
+▸ **readActiveWalletIdentityAt**(`provider`, `blockNumber`, `label`): `Promise`\<`undefined` \| [`ActiveWalletIdentity`](../interfaces/ActiveWalletIdentity.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `provider` | `Provider` |
+| `blockNumber` | `number` |
+| `label` | `string` |
+
+#### Returns
+
+`Promise`\<`undefined` \| [`ActiveWalletIdentity`](../interfaces/ActiveWalletIdentity.md)\>
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:917](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L917)
 
 ___
 
@@ -637,7 +746,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:580](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L580)
+[src/lib/ethereum/bridge.ts:670](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L670)
 
 ___
 
@@ -668,7 +777,7 @@ The compressed wallet public key, or undefined when unavailable.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1188](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1188)
+[src/lib/ethereum/bridge.ts:1475](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1475)
 
 ___
 
@@ -697,7 +806,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:453](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L453)
+[src/lib/ethereum/bridge.ts:543](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L543)
 
 ___
 
@@ -726,7 +835,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:514](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L514)
+[src/lib/ethereum/bridge.ts:604](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L604)
 
 ___
 
@@ -755,7 +864,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:626](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L626)
+[src/lib/ethereum/bridge.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L716)
 
 ___
 
@@ -782,7 +891,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:702](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L702)
+[src/lib/ethereum/bridge.ts:792](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L792)
 
 ___
 
@@ -796,7 +905,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:236](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L236)
+[src/lib/ethereum/bridge.ts:324](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L324)
 
 ___
 
@@ -823,7 +932,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:377](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L377)
+[src/lib/ethereum/bridge.ts:467](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L467)
 
 ___
 
@@ -843,7 +952,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:566](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L566)
+[src/lib/ethereum/bridge.ts:656](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L656)
 
 ___
 
@@ -869,7 +978,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1052](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1052)
+[src/lib/ethereum/bridge.ts:1339](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1339)
 
 ___
 
@@ -895,7 +1004,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1100)
+[src/lib/ethereum/bridge.ts:1387](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1387)
 
 ___
 
@@ -915,7 +1024,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:975](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L975)
+[src/lib/ethereum/bridge.ts:1262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1262)
 
 ___
 
@@ -941,7 +1050,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:992](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L992)
+[src/lib/ethereum/bridge.ts:1279](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1279)
 
 ___
 
@@ -967,7 +1076,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:1010](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1010)
+[src/lib/ethereum/bridge.ts:1297](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L1297)
 
 ___
 
@@ -992,7 +1101,7 @@ Deposit key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:729](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L729)
+[src/lib/ethereum/bridge.ts:819](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L819)
 
 ___
 
@@ -1017,7 +1126,7 @@ The redemption key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:405](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L405)
+[src/lib/ethereum/bridge.ts:495](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L495)
 
 ___
 
@@ -1038,7 +1147,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L165)
+[src/lib/ethereum/bridge.ts:209](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L209)
 
 ___
 
@@ -1059,7 +1168,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:83](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L83)
+[src/lib/ethereum/bridge.ts:127](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L127)
 
 ___
 
@@ -1079,7 +1188,28 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:97](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L97)
+[src/lib/ethereum/bridge.ts:141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L141)
+
+___
+
+### normalizeTrustDomainID
+
+▸ **normalizeTrustDomainID**(`value`, `label`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+| `label` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:119](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L119)
 
 ___
 
@@ -1099,7 +1229,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L176)
+[src/lib/ethereum/bridge.ts:220](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L220)
 
 ___
 
@@ -1119,7 +1249,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:192](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L192)
+[src/lib/ethereum/bridge.ts:236](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L236)
 
 ___
 
@@ -1145,4 +1275,4 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:128](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L128)
+[src/lib/ethereum/bridge.ts:172](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L172)

--- a/typescript/api-reference/classes/TBTC.md
+++ b/typescript/api-reference/classes/TBTC.md
@@ -66,7 +66,7 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
-[src/services/tbtc.ts:40](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L40)
+[src/services/tbtc.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L43)
 
 ## Properties
 
@@ -76,7 +76,7 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
-[src/services/tbtc.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L35)
+[src/services/tbtc.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L38)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[src/services/tbtc.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L33)
+[src/services/tbtc.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
 
 ___
 
@@ -102,7 +102,7 @@ Will be removed in next major version.
 
 #### Defined in
 
-[src/services/tbtc.ts:199](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L199)
+[src/services/tbtc.ts:253](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L253)
 
 ___
 
@@ -118,7 +118,7 @@ Bitcoin client handle for low-level access.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L45)
+[src/services/tbtc-core.ts:46](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L46)
 
 ___
 
@@ -134,7 +134,7 @@ Service supporting the tBTC v2 deposit flow.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L28)
+[src/services/tbtc-core.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L29)
 
 ___
 
@@ -151,7 +151,7 @@ and operators.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L33)
+[src/services/tbtc-core.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L34)
 
 ___
 
@@ -167,7 +167,7 @@ Service supporting the tBTC v2 redemption flow.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:37](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L37)
+[src/services/tbtc-core.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L38)
 
 ___
 
@@ -183,7 +183,7 @@ Handle to tBTC contracts for low-level access.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L41)
+[src/services/tbtc-core.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L42)
 
 ## Methods
 
@@ -215,7 +215,7 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
-[src/services/tbtc.ts:382](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L382)
+[src/services/tbtc.ts:436](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L436)
 
 ___
 
@@ -267,7 +267,7 @@ Throws an error if:
 
 #### Defined in
 
-[src/services/tbtc.ts:239](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L239)
+[src/services/tbtc.ts:293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L293)
 
 ___
 
@@ -295,7 +295,7 @@ Throws an error if the provider is invalid or address cannot be extracted.
 
 #### Defined in
 
-[src/services/tbtc.ts:153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L153)
+[src/services/tbtc.ts:207](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L207)
 
 ___
 
@@ -331,13 +331,13 @@ This function is especially useful for local development as it gives
 
 #### Defined in
 
-[src/services/tbtc-core.ts:150](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L150)
+[src/services/tbtc-core.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L163)
 
 ___
 
 ### initializeEthereum
 
-▸ **initializeEthereum**(`ethereumSignerOrProvider`, `ethereumChainId`, `bitcoinNetwork`, `crossChainSupport?`): `Promise`\<[`TBTC`](TBTC.md)\>
+▸ **initializeEthereum**(`ethereumSignerOrProvider`, `ethereumChainId`, `bitcoinNetwork`, `crossChainSupportOrActiveWalletIdentityQuorum?`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTC`](TBTC.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for the given Ethereum network and Bitcoin network.
 The initialized instance uses default Electrum servers to interact
@@ -350,7 +350,8 @@ with Bitcoin network.
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | `undefined` | Ethereum signer or provider. |
 | `ethereumChainId` | [`Ethereum`](../enums/Chains.Ethereum.md) | `undefined` | Ethereum chain ID. |
 | `bitcoinNetwork` | [`BitcoinNetwork`](../enums/BitcoinNetwork-1.md) | `undefined` | Bitcoin network. |
-| `crossChainSupport` | `boolean` | `false` | Whether to enable cross-chain support. False by default. |
+| `crossChainSupportOrActiveWalletIdentityQuorum` | `boolean` \| [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `false` | Whether to enable cross-chain support, or the wallet-identity quorum when cross-chain support is disabled. False by default. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `undefined` | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -369,13 +370,13 @@ Throws an error if the underlying signer's Ethereum network is
 
 #### Defined in
 
-[src/services/tbtc.ts:113](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L113)
+[src/services/tbtc.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L154)
 
 ___
 
 ### initializeMainnet
 
-▸ **initializeMainnet**(`ethereumSignerOrProvider`, `crossChainSupport?`): `Promise`\<[`TBTC`](TBTC.md)\>
+▸ **initializeMainnet**(`ethereumSignerOrProvider`, `crossChainSupportOrActiveWalletIdentityQuorum?`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTC`](TBTC.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for Ethereum and Bitcoin mainnets.
 The initialized instance uses default Electrum servers to interact
@@ -386,7 +387,8 @@ with Bitcoin mainnet
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | `undefined` | Ethereum signer or provider. |
-| `crossChainSupport` | `boolean` | `false` | Whether to enable cross-chain support. False by default. |
+| `crossChainSupportOrActiveWalletIdentityQuorum` | `boolean` \| [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `false` | Whether to enable cross-chain support, or the wallet-identity quorum when cross-chain support is disabled. False by default. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `undefined` | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -405,13 +407,13 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[src/services/tbtc.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L59)
+[src/services/tbtc.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L66)
 
 ___
 
 ### initializeSepolia
 
-▸ **initializeSepolia**(`ethereumSignerOrProvider`, `crossChainSupport?`): `Promise`\<[`TBTC`](TBTC.md)\>
+▸ **initializeSepolia**(`ethereumSignerOrProvider`, `crossChainSupportOrActiveWalletIdentityQuorum?`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTC`](TBTC.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for Ethereum Sepolia and Bitcoin testnet4.
 The initialized instance uses default Electrum servers to interact
@@ -430,7 +432,8 @@ upgrading this SDK.
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | `undefined` | Ethereum signer or provider. |
-| `crossChainSupport` | `boolean` | `false` | Whether to enable cross-chain support. False by default. |
+| `crossChainSupportOrActiveWalletIdentityQuorum` | `boolean` \| [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `false` | Whether to enable cross-chain support, or the wallet-identity quorum when cross-chain support is disabled. False by default. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | `undefined` | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -449,4 +452,4 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[src/services/tbtc.ts:89](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L89)
+[src/services/tbtc.ts:113](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L113)

--- a/typescript/api-reference/classes/TBTCCore.md
+++ b/typescript/api-reference/classes/TBTCCore.md
@@ -55,7 +55,7 @@ which provides the full TBTC class with `initializeCrossChain`.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L47)
+[src/services/tbtc-core.ts:48](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L48)
 
 ## Properties
 
@@ -67,7 +67,7 @@ Bitcoin client handle for low-level access.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:45](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L45)
+[src/services/tbtc-core.ts:46](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L46)
 
 ___
 
@@ -79,7 +79,7 @@ Service supporting the tBTC v2 deposit flow.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:28](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L28)
+[src/services/tbtc-core.ts:29](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L29)
 
 ___
 
@@ -92,7 +92,7 @@ and operators.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:33](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L33)
+[src/services/tbtc-core.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L34)
 
 ___
 
@@ -104,7 +104,7 @@ Service supporting the tBTC v2 redemption flow.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:37](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L37)
+[src/services/tbtc-core.ts:38](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L38)
 
 ___
 
@@ -116,7 +116,7 @@ Handle to tBTC contracts for low-level access.
 
 #### Defined in
 
-[src/services/tbtc-core.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L41)
+[src/services/tbtc-core.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L42)
 
 ## Methods
 
@@ -148,13 +148,13 @@ This function is especially useful for local development as it gives
 
 #### Defined in
 
-[src/services/tbtc-core.ts:150](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L150)
+[src/services/tbtc-core.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L163)
 
 ___
 
 ### initializeEthereum
 
-▸ **initializeEthereum**(`ethereumSignerOrProvider`, `ethereumChainId`, `bitcoinNetwork`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
+▸ **initializeEthereum**(`ethereumSignerOrProvider`, `ethereumChainId`, `bitcoinNetwork`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for the given Ethereum network
 and Bitcoin network. The initialized instance uses default Electrum
@@ -167,6 +167,7 @@ servers to interact with Bitcoin network.
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | Ethereum signer or provider. |
 | `ethereumChainId` | [`Ethereum`](../enums/Chains.Ethereum.md) | Ethereum chain ID. |
 | `bitcoinNetwork` | [`BitcoinNetwork`](../enums/BitcoinNetwork-1.md) | Bitcoin network. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -181,13 +182,13 @@ Throws an error if the underlying signer's Ethereum network is
 
 #### Defined in
 
-[src/services/tbtc-core.ts:115](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L115)
+[src/services/tbtc-core.ts:126](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L126)
 
 ___
 
 ### initializeMainnet
 
-▸ **initializeMainnet**(`ethereumSignerOrProvider`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
+▸ **initializeMainnet**(`ethereumSignerOrProvider`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for Ethereum and Bitcoin mainnets.
 The initialized instance uses default Electrum servers to interact
@@ -198,6 +199,7 @@ with Bitcoin mainnet
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | Ethereum signer or provider. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -212,13 +214,13 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[src/services/tbtc-core.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L67)
+[src/services/tbtc-core.ts:70](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L70)
 
 ___
 
 ### initializeSepolia
 
-▸ **initializeSepolia**(`ethereumSignerOrProvider`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
+▸ **initializeSepolia**(`ethereumSignerOrProvider`, `activeWalletIdentityQuorum?`): `Promise`\<[`TBTCCore`](TBTCCore.md)\>
 
 Initializes the tBTC v2 SDK entrypoint for Ethereum Sepolia and Bitcoin testnet4.
 The initialized instance uses default Electrum servers to interact
@@ -237,6 +239,7 @@ upgrading this SDK.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `ethereumSignerOrProvider` | [`EthereumSigner`](../README.md#ethereumsigner) | Ethereum signer or provider. |
+| `activeWalletIdentityQuorum?` | [`EthereumActiveWalletIdentityQuorum`](../interfaces/EthereumActiveWalletIdentityQuorum.md) | Independent finalized-state provider required before the SDK can create deposit addresses. |
 
 #### Returns
 
@@ -251,4 +254,4 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-[src/services/tbtc-core.ts:94](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L94)
+[src/services/tbtc-core.ts:101](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc-core.ts#L101)

--- a/typescript/api-reference/enums/WalletState-1.md
+++ b/typescript/api-reference/enums/WalletState-1.md
@@ -22,7 +22,7 @@ any action in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:501](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L501)
+[src/lib/contracts/bridge.ts:525](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L525)
 
 ___
 
@@ -36,7 +36,7 @@ and must defend against them.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:496](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L496)
+[src/lib/contracts/bridge.ts:520](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L520)
 
 ___
 
@@ -48,7 +48,7 @@ The wallet can sweep deposits and accept redemption requests.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:483](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L483)
+[src/lib/contracts/bridge.ts:507](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L507)
 
 ___
 
@@ -63,7 +63,7 @@ accepted.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:490](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L490)
+[src/lib/contracts/bridge.ts:514](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L514)
 
 ___
 
@@ -78,7 +78,7 @@ any actions in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:508](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L508)
+[src/lib/contracts/bridge.ts:532](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L532)
 
 ___
 
@@ -90,4 +90,4 @@ The wallet is unknown to the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:479](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L479)
+[src/lib/contracts/bridge.ts:503](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L503)

--- a/typescript/api-reference/interfaces/ActiveWalletIdentity.md
+++ b/typescript/api-reference/interfaces/ActiveWalletIdentity.md
@@ -1,0 +1,34 @@
+# Interface: ActiveWalletIdentity
+
+Canonically bound identity of an active Bridge wallet.
+
+## Table of contents
+
+### Properties
+
+- [walletID](ActiveWalletIdentity.md#walletid)
+- [walletPublicKeyHash](ActiveWalletIdentity.md#walletpublickeyhash)
+
+## Properties
+
+### walletID
+
+• **walletID**: [`Hex`](../classes/Hex.md)
+
+Canonical wallet ID: a legacy alias or native FROST x-only key.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L272)
+
+___
+
+### walletPublicKeyHash
+
+• **walletPublicKeyHash**: [`Hex`](../classes/Hex.md)
+
+20-byte compatibility public-key hash used by legacy Bridge paths.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:270](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L270)

--- a/typescript/api-reference/interfaces/Bridge.md
+++ b/typescript/api-reference/interfaces/Bridge.md
@@ -18,6 +18,7 @@ Interface for communication with the Bridge on-chain contract.
 ### Methods
 
 - [activeWalletID](Bridge.md#activewalletid)
+- [activeWalletIdentity](Bridge.md#activewalletidentity)
 - [activeWalletPublicKey](Bridge.md#activewalletpublickey)
 - [activeWalletPublicKeyHash](Bridge.md#activewalletpublickeyhash)
 - [buildUtxoHash](Bridge.md#buildutxohash)
@@ -68,7 +69,7 @@ GetEventsFunction
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L195)
+[src/lib/contracts/bridge.ts:209](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L209)
 
 ___
 
@@ -84,7 +85,7 @@ GetEventsFunction
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:248](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L248)
+[src/lib/contracts/bridge.ts:262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L262)
 
 ___
 
@@ -118,7 +119,33 @@ Canonical wallet ID of the active wallet, if set.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:235](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L235)
+[src/lib/contracts/bridge.ts:249](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L249)
+
+___
+
+### activeWalletIdentity
+
+▸ **activeWalletIdentity**(): `Promise`\<`undefined` \| [`ActiveWalletIdentity`](ActiveWalletIdentity.md)\>
+
+Gets an independently verified, canonical identity of the current active
+wallet. Implementations used for deposit creation must authenticate the
+identity against at least two operationally independent chain views and
+require the same fully bound identity at each view's own authenticated
+finalized head.
+
+This method is optional for backward source compatibility with custom
+Bridge implementations. Deposit creation fails closed when it is absent.
+
+#### Returns
+
+`Promise`\<`undefined` \| [`ActiveWalletIdentity`](ActiveWalletIdentity.md)\>
+
+Canonically bound active wallet identity. If there is no active
+         wallet at the verified block, undefined is returned.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L195)
 
 ___
 
@@ -138,7 +165,7 @@ Compressed (33 bytes long with 02 or 03 prefix) active wallet's
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:189](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L189)
+[src/lib/contracts/bridge.ts:203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L203)
 
 ___
 
@@ -181,7 +208,7 @@ The hash of the UTXO.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:242](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L242)
+[src/lib/contracts/bridge.ts:256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L256)
 
 ___
 
@@ -479,7 +506,7 @@ Canonical wallet ID.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:222](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L222)
+[src/lib/contracts/bridge.ts:236](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L236)
 
 ___
 
@@ -503,7 +530,7 @@ Resolves legacy wallet public key hash from canonical wallet ID.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:229](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L229)
+[src/lib/contracts/bridge.ts:243](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L243)
 
 ___
 
@@ -519,7 +546,7 @@ Returns the attached WalletRegistry instance.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:200](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L200)
+[src/lib/contracts/bridge.ts:214](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L214)
 
 ___
 
@@ -543,7 +570,7 @@ Promise with the wallet details.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:208](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L208)
+[src/lib/contracts/bridge.ts:222](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L222)
 
 ___
 
@@ -567,4 +594,4 @@ Promise with the wallet details.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:215](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L215)
+[src/lib/contracts/bridge.ts:229](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L229)

--- a/typescript/api-reference/interfaces/DepositReceipt.md
+++ b/typescript/api-reference/interfaces/DepositReceipt.md
@@ -27,7 +27,7 @@ public key and refund public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:265](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L265)
+[src/lib/contracts/bridge.ts:289](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L289)
 
 ___
 
@@ -39,7 +39,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:259](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L259)
+[src/lib/contracts/bridge.ts:283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L283)
 
 ___
 
@@ -51,7 +51,7 @@ Optional 32-byte extra data.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:302](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L302)
+[src/lib/contracts/bridge.ts:326](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L326)
 
 ___
 
@@ -63,7 +63,7 @@ A 4-byte little-endian refund locktime.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:297](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L297)
+[src/lib/contracts/bridge.ts:321](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L321)
 
 ___
 
@@ -78,7 +78,7 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:280](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L280)
+[src/lib/contracts/bridge.ts:304](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L304)
 
 ___
 
@@ -91,7 +91,7 @@ for Taproot-native deposits. Present only for P2TR deposit receipts.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:292](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L292)
+[src/lib/contracts/bridge.ts:316](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L316)
 
 ___
 
@@ -105,7 +105,7 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L272)
+[src/lib/contracts/bridge.ts:296](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
 
 ___
 
@@ -118,4 +118,4 @@ Taproot-native deposits. Present only for P2TR deposit receipts.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:286](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L286)
+[src/lib/contracts/bridge.ts:310](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L310)

--- a/typescript/api-reference/interfaces/DepositRequest.md
+++ b/typescript/api-reference/interfaces/DepositRequest.md
@@ -24,7 +24,7 @@ Deposit amount in satoshis.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L372)
+[src/lib/contracts/bridge.ts:396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L396)
 
 ___
 
@@ -36,7 +36,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:367](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L367)
+[src/lib/contracts/bridge.ts:391](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L391)
 
 ___
 
@@ -48,7 +48,7 @@ Optional 32-byte extra data committed by the deposit script.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L397)
+[src/lib/contracts/bridge.ts:421](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L421)
 
 ___
 
@@ -60,7 +60,7 @@ UNIX timestamp the deposit was revealed at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:382](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L382)
+[src/lib/contracts/bridge.ts:406](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L406)
 
 ___
 
@@ -73,7 +73,7 @@ should have zero as value.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:387](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L387)
+[src/lib/contracts/bridge.ts:411](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L411)
 
 ___
 
@@ -86,7 +86,7 @@ Denominated in satoshi.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:392](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L392)
+[src/lib/contracts/bridge.ts:416](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L416)
 
 ___
 
@@ -98,4 +98,4 @@ Optional identifier of the vault the deposit should be routed in.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:377](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L377)
+[src/lib/contracts/bridge.ts:401](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L401)

--- a/typescript/api-reference/interfaces/EthereumActiveWalletIdentityQuorum.md
+++ b/typescript/api-reference/interfaces/EthereumActiveWalletIdentityQuorum.md
@@ -1,0 +1,32 @@
+# Interface: EthereumActiveWalletIdentityQuorum
+
+Two-provider quorum required before Ethereum state can select Bitcoin
+deposit custody. Both providers must support Ethereum's `finalized` block
+tag and the upgraded Bridge wallet-identity selectors.
+
+## Table of contents
+
+### Properties
+
+- [canonicalProvider](EthereumActiveWalletIdentityQuorum.md#canonicalprovider)
+- [sourceTrustDomainID](EthereumActiveWalletIdentityQuorum.md#sourcetrustdomainid)
+
+## Properties
+
+### canonicalProvider
+
+• `Readonly` **canonicalProvider**: [`EthereumCanonicalActiveWalletIdentityProvider`](EthereumCanonicalActiveWalletIdentityProvider.md)
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:96](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L96)
+
+___
+
+### sourceTrustDomainID
+
+• `Readonly` **sourceTrustDomainID**: `string`
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:95](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L95)

--- a/typescript/api-reference/interfaces/EthereumBridgeConfig.md
+++ b/typescript/api-reference/interfaces/EthereumBridgeConfig.md
@@ -1,0 +1,85 @@
+# Interface: EthereumBridgeConfig
+
+Ethereum Bridge configuration.
+
+## Hierarchy
+
+- [`EthereumContractConfig`](EthereumContractConfig.md)
+
+  ↳ **`EthereumBridgeConfig`**
+
+## Table of contents
+
+### Properties
+
+- [activeWalletIdentityQuorum](EthereumBridgeConfig.md#activewalletidentityquorum)
+- [address](EthereumBridgeConfig.md#address)
+- [deployedAtBlockNumber](EthereumBridgeConfig.md#deployedatblocknumber)
+- [signerOrProvider](EthereumBridgeConfig.md#signerorprovider)
+
+## Properties
+
+### activeWalletIdentityQuorum
+
+• `Optional` `Readonly` **activeWalletIdentityQuorum**: [`EthereumActiveWalletIdentityQuorum`](EthereumActiveWalletIdentityQuorum.md)
+
+Independent finalized-state verifier for deposit wallet identities.
+Ordinary read APIs remain available without this option, but deposit
+creation fails closed.
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:106](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L106)
+
+___
+
+### address
+
+• `Optional` **address**: `string`
+
+Address of the Ethereum contract as a 0x-prefixed hex string.
+Optional parameter, if not provided the value will be resolved from the
+contract artifact.
+
+#### Inherited from
+
+[EthereumContractConfig](EthereumContractConfig.md).[address](EthereumContractConfig.md#address)
+
+#### Defined in
+
+[src/lib/ethereum/adapter.ts:53](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L53)
+
+___
+
+### deployedAtBlockNumber
+
+• `Optional` **deployedAtBlockNumber**: `number`
+
+Number of a block in which the contract was deployed.
+Optional parameter, if not provided the value will be resolved from the
+contract artifact.
+
+#### Inherited from
+
+[EthereumContractConfig](EthereumContractConfig.md).[deployedAtBlockNumber](EthereumContractConfig.md#deployedatblocknumber)
+
+#### Defined in
+
+[src/lib/ethereum/adapter.ts:64](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L64)
+
+___
+
+### signerOrProvider
+
+• **signerOrProvider**: `Signer` \| `Provider`
+
+Signer - will return a Contract which will act on behalf of that signer. The signer will sign all contract transactions.
+Provider - will return a downgraded Contract which only has read-only access (i.e. constant calls)
+
+#### Inherited from
+
+[EthereumContractConfig](EthereumContractConfig.md).[signerOrProvider](EthereumContractConfig.md#signerorprovider)
+
+#### Defined in
+
+[src/lib/ethereum/adapter.ts:58](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/adapter.ts#L58)

--- a/typescript/api-reference/interfaces/EthereumCanonicalActiveWalletIdentityProvider.md
+++ b/typescript/api-reference/interfaces/EthereumCanonicalActiveWalletIdentityProvider.md
@@ -1,0 +1,32 @@
+# Interface: EthereumCanonicalActiveWalletIdentityProvider
+
+Independently operated provider used to verify the primary provider's active
+wallet identity. Trust-domain IDs must describe real operational failure
+domains, not merely different URLs backed by the same provider organization.
+
+## Table of contents
+
+### Properties
+
+- [provider](EthereumCanonicalActiveWalletIdentityProvider.md#provider)
+- [trustDomainID](EthereumCanonicalActiveWalletIdentityProvider.md#trustdomainid)
+
+## Properties
+
+### provider
+
+• `Readonly` **provider**: `Provider`
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:86](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L86)
+
+___
+
+### trustDomainID
+
+• `Readonly` **trustDomainID**: `string`
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:85](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L85)

--- a/typescript/api-reference/interfaces/EthereumContractConfig.md
+++ b/typescript/api-reference/interfaces/EthereumContractConfig.md
@@ -2,6 +2,12 @@
 
 Represents a config set required to connect an Ethereum contract.
 
+## Hierarchy
+
+- **`EthereumContractConfig`**
+
+  ↳ [`EthereumBridgeConfig`](EthereumBridgeConfig.md)
+
 ## Table of contents
 
 ### Properties

--- a/typescript/api-reference/interfaces/RedemptionRequest.md
+++ b/typescript/api-reference/interfaces/RedemptionRequest.md
@@ -23,7 +23,7 @@ On-chain identifier of the redeemer.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:426](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
+[src/lib/contracts/bridge.ts:450](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L450)
 
 ___
 
@@ -36,7 +36,7 @@ prepended with length.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:432](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L432)
+[src/lib/contracts/bridge.ts:456](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L456)
 
 ___
 
@@ -50,7 +50,7 @@ by the sum of the fee share and the treasury fee for this particular output.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:439](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L439)
+[src/lib/contracts/bridge.ts:463](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L463)
 
 ___
 
@@ -62,7 +62,7 @@ UNIX timestamp the request was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:458](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L458)
+[src/lib/contracts/bridge.ts:482](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L482)
 
 ___
 
@@ -77,7 +77,7 @@ on-chain contract at the time the redemption request was made.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:447](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L447)
+[src/lib/contracts/bridge.ts:471](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L471)
 
 ___
 
@@ -90,4 +90,4 @@ redemption's `requestedAmount` to pay the transaction network fee.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:453](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L453)
+[src/lib/contracts/bridge.ts:477](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L477)

--- a/typescript/api-reference/interfaces/Wallet.md
+++ b/typescript/api-reference/interfaces/Wallet.md
@@ -28,7 +28,7 @@ UNIX timestamp indicating the moment the wallet's closing period started.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:563](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L563)
+[src/lib/contracts/bridge.ts:587](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L587)
 
 ___
 
@@ -40,7 +40,7 @@ UNIX timestamp the wallet was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:554](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L554)
+[src/lib/contracts/bridge.ts:578](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L578)
 
 ___
 
@@ -52,7 +52,7 @@ Identifier of a ECDSA Wallet registered in the ECDSA Wallet Registry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:536](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L536)
+[src/lib/contracts/bridge.ts:560](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L560)
 
 ___
 
@@ -64,7 +64,7 @@ Latest wallet's main UTXO hash.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:546](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L546)
+[src/lib/contracts/bridge.ts:570](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L570)
 
 ___
 
@@ -77,7 +77,7 @@ funds.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:559](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L559)
+[src/lib/contracts/bridge.ts:583](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L583)
 
 ___
 
@@ -89,7 +89,7 @@ Moving funds target wallet commitment submitted by the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:575](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L575)
+[src/lib/contracts/bridge.ts:599](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L599)
 
 ___
 
@@ -101,7 +101,7 @@ Total count of pending moved funds sweep requests targeting this wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:567](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L567)
+[src/lib/contracts/bridge.ts:591](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L591)
 
 ___
 
@@ -113,7 +113,7 @@ The total redeemable value of pending redemption requests targeting that wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:550](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L550)
+[src/lib/contracts/bridge.ts:574](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L574)
 
 ___
 
@@ -125,7 +125,7 @@ Current state of the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:571](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L571)
+[src/lib/contracts/bridge.ts:595](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L595)
 
 ___
 
@@ -137,7 +137,7 @@ Canonical wallet identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:532](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L532)
+[src/lib/contracts/bridge.ts:556](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L556)
 
 ___
 
@@ -151,4 +151,4 @@ WalletRegistry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:542](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L542)
+[src/lib/contracts/bridge.ts:566](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L566)

--- a/typescript/api-reference/modules/WalletState.md
+++ b/typescript/api-reference/modules/WalletState.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:514](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L514)
+[src/lib/contracts/bridge.ts:538](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L538)

--- a/typescript/src/lib/contracts/bridge.ts
+++ b/typescript/src/lib/contracts/bridge.ts
@@ -181,6 +181,20 @@ export interface Bridge {
   activeWalletPublicKeyHash(): Promise<Hex | undefined>
 
   /**
+   * Gets an independently verified, canonical identity of the current active
+   * wallet. Implementations used for deposit creation must authenticate the
+   * identity against at least two operationally independent chain views and
+   * require the same fully bound identity at each view's own authenticated
+   * finalized head.
+   *
+   * This method is optional for backward source compatibility with custom
+   * Bridge implementations. Deposit creation fails closed when it is absent.
+   * @returns Canonically bound active wallet identity. If there is no active
+   *          wallet at the verified block, undefined is returned.
+   */
+  activeWalletIdentity?(): Promise<ActiveWalletIdentity | undefined>
+
+  /**
    * Gets the public key of the current active wallet.
    * @returns Compressed (33 bytes long with 02 or 03 prefix) active wallet's
    *          public key. If there is no active wallet at the moment, undefined
@@ -246,6 +260,16 @@ export interface Bridge {
    * @see GetEventsFunction
    */
   getRedemptionRequestedEvents: GetChainEvents.Function<RedemptionRequestedEvent>
+}
+
+/**
+ * Canonically bound identity of an active Bridge wallet.
+ */
+export interface ActiveWalletIdentity {
+  /** 20-byte compatibility public-key hash used by legacy Bridge paths. */
+  walletPublicKeyHash: Hex
+  /** Canonical wallet ID: a legacy alias or native FROST x-only key. */
+  walletID: Hex
 }
 
 /**

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -19,6 +19,7 @@ import {
   DepositRequest,
   TaprootDepositRevealedEvent,
   Chains,
+  ActiveWalletIdentity,
 } from "../contracts"
 import { WalletIDUtils } from "../contracts/wallet-id"
 import { Event as EthersEvent } from "@ethersproject/contracts"
@@ -27,11 +28,13 @@ import {
   constants,
   Contract,
   ContractTransaction,
+  providers,
   utils,
 } from "ethers"
 import { backoffRetrier, Hex } from "../utils"
 import {
   BitcoinPublicKeyUtils,
+  BitcoinHashUtils,
   BitcoinRawTxVectors,
   BitcoinSpvProof,
   BitcoinCompactSizeUint,
@@ -66,11 +69,42 @@ const TaprootDepositRevealABI = [
 const BridgeV2CompatibilityABI = [
   ...TaprootDepositRevealABI,
   "event NewWalletRegisteredV2(bytes32 indexed walletID, bytes32 indexed ecdsaWalletID, bytes20 indexed walletPubKeyHash)",
+  "function activeWalletPubKeyHash() view returns (bytes20)",
   "function activeWalletID() view returns (bytes32)",
   "function taprootDepositOutputKeyCommitment(uint256 depositKey) view returns (bytes32)",
   "function walletID(bytes20 walletPubKeyHash) view returns (bytes32)",
   "function walletPubKeyHashForWalletID(bytes32 walletID) view returns (bytes20)",
 ]
+
+/**
+ * Independently operated provider used to verify the primary provider's active
+ * wallet identity. Trust-domain IDs must describe real operational failure
+ * domains, not merely different URLs backed by the same provider organization.
+ */
+export interface EthereumCanonicalActiveWalletIdentityProvider {
+  readonly trustDomainID: string
+  readonly provider: providers.Provider
+}
+
+/**
+ * Two-provider quorum required before Ethereum state can select Bitcoin
+ * deposit custody. Both providers must support Ethereum's `finalized` block
+ * tag and the upgraded Bridge wallet-identity selectors.
+ */
+export interface EthereumActiveWalletIdentityQuorum {
+  readonly sourceTrustDomainID: string
+  readonly canonicalProvider: EthereumCanonicalActiveWalletIdentityProvider
+}
+
+/** Ethereum Bridge configuration. */
+export interface EthereumBridgeConfig extends EthersContractConfig {
+  /**
+   * Independent finalized-state verifier for deposit wallet identities.
+   * Ordinary read APIs remain available without this option, but deposit
+   * creation fails closed.
+   */
+  readonly activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
+}
 
 /**
  * Implementation of the Ethereum Bridge handle.
@@ -80,6 +114,16 @@ export class EthereumBridge
   extends EthersContractHandle<BridgeTypechain>
   implements Bridge
 {
+  private readonly activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
+
+  private static normalizeTrustDomainID(value: string, label: string): string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`${label} must be non-empty`)
+    }
+
+    return value.trim().toLowerCase()
+  }
+
   private static ensureBridgeV2CompatibilityFallback(
     error: unknown,
     methodName: string
@@ -203,7 +247,7 @@ export class EthereumBridge
   }
 
   constructor(
-    config: EthersContractConfig,
+    config: EthereumBridgeConfig,
     chainId: Chains.Ethereum = Chains.Ethereum.Local
   ) {
     let deployment: EthersContractDeployment
@@ -223,6 +267,50 @@ export class EthereumBridge
     }
 
     super(config, deployment)
+
+    if (config.activeWalletIdentityQuorum) {
+      const sourceTrustDomainID = EthereumBridge.normalizeTrustDomainID(
+        config.activeWalletIdentityQuorum.sourceTrustDomainID,
+        "Active wallet identity source trust-domain ID"
+      )
+      const canonicalTrustDomainID = EthereumBridge.normalizeTrustDomainID(
+        config.activeWalletIdentityQuorum.canonicalProvider.trustDomainID,
+        "Active wallet identity canonical provider trust-domain ID"
+      )
+
+      if (sourceTrustDomainID === canonicalTrustDomainID) {
+        throw new Error(
+          "Active wallet identity providers must use different trust domains"
+        )
+      }
+
+      const canonicalProvider =
+        config.activeWalletIdentityQuorum.canonicalProvider.provider
+      if (
+        canonicalProvider === undefined ||
+        typeof canonicalProvider.getNetwork !== "function" ||
+        typeof canonicalProvider.getBlock !== "function" ||
+        typeof canonicalProvider.call !== "function"
+      ) {
+        throw new Error(
+          "Active wallet identity canonical provider must be an Ethers provider"
+        )
+      }
+
+      if (canonicalProvider === this._instance.provider) {
+        throw new Error(
+          "Active wallet identity providers must use different provider instances"
+        )
+      }
+
+      this.activeWalletIdentityQuorum = {
+        sourceTrustDomainID,
+        canonicalProvider: {
+          trustDomainID: canonicalTrustDomainID,
+          provider: canonicalProvider,
+        },
+      }
+    }
   }
 
   // eslint-disable-next-line valid-jsdoc
@@ -237,11 +325,13 @@ export class EthereumBridge
     return this.bridgeV2CompatibilityContract()
   }
 
-  private bridgeV2CompatibilityContract(): Contract {
+  private bridgeV2CompatibilityContract(
+    provider?: providers.Provider
+  ): Contract {
     return new Contract(
       this._instance.address,
       BridgeV2CompatibilityABI,
-      this._instance.signer || this._instance.provider
+      provider ?? this._instance.signer ?? this._instance.provider
     )
   }
 
@@ -764,6 +854,246 @@ export class EthereumBridge
     }
   }
 
+  private async getFinalizedBlock(
+    provider: providers.Provider,
+    label: string
+  ): Promise<{ number: number; hash: string }> {
+    const rpcProvider = provider as providers.Provider & {
+      send?: (method: string, params: unknown[]) => Promise<unknown>
+    }
+
+    if (typeof rpcProvider.send !== "function") {
+      throw new Error(`${label} must support the Ethereum finalized block tag`)
+    }
+
+    const rawBlock = (await backoffRetrier<unknown>(this._totalRetryAttempts)(
+      async () =>
+        rpcProvider.send!("eth_getBlockByNumber", ["finalized", false])
+    )) as { number?: unknown; hash?: unknown } | null
+
+    if (
+      rawBlock === null ||
+      typeof rawBlock !== "object" ||
+      typeof rawBlock.number !== "string" ||
+      typeof rawBlock.hash !== "string" ||
+      !utils.isHexString(rawBlock.hash, 32)
+    ) {
+      throw new Error(`${label} did not return a finalized block`)
+    }
+
+    let number: number
+    try {
+      number = BigNumber.from(rawBlock.number).toNumber()
+    } catch (_) {
+      throw new Error(`${label} returned an invalid finalized block number`)
+    }
+
+    if (!Number.isSafeInteger(number) || number < 0) {
+      throw new Error(`${label} returned an invalid finalized block number`)
+    }
+
+    return { number, hash: rawBlock.hash.toLowerCase() }
+  }
+
+  private async authenticateFinalizedBlock(
+    provider: providers.Provider,
+    finalizedBlock: { number: number; hash: string },
+    label: string
+  ): Promise<void> {
+    const block = await backoffRetrier<providers.Block>(
+      this._totalRetryAttempts
+    )(async () => provider.getBlock(finalizedBlock.number))
+
+    if (
+      !block ||
+      block.number !== finalizedBlock.number ||
+      !utils.isHexString(block.hash, 32) ||
+      block.hash.toLowerCase() !== finalizedBlock.hash
+    ) {
+      throw new Error(`${label} did not authenticate its finalized block`)
+    }
+  }
+
+  private async readActiveWalletIdentityAt(
+    provider: providers.Provider,
+    blockNumber: number,
+    label: string
+  ): Promise<ActiveWalletIdentity | undefined> {
+    const bridge = this.bridgeV2CompatibilityContract(provider) as unknown as {
+      activeWalletPubKeyHash: (overrides: {
+        blockTag: number
+      }) => Promise<string>
+      activeWalletID: (overrides: { blockTag: number }) => Promise<string>
+      walletID: (
+        walletPublicKeyHash: string,
+        overrides: { blockTag: number }
+      ) => Promise<string>
+      walletPubKeyHashForWalletID: (
+        walletID: string,
+        overrides: { blockTag: number }
+      ) => Promise<string>
+    }
+
+    let walletPublicKeyHashRaw: string
+    let walletIDRaw: string
+    try {
+      ;[walletPublicKeyHashRaw, walletIDRaw] = await Promise.all([
+        bridge.activeWalletPubKeyHash({ blockTag: blockNumber }),
+        bridge.activeWalletID({ blockTag: blockNumber }),
+      ])
+    } catch (_) {
+      throw new Error(
+        `${label} could not prove upgraded Bridge wallet-identity selectors`
+      )
+    }
+
+    const noWalletPublicKeyHash =
+      walletPublicKeyHashRaw === "0x0000000000000000000000000000000000000000"
+    const noWalletID = walletIDRaw === constants.HashZero
+    if (noWalletPublicKeyHash || noWalletID) {
+      if (noWalletPublicKeyHash && noWalletID) {
+        return undefined
+      }
+
+      throw new Error("Active wallet identity is not canonically bound")
+    }
+
+    const walletPublicKeyHash = Hex.from(walletPublicKeyHashRaw)
+    const walletID = Hex.from(walletIDRaw)
+    if (
+      walletPublicKeyHash.toBuffer().length !== 20 ||
+      walletID.toBuffer().length !== 32
+    ) {
+      throw new Error("Active wallet identity is not canonically bound")
+    }
+
+    let mappedWalletID: Hex
+    let reverseWalletPublicKeyHash: Hex
+    try {
+      ;[mappedWalletID, reverseWalletPublicKeyHash] = await Promise.all([
+        bridge
+          .walletID(walletPublicKeyHash.toPrefixedString(), {
+            blockTag: blockNumber,
+          })
+          .then(Hex.from),
+        bridge
+          .walletPubKeyHashForWalletID(walletID.toPrefixedString(), {
+            blockTag: blockNumber,
+          })
+          .then(Hex.from),
+      ])
+    } catch (_) {
+      throw new Error(
+        `${label} could not prove upgraded Bridge wallet-identity selectors`
+      )
+    }
+
+    if (
+      !mappedWalletID.equals(walletID) ||
+      !reverseWalletPublicKeyHash.equals(walletPublicKeyHash)
+    ) {
+      throw new Error("Active wallet identity is not canonically bound")
+    }
+
+    if (!WalletIDUtils.isLegacyWalletID(walletID, walletPublicKeyHash)) {
+      const derivedWalletPublicKeyHash = BitcoinHashUtils.computeHash160(
+        Hex.from(Buffer.concat([Buffer.from([0x02]), walletID.toBuffer()]))
+      )
+      if (!derivedWalletPublicKeyHash.equals(walletPublicKeyHash)) {
+        throw new Error("Active wallet identity is not canonically bound")
+      }
+    }
+
+    return { walletPublicKeyHash, walletID }
+  }
+
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * @see {Bridge#activeWalletIdentity}
+   */
+  async activeWalletIdentity(): Promise<ActiveWalletIdentity | undefined> {
+    const quorum = this.activeWalletIdentityQuorum
+    if (!quorum) {
+      throw new Error(
+        "Deposit wallet identity requires an independent Ethereum provider"
+      )
+    }
+
+    const sourceProvider = this._instance.provider
+    if (!sourceProvider) {
+      throw new Error(
+        "Deposit wallet identity requires a primary Ethereum provider"
+      )
+    }
+    const canonicalProvider = quorum.canonicalProvider.provider
+
+    const [sourceNetwork, canonicalNetwork] = await Promise.all([
+      sourceProvider.getNetwork(),
+      canonicalProvider.getNetwork(),
+    ])
+    if (sourceNetwork.chainId !== canonicalNetwork.chainId) {
+      throw new Error(
+        "Active wallet identity providers use different Ethereum chains"
+      )
+    }
+
+    const [sourceFinalized, canonicalFinalized] = await Promise.all([
+      this.getFinalizedBlock(
+        sourceProvider,
+        "Active wallet identity source provider"
+      ),
+      this.getFinalizedBlock(
+        canonicalProvider,
+        "Active wallet identity canonical provider"
+      ),
+    ])
+
+    await Promise.all([
+      this.authenticateFinalizedBlock(
+        sourceProvider,
+        sourceFinalized,
+        "Active wallet identity source provider"
+      ),
+      this.authenticateFinalizedBlock(
+        canonicalProvider,
+        canonicalFinalized,
+        "Active wallet identity canonical provider"
+      ),
+    ])
+
+    const [sourceIdentity, canonicalIdentity] = await Promise.all([
+      this.readActiveWalletIdentityAt(
+        sourceProvider,
+        sourceFinalized.number,
+        "Active wallet identity source provider"
+      ),
+      this.readActiveWalletIdentityAt(
+        canonicalProvider,
+        canonicalFinalized.number,
+        "Active wallet identity canonical provider"
+      ),
+    ])
+
+    if (!sourceIdentity || !canonicalIdentity) {
+      if (!sourceIdentity && !canonicalIdentity) {
+        return undefined
+      }
+
+      throw new Error("Active wallet identity providers disagree")
+    }
+
+    if (
+      !sourceIdentity.walletPublicKeyHash.equals(
+        canonicalIdentity.walletPublicKeyHash
+      ) ||
+      !sourceIdentity.walletID.equals(canonicalIdentity.walletID)
+    ) {
+      throw new Error("Active wallet identity providers disagree")
+    }
+
+    return sourceIdentity
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * @see {Bridge#activeWalletPublicKeyHash}
@@ -806,41 +1136,12 @@ export class EthereumBridge
    * @see {Bridge#activeWalletID}
    */
   async activeWalletID(): Promise<Hex | undefined> {
-    const bridgeContract = this._instance as unknown as {
-      activeWalletID?: () => Promise<string>
-      activeWalletPubKeyHash: () => Promise<string>
-    }
-
-    if (typeof bridgeContract.activeWalletID === "function") {
-      try {
-        const walletID = await backoffRetrier<string>(this._totalRetryAttempts)(
-          async () => bridgeContract.activeWalletID!()
-        )
-
-        if (walletID === constants.HashZero) {
-          return undefined
-        }
-
-        return Hex.from(walletID)
-      } catch (err) {
-        // The bundled artifact ABI may expose this selector while the deployed
-        // (pre-upgrade) bytecode does not; fall through to the compatibility
-        // contract and legacy path below rather than throwing.
-        EthereumBridge.ensureBridgeV2CompatibilityFallback(
-          err,
-          "activeWalletID"
-        )
-      }
-    }
-
     const bridgeV2Contract =
       this.bridgeV2CompatibilityContract() as unknown as {
         activeWalletID: () => Promise<string>
       }
     try {
-      const walletID = await backoffRetrier<string>(this._totalRetryAttempts)(
-        async () => bridgeV2Contract.activeWalletID()
-      )
+      const walletID = await bridgeV2Contract.activeWalletID()
 
       if (walletID === constants.HashZero) {
         return undefined
@@ -848,26 +1149,12 @@ export class EthereumBridge
 
       return Hex.from(walletID)
     } catch (err) {
-      EthereumBridge.ensureBridgeV2CompatibilityFallback(err, "activeWalletID")
-      // Fall back to the legacy alias below for pre-upgrade Bridge contracts
-      // whose ABI and bytecode do not expose `activeWalletID`.
+      if (EthereumBridge.isMissingBridgeV2CompatibilityMethodError(err)) {
+        throw new Error("Bridge does not expose a canonical active wallet ID")
+      }
+
+      throw err
     }
-
-    const activeWalletPublicKeyHash: string = await backoffRetrier<string>(
-      this._totalRetryAttempts
-    )(async () => {
-      return await bridgeContract.activeWalletPubKeyHash()
-    })
-
-    if (
-      activeWalletPublicKeyHash === "0x0000000000000000000000000000000000000000"
-    ) {
-      return undefined
-    }
-
-    return WalletIDUtils.legacyWalletIDFromPublicKeyHash(
-      Hex.from(activeWalletPublicKeyHash)
-    )
   }
 
   private async getWalletCompressedPublicKey(

--- a/typescript/src/lib/ethereum/index.ts
+++ b/typescript/src/lib/ethereum/index.ts
@@ -1,6 +1,6 @@
 import { Chains, TBTCContracts } from "../contracts"
 import { providers, Signer } from "ethers"
-import { EthereumBridge } from "./bridge"
+import { EthereumActiveWalletIdentityQuorum, EthereumBridge } from "./bridge"
 import { EthereumWalletRegistry } from "./wallet-registry"
 import { EthereumTBTCToken } from "./tbtc-token"
 import { EthereumTBTCVault } from "./tbtc-vault"
@@ -67,20 +67,26 @@ export async function ethereumAddressFromSigner(
  * chain ID and attaches the given signer there.
  * @param signer Signer that should be attached to tBTC contracts.
  * @param chainId Ethereum chain ID.
+ * @param activeWalletIdentityQuorum Independent finalized-state provider
+ *        required before the SDK can create a deposit address.
  * @returns Handle to tBTC core contracts.
  * @throws Throws an error if the signer's Ethereum chain ID is other than
  *         the one used to load tBTC contracts.
  */
 export async function loadEthereumCoreContracts(
   signer: EthereumSigner,
-  chainId: Chains.Ethereum
+  chainId: Chains.Ethereum,
+  activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
 ): Promise<TBTCContracts> {
   const signerChainId = await chainIdFromSigner(signer)
   if (signerChainId !== chainId) {
     throw new Error("Signer uses different chain than Ethereum core contracts")
   }
 
-  const bridge = new EthereumBridge({ signerOrProvider: signer }, chainId)
+  const bridge = new EthereumBridge(
+    { signerOrProvider: signer, activeWalletIdentityQuorum },
+    chainId
+  )
   const tbtcToken = new EthereumTBTCToken({ signerOrProvider: signer }, chainId)
   const tbtcVault = new EthereumTBTCVault({ signerOrProvider: signer }, chainId)
   const walletRegistry = new EthereumWalletRegistry(

--- a/typescript/src/services/deposits/deposit.ts
+++ b/typescript/src/services/deposits/deposit.ts
@@ -19,6 +19,7 @@ import {
 import { payments, Stack, script, opcodes } from "bitcoinjs-lib"
 import { Hex } from "../../lib/utils"
 import { TransactionReceipt } from "@ethersproject/providers"
+import { resolveBitcoinTxOutpoint } from "./utxo"
 
 export const DepositScriptType = {
   P2SH: "p2sh",
@@ -176,9 +177,22 @@ export class Deposit {
 
     const { transactionHash, outputIndex } = resolvedFundingOutpoint
 
-    const depositFundingTx = extractBitcoinRawTxVectors(
-      await this.bitcoinClient.getRawTransaction(transactionHash)
+    const rawFundingTransaction = await this.bitcoinClient.getRawTransaction(
+      transactionHash
     )
+    const { output: fundingOutput } = resolveBitcoinTxOutpoint(
+      resolvedFundingOutpoint,
+      rawFundingTransaction
+    )
+    const resolvedFundingUtxo = resolvedFundingOutpoint as Partial<BitcoinUtxo>
+    if (
+      resolvedFundingUtxo.value !== undefined &&
+      !resolvedFundingUtxo.value.eq(fundingOutput.value)
+    ) {
+      throw new Error("Funding output value does not match detected UTXO value")
+    }
+
+    const depositFundingTx = extractBitcoinRawTxVectors(rawFundingTransaction)
 
     const { bridge, tbtcVault } = this.tbtcContracts
 

--- a/typescript/src/services/deposits/deposits-service.ts
+++ b/typescript/src/services/deposits/deposits-service.ts
@@ -11,6 +11,7 @@ import { WalletIDUtils } from "../../lib/contracts/wallet-id"
 import {
   BitcoinAddressConverter,
   BitcoinClient,
+  BitcoinHashUtils,
   BitcoinLocktimeUtils,
   BitcoinScriptUtils,
 } from "../../lib/bitcoin"
@@ -282,14 +283,33 @@ export class DepositsService {
   ): Promise<DepositReceipt> {
     const blindingFactor = Hex.from(crypto.randomBytes(8))
 
-    const walletPublicKeyHash =
-      await this.tbtcContracts.bridge.activeWalletPublicKeyHash()
+    const activeWalletIdentity = this.tbtcContracts.bridge.activeWalletIdentity
+    if (typeof activeWalletIdentity !== "function") {
+      throw new Error("Deposit wallet identity verification is not available")
+    }
 
-    if (!walletPublicKeyHash) {
+    const walletIdentity = await activeWalletIdentity.call(
+      this.tbtcContracts.bridge
+    )
+    if (!walletIdentity) {
       throw new Error("Could not get active wallet public key hash")
     }
 
-    const activeWalletID = await this.tbtcContracts.bridge.activeWalletID()
+    const { walletPublicKeyHash, walletID: activeWalletID } = walletIdentity
+    const isLegacyWallet = WalletIDUtils.isLegacyWalletID(
+      activeWalletID,
+      walletPublicKeyHash
+    )
+    if (!isLegacyWallet) {
+      const derivedWalletPublicKeyHash = BitcoinHashUtils.computeHash160(
+        Hex.from(
+          Buffer.concat([Buffer.from([0x02]), activeWalletID.toBuffer()])
+        )
+      )
+      if (!derivedWalletPublicKeyHash.equals(walletPublicKeyHash)) {
+        throw new Error("Active wallet identity is not canonically bound")
+      }
+    }
 
     const bitcoinNetwork = await this.bitcoinClient.getNetwork()
 
@@ -303,10 +323,7 @@ export class DepositsService {
     let refundXOnlyPublicKey: Hex | undefined
 
     if (scriptType == DepositScriptType.P2TR) {
-      if (
-        !activeWalletID ||
-        WalletIDUtils.isLegacyWalletID(activeWalletID, walletPublicKeyHash)
-      ) {
+      if (isLegacyWallet) {
         throw new Error(
           "Taproot deposits require an active FROST wallet with a P2TR wallet ID"
         )
@@ -326,10 +343,7 @@ export class DepositsService {
           refundXOnlyPublicKey
         )
     } else {
-      if (
-        activeWalletID &&
-        !WalletIDUtils.isLegacyWalletID(activeWalletID, walletPublicKeyHash)
-      ) {
+      if (!isLegacyWallet) {
         throw new Error(
           "Legacy deposits are not supported for FROST active wallets"
         )

--- a/typescript/src/services/deposits/utxo.ts
+++ b/typescript/src/services/deposits/utxo.ts
@@ -1,11 +1,54 @@
 import { BigNumber } from "ethers"
 import { Transaction } from "bitcoinjs-lib"
-import { BitcoinRawTx, BitcoinUtxo } from "../../lib/bitcoin"
+import { BitcoinRawTx, BitcoinTxOutpoint, BitcoinUtxo } from "../../lib/bitcoin"
 
-export type ResolvedBitcoinUtxo = {
+export type ResolvedBitcoinTxOutpoint = {
   transaction: Transaction
   output: Transaction["outs"][number]
+}
+
+export type ResolvedBitcoinUtxo = {
+  transaction: ResolvedBitcoinTxOutpoint["transaction"]
+  output: ResolvedBitcoinTxOutpoint["output"]
   value: BigNumber
+}
+
+/**
+ * Resolves an outpoint against provider-returned raw transaction bytes and
+ * rejects identity or index mismatches before the transaction is used.
+ * @param outpoint Expected transaction hash and output index.
+ * @param rawTransaction Raw transaction returned for the expected hash.
+ * @param errorContext Selects user-facing errors for funding or signing flows.
+ * @returns The authenticated transaction and selected output.
+ */
+export function resolveBitcoinTxOutpoint(
+  outpoint: BitcoinTxOutpoint,
+  rawTransaction: BitcoinRawTx,
+  errorContext: "funding" | "utxo" = "funding"
+): ResolvedBitcoinTxOutpoint {
+  const transaction = Transaction.fromHex(rawTransaction.transactionHex)
+
+  if (transaction.getId() !== outpoint.transactionHash.toString()) {
+    throw new Error(
+      errorContext === "utxo"
+        ? "Raw transaction does not match UTXO transaction hash"
+        : "Funding transaction bytes do not match requested transaction hash"
+    )
+  }
+
+  if (
+    !Number.isInteger(outpoint.outputIndex) ||
+    outpoint.outputIndex < 0 ||
+    outpoint.outputIndex >= transaction.outs.length
+  ) {
+    throw new Error(
+      errorContext === "utxo"
+        ? "UTXO output index is out of range"
+        : "Funding output index is out of range"
+    )
+  }
+
+  return { transaction, output: transaction.outs[outpoint.outputIndex] }
 }
 
 /**
@@ -17,21 +60,7 @@ export type ResolvedBitcoinUtxo = {
 export function resolveBitcoinUtxo(
   utxo: BitcoinUtxo & BitcoinRawTx
 ): ResolvedBitcoinUtxo {
-  const transaction = Transaction.fromHex(utxo.transactionHex)
-
-  if (transaction.getId() !== utxo.transactionHash.toString()) {
-    throw new Error("Raw transaction does not match UTXO transaction hash")
-  }
-
-  if (
-    !Number.isInteger(utxo.outputIndex) ||
-    utxo.outputIndex < 0 ||
-    utxo.outputIndex >= transaction.outs.length
-  ) {
-    throw new Error("UTXO output index is out of range")
-  }
-
-  const output = transaction.outs[utxo.outputIndex]
+  const { transaction, output } = resolveBitcoinTxOutpoint(utxo, utxo, "utxo")
   const value = BigNumber.from(output.value)
 
   if (!value.eq(utxo.value)) {

--- a/typescript/src/services/tbtc-core.ts
+++ b/typescript/src/services/tbtc-core.ts
@@ -5,6 +5,7 @@ import { Chains, TBTCContracts } from "../lib/contracts"
 import { BitcoinClient, BitcoinNetwork } from "../lib/bitcoin"
 import {
   ethereumAddressFromSigner,
+  EthereumActiveWalletIdentityQuorum,
   EthereumSigner,
   loadEthereumCoreContracts,
 } from "../lib/ethereum"
@@ -60,17 +61,21 @@ export class TBTC {
    * The initialized instance uses default Electrum servers to interact
    * with Bitcoin mainnet
    * @param ethereumSignerOrProvider Ethereum signer or provider.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the signer's Ethereum network is other than
    *         Ethereum mainnet.
    */
   static async initializeMainnet(
-    ethereumSignerOrProvider: EthereumSigner | providers.Provider
+    ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
     return this.initializeEthereum(
       ethereumSignerOrProvider,
       Chains.Ethereum.Mainnet,
-      BitcoinNetwork.Mainnet
+      BitcoinNetwork.Mainnet,
+      activeWalletIdentityQuorum
     )
   }
 
@@ -87,17 +92,21 @@ export class TBTC {
    * updated. Update your integration to testnet4 Bitcoin tooling before
    * upgrading this SDK.
    * @param ethereumSignerOrProvider Ethereum signer or provider.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the signer's Ethereum network is other than
    *         Ethereum mainnet.
    */
   static async initializeSepolia(
-    ethereumSignerOrProvider: EthereumSigner | providers.Provider
+    ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
     return this.initializeEthereum(
       ethereumSignerOrProvider,
       Chains.Ethereum.Sepolia,
-      BitcoinNetwork.Testnet4
+      BitcoinNetwork.Testnet4,
+      activeWalletIdentityQuorum
     )
   }
 
@@ -108,6 +117,8 @@ export class TBTC {
    * @param ethereumSignerOrProvider Ethereum signer or provider.
    * @param ethereumChainId Ethereum chain ID.
    * @param bitcoinNetwork Bitcoin network.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the underlying signer's Ethereum network is
    *         other than the given Ethereum network.
@@ -115,14 +126,16 @@ export class TBTC {
   protected static async initializeEthereum(
     ethereumSignerOrProvider: EthereumSigner | providers.Provider,
     ethereumChainId: Chains.Ethereum,
-    bitcoinNetwork: BitcoinNetwork
+    bitcoinNetwork: BitcoinNetwork,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
     const signerAddress = await ethereumAddressFromSigner(
       ethereumSignerOrProvider
     )
     const tbtcContracts = await loadEthereumCoreContracts(
       ethereumSignerOrProvider,
-      ethereumChainId
+      ethereumChainId,
+      activeWalletIdentityQuorum
     )
 
     const bitcoinClient = ElectrumClient.fromDefaultConfig(bitcoinNetwork)

--- a/typescript/src/services/tbtc.ts
+++ b/typescript/src/services/tbtc.ts
@@ -8,7 +8,10 @@ import {
   TBTCContracts,
 } from "../lib/contracts"
 import { BitcoinClient, BitcoinNetwork } from "../lib/bitcoin"
-import { EthereumSigner } from "../lib/ethereum"
+import {
+  EthereumActiveWalletIdentityQuorum,
+  EthereumSigner,
+} from "../lib/ethereum"
 import type { AnchorProvider } from "@coral-xyz/anchor"
 import type { StarkNetProvider } from "../lib/starknet"
 import type { SuiSignerWithAddress } from "../lib/sui"
@@ -51,20 +54,37 @@ export class TBTC extends TBTCCore {
    * The initialized instance uses default Electrum servers to interact
    * with Bitcoin mainnet
    * @param ethereumSignerOrProvider Ethereum signer or provider.
-   * @param crossChainSupport Whether to enable cross-chain support. False by default.
+   * @param crossChainSupportOrActiveWalletIdentityQuorum Whether to enable
+   *        cross-chain support, or the wallet-identity quorum when cross-chain
+   *        support is disabled. False by default.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the signer's Ethereum network is other than
    *         Ethereum mainnet.
    */
   static async initializeMainnet(
     ethereumSignerOrProvider: EthereumSigner | providers.Provider,
-    crossChainSupport: boolean = false
+    crossChainSupportOrActiveWalletIdentityQuorum:
+      | boolean
+      | EthereumActiveWalletIdentityQuorum = false,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
+    const crossChainSupport =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? crossChainSupportOrActiveWalletIdentityQuorum
+        : false
+    const resolvedActiveWalletIdentityQuorum =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? activeWalletIdentityQuorum
+        : crossChainSupportOrActiveWalletIdentityQuorum
+
     return this.initializeEthereum(
       ethereumSignerOrProvider,
       Chains.Ethereum.Mainnet,
       BitcoinNetwork.Mainnet,
-      crossChainSupport
+      crossChainSupport,
+      resolvedActiveWalletIdentityQuorum
     )
   }
 
@@ -81,20 +101,37 @@ export class TBTC extends TBTCCore {
    * updated. Update your integration to testnet4 Bitcoin tooling before
    * upgrading this SDK.
    * @param ethereumSignerOrProvider Ethereum signer or provider.
-   * @param crossChainSupport Whether to enable cross-chain support. False by default.
+   * @param crossChainSupportOrActiveWalletIdentityQuorum Whether to enable
+   *        cross-chain support, or the wallet-identity quorum when cross-chain
+   *        support is disabled. False by default.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the signer's Ethereum network is other than
    *         Ethereum mainnet.
    */
   static async initializeSepolia(
     ethereumSignerOrProvider: EthereumSigner | providers.Provider,
-    crossChainSupport: boolean = false
+    crossChainSupportOrActiveWalletIdentityQuorum:
+      | boolean
+      | EthereumActiveWalletIdentityQuorum = false,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
+    const crossChainSupport =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? crossChainSupportOrActiveWalletIdentityQuorum
+        : false
+    const resolvedActiveWalletIdentityQuorum =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? activeWalletIdentityQuorum
+        : crossChainSupportOrActiveWalletIdentityQuorum
+
     return this.initializeEthereum(
       ethereumSignerOrProvider,
       Chains.Ethereum.Sepolia,
       BitcoinNetwork.Testnet4,
-      crossChainSupport
+      crossChainSupport,
+      resolvedActiveWalletIdentityQuorum
     )
   }
 
@@ -105,7 +142,11 @@ export class TBTC extends TBTCCore {
    * @param ethereumSignerOrProvider Ethereum signer or provider.
    * @param ethereumChainId Ethereum chain ID.
    * @param bitcoinNetwork Bitcoin network.
-   * @param crossChainSupport Whether to enable cross-chain support. False by default.
+   * @param crossChainSupportOrActiveWalletIdentityQuorum Whether to enable
+   *        cross-chain support, or the wallet-identity quorum when cross-chain
+   *        support is disabled. False by default.
+   * @param activeWalletIdentityQuorum Independent finalized-state provider
+   *        required before the SDK can create deposit addresses.
    * @returns Initialized tBTC v2 SDK entrypoint.
    * @throws Throws an error if the underlying signer's Ethereum network is
    *         other than the given Ethereum network.
@@ -114,12 +155,25 @@ export class TBTC extends TBTCCore {
     ethereumSignerOrProvider: EthereumSigner | providers.Provider,
     ethereumChainId: Chains.Ethereum,
     bitcoinNetwork: BitcoinNetwork,
-    crossChainSupport = false
+    crossChainSupportOrActiveWalletIdentityQuorum:
+      | boolean
+      | EthereumActiveWalletIdentityQuorum = false,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
   ): Promise<TBTC> {
+    const crossChainSupport =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? crossChainSupportOrActiveWalletIdentityQuorum
+        : false
+    const resolvedActiveWalletIdentityQuorum =
+      typeof crossChainSupportOrActiveWalletIdentityQuorum === "boolean"
+        ? activeWalletIdentityQuorum
+        : crossChainSupportOrActiveWalletIdentityQuorum
+
     const tbtc = (await super.initializeEthereum(
       ethereumSignerOrProvider,
       ethereumChainId,
-      bitcoinNetwork
+      bitcoinNetwork,
+      resolvedActiveWalletIdentityQuorum
     )) as TBTC
 
     if (crossChainSupport) {

--- a/typescript/test/lib/ethereum.test.ts
+++ b/typescript/test/lib/ethereum.test.ts
@@ -19,7 +19,15 @@ import {
   MockContract,
 } from "@ethereum-waffle/mock-contract"
 import chai, { expect } from "chai"
-import { BigNumber, Wallet, constants, getDefaultProvider, utils } from "ethers"
+import chaiAsPromised from "chai-as-promised"
+import {
+  BigNumber,
+  Wallet,
+  constants,
+  getDefaultProvider,
+  providers,
+  utils,
+} from "ethers"
 import { MockProvider } from "@ethereum-waffle/provider"
 import { waffleChai } from "@ethereum-waffle/chai"
 import { assertContractCalledWith } from "../utils/helpers"
@@ -32,6 +40,7 @@ import { abi as BaseL1BitcoinDepositorABI } from "../../src/lib/ethereum/artifac
 import { abi as ArbitrumL1BitcoinDepositorABI } from "../../src/lib/ethereum/artifacts/sepolia/ArbitrumL1BitcoinDepositor.json"
 
 chai.use(waffleChai)
+chai.use(chaiAsPromised)
 
 const BridgeABIWithTaprootDepositReveal = [
   ...BridgeABI,
@@ -52,9 +61,10 @@ describe("Ethereum", () => {
     let walletRegistry: MockContract
     let bridgeContract: MockContract
     let bridgeHandle: EthereumBridge
+    let signer: Wallet
 
     beforeEach(async () => {
-      const [signer] = new MockProvider().getWallets()
+      ;[signer] = new MockProvider().getWallets()
 
       walletRegistry = await deployMockContract(
         signer,
@@ -97,6 +107,17 @@ describe("Ethereum", () => {
         )
       })
 
+      it("should not synthesize an active wallet ID when the selector is unavailable", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          walletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.reverts()
+
+        await expect(bridgeHandle.activeWalletID()).to.be.rejectedWith(
+          "Bridge does not expose a canonical active wallet ID"
+        )
+      })
+
       it("should resolve canonical wallet ID from wallet public key hash despite stale local ABI", async () => {
         await bridgeContract.mock.walletID
           .withArgs(walletPublicKeyHash.toPrefixedString())
@@ -117,6 +138,435 @@ describe("Ethereum", () => {
             await bridgeHandle.walletPublicKeyHashForWalletID(walletID)
           ).toString()
         ).to.equal(walletPublicKeyHash.toString())
+      })
+    })
+
+    describe("activeWalletIdentity", () => {
+      const frostWalletID = Hex.from(
+        "2336f65004d8f122f1fe947ebd009a8b4add3a0d937356d568e30f7fcc2e4008"
+      )
+      const frostWalletPublicKeyHash = Hex.from(
+        "c92a772f11bc97d8938a16a9db435401f4e6a7bc"
+      )
+      let sourceProvider: providers.JsonRpcProvider
+      let originalSend: providers.JsonRpcProvider["send"]
+
+      // Local provider test double only. A wrapper around one provider is not
+      // an independent production trust domain; README documents the operator
+      // requirement that cannot be reproduced by this in-process unit test.
+      const distinctProviderTestDouble = (
+        provider: providers.Provider = sourceProvider
+      ): providers.Provider =>
+        new Proxy(provider, {
+          get(target, property) {
+            const value = Reflect.get(target, property, target)
+            return typeof value === "function" ? value.bind(target) : value
+          },
+        })
+
+      const identityHandle = (
+        canonicalProvider: providers.Provider = distinctProviderTestDouble(),
+        sourceTrustDomainID = "source.example",
+        canonicalTrustDomainID = "canonical.example"
+      ) =>
+        new EthereumBridge({
+          address: bridgeContract.address,
+          signerOrProvider: signer,
+          activeWalletIdentityQuorum: {
+            sourceTrustDomainID,
+            canonicalProvider: {
+              trustDomainID: canonicalTrustDomainID,
+              provider: canonicalProvider,
+            },
+          },
+        })
+
+      beforeEach(() => {
+        sourceProvider = signer.provider as providers.JsonRpcProvider
+        originalSend = sourceProvider.send.bind(sourceProvider)
+        sourceProvider.send = async (method, params) => {
+          if (method === "eth_getBlockByNumber" && params[0] === "finalized") {
+            return originalSend(method, ["latest", params[1]])
+          }
+
+          return originalSend(method, params)
+        }
+      })
+
+      afterEach(() => {
+        sourceProvider.send = originalSend
+      })
+
+      it("should fail closed without an independent provider", async () => {
+        await expect(bridgeHandle.activeWalletIdentity()).to.be.rejectedWith(
+          "Deposit wallet identity requires an independent Ethereum provider"
+        )
+      })
+
+      it("should reject providers declaring the same trust domain", () => {
+        expect(() =>
+          identityHandle(sourceProvider, " Shared.Example ", "shared.example")
+        ).to.throw(
+          "Active wallet identity providers must use different trust domains"
+        )
+      })
+
+      it("should reject the same provider instance across trust domains", () => {
+        expect(() => identityHandle(sourceProvider)).to.throw(
+          "Active wallet identity providers must use different provider instances"
+        )
+      })
+
+      it("should return a canonically bound FROST identity", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          frostWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(frostWalletPublicKeyHash.toPrefixedString())
+          .returns(frostWalletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(frostWalletID.toPrefixedString())
+          .returns(frostWalletPublicKeyHash.toPrefixedString())
+
+        expect(await identityHandle().activeWalletIdentity()).to.deep.equal({
+          walletPublicKeyHash: frostWalletPublicKeyHash,
+          walletID: frostWalletID,
+        })
+      })
+
+      it("should preserve an upgraded-Bridge legacy ECDSA identity", async () => {
+        const walletPublicKeyHash = Hex.from(
+          "2a621226d6f9916a929c0ab8cc7d3252c1485708"
+        )
+        const walletID = Hex.from(
+          utils.hexZeroPad(walletPublicKeyHash.toPrefixedString(), 32)
+        )
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          walletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          walletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(walletPublicKeyHash.toPrefixedString())
+          .returns(walletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(walletID.toPrefixedString())
+          .returns(walletPublicKeyHash.toPrefixedString())
+
+        expect(await identityHandle().activeWalletIdentity()).to.deep.equal({
+          walletPublicKeyHash,
+          walletID,
+        })
+      })
+
+      it("should reject a provider response that is not canonically mapped", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          frostWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(frostWalletPublicKeyHash.toPrefixedString())
+          .returns(constants.HashZero)
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(frostWalletID.toPrefixedString())
+          .returns(frostWalletPublicKeyHash.toPrefixedString())
+
+        await expect(
+          identityHandle().activeWalletIdentity()
+        ).to.be.rejectedWith("Active wallet identity is not canonically bound")
+      })
+
+      it("should reject two internally coherent provider identities that disagree", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          frostWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(frostWalletPublicKeyHash.toPrefixedString())
+          .returns(frostWalletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(frostWalletID.toPrefixedString())
+          .returns(frostWalletPublicKeyHash.toPrefixedString())
+
+        const attackerWalletID = Hex.from(
+          "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        )
+        const attackerWalletPublicKeyHash = BitcoinHashUtils.computeHash160(
+          Hex.from(
+            Buffer.concat([Buffer.from([0x02]), attackerWalletID.toBuffer()])
+          )
+        )
+        const identityInterface = new utils.Interface([
+          "function activeWalletPubKeyHash() view returns (bytes20)",
+          "function activeWalletID() view returns (bytes32)",
+          "function walletID(bytes20) view returns (bytes32)",
+          "function walletPubKeyHashForWalletID(bytes32) view returns (bytes20)",
+        ])
+        const canonicalProvider = new Proxy(sourceProvider, {
+          get(target, property) {
+            if (property === "call") {
+              return async (transaction: providers.TransactionRequest) => {
+                const data = transaction.data?.toString() ?? ""
+                const selector = data.slice(0, 10)
+                if (
+                  selector ===
+                  identityInterface.getSighash("activeWalletPubKeyHash")
+                ) {
+                  return identityInterface.encodeFunctionResult(
+                    "activeWalletPubKeyHash",
+                    [attackerWalletPublicKeyHash.toPrefixedString()]
+                  )
+                }
+                if (
+                  selector === identityInterface.getSighash("activeWalletID")
+                ) {
+                  return identityInterface.encodeFunctionResult(
+                    "activeWalletID",
+                    [attackerWalletID.toPrefixedString()]
+                  )
+                }
+                if (selector === identityInterface.getSighash("walletID")) {
+                  return identityInterface.encodeFunctionResult("walletID", [
+                    attackerWalletID.toPrefixedString(),
+                  ])
+                }
+                if (
+                  selector ===
+                  identityInterface.getSighash("walletPubKeyHashForWalletID")
+                ) {
+                  return identityInterface.encodeFunctionResult(
+                    "walletPubKeyHashForWalletID",
+                    [attackerWalletPublicKeyHash.toPrefixedString()]
+                  )
+                }
+
+                return target.call(transaction)
+              }
+            }
+
+            const value = Reflect.get(target, property, target)
+            return typeof value === "function" ? value.bind(target) : value
+          },
+        }) as providers.Provider
+
+        await expect(
+          identityHandle(canonicalProvider).activeWalletIdentity()
+        ).to.be.rejectedWith("Active wallet identity providers disagree")
+      })
+
+      it("should authenticate and read each provider at its own finalized head", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          frostWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(frostWalletPublicKeyHash.toPrefixedString())
+          .returns(frostWalletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(frostWalletID.toPrefixedString())
+          .returns(frostWalletPublicKeyHash.toPrefixedString())
+
+        await originalSend("evm_mine", [])
+        const canonicalFinalizedBlock = await sourceProvider.getBlock("latest")
+        await originalSend("evm_mine", [])
+        const sourceFinalizedBlock = await sourceProvider.getBlock("latest")
+        const sourceIdentityBlockTags: Array<
+          providers.BlockTag | Promise<providers.BlockTag>
+        > = []
+        const canonicalIdentityBlockTags: Array<
+          providers.BlockTag | Promise<providers.BlockTag>
+        > = []
+        const sourceCall = sourceProvider.call.bind(sourceProvider)
+
+        sourceProvider.send = async (method, params) => {
+          if (method === "eth_getBlockByNumber" && params[0] === "finalized") {
+            return {
+              number: utils.hexValue(sourceFinalizedBlock.number),
+              hash: sourceFinalizedBlock.hash,
+            }
+          }
+
+          return originalSend(method, params)
+        }
+        sourceProvider.call = async (transaction, blockTag) => {
+          sourceIdentityBlockTags.push(blockTag ?? "latest")
+          return sourceCall(transaction, blockTag)
+        }
+
+        const canonicalProvider = new Proxy(sourceProvider, {
+          get(target, property) {
+            if (property === "send") {
+              return async (method: string, params: unknown[]) => {
+                if (
+                  method === "eth_getBlockByNumber" &&
+                  params[0] === "finalized"
+                ) {
+                  return {
+                    number: utils.hexValue(canonicalFinalizedBlock.number),
+                    hash: canonicalFinalizedBlock.hash,
+                  }
+                }
+
+                return originalSend(method, params)
+              }
+            }
+            if (property === "call") {
+              return async (
+                transaction: providers.TransactionRequest,
+                blockTag?: providers.BlockTag
+              ) => {
+                canonicalIdentityBlockTags.push(blockTag ?? "latest")
+                return sourceCall(transaction, blockTag)
+              }
+            }
+
+            const value = Reflect.get(target, property, target)
+            return typeof value === "function" ? value.bind(target) : value
+          },
+        }) as providers.Provider
+
+        try {
+          expect(
+            await identityHandle(canonicalProvider).activeWalletIdentity()
+          ).to.deep.equal({
+            walletPublicKeyHash: frostWalletPublicKeyHash,
+            walletID: frostWalletID,
+          })
+        } finally {
+          sourceProvider.call = sourceCall
+        }
+
+        expect(sourceIdentityBlockTags).to.have.length(4)
+        expect(canonicalIdentityBlockTags).to.have.length(4)
+        for (const blockTag of sourceIdentityBlockTags) {
+          expect(BigNumber.from(await blockTag).toNumber()).to.equal(
+            sourceFinalizedBlock.number
+          )
+        }
+        for (const blockTag of canonicalIdentityBlockTags) {
+          expect(BigNumber.from(await blockTag).toNumber()).to.equal(
+            canonicalFinalizedBlock.number
+          )
+        }
+      })
+
+      it("should reject an unauthenticated advertised finalized hash", async () => {
+        const finalizedBlock = await sourceProvider.getBlock("latest")
+        const canonicalProvider = new Proxy(sourceProvider, {
+          get(target, property) {
+            if (property === "send") {
+              return async (method: string, params: unknown[]) => {
+                if (
+                  method === "eth_getBlockByNumber" &&
+                  params[0] === "finalized"
+                ) {
+                  return {
+                    number: utils.hexValue(finalizedBlock.number),
+                    hash: constants.HashZero,
+                  }
+                }
+
+                return originalSend(method, params)
+              }
+            }
+
+            const value = Reflect.get(target, property, target)
+            return typeof value === "function" ? value.bind(target) : value
+          },
+        }) as providers.Provider
+
+        await expect(
+          identityHandle(canonicalProvider).activeWalletIdentity()
+        ).to.be.rejectedWith(
+          "Active wallet identity canonical provider did not authenticate its finalized block"
+        )
+      })
+
+      it("should reject a retired wallet from a stale finalized head", async () => {
+        const retiredWalletID = Hex.from(
+          "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        )
+        const retiredWalletPublicKeyHash = BitcoinHashUtils.computeHash160(
+          Hex.from(
+            Buffer.concat([Buffer.from([0x02]), retiredWalletID.toBuffer()])
+          )
+        )
+
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          retiredWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          retiredWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(retiredWalletPublicKeyHash.toPrefixedString())
+          .returns(retiredWalletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(retiredWalletID.toPrefixedString())
+          .returns(retiredWalletPublicKeyHash.toPrefixedString())
+        const retiredWalletBlock = await sourceProvider.getBlock("latest")
+
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+        await bridgeContract.mock.activeWalletID.returns(
+          frostWalletID.toPrefixedString()
+        )
+        await bridgeContract.mock.walletID
+          .withArgs(frostWalletPublicKeyHash.toPrefixedString())
+          .returns(frostWalletID.toPrefixedString())
+        await bridgeContract.mock.walletPubKeyHashForWalletID
+          .withArgs(frostWalletID.toPrefixedString())
+          .returns(frostWalletPublicKeyHash.toPrefixedString())
+
+        const canonicalProvider = new Proxy(sourceProvider, {
+          get(target, property) {
+            if (property === "send") {
+              return async (method: string, params: unknown[]) => {
+                if (
+                  method === "eth_getBlockByNumber" &&
+                  params[0] === "finalized"
+                ) {
+                  return {
+                    number: utils.hexValue(retiredWalletBlock.number),
+                    hash: retiredWalletBlock.hash,
+                  }
+                }
+
+                return originalSend(method, params)
+              }
+            }
+
+            const value = Reflect.get(target, property, target)
+            return typeof value === "function" ? value.bind(target) : value
+          },
+        }) as providers.Provider
+
+        await expect(
+          identityHandle(canonicalProvider).activeWalletIdentity()
+        ).to.be.rejectedWith("Active wallet identity providers disagree")
+      })
+
+      it("should not downgrade when V2 identity selectors are unavailable", async () => {
+        await bridgeContract.mock.activeWalletPubKeyHash.returns(
+          frostWalletPublicKeyHash.toPrefixedString()
+        )
+
+        await expect(
+          identityHandle().activeWalletIdentity()
+        ).to.be.rejectedWith(
+          "could not prove upgraded Bridge wallet-identity selectors"
+        )
       })
     })
 

--- a/typescript/test/services/deposits.test.ts
+++ b/typescript/test/services/deposits.test.ts
@@ -1864,6 +1864,174 @@ describe("Deposits", () => {
     })
 
     describe("initiateMinting", () => {
+      const assertMismatchedFundingTransactionRejected = async (
+        autoDetect: boolean,
+        useDepositorProxy: boolean
+      ) => {
+        const fee = BigNumber.from(1520)
+        const depositFunding = DepositFunding.fromScript(
+          DepositScript.fromReceipt(
+            taprootDepositFixture.receipt,
+            DepositScriptType.P2TR
+          )
+        )
+        const result = await depositFunding.assembleTransaction(
+          BitcoinNetwork.Testnet,
+          depositAmount,
+          [testnetUTXO],
+          fee,
+          testnetPrivateKey
+        )
+
+        const requestedTransaction = Transaction.fromHex(
+          result.rawTransaction.transactionHex
+        )
+        const mismatchedTransaction = requestedTransaction.clone()
+        mismatchedTransaction.version += 1
+
+        expect(mismatchedTransaction.getId()).not.to.equal(
+          result.depositUtxo.transactionHash.toString()
+        )
+
+        const bitcoinClient = new MockBitcoinClient()
+        bitcoinClient.rawTransactions = new Map([
+          [
+            result.depositUtxo.transactionHash.toString(),
+            { transactionHex: mismatchedTransaction.toHex() },
+          ],
+        ])
+
+        if (autoDetect) {
+          bitcoinClient.unspentTransactionOutputs = new Map([
+            [
+              await DepositScript.fromReceipt(
+                taprootDepositFixture.receipt,
+                DepositScriptType.P2TR
+              ).deriveAddress(BitcoinNetwork.Testnet),
+              [result.depositUtxo],
+            ],
+          ])
+        }
+
+        const tbtcContracts = new MockTBTCContracts()
+        const depositorProxy = useDepositorProxy
+          ? new MockDepositorProxy(true)
+          : undefined
+        const deposit = await Deposit.fromReceipt(
+          taprootDepositFixture.receipt,
+          tbtcContracts,
+          bitcoinClient,
+          depositorProxy,
+          DepositScriptType.P2TR
+        )
+
+        await expect(
+          deposit.initiateMinting(autoDetect ? undefined : result.depositUtxo)
+        ).to.be.rejectedWith(
+          "Funding transaction bytes do not match requested transaction hash"
+        )
+        expect(tbtcContracts.bridge.revealDepositLog).to.be.empty
+        if (depositorProxy) {
+          expect(depositorProxy.revealDepositLog).to.be.empty
+        }
+      }
+
+      const assertInvalidDetectedFundingMetadataRejected = async (
+        useDepositorProxy: boolean,
+        invalidField: "outputIndex" | "value"
+      ) => {
+        const fee = BigNumber.from(1520)
+        const depositFunding = DepositFunding.fromScript(
+          DepositScript.fromReceipt(
+            taprootDepositFixture.receipt,
+            DepositScriptType.P2TR
+          )
+        )
+        const result = await depositFunding.assembleTransaction(
+          BitcoinNetwork.Testnet,
+          depositAmount,
+          [testnetUTXO],
+          fee,
+          testnetPrivateKey
+        )
+        const transaction = Transaction.fromHex(
+          result.rawTransaction.transactionHex
+        )
+        const invalidUtxo: BitcoinUtxo = {
+          ...result.depositUtxo,
+          ...(invalidField === "outputIndex"
+            ? { outputIndex: transaction.outs.length }
+            : { value: result.depositUtxo.value.add(1) }),
+        }
+
+        const bitcoinClient = new MockBitcoinClient()
+        bitcoinClient.rawTransactions = new Map([
+          [
+            result.depositUtxo.transactionHash.toString(),
+            result.rawTransaction,
+          ],
+        ])
+        bitcoinClient.unspentTransactionOutputs = new Map([
+          [
+            await DepositScript.fromReceipt(
+              taprootDepositFixture.receipt,
+              DepositScriptType.P2TR
+            ).deriveAddress(BitcoinNetwork.Testnet),
+            [invalidUtxo],
+          ],
+        ])
+
+        const tbtcContracts = new MockTBTCContracts()
+        const depositorProxy = useDepositorProxy
+          ? new MockDepositorProxy(true)
+          : undefined
+        const deposit = await Deposit.fromReceipt(
+          taprootDepositFixture.receipt,
+          tbtcContracts,
+          bitcoinClient,
+          depositorProxy,
+          DepositScriptType.P2TR
+        )
+
+        await expect(deposit.initiateMinting()).to.be.rejectedWith(
+          invalidField === "outputIndex"
+            ? "Funding output index is out of range"
+            : "Funding output value does not match detected UTXO value"
+        )
+        expect(tbtcContracts.bridge.revealDepositLog).to.be.empty
+        if (depositorProxy) {
+          expect(depositorProxy.revealDepositLog).to.be.empty
+        }
+      }
+
+      ;[
+        { autoDetect: true, useDepositorProxy: false },
+        { autoDetect: true, useDepositorProxy: true },
+        { autoDetect: false, useDepositorProxy: false },
+        { autoDetect: false, useDepositorProxy: true },
+      ].forEach(({ autoDetect, useDepositorProxy }) => {
+        it(`should reject mismatched raw transaction bytes before ${
+          useDepositorProxy ? "proxy" : "Bridge"
+        } reveal in ${autoDetect ? "auto" : "manual"} mode`, async () => {
+          await assertMismatchedFundingTransactionRejected(
+            autoDetect,
+            useDepositorProxy
+          )
+        })
+      })
+      ;[false, true].forEach((useDepositorProxy) => {
+        ;(["outputIndex", "value"] as const).forEach((invalidField) => {
+          it(`should reject an auto-detected ${invalidField} mismatch before ${
+            useDepositorProxy ? "proxy" : "Bridge"
+          } reveal`, async () => {
+            await assertInvalidDetectedFundingMetadataRejected(
+              useDepositorProxy,
+              invalidField
+            )
+          })
+        })
+      })
+
       context("auto funding outpoint detection mode", () => {
         context("when no funding UTXOs found", () => {
           let deposit: Deposit
@@ -2551,6 +2719,20 @@ describe("Deposits", () => {
               activeWalletPublicKeyHash
             )
             tbtcContracts.bridge.setActiveWalletID(activeWalletID)
+          })
+
+          it("should reject an unbound active wallet ID before deriving an address", async () => {
+            tbtcContracts.bridge.setActiveWalletID(
+              Hex.from(
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+              )
+            )
+
+            await expect(
+              depositService.initiateTaprootDeposit(taprootRecoveryAddress)
+            ).to.be.rejectedWith(
+              "Active wallet identity is not canonically bound"
+            )
           })
 
           context("when recovery address is not P2TR", () => {

--- a/typescript/test/services/tbtc-wallet-identity-init.test.ts
+++ b/typescript/test/services/tbtc-wallet-identity-init.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai"
+import { providers } from "ethers"
+import {
+  BitcoinNetwork,
+  Chains,
+  EthereumActiveWalletIdentityQuorum,
+  EthereumSigner,
+  TBTC,
+} from "../../src"
+
+type InitializationCall = {
+  ethereumChainID: Chains.Ethereum
+  bitcoinNetwork: BitcoinNetwork
+  crossChainSupport: boolean | EthereumActiveWalletIdentityQuorum
+  activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
+}
+
+class InitializationProbe extends TBTC {
+  static calls: InitializationCall[] = []
+
+  protected static async initializeEthereum(
+    _ethereumSignerOrProvider: EthereumSigner | providers.Provider,
+    ethereumChainID: Chains.Ethereum,
+    bitcoinNetwork: BitcoinNetwork,
+    crossChainSupport: boolean | EthereumActiveWalletIdentityQuorum = false,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
+  ): Promise<TBTC> {
+    this.calls.push({
+      ethereumChainID,
+      bitcoinNetwork,
+      crossChainSupport,
+      activeWalletIdentityQuorum,
+    })
+
+    return {} as TBTC
+  }
+}
+
+describe("TBTC wallet-identity quorum initialization", () => {
+  const primaryProvider = {} as providers.Provider
+  const quorum: EthereumActiveWalletIdentityQuorum = {
+    sourceTrustDomainID: "primary.example",
+    canonicalProvider: {
+      trustDomainID: "canonical.example",
+      provider: {} as providers.Provider,
+    },
+  }
+
+  beforeEach(() => {
+    InitializationProbe.calls = []
+  })
+
+  const expectCall = (
+    ethereumChainID: Chains.Ethereum,
+    bitcoinNetwork: BitcoinNetwork,
+    crossChainSupport: boolean,
+    activeWalletIdentityQuorum?: EthereumActiveWalletIdentityQuorum
+  ) => {
+    expect(InitializationProbe.calls).to.deep.equal([
+      {
+        ethereumChainID,
+        bitcoinNetwork,
+        crossChainSupport,
+        activeWalletIdentityQuorum,
+      },
+    ])
+  }
+
+  it("preserves the legacy mainnet boolean argument", async () => {
+    await InitializationProbe.initializeMainnet(primaryProvider, false)
+
+    expectCall(Chains.Ethereum.Mainnet, BitcoinNetwork.Mainnet, false)
+  })
+
+  it("accepts the mainnet quorum as the second argument", async () => {
+    await InitializationProbe.initializeMainnet(primaryProvider, quorum)
+
+    expectCall(Chains.Ethereum.Mainnet, BitcoinNetwork.Mainnet, false, quorum)
+  })
+
+  it("accepts the mainnet quorum as the third argument", async () => {
+    await InitializationProbe.initializeMainnet(primaryProvider, false, quorum)
+
+    expectCall(Chains.Ethereum.Mainnet, BitcoinNetwork.Mainnet, false, quorum)
+  })
+
+  it("preserves cross-chain support with a mainnet quorum", async () => {
+    await InitializationProbe.initializeMainnet(primaryProvider, true, quorum)
+
+    expectCall(Chains.Ethereum.Mainnet, BitcoinNetwork.Mainnet, true, quorum)
+  })
+
+  it("accepts the Sepolia quorum as the second argument", async () => {
+    await InitializationProbe.initializeSepolia(primaryProvider, quorum)
+
+    expectCall(Chains.Ethereum.Sepolia, BitcoinNetwork.Testnet4, false, quorum)
+  })
+
+  it("preserves cross-chain support with a Sepolia quorum", async () => {
+    await InitializationProbe.initializeSepolia(primaryProvider, true, quorum)
+
+    expectCall(Chains.Ethereum.Sepolia, BitcoinNetwork.Testnet4, true, quorum)
+  })
+})

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -11,6 +11,7 @@ import {
   DepositRevealedEvent,
   DepositRequest,
   TaprootDepositRevealedEvent,
+  ActiveWalletIdentity,
 } from "../../src/lib/contracts"
 import { WalletIDUtils } from "../../src/lib/contracts/wallet-id"
 import {
@@ -434,6 +435,16 @@ export class MockBridge implements Bridge {
 
   async activeWalletPublicKeyHash(): Promise<Hex | undefined> {
     return this._activeWalletPublicKeyHash
+  }
+
+  async activeWalletIdentity(): Promise<ActiveWalletIdentity | undefined> {
+    const walletPublicKeyHash = this._activeWalletPublicKeyHash
+    const walletID = await this.activeWalletID()
+    if (!walletPublicKeyHash || !walletID) {
+      return undefined
+    }
+
+    return { walletPublicKeyHash, walletID }
   }
 
   async activeWalletID(): Promise<Hex | undefined> {


### PR DESCRIPTION
## Summary

- require two independently operated Ethereum views before selecting Bitcoin deposit custody
- authenticate each provider's advertised finalized block and read the complete wallet identity at that provider's own finalized head
- bind the active wallet hash, canonical wallet ID, forward mapping, reverse mapping, and local FROST alias derivation before deriving a deposit address
- authenticate Bitcoin funding transaction bytes, output index, and detected value before direct or proxy reveal
- preserve the existing TBTC initializer boolean API while adding explicit wallet-identity quorum forms

## Security findings addressed

- **C022 — active-wallet identity binding/quorum:** Each provider authenticates its own advertised finalized `{number, hash}` with `getBlock`, then reads `activeWalletPubKeyHash`, `activeWalletID`, `walletID`, and `walletPubKeyHashForWalletID` at that own head. Both fully bound identities must match. A stale provider returning a genuine retired wallet is rejected. The public `activeWalletID` accessor also fails closed when the canonical selector is unavailable instead of synthesizing a legacy alias.
- **C023 — SDK side of scheme-specific deposit scripts:** Every direct, proxy, and cross-chain deposit path uses only the verified active-wallet identity. Legacy deposits reject active FROST wallets, while Taproot deposits require a canonically bound FROST wallet. Missing quorum or V2 selectors stops address derivation without a legacy downgrade.
- **C025 — funding transaction authentication:** Raw funding bytes must match the requested txid and contain the selected output. Auto-detected UTXO values must match the authoritative raw prevout before Bridge or proxy reveal. Existing funding/refund construction uses authenticated prevout values and validates the exact requested fee.

## Verification

- post-rebase `npm run build`: passed, including TypeChain generation and TypeScript build
- post-rebase focused security matrix: **208 passing**
- full SDK suite on the patch-equivalent commit: **965 passing, 63 pending**
- both TypeScript no-emit configurations: passed
- full ESLint and Prettier checks: passed
- stacked `git diff --check`: passed
- `git range-diff` reports the reviewed pre-rebase SDK commit and its rebased security commit as identical
- independent adversarial rereview: passed with no remaining concrete SDK defect
- documentation generation: passed twice with existing warnings; both runs produced the identical API-reference tree hash, and the generated reference is committed as required by CI

## Rollout and stack dependency

This PR is stacked on and depends on #1027. Merge or retarget it only after the wallet/Bridge changes in #1027 are available.

Deposit activation is intentionally fail closed. The deployed Bridge must expose `activeWalletID`, `walletID`, and `walletPubKeyHashForWalletID`, and applications must configure two finalized-capable providers before enabling this SDK version. Otherwise all SDK deposit paths stop before producing an address.

Trust-domain IDs are operator assertions. The SDK normalizes and compares them and rejects the same provider instance, but integrations must still choose providers with genuinely independent infrastructure, administration, and upstream failure domains. Wrapping one provider or using two URLs controlled by the same operator is not an independent quorum.
