### PR TITLE
fix(bridge): gate incomplete P2TR fraud evidence

### DIFF
--- a/solidity/contracts/bridge/P2TRFraudEvidenceProtocol.sol
+++ b/solidity/contracts/bridge/P2TRFraudEvidenceProtocol.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+/// @notice Minimal handshake required before Bridge may activate FROST custody.
+interface IP2TRFraudEvidenceProtocol {
+    function bridge() external view returns (address);
+
+    function evidenceProtocolID() external view returns (bytes32);
+}
+
+/// @notice Version identifiers and strict handshake for P2TR signature-fraud
+///         evidence protocols.
+/// @dev BOUNDED_V1 reconstructs full BIP-341 sighashes subject to finite
+///      transaction-shape limits. It is useful for verification and testing,
+///      but cannot safely protect FROST custody because a valid Bitcoin
+///      transaction can exceed those limits. COMPLETE_V2 is reserved for a
+///      future, reviewed protocol that can adjudicate every valid wallet spend
+///      shape and correlate an accepted spend with the exact BIP-341
+///      authorization being challenged. That correlation must authenticate
+///      witness data through a wtxid proof anchored in the BIP-141 witness
+///      commitment, and separately authenticate authoritative prevout
+///      values/scripts through trusted Bridge state or Bitcoin UTXO evidence.
+///      It must also bind the signed outpoint to the wallet and map every
+///      accepted representation/sighash mode to the challenged authorization.
+///      A txid alone is insufficient because it commits neither witness/annex
+///      data nor the prevout data used by the Taproot sighash.
+///
+///      The protocol ID is a compatibility handshake, not a security
+///      certification. Governance must separately review the router bytecode,
+///      immutability, and evidence construction before activating custody.
+library P2TRFraudEvidenceProtocol {
+    bytes32 internal constant BOUNDED_V1 =
+        keccak256("tbtc/p2tr-signature-fraud/evidence/bounded-v1");
+    bytes32 internal constant COMPLETE_V2 =
+        keccak256("tbtc/p2tr-signature-fraud/evidence/complete-v2");
+
+    error P2TRFraudEvidenceUnavailable();
+
+    /// @notice Requires an exact COMPLETE_V2 handshake bound to the expected
+    ///         Bridge address.
+    /// @dev Absent, reverting, malformed, wrong-Bridge, and bounded routers all
+    ///      fail closed with the same error. Exact 32-byte ABI words are
+    ///      required so fallback data cannot accidentally satisfy the check.
+    function requireCompleteRouter(address router, address expectedBridge)
+        internal
+        view
+    {
+        if (router == address(0)) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        (bool bridgeCallSucceeded, bytes memory bridgeResult) = router
+            .staticcall(
+                abi.encodeWithSelector(
+                    IP2TRFraudEvidenceProtocol.bridge.selector
+                )
+            );
+        if (!bridgeCallSucceeded || bridgeResult.length != 32) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        bytes32 encodedBridge = abi.decode(bridgeResult, (bytes32));
+        if (
+            uint256(encodedBridge) >> 160 != 0 ||
+            address(uint160(uint256(encodedBridge))) != expectedBridge
+        ) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        (bool protocolCallSucceeded, bytes memory protocolResult) = router
+            .staticcall(
+                abi.encodeWithSelector(
+                    IP2TRFraudEvidenceProtocol.evidenceProtocolID.selector
+                )
+            );
+        if (!protocolCallSucceeded || protocolResult.length != 32) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+
+        if (abi.decode(protocolResult, (bytes32)) != COMPLETE_V2) {
+            revert P2TRFraudEvidenceUnavailable();
+        }
+    }
+}

--- a/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
+++ b/solidity/contracts/bridge/P2TRSignatureFraudRouter.sol
@@ -6,8 +6,8 @@ import "./CheckBitcoinBIP341Sighash.sol";
 import "./CheckBitcoinP2TRSignatureFraud.sol";
 import "./Deposit.sol";
 import "./Fraud.sol";
-import "./MovingFunds.sol";
 import "./P2TRSignatureFraud.sol";
+import "./P2TRFraudEvidenceProtocol.sol";
 import "./Wallets.sol";
 
 /// @notice State the P2TR fraud router needs to read from Bridge while
@@ -41,22 +41,10 @@ interface IBridgeForP2TRFraud {
 
     function treasury() external view returns (address);
 
-    function deposits(uint256 depositKey)
-        external
-        view
-        returns (Deposit.DepositRequest memory);
-
     function taprootDepositOutputKeyCommitment(uint256 depositKey)
         external
         view
         returns (bytes32);
-
-    function spentMainUTXOs(uint256 utxoKey) external view returns (bool);
-
-    function movedFundsSweepRequests(uint256 requestKey)
-        external
-        view
-        returns (MovingFunds.MovedFundsSweepRequest memory);
 
     function legacyFraudChallengeExists(uint256 challengeKey)
         external
@@ -228,6 +216,14 @@ contract P2TRSignatureFraudRouter {
         bridge = _bridge;
     }
 
+    /// @notice Identifies the evidence protocol implemented by this router.
+    /// @dev BOUNDED_V1 deliberately must not activate FROST custody. Its finite
+    ///      shape limits leave valid, larger Bitcoin transactions outside the
+    ///      on-chain adjudication boundary.
+    function evidenceProtocolID() public pure virtual returns (bytes32) {
+        return P2TRFraudEvidenceProtocol.BOUNDED_V1;
+    }
+
     /// @notice Accepts ETH + challenge records for legacy P2TR fraud
     ///         challenges migrated from Bridge.
     /// @dev Same contract as ECDSA router's `acceptMigration`. Called
@@ -244,6 +240,7 @@ contract P2TRSignatureFraudRouter {
         uint256[] calldata challengeKeys,
         Fraud.FraudChallenge[] calldata data
     ) external payable {
+        _requireCompleteEvidenceProtocol();
         require(msg.sender == bridge, "Caller is not Bridge");
         require(challengeKeys.length == data.length, "Length mismatch");
 
@@ -292,6 +289,8 @@ contract P2TRSignatureFraudRouter {
         bytes calldata payload,
         uint32[] calldata walletMembersIDs
     ) external payable {
+        _requireCompleteEvidenceProtocol();
+
         require(
             payload.length <= P2TRSignatureFraudMaxPayloadBytes,
             "P2TR payload too large"
@@ -377,44 +376,21 @@ contract P2TRSignatureFraudRouter {
         );
     }
 
+    function _requireCompleteEvidenceProtocol() internal view {
+        if (evidenceProtocolID() != P2TRFraudEvidenceProtocol.COMPLETE_V2) {
+            revert P2TRFraudEvidenceProtocol.P2TRFraudEvidenceUnavailable();
+        }
+    }
+
     function _defeat(
-        CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload
-            memory payload
+        CheckBitcoinP2TRSignatureFraud.BridgeChallengeIdentityPayload memory
     ) internal {
-        IBridgeForP2TRFraud b = IBridgeForP2TRFraud(bridge);
-
-        _validatePayloadShape(payload);
-
-        ChallengeContext memory context = _computeChallengeContext(
-            _resolveWalletPubKeyHash(b, payload.walletID),
-            payload
-        );
-
-        Fraud.FraudChallenge storage challenge = _unresolvedChallenge(
-            context.challengeKey
-        );
-
-        require(
-            _isHonestlySpent(b, _signedInputUtxoKey(payload)),
-            "Spent UTXO not found among correctly spent UTXOs"
-        );
-
-        challenge.resolved = true;
-        _decrementOpenFraudChallengeCount(context.challengeKey);
-
-        address treasury = b.treasury();
-        /* solhint-disable avoid-low-level-calls */
-        // slither-disable-next-line low-level-calls,unchecked-lowlevel,arbitrary-send-eth
-        treasury.call{gas: 100000, value: challenge.depositAmount}("");
-        /* solhint-enable avoid-low-level-calls */
-
-        emit P2TRSignatureFraudChallengeDefeated(
-            payload.walletID,
-            context.walletPubKeyHash,
-            context.bridgeChallengeIdentity,
-            context.challengeKey,
-            context.sighash
-        );
+        // BOUNDED_V1 cannot prove that an accepted Bitcoin authorization is
+        // identical to the challenged BIP-341 authorization. A Bitcoin txid
+        // does not commit witness/annex data or the prevout values and scripts
+        // used by the sighash. Keep defeat fail-closed until COMPLETE_V2
+        // supplies authenticated, authorization-complete evidence.
+        revert P2TRFraudEvidenceProtocol.P2TRFraudEvidenceUnavailable();
     }
 
     function _notifyTimeout(
@@ -541,18 +517,6 @@ contract P2TRSignatureFraudRouter {
             openFraudChallengeCountByWallet[walletPubKeyHash]--;
             delete fraudChallengeWalletPubKeyHash[challengeKey];
         }
-    }
-
-    function _isHonestlySpent(IBridgeForP2TRFraud b, uint256 utxoKey)
-        internal
-        view
-        returns (bool)
-    {
-        return
-            b.deposits(utxoKey).sweptAt > 0 ||
-            b.spentMainUTXOs(utxoKey) ||
-            b.movedFundsSweepRequests(utxoKey).state ==
-            MovingFunds.MovedFundsSweepRequestState.Processed;
     }
 
     /// @dev Deposit inputs verify against their tweaked output key only after

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -22,6 +22,7 @@ import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./BridgeState.sol";
 import "./IBridgeLifecycleRouter.sol";
+import "./P2TRFraudEvidenceProtocol.sol";
 
 /// @notice Minimal interface for the FROST wallet registry's wallet
 ///         creation entry point and lifecycle-owner handshake. The
@@ -270,6 +271,7 @@ library Wallets {
         if (frostWalletRegistry == address(0)) {
             revert FrostWalletRegistryNotSet();
         }
+        requireCompleteP2TRFraudEvidence(self);
         address lifecycleRouter = self.lifecycleRouter;
         if (lifecycleRouter == address(0)) {
             revert LifecycleRouterNotSet();
@@ -437,6 +439,7 @@ library Wallets {
         if (msg.sender != frostWalletRegistry) {
             revert CallerIsNotFrostWalletRegistry();
         }
+        requireCompleteP2TRFraudEvidence(self);
         // Gate FROST wallet creation on both ends of the lifecycle
         // path being wired up. Without a lifecycle router, the
         // wallet's eventual closeWallet/seize/isWalletMember would
@@ -499,6 +502,22 @@ library Wallets {
             xOnlyOutputKey
         );
         emit NewWalletRegisteredV2(walletID, bytes32(0), walletPubKeyHash);
+    }
+
+    /// @notice Requires a complete P2TR fraud-evidence protocol bound to this
+    ///         Bridge before FROST custody can begin.
+    /// @dev Low-level calls deliberately normalize absent, reverting, and
+    ///      malformed implementations to one fail-closed custom error. Exact
+    ///      32-byte ABI words are required so a fallback cannot accidentally
+    ///      satisfy the handshake with trailing or truncated data.
+    function requireCompleteP2TRFraudEvidence(BridgeState.Storage storage self)
+        internal
+        view
+    {
+        P2TRFraudEvidenceProtocol.requireCompleteRouter(
+            self.p2trFraudRouter,
+            address(this)
+        );
     }
 
     /// @notice Derives canonical wallet ID for legacy ECDSA wallets.

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -145,6 +145,22 @@ contract BridgeStub is Bridge {
         self.p2trFraudRouter = router;
     }
 
+    function emitNewFrostWalletRegisteredForTest() external {
+        emit Wallets.NewFrostWalletRegistered(
+            bytes32(uint256(1)),
+            bytes20(uint160(1)),
+            bytes32(uint256(1))
+        );
+    }
+
+    function emitZeroEcdsaWalletRegisteredV2ForTest() external {
+        emit Wallets.NewWalletRegisteredV2(
+            bytes32(uint256(1)),
+            bytes32(0),
+            bytes20(uint160(1))
+        );
+    }
+
     function setLegacyFraudChallengeForTest(
         uint256 challengeKey,
         Fraud.FraudChallenge calldata challenge

--- a/solidity/contracts/test/P2TRFraudEvidenceProtocolStub.sol
+++ b/solidity/contracts/test/P2TRFraudEvidenceProtocolStub.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import "../bridge/P2TRFraudEvidenceProtocol.sol";
+import "../bridge/P2TRSignatureFraudRouter.sol";
+
+/// @notice Handshake-only test stub advertising the reserved future protocol.
+/// @dev This is not a functional COMPLETE_V2 implementation and must never be
+///      deployed as custody protection. It only lets tests exercise Bridge's
+///      strict request/callback compatibility gate.
+contract HandshakeOnlyCompleteP2TRSignatureFraudRouterStub is
+    P2TRSignatureFraudRouter
+{
+    constructor(address bridgeAddress)
+        P2TRSignatureFraudRouter(bridgeAddress)
+    {}
+
+    function evidenceProtocolID() public pure override returns (bytes32) {
+        return P2TRFraudEvidenceProtocol.COMPLETE_V2;
+    }
+}
+
+/// @notice Configurable handshake stub for activation-gate tests.
+contract P2TRFraudEvidenceProtocolStub {
+    address public immutable bridge;
+    bytes32 public immutable evidenceProtocolID;
+
+    constructor(address bridgeAddress, bytes32 protocolID) {
+        bridge = bridgeAddress;
+        evidenceProtocolID = protocolID;
+    }
+}
+
+/// @notice Returns a truncated protocol word to prove strict ABI validation.
+contract MalformedP2TRFraudEvidenceProtocolStub {
+    address public immutable bridge;
+
+    constructor(address bridgeAddress) {
+        bridge = bridgeAddress;
+    }
+
+    function evidenceProtocolID() external pure {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0, 0)
+            return(0, 31)
+        }
+    }
+}

--- a/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
+++ b/solidity/deploy/45_deploy_p2tr_signature_fraud_router.ts
@@ -1,32 +1,241 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
+import { utils } from "ethers"
 
-// Returns a signer for `address` only when that account is configured for the
-// current network. Used to decide whether a governance-gated call can be sent by
-// this deployment, or must instead be emitted as calldata for manual governance
-// execution (the governance owner -- e.g. a Safe -- is not a deployer-controlled
-// signer in production). Mirrors 48_deploy_frost_wallet_registry.
-async function getConfiguredSigner(
+export const BOUNDED_V1_PROTOCOL_ID = utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+)
+export const COMPLETE_V2_PROTOCOL_ID = utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/complete-v2"
+)
+
+const FROST_REGISTRATION_SCAN_PAGE_SIZE = 10000
+
+// Formal storage layout for Bridge at this upgrade boundary:
+// Bridge.self starts at absolute slot 51. Within BridgeState.Storage,
+// frostWalletRegistry is relative slot 32 and p2trFraudRouter is relative slot
+// 34. Reading the proxy slots directly works before the candidate getters are
+// installed and proves both reserved fields are exactly zero.
+export const BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT = 51 + 32
+export const BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT = 51 + 34
+
+export interface FrostCustodyPreflightReceipt {
+  schemaVersion: "tbtc/frost-custody-preflight/v1"
+  networkName: string
+  chainId: string
+  bridge: string
+  snapshotBlockNumber: number
+  snapshotBlockHash: string
+  scanFromBlock: 0
+  scanToBlock: number
+  registrationsFound: 0
+  frostWalletRegistry: string
+  configuredP2TRFraudRouter: string
+  configuredRouterStatus: "unset"
+  frostWalletRegistryStorageSlot: number
+  p2trFraudRouterStorageSlot: number
+  storageLayoutEvidence: "test/formal/Bridge.storage-layout.json"
+}
+
+const requireExactResultLength = (
+  result: string,
+  bytes: number,
+  description: string
+): void => {
+  if (!/^0x[0-9a-fA-F]*$/.test(result) || result.length !== 2 + bytes * 2) {
+    throw new Error(
+      `FROST custody preflight failed: malformed ${description} result`
+    )
+  }
+}
+
+const readBridgePreflightState = async (
   hre: HardhatRuntimeEnvironment,
-  address: string
-) {
-  const configuredAccounts = (await hre.ethers.provider.listAccounts()).map(
-    (account) => account.toLowerCase()
-  )
+  bridgeAddress: string,
+  snapshotBlockNumber: number
+): Promise<{
+  frostWalletRegistry: string
+  configuredP2TRFraudRouter: string
+  configuredRouterStatus: "unset"
+}> => {
+  const { ethers } = hre
 
-  if (!configuredAccounts.includes(address.toLowerCase())) {
-    return undefined
+  const frostWalletRegistryWord = await ethers.provider.getStorageAt(
+    bridgeAddress,
+    BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+    snapshotBlockNumber
+  )
+  requireExactResultLength(
+    frostWalletRegistryWord,
+    32,
+    `Bridge storage slot ${BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT}`
+  )
+  if (frostWalletRegistryWord !== ethers.constants.HashZero) {
+    throw new Error(
+      `FROST custody preflight failed: Bridge frost registry storage slot ${BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT} is non-zero (${frostWalletRegistryWord})`
+    )
   }
 
-  return hre.ethers.getSigner(address)
+  const p2trFraudRouterWord = await ethers.provider.getStorageAt(
+    bridgeAddress,
+    BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+    snapshotBlockNumber
+  )
+  requireExactResultLength(
+    p2trFraudRouterWord,
+    32,
+    `Bridge storage slot ${BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT}`
+  )
+  if (p2trFraudRouterWord !== ethers.constants.HashZero) {
+    throw new Error(
+      `FROST custody preflight failed: Bridge P2TR router storage slot ${BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT} is non-zero (${p2trFraudRouterWord})`
+    )
+  }
+
+  return {
+    frostWalletRegistry: ethers.constants.AddressZero,
+    configuredP2TRFraudRouter: ethers.constants.AddressZero,
+    configuredRouterStatus: "unset",
+  }
 }
+
+const assertNoFrostRegistrationHistory = async (
+  hre: HardhatRuntimeEnvironment,
+  bridgeAddress: string,
+  snapshotBlockNumber: number
+): Promise<void> => {
+  const { ethers } = hre
+  const newFrostWalletRegisteredTopic = ethers.utils.id(
+    "NewFrostWalletRegistered(bytes32,bytes20,bytes32)"
+  )
+  const newWalletRegisteredV2Topic = ethers.utils.id(
+    "NewWalletRegisteredV2(bytes32,bytes32,bytes20)"
+  )
+
+  for (
+    let fromBlock = 0;
+    fromBlock <= snapshotBlockNumber;
+    fromBlock += FROST_REGISTRATION_SCAN_PAGE_SIZE
+  ) {
+    const toBlock = Math.min(
+      snapshotBlockNumber,
+      fromBlock + FROST_REGISTRATION_SCAN_PAGE_SIZE - 1
+    )
+
+    // Both queries are required. NewFrostWalletRegistered covers the current
+    // callback, while the zero-ECDSA V2 marker covers intermediate deployments.
+    // Any provider or decoding failure propagates and aborts the deployment.
+    // eslint-disable-next-line no-await-in-loop
+    const newFrostWalletLogs = await ethers.provider.getLogs({
+      address: bridgeAddress,
+      fromBlock,
+      toBlock,
+      topics: [newFrostWalletRegisteredTopic],
+    })
+    // eslint-disable-next-line no-await-in-loop
+    const zeroEcdsaWalletV2Logs = await ethers.provider.getLogs({
+      address: bridgeAddress,
+      fromBlock,
+      toBlock,
+      topics: [newWalletRegisteredV2Topic, null, ethers.constants.HashZero],
+    })
+
+    if (newFrostWalletLogs.length > 0 || zeroEcdsaWalletV2Logs.length > 0) {
+      const firstLog = newFrostWalletLogs[0] ?? zeroEcdsaWalletV2Logs[0]
+      throw new Error(
+        `FROST custody preflight failed: prior FROST wallet registration at block ${firstLog.blockNumber}`
+      )
+    }
+  }
+}
+
+export const runFrostCustodyPreflight = async (
+  hre: HardhatRuntimeEnvironment,
+  bridgeAddress: string
+): Promise<FrostCustodyPreflightReceipt> => {
+  const snapshotBlockNumber = await hre.ethers.provider.getBlockNumber()
+  const snapshotBlock = await hre.ethers.provider.getBlock(snapshotBlockNumber)
+  if (!snapshotBlock?.hash) {
+    throw new Error(
+      "FROST custody preflight failed: snapshot block has no hash"
+    )
+  }
+
+  const bridgeState = await readBridgePreflightState(
+    hre,
+    bridgeAddress,
+    snapshotBlockNumber
+  )
+  await assertNoFrostRegistrationHistory(
+    hre,
+    bridgeAddress,
+    snapshotBlockNumber
+  )
+
+  const canonicalSnapshot = await hre.ethers.provider.getBlock(
+    snapshotBlockNumber
+  )
+  if (
+    !canonicalSnapshot?.hash ||
+    canonicalSnapshot.hash.toLowerCase() !== snapshotBlock.hash.toLowerCase()
+  ) {
+    throw new Error("FROST custody preflight failed: snapshot block reorged")
+  }
+
+  return {
+    schemaVersion: "tbtc/frost-custody-preflight/v1",
+    networkName: hre.network.name,
+    chainId: await hre.getChainId(),
+    bridge: bridgeAddress,
+    snapshotBlockNumber,
+    snapshotBlockHash: snapshotBlock.hash,
+    scanFromBlock: 0,
+    scanToBlock: snapshotBlockNumber,
+    registrationsFound: 0,
+    frostWalletRegistry: bridgeState.frostWalletRegistry,
+    configuredP2TRFraudRouter: bridgeState.configuredP2TRFraudRouter,
+    configuredRouterStatus: bridgeState.configuredRouterStatus,
+    frostWalletRegistryStorageSlot: BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+    p2trFraudRouterStorageSlot: BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+    storageLayoutEvidence: "test/formal/Bridge.storage-layout.json",
+  }
+}
+
+export const abortLiveBridgeUpgradeWithoutVettedCompleteV2 = async (
+  hre: HardhatRuntimeEnvironment,
+  upgradePath: string
+): Promise<never> => {
+  const Bridge = await hre.deployments.get("Bridge")
+  const receipt = await runFrostCustodyPreflight(hre, Bridge.address)
+
+  // Machine-readable, write-free receipt for operator review. The script
+  // throws immediately afterward, so no deployment or governance calldata is
+  // produced on live/custom networks.
+  console.log(`FROST_CUSTODY_PREFLIGHT_RECEIPT=${JSON.stringify(receipt)}`)
+
+  throw new Error(
+    `NO-GO ${upgradePath}: zero-FROST preflight passed at ${receipt.snapshotBlockNumber}/${receipt.snapshotBlockHash}, ` +
+      "but no vetted immutable COMPLETE_V2 evidence router exists. Do not deploy an implementation, execute a proxy upgrade, or emit governance calldata. " +
+      "The eventual governance operation must atomically validate the vetted router before enabling FROST-only replacement-wallet creation."
+  )
+}
+
+export const isEphemeralLocalNetwork = (networkName: string): boolean =>
+  ["hardhat", "development", "system_tests"].includes(networkName)
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { deployments, helpers, getNamedAccounts, ethers } = hre
-  const { deploy } = deployments
+  const { deploy, save } = deployments
   const { deployer } = await getNamedAccounts()
 
   const Bridge = await deployments.get("Bridge")
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "45_deploy_p2tr_signature_fraud_router"
+    )
+  }
+  const preflightReceipt = await runFrostCustodyPreflight(hre, Bridge.address)
 
   // P2TRSignatureFraudRouter is a plain (non-upgradeable) contract
   // that pins the Bridge address at construction. Sister sidecar to
@@ -38,190 +247,50 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
-  // Wire the router onto the Bridge via the one-time governance setter
-  // `Bridge.setP2TRFraudRouter`. Until this lands, `Bridge.p2trFraudRouter()`
-  // stays `address(0)`, `slashWalletForP2TRFraud` (the router's only privileged
-  // Bridge entry point, gated by `onlyP2TRFraudRouter`) is unreachable, and all
-  // P2TR fraud slashing is dead -- the router is deployed-but-dead until this
-  // call runs. The setter is one-time (reverts `P2TRFraudRouterAlreadySet()`
-  // once set), so this wiring is idempotent and must skip cleanly on re-runs.
-  //
-  // This mirrors the `setFrostWalletRegistry` wiring in
-  // 48_deploy_frost_wallet_registry: read the current Bridge value, send the
-  // setter when the deployer/governance owner is a configured signer, else emit
-  // the exact governance calldata for manual execution, and verify idempotently.
-  const bridgeContract = await ethers.getContractAt("Bridge", Bridge.address)
-  const bridgeGovernance = await ethers.getContractAt(
-    "BridgeGovernance",
-    (
-      await deployments.get("BridgeGovernance")
-    ).address
+  const routerContract = await ethers.getContractAt(
+    "P2TRSignatureFraudRouter",
+    p2trFraudRouter.address
+  )
+  if (
+    (await routerContract.bridge()).toLowerCase() !==
+    Bridge.address.toLowerCase()
+  ) {
+    throw new Error("P2TRSignatureFraudRouter is bound to the wrong Bridge")
+  }
+  if (
+    (await routerContract.evidenceProtocolID()).toLowerCase() !==
+    BOUNDED_V1_PROTOCOL_ID.toLowerCase()
+  ) {
+    throw new Error("Unexpected P2TR fraud evidence protocol ID")
+  }
+
+  // Re-read both reserved slots after the deployment transaction. Governance
+  // ordering requires them to remain zero until an independently reviewed,
+  // immutable COMPLETE_V2 router is available.
+  await readBridgePreflightState(
+    hre,
+    Bridge.address,
+    await ethers.provider.getBlockNumber()
   )
 
-  // Route the setter based on the current `Bridge.governance()`. On a fresh
-  // deploy chain (test/local) `21_transfer_bridge_governance.ts` runs last
-  // (`runAtTheEnd = true`), so this script executes while `Bridge.governance`
-  // is still the `deployer` named account -- the only address that passes
-  // `Bridge.onlyGovernance` in that window (routing through `BridgeGovernance`
-  // there would revert with "Caller is not the governance"). Once governance
-  // has been transferred, `Bridge.governance` is the `BridgeGovernance`
-  // contract and the setter must be routed through its `onlyOwner` wrapper
-  // (production deploys substitute the governance multisig signer there).
-  const currentBridgeGovernance = await bridgeContract.governance()
-  const governanceIsDeployer =
-    currentBridgeGovernance.toLowerCase() === deployer.toLowerCase()
-  const ALREADY_SET_SELECTOR = ethers.utils
-    .id("P2TRFraudRouterAlreadySet()")
-    .slice(0, 10)
+  await save("P2TRSignatureFraudRouter", {
+    ...p2trFraudRouter,
+    linkedData: {
+      ...(p2trFraudRouter.linkedData ?? {}),
+      frostCustodyPreflight: preflightReceipt,
+    },
+  })
 
-  // Idempotency pre-check via the public getter. `setP2TRFraudRouter` is a
-  // one-shot setter, so a re-run must skip cleanly on EVERY governance
-  // configuration -- including a multisig owner that is not a configured
-  // signer, where the wiring is emitted as calldata (not sent) and the
-  // AlreadySet revert path is never reached.
-  //
-  // When preparing the atomic upgrade of an EXISTING Bridge, the proxy is
-  // still on the pre-upgrade implementation, which has no `p2trFraudRouter()`
-  // selector until the governance proposal executes -- so this read reverts
-  // with a CALL_EXCEPTION (the eth_call returns no data to decode). A plain
-  // getter cannot revert for any other reason, so tolerate ONLY that case:
-  // treat the router as unwired and fall through to emit the setter calldata
-  // the operator needs for the upgrade/wiring proposal, rather than aborting
-  // before that branch is reached. Any other error (e.g. an RPC failure)
-  // rethrows so it is not silently swallowed (cf. the blanket-catch regression
-  // fixed in 48_deploy_frost_wallet_registry).
-  let currentP2TRFraudRouter: string
-  let bridgeExposesGetter = true
-  try {
-    currentP2TRFraudRouter = await bridgeContract.p2trFraudRouter()
-  } catch (err) {
-    if ((err as { code?: string }).code !== "CALL_EXCEPTION") {
-      throw err
-    }
-    console.log(
-      "Bridge.p2trFraudRouter() reverted (no such selector on the current " +
-        "Bridge implementation -- pre-upgrade proxy); treating the router as " +
-        "unwired and emitting wiring for the upgrade proposal"
-    )
-    currentP2TRFraudRouter = ethers.constants.AddressZero
-    bridgeExposesGetter = false
-  }
-
-  if (
-    currentP2TRFraudRouter.toLowerCase() ===
-    p2trFraudRouter.address.toLowerCase()
-  ) {
-    console.log(
-      `P2TRSignatureFraudRouter already wired on this Bridge at ${p2trFraudRouter.address}; skipping`
-    )
-  } else if (currentP2TRFraudRouter !== ethers.constants.AddressZero) {
-    throw new Error(
-      "Bridge is already wired to a different P2TRSignatureFraudRouter " +
-        `(${currentP2TRFraudRouter}); refusing to wire ` +
-        `${p2trFraudRouter.address}`
-    )
-  } else {
-    // Resolve the authorized caller. In the governance-wrapper case the setter
-    // is `BridgeGovernance.onlyOwner`, so the call must come from the wrapper
-    // owner -- which post-handoff is the governance multisig, not `deployer`.
-    // When that owner is not a configured signer, emit the calldata for manual
-    // governance execution and skip (mainnet) rather than sending from
-    // `deployer` and reverting.
-    const setterContract = governanceIsDeployer
-      ? bridgeContract
-      : bridgeGovernance
-    const setterCaller = governanceIsDeployer
-      ? deployer
-      : await bridgeGovernance.owner()
-    // A pre-upgrade Bridge has no `setP2TRFraudRouter` selector yet, so the
-    // transaction cannot be sent regardless of who is a configured signer.
-    // Force the calldata-emission path in that case (leave the signer
-    // unresolved) rather than attempting -- and reverting -- the send.
-    const setterSigner = bridgeExposesGetter
-      ? await getConfiguredSigner(hre, setterCaller)
-      : undefined
-
-    if (!setterSigner) {
-      const calldata = setterContract.interface.encodeFunctionData(
-        "setP2TRFraudRouter",
-        [p2trFraudRouter.address]
-      )
-      const reason = !bridgeExposesGetter
-        ? `the Bridge at ${Bridge.address} does not yet expose ` +
-          "setP2TRFraudRouter (pre-upgrade implementation); wire it as part " +
-          "of the upgrade proposal"
-        : `${setterCaller} is not a configured signer for network ${hre.network.name}`
-      const message =
-        `P2TRSignatureFraudRouter wiring must be executed by governance -- ${reason}. ` +
-        "Submit this call from governance:\n" +
-        `  target: ${setterContract.address}\n` +
-        `  data:   ${calldata}`
-
-      // A pre-upgrade Bridge genuinely cannot be wired now on ANY network, so
-      // emit the calldata and continue. Otherwise keep the existing guard:
-      // skip on mainnet (a non-signer governance owner is expected there) and
-      // error elsewhere so an unexpected non-signer is surfaced.
-      if (!bridgeExposesGetter || hre.network.name === "mainnet") {
-        console.log(`${message}\nskipping for manual governance execution`)
-      } else {
-        throw new Error(message)
-      }
-    } else {
-      try {
-        const tx = await setterContract
-          .connect(setterSigner)
-          .setP2TRFraudRouter(p2trFraudRouter.address)
-        await tx.wait(1)
-        console.log(
-          `wired P2TRSignatureFraudRouter at ${
-            p2trFraudRouter.address
-          } onto Bridge ${
-            governanceIsDeployer
-              ? "directly (governance is still deployer)"
-              : "via BridgeGovernance"
-          }`
-        )
-      } catch (err) {
-        // Tolerate only a concurrent deployment that wired the SAME router
-        // between the pre-check read above and this call (AlreadySet revert).
-        const errAny = err as {
-          data?: string
-          error?: { data?: string }
-          message?: string
-        }
-        const revertData =
-          errAny.data || errAny.error?.data || errAny.message || ""
-        if (
-          typeof revertData === "string" &&
-          revertData.toLowerCase().includes(ALREADY_SET_SELECTOR.toLowerCase())
-        ) {
-          console.log(
-            "P2TRSignatureFraudRouter already wired on this Bridge; skipping"
-          )
-        } else {
-          console.error(
-            "setP2TRFraudRouter call reverted with an unexpected error;",
-            "deploy aborted so the operator can investigate:",
-            errAny.message || err
-          )
-          throw err
-        }
-      }
-
-      // Idempotent post-check: assert the on-chain value now reflects this
-      // router. Only meaningful when the setter was actually sent; the
-      // calldata-emit path skips before reaching here. Also catches a
-      // concurrent deploy that wired a DIFFERENT router (AlreadySet caught
-      // above) between the pre-check and this send.
-      const wiredRouter = await bridgeContract.p2trFraudRouter()
-      if (wiredRouter.toLowerCase() !== p2trFraudRouter.address.toLowerCase()) {
-        throw new Error(
-          "Bridge.p2trFraudRouter mismatch after deploy: " +
-            `expected ${p2trFraudRouter.address}, got ${wiredRouter}`
-        )
-      }
-    }
-  }
+  // NO-GO: BOUNDED_V1 cannot adjudicate every valid Bitcoin transaction
+  // shape, so wiring it would make an unchallengeable FROST spend possible.
+  // Do not call the one-shot setter and do not emit governance calldata. The
+  // slot must remain available for a future COMPLETE_V2 implementation.
+  console.log(
+    `NO-GO: deployed bounded P2TR fraud router ${p2trFraudRouter.address}; ` +
+      "leaving Bridge.p2trFraudRouter unset. Zero-FROST receipt: " +
+      `${preflightReceipt.snapshotBlockNumber}/${preflightReceipt.snapshotBlockHash}. ` +
+      "Do not upgrade this Bridge until a vetted immutable COMPLETE_V2 router exists."
+  )
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(p2trFraudRouter)
@@ -238,4 +307,4 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 export default func
 
 func.tags = ["P2TRSignatureFraudRouter"]
-func.dependencies = ["Bridge", "BridgeGovernance"]
+func.dependencies = ["FrostCustodyNoGo", "Bridge", "BridgeGovernance"]

--- a/solidity/deploy/47_assert_frost_custody_no_go.ts
+++ b/solidity/deploy/47_assert_frost_custody_no_go.ts
@@ -1,0 +1,23 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
+
+/// @notice Write-free guard placed first in every FROST deployment dependency
+///         chain. Live/custom networks fail before FROST dependencies deploy.
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  if (isEphemeralLocalNetwork(hre.network.name)) {
+    return
+  }
+
+  await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+    hre,
+    "47_assert_frost_custody_no_go"
+  )
+}
+
+export default func
+
+func.tags = ["FrostCustodyNoGo"]

--- a/solidity/deploy/48_deploy_frost_wallet_registry.ts
+++ b/solidity/deploy/48_deploy_frost_wallet_registry.ts
@@ -1,5 +1,9 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 // Returns a signer for `address` only when that account is configured for the
 // current network. Used to decide whether a governance-gated call can be sent by
@@ -24,6 +28,13 @@ async function getConfiguredSigner(
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { getNamedAccounts, deployments, ethers, helpers } = hre
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "48_deploy_frost_wallet_registry"
+    )
+  }
 
   const FrostSortitionPool = await deployments.get("FrostSortitionPool")
   const ReimbursementPool = await deployments.get("ReimbursementPool")
@@ -354,6 +365,7 @@ export default func
 
 func.tags = ["FrostWalletRegistry"]
 func.dependencies = [
+  "FrostCustodyNoGo",
   "Bridge",
   "BridgeGovernance",
   "FrostSortitionPool",

--- a/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
+++ b/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
@@ -16,11 +16,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, deployments, getNamedAccounts } = hre
   const { get } = deployments
   const { deployer, treasury } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "80_upgrade_bridge_v2_DEPRECATED"
+    )
+  }
 
   const Bank = await deployments.get("Bank")
   const LightRelay = await deployments.get("LightRelay")
@@ -147,6 +158,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["UpgradeBridge"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Set UPGRADE_BRIDGE=true when running an upgrade.
 // yarn deploy --tags UpgradeBridge --network <NETWORK>
 func.skip = async () => process.env.UPGRADE_BRIDGE !== "true"

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs.ts
@@ -2,11 +2,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, helpers, deployments, getNamedAccounts } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "82_deploy_rebate_and_prepare_txs"
+    )
+  }
 
   console.log("\n========== REBATE DEPLOYMENT STARTING ==========")
   console.log("Network:", hre.network.name)
@@ -446,6 +457,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployRebateAndPrepareTxs"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Dependencies remain removed so standalone live-network execution does not
-// rerun the full Bridge deployment chain.
+// rerun the full Bridge deployment chain. The write-free NO-GO dependency is
+// the sole exception and aborts non-ephemeral networks before this function.
 // func.dependencies = ["Bridge", "BridgeGovernance"]

--- a/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
+++ b/solidity/deploy/84_upgrade_bridge_c2_1_counter.ts
@@ -1,5 +1,9 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 /// Phase C-2.1a upgrade script — deploys the current versions of all
 /// external libraries linked by `Bridge` and upgrades the proxy using
@@ -19,6 +23,13 @@ const func: DeployFunction = async function upgradeBridgeC21Counter(
   const { ethers, helpers, deployments, getNamedAccounts } = hre
   const { get, deploy, log } = deployments
   const { deployer, treasury } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "84_upgrade_bridge_c2_1_counter"
+    )
+  }
 
   const Bank = await get("Bank")
   const LightRelay = await get("LightRelay")
@@ -133,6 +144,7 @@ const func: DeployFunction = async function upgradeBridgeC21Counter(
 export default func
 
 func.tags = ["UpgradeBridgeC21Counter"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Off by default. To run, set the environment variable
 // `RUN_UPGRADE_C2_1_COUNTER=1` and invoke:
 //

--- a/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
+++ b/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
@@ -19,11 +19,22 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 import fs from "fs"
 import path from "path"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, deployments, getNamedAccounts, upgrades } = hre
   const { get, log } = deployments
   const { deployer } = await getNamedAccounts()
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "84_upgrade_bridge_repair_rebate_staking_DEPRECATED"
+    )
+  }
 
   const repairTarget =
     process.env.REBATE_STAKING_REPAIR_TARGET ?? ethers.constants.AddressZero
@@ -151,4 +162,5 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["RepairBridgeRebateStaking"]
+func.dependencies = ["FrostCustodyNoGo"]
 func.skip = async () => process.env.REPAIR_BRIDGE_REBATE_STAKING !== "true"

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -4,6 +4,10 @@ import https from "https"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
 import { utils } from "ethers"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 // EIP-1967 transparent proxy admin storage slot. Defined by the standard
 // at https://eips.ethereum.org/EIPS/eip-1967#admin-address and used to
@@ -303,6 +307,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy, get } = deployments
   const { deployer } = await getNamedAccounts()
   const { ethers } = hre
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "85_deploy_tip109_governance_upgrade"
+    )
+  }
 
   const deployOptions: DeployOptions = {
     from: deployer,
@@ -707,6 +718,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployTIP109GovernanceUpgrade"]
+func.dependencies = ["FrostCustodyNoGo"]
 // Set DEPLOY_TIP109=true when running the deployment.
 // yarn deploy --tags DeployTIP109GovernanceUpgrade --network <NETWORK>
 func.skip = async () => process.env.DEPLOY_TIP109 !== "true"

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -11,6 +11,10 @@ import {
   KNOWN_TIMELOCK,
   KNOWN_COUNCIL_SAFE,
 } from "./85_deploy_tip109_governance_upgrade"
+import {
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+} from "./45_deploy_p2tr_signature_fraud_router"
 
 const PROXY_ADMIN_ABI = [
   "function upgrade(address proxy, address implementation)",
@@ -91,6 +95,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy, get, save } = deployments
   const { deployer } = await getNamedAccounts()
   const { ethers } = hre
+
+  if (!isEphemeralLocalNetwork(hre.network.name)) {
+    await abortLiveBridgeUpgradeWithoutVettedCompleteV2(
+      hre,
+      "86_deploy_tip109_hotfix"
+    )
+  }
 
   // Patch ethers.js v5 Formatter to handle empty-string `to` field returned
   // by some RPC providers for contract-creation transactions. Without this
@@ -434,4 +445,5 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["DeployTIP109Hotfix"]
+func.dependencies = ["FrostCustodyNoGo"]
 func.skip = async () => process.env.DEPLOY_TIP109_HOTFIX !== "true"

--- a/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
+++ b/solidity/test/bridge/Bridge.FrostWalletRegistration.test.ts
@@ -28,6 +28,44 @@ const { lastBlockTime } = helpers.time
 // must be structurally distinguishable from a left-padded legacy alias.
 const frostXOnlyOutputKey =
   "0xb1de1afa17e1cbb20d8a4f8e54f8a55fbf5c8d2da9e1c6c4d1f0c7b3a2e5d4c8"
+const boundedEvidenceProtocolID = ethers.utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+)
+const completeEvidenceProtocolID = ethers.utils.id(
+  "tbtc/p2tr-signature-fraud/evidence/complete-v2"
+)
+
+async function deployBoundedP2TRFraudRouter(
+  bridgeAddress: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory("P2TRSignatureFraudRouter")
+  const router = await factory.deploy(bridgeAddress)
+  await router.deployed()
+  return router.address
+}
+
+async function deployEvidenceProtocolStub(
+  bridgeAddress: string,
+  protocolID: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory(
+    "P2TRFraudEvidenceProtocolStub"
+  )
+  const router = await factory.deploy(bridgeAddress, protocolID)
+  await router.deployed()
+  return router.address
+}
+
+async function deployMalformedEvidenceProtocolStub(
+  bridgeAddress: string
+): Promise<string> {
+  const factory = await ethers.getContractFactory(
+    "MalformedP2TRFraudEvidenceProtocolStub"
+  )
+  const router = await factory.deploy(bridgeAddress)
+  await router.deployed()
+  return router.address
+}
 
 // Local helper: assert a transaction reverts with a specific no-arg
 // custom error. The project's test toolchain (hardhat-waffle 2.x +
@@ -70,6 +108,24 @@ async function expectCustomError(
   throw new Error(
     `expected revert with custom error ${errorName} but tx succeeded`
   )
+}
+
+async function expectFrostActivationRejectedWithoutStateChanges(
+  bridge: Bridge & BridgeStub,
+  action: () => Promise<unknown>
+): Promise<void> {
+  const activeWalletPubKeyHash = await bridge.activeWalletPubKeyHash()
+  const activeWalletID = await bridge.activeWalletID()
+  const liveWalletsCount = await bridge.liveWalletsCount()
+
+  await expectCustomError(action(), "P2TRFraudEvidenceUnavailable")
+
+  expect(await bridge.activeWalletPubKeyHash()).to.equal(activeWalletPubKeyHash)
+  expect(await bridge.activeWalletID()).to.equal(activeWalletID)
+  expect(await bridge.liveWalletsCount()).to.equal(liveWalletsCount)
+  expect(
+    await bridge.walletPubKeyHashForWalletID(frostXOnlyOutputKey)
+  ).to.equal(ethers.constants.AddressZero)
 }
 
 describe("Bridge - FROST Wallet Registration", () => {
@@ -215,6 +271,57 @@ describe("Bridge - FROST Wallet Registration", () => {
       await restoreSnapshot()
     })
 
+    it("should fail closed before DKG when the router is unset without changing state", async () => {
+      await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject the bounded V1 router before DKG", async () => {
+      const routerAddress = await deployBoundedP2TRFraudRouter(bridge.address)
+      const router = await ethers.getContractAt(
+        "P2TRSignatureFraudRouter",
+        routerAddress
+      )
+      expect(await router.evidenceProtocolID()).to.equal(
+        boundedEvidenceProtocolID
+      )
+      await bridge.resetP2TRFraudRouterForTest(routerAddress)
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject malformed protocol data before DKG", async () => {
+      await bridge.resetP2TRFraudRouterForTest(
+        await deployMalformedEvidenceProtocolStub(bridge.address)
+      )
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
+    it("should reject a complete protocol bound to another Bridge before DKG", async () => {
+      await bridge.resetP2TRFraudRouterForTest(
+        await deployEvidenceProtocolStub(
+          thirdParty.address,
+          completeEvidenceProtocolID
+        )
+      )
+
+      await expectFrostActivationRejectedWithoutStateChanges(bridge, async () =>
+        bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
+      )
+      expect(await frostRegistry.requestNewWalletCalled()).to.equal(false)
+    })
+
     it("should fail before DKG when lifecycle router is unset", async () => {
       await bridge.resetLifecycleRouterForTest(ethers.constants.AddressZero)
       await frostRegistry.setLifecycleOwner(thirdParty.address)
@@ -238,6 +345,14 @@ describe("Bridge - FROST Wallet Registration", () => {
 
     it("should dispatch when registry lifecycle owner matches Bridge lifecycle router", async () => {
       await frostRegistry.setLifecycleOwner(thirdParty.address)
+
+      const router = await ethers.getContractAt(
+        "P2TRSignatureFraudRouter",
+        await bridge.p2trFraudRouter()
+      )
+      expect(await router.evidenceProtocolID()).to.equal(
+        completeEvidenceProtocolID
+      )
 
       await expect(
         bridge.connect(thirdParty).requestNewWallet(NO_MAIN_UTXO)
@@ -280,6 +395,63 @@ describe("Bridge - FROST Wallet Registration", () => {
               .__frostWalletCreatedCallback(frostXOnlyOutputKey),
             "CallerIsNotFrostWalletRegistry"
           ))
+      })
+
+      context("when complete P2TR fraud evidence is unavailable", () => {
+        beforeEach(async () => {
+          await createSnapshot()
+        })
+
+        afterEach(async () => {
+          await restoreSnapshot()
+        })
+
+        const callRegistration = async () =>
+          frostRegistry.callBridgeFrostWalletCreatedCallback(
+            bridge.address,
+            frostXOnlyOutputKey
+          )
+
+        it("should reject an unset router without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject bounded V1 without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployBoundedP2TRFraudRouter(bridge.address)
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject malformed protocol data without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployMalformedEvidenceProtocolStub(bridge.address)
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
+
+        it("should reject a protocol bound to another Bridge without registering a Live wallet", async () => {
+          await bridge.resetP2TRFraudRouterForTest(
+            await deployEvidenceProtocolStub(
+              thirdParty.address,
+              completeEvidenceProtocolID
+            )
+          )
+          await expectFrostActivationRejectedWithoutStateChanges(
+            bridge,
+            callRegistration
+          )
+        })
       })
 
       context(
@@ -339,6 +511,13 @@ describe("Bridge - FROST Wallet Registration", () => {
 
         before(async () => {
           await createSnapshot()
+          const router = await ethers.getContractAt(
+            "P2TRSignatureFraudRouter",
+            await bridge.p2trFraudRouter()
+          )
+          expect(await router.evidenceProtocolID()).to.equal(
+            completeEvidenceProtocolID
+          )
           tx = await frostRegistry.callBridgeFrostWalletCreatedCallback(
             bridge.address,
             frostXOnlyOutputKey
@@ -626,6 +805,30 @@ describe("Bridge - FROST Wallet Registration", () => {
           ecdsaWalletTestData.walletID,
           ecdsaWalletTestData.pubKeyHash160
         )
+    })
+  })
+
+  describe("ECDSA registration while P2TR evidence is unavailable", () => {
+    before(async () => {
+      await createSnapshot()
+      await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+      await bridge
+        .connect(walletRegistry.wallet)
+        .__ecdsaWalletCreatedCallback(
+          ecdsaWalletTestData.walletID,
+          ecdsaWalletTestData.publicKeyX,
+          ecdsaWalletTestData.publicKeyY
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should preserve the legacy ECDSA callback path", async () => {
+      const wallet = await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)
+      expect(wallet.ecdsaWalletID).to.equal(ecdsaWalletTestData.walletID)
+      expect(wallet.state).to.equal(walletState.Live)
     })
   })
 

--- a/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
+++ b/solidity/test/bridge/Bridge.LegacyFraudMigration.test.ts
@@ -18,6 +18,28 @@ import { constants, walletState } from "../fixtures"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
+const expectCustomError = async (
+  promise: Promise<unknown>,
+  errorName: string
+): Promise<void> => {
+  const selector = ethers.utils.id(`${errorName}()`).slice(0, 10)
+
+  try {
+    await promise
+    expect.fail(`expected ${errorName}`)
+  } catch (error) {
+    const errorData = error as {
+      data?: string
+      error?: { data?: string }
+      message?: string
+    }
+    const data = errorData.data ?? errorData.error?.data ?? ""
+    expect(`${data} ${errorData.message ?? ""}`.toLowerCase()).to.include(
+      selector.toLowerCase()
+    )
+  }
+}
+
 describe("Bridge - legacy fraud challenge migration", () => {
   let deployer: SignerWithAddress
   let governance: SignerWithAddress
@@ -260,7 +282,7 @@ describe("Bridge - legacy fraud challenge migration", () => {
     expect(await ecdsaFraudRouter.openFraudChallengeCount()).to.equal(0)
   })
 
-  it("routes P2TR records only to the P2TR router", async () => {
+  it("routes P2TR records only to the handshake-only P2TR test stub", async () => {
     const key = 201
     const deposit = ethers.utils.parseEther("0.25")
     await seedChallenge(key, deposit)
@@ -380,7 +402,10 @@ describe("Bridge - legacy fraud challenge migration", () => {
     )
   })
 
-  for (const routerName of ["EcdsaFraudRouter", "P2TRSignatureFraudRouter"]) {
+  for (const routerName of [
+    "EcdsaFraudRouter",
+    "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+  ]) {
     it(`${routerName} rejects resolved migration records`, async () => {
       const factory = await ethers.getContractFactory(routerName, deployer)
       const router = await factory.deploy(thirdParty.address)
@@ -403,4 +428,20 @@ describe("Bridge - legacy fraud challenge migration", () => {
       ).to.be.revertedWith("Challenge already resolved")
     })
   }
+
+  it("keeps production BOUNDED_V1 migration dormant", async () => {
+    const factory = await ethers.getContractFactory(
+      "P2TRSignatureFraudRouter",
+      deployer
+    )
+    const router = await factory.deploy(thirdParty.address)
+    await router.deployed()
+
+    await expectCustomError(
+      router.connect(thirdParty).acceptMigration([], []),
+      "P2TRFraudEvidenceUnavailable"
+    )
+    expect(await router.openFraudChallengeCount()).to.equal(0)
+    expect(await ethers.provider.getBalance(router.address)).to.equal(0)
+  })
 })

--- a/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
+++ b/solidity/test/bridge/Bridge.P2TRFrauds.test.ts
@@ -36,6 +36,7 @@ type PrevoutVector = {
 
 type SignatureFraudVector = {
   id: string
+  annexHex?: string
   walletIDHex: string
   unsignedTransactionHex: string
   signedInputIndex: number
@@ -333,6 +334,7 @@ async function expectBalanceDelta(
 
 describe("Bridge - P2TR signature fraud", () => {
   const vectorCorpus = loadVectorCorpus()
+  const fullSighashVectorCorpus = loadVectorCorpus(fullSighashVectorCorpusPath)
   const vector = vectorCorpus.cases[0]
   const multiInputVector = vectorCorpus.cases.find(
     ({ id }) => id === "bip341-keypath-sighash-default-multi-input-multi-output"
@@ -340,9 +342,15 @@ describe("Bridge - P2TR signature fraud", () => {
   const distinctWalletVector = vectorCorpus.cases.find(
     ({ walletIDHex }) => walletIDHex !== vector.walletIDHex
   )
-  const sighashNoneVector = loadVectorCorpus(
-    fullSighashVectorCorpusPath
-  ).cases.find(({ id }) => id === "bip341-keypath-none-multi")!
+  const sighashNoneVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-none-multi"
+  )!
+  const annexVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-default-with-annex"
+  )!
+  const noAnnexVector = fullSighashVectorCorpus.cases.find(
+    ({ id }) => id === "bip341-keypath-default-multi"
+  )!
   if (!distinctWalletVector) {
     throw new Error("P2TR fraud vector corpus needs two distinct wallets")
   }
@@ -515,6 +523,49 @@ describe("Bridge - P2TR signature fraud", () => {
       await p2trFraudRouter.hasOpenFraudChallengeForWallet(walletPubKeyHash)
     ).to.equal(expectedWalletCount > 0 || expectedUnattributedCount > 0)
   }
+
+  it("keeps the production BOUNDED_V1 lifecycle and migration completely dormant", async () => {
+    const factory = await ethers.getContractFactory("P2TRSignatureFraudRouter")
+    const boundedRouter = (await factory.deploy(
+      bridge.address
+    )) as P2TRSignatureFraudRouter
+    await boundedRouter.deployed()
+
+    expect(await boundedRouter.evidenceProtocolID()).to.equal(
+      ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes(
+          "tbtc/p2tr-signature-fraud/evidence/bounded-v1"
+        )
+      )
+    )
+
+    const encodedPayload = encodePayload(vectorPayload(vector))
+    for (const action of [
+      p2trFraudAction.Submit,
+      p2trFraudAction.Defeat,
+      p2trFraudAction.Timeout,
+    ]) {
+      await expectCustomError(
+        boundedRouter
+          .connect(thirdParty)
+          .processP2TRSignatureFraudChallenge(action, encodedPayload, [], {
+            value:
+              action === p2trFraudAction.Submit
+                ? fraudChallengeDepositAmount
+                : 0,
+          }),
+        "P2TRFraudEvidenceUnavailable"
+      )
+    }
+
+    await expectCustomError(
+      boundedRouter.connect(thirdParty).acceptMigration([], []),
+      "P2TRFraudEvidenceUnavailable"
+    )
+
+    expect(await boundedRouter.openFraudChallengeCount()).to.equal(0)
+    expect(await ethers.provider.getBalance(boundedRouter.address)).to.equal(0)
+  })
 
   it("submits and stores a P2TR signature-fraud challenge", async () => {
     const payload = vectorPayload(vector)
@@ -791,6 +842,30 @@ describe("Bridge - P2TR signature fraud", () => {
           { value: fraudChallengeDepositAmount }
         )
     ).to.be.revertedWith("Fraud challenge already exists")
+  })
+
+  it("treats the same txid with different annex authorization as distinct evidence", async () => {
+    expect(annexVector.unsignedTransactionHex).to.equal(
+      noAnnexVector.unsignedTransactionHex
+    )
+
+    const noAnnexPayload = vectorPayload(noAnnexVector)
+    const annexPayload = vectorPayload(annexVector, {
+      annexHex: hex(annexVector.annexHex!),
+    })
+    const walletPubKeyHash = await registerP2TRWallet(noAnnexPayload.walletID)
+
+    const first = await submitChallenge(noAnnexPayload, noAnnexVector)
+    const second = await submitChallenge(annexPayload, annexVector)
+
+    expect(first.challengeKey).to.not.equal(second.challengeKey)
+    expect(
+      (await p2trFraudRouter.fraudChallenges(first.challengeKey)).reportedAt
+    ).to.be.greaterThan(0)
+    expect(
+      (await p2trFraudRouter.fraudChallenges(second.challengeKey)).reportedAt
+    ).to.be.greaterThan(0)
+    await expectChallengeCounters(walletPubKeyHash, 2, 0, 2)
   })
 
   it("blocks public evidence from pre-seeding a legacy P2TR migration key", async () => {
@@ -1173,58 +1248,71 @@ describe("Bridge - P2TR signature fraud", () => {
   ]
 
   for (const scenario of honestSpendDefeatScenarios) {
-    it(`defeats a P2TR challenge after the signed input is a ${scenario.name}`, async () => {
+    it(`keeps authorization-incomplete defeat fail-closed after the signed input is a ${scenario.name}`, async () => {
       const payload = vectorPayload(vector)
       const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
-      const { challengeKey, bridgeChallengeIdentity } = await submitChallenge(
-        payload
-      )
+      const { challengeKey } = await submitChallenge(payload)
 
       await scenario.markHonestSpend(payload, walletPubKeyHash)
 
-      const tx = await p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Defeat,
-          encodePayload(payload),
-          []
-        )
-
-      await expectBalanceDelta(tx, treasury, fraudChallengeDepositAmount)
-
-      expect((await p2trFraudRouter.fraudChallenges(challengeKey)).resolved).to
-        .be.true
-      await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
-
-      const event = await findP2TREvent(
-        tx,
-        p2trFraudRouter.address,
-        "P2TRSignatureFraudChallengeDefeated"
+      await expectCustomError(
+        p2trFraudRouter
+          .connect(thirdParty)
+          .processP2TRSignatureFraudChallenge(
+            p2trFraudAction.Defeat,
+            encodePayload(payload),
+            []
+          ),
+        "P2TRFraudEvidenceUnavailable"
       )
-      expect(event.args.walletID).to.equal(payload.walletID)
-      expect(event.args.walletPubKeyHash).to.equal(walletPubKeyHash)
-      expect(event.args.bridgeChallengeIdentity).to.equal(
-        bridgeChallengeIdentity
-      )
-      expect(event.args.challengeKey).to.equal(challengeKey)
-      expect(event.args.sighash).to.equal(hex(vector.expectedBip341SighashHex))
+
+      expect(
+        (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+      ).to.equal(false)
+      await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
     })
   }
 
-  it("rejects P2TR defeat before the signed input is proven honestly spent", async () => {
-    const payload = vectorPayload(vector)
-    await registerP2TRWallet(payload.walletID)
-    await submitChallenge(payload)
+  it("keeps defeat fail-closed for a valid annex authorization", async () => {
+    const payload = vectorPayload(annexVector, {
+      annexHex: hex(annexVector.annexHex!),
+    })
+    const walletPubKeyHash = await registerP2TRWallet(payload.walletID)
+    const { challengeKey } = await submitChallenge(payload, annexVector)
 
-    await expect(
+    await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
+
+    expect(
+      (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+    ).to.equal(false)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+  })
+
+  it("rejects P2TR defeat before the signed input is proven honestly spent", async () => {
+    const payload = vectorPayload(vector)
+    await registerP2TRWallet(payload.walletID)
+    await submitChallenge(payload)
+
+    await expectCustomError(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Defeat,
+          encodePayload(payload),
+          []
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
   })
 
   it("rejects P2TR defeat when only a different outpoint is proven honestly spent", async () => {
@@ -1240,15 +1328,16 @@ describe("Bridge - P2TR signature fraud", () => {
       },
     ])
 
-    await expect(
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
   })
 
   const movedFundsNonDefeatScenarios: {
@@ -1288,15 +1377,16 @@ describe("Bridge - P2TR signature fraud", () => {
 
       await scenario.markMovedFundsRequest(payload, walletPubKeyHash)
 
-      await expect(
+      await expectCustomError(
         p2trFraudRouter
           .connect(thirdParty)
           .processP2TRSignatureFraudChallenge(
             p2trFraudAction.Defeat,
             encodePayload(payload),
             []
-          )
-      ).to.be.revertedWith("Spent UTXO not found among correctly spent UTXOs")
+          ),
+        "P2TRFraudEvidenceUnavailable"
+      )
     })
   }
 
@@ -1393,35 +1483,42 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
   })
 
-  it("allows FROST wallet closure after its P2TR challenge is defeated", async () => {
+  it("does not let an outpoint-only honest-spend marker defeat a challenge", async () => {
     const payload = vectorPayload(vector)
     const remainingClosingTime = Math.floor(fraudChallengeDefeatTimeout / 2)
     const walletPubKeyHash = await registerClosingFrostWallet(
       vector,
       remainingClosingTime
     )
-    await submitChallenge(payload)
+    const { challengeKey } = await submitChallenge(payload)
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-    await p2trFraudRouter
-      .connect(thirdParty)
-      .processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodePayload(payload),
-        []
-      )
-    await expectChallengeCounters(walletPubKeyHash, 0, 0, 0)
+    await expectCustomError(
+      p2trFraudRouter
+        .connect(thirdParty)
+        .processP2TRSignatureFraudChallenge(
+          p2trFraudAction.Defeat,
+          encodePayload(payload),
+          []
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
+    expect(
+      (await p2trFraudRouter.fraudChallenges(challengeKey)).resolved
+    ).to.equal(false)
+    await expectChallengeCounters(walletPubKeyHash, 1, 0, 1)
+
     await increaseTime(remainingClosingTime)
 
-    await bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash)
+    await expectCustomError(
+      bridge.notifyWalletClosingPeriodElapsed(walletPubKeyHash),
+      "P2TRFraudChallengePending"
+    )
 
     expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
-      walletState.Closed
+      walletState.Closing
     )
-    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(true)
-    expect(await frostWalletRegistry.lastClosedWalletID()).to.equal(
-      payload.walletID
-    )
+    expect(await frostWalletRegistry.closeWalletCalled()).to.equal(false)
   })
 
   it("allows an unrelated FROST wallet to close while a P2TR challenge is open", async () => {
@@ -1625,43 +1722,6 @@ describe("Bridge - P2TR signature fraud", () => {
     expect(event.args.sighash).to.equal(hex(vector.expectedBip341SighashHex))
   })
 
-  it("rejects later P2TR timeout or defeat after an honest-spend defeat", async () => {
-    const payload = vectorPayload(vector)
-    await registerP2TRWallet(payload.walletID)
-    await submitChallenge(payload)
-
-    await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-    await p2trFraudRouter
-      .connect(thirdParty)
-      .processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodePayload(payload),
-        []
-      )
-
-    await increaseTime(fraudChallengeDefeatTimeout)
-
-    await expect(
-      p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Timeout,
-          encodePayload(payload),
-          [1, 2, 3]
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
-
-    await expect(
-      p2trFraudRouter
-        .connect(thirdParty)
-        .processP2TRSignatureFraudChallenge(
-          p2trFraudAction.Defeat,
-          encodePayload(payload),
-          []
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
-  })
-
   it("rejects later P2TR defeat or repeated timeout after timeout resolution", async () => {
     const payload = vectorPayload(vector)
     await registerP2TRWallet(payload.walletID)
@@ -1678,15 +1738,16 @@ describe("Bridge - P2TR signature fraud", () => {
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
 
-    await expect(
+    await expectCustomError(
       p2trFraudRouter
         .connect(thirdParty)
         .processP2TRSignatureFraudChallenge(
           p2trFraudAction.Defeat,
           encodePayload(payload),
           []
-        )
-    ).to.be.revertedWith("Fraud challenge has already been resolved")
+        ),
+      "P2TRFraudEvidenceUnavailable"
+    )
 
     await expect(
       p2trFraudRouter
@@ -1713,17 +1774,9 @@ describe("Bridge - P2TR signature fraud", () => {
         { value: fraudChallengeDepositAmount }
       )
 
-    const { challengeKey } = await submitChallenge(payload)
+    await submitChallenge(payload)
 
     await bridge.setSpentMainUtxos([signedInputUtxo(payload)])
-
-    const defeatGas = await p2trFraudRouter
-      .connect(thirdParty)
-      .estimateGas.processP2TRSignatureFraudChallenge(
-        p2trFraudAction.Defeat,
-        encodedPayload,
-        []
-      )
 
     await increaseTime(fraudChallengeDefeatTimeout)
 
@@ -1738,12 +1791,9 @@ describe("Bridge - P2TR signature fraud", () => {
     // eslint-disable-next-line no-console
     console.log(`p2tr_submitChallenge_gas=${submitGas.toString()}`)
     // eslint-disable-next-line no-console
-    console.log(`p2tr_defeatChallenge_gas=${defeatGas.toString()}`)
-    // eslint-disable-next-line no-console
     console.log(`p2tr_timeoutChallenge_gas=${timeoutGas.toString()}`)
 
     expect(submitGas.toNumber()).to.be.lessThan(6000000)
-    expect(defeatGas.toNumber()).to.be.lessThan(1000000)
     expect(timeoutGas.toNumber()).to.be.lessThan(1500000)
   })
 

--- a/solidity/test/deploy/45_deploy_p2tr_signature_fraud_router.test.ts
+++ b/solidity/test/deploy/45_deploy_p2tr_signature_fraud_router.test.ts
@@ -1,0 +1,378 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai"
+import hre, { deployments, ethers } from "hardhat"
+import fs from "fs"
+import path from "path"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { BridgeStub, P2TRSignatureFraudRouter } from "../../typechain"
+import type { FrostCustodyPreflightReceipt } from "../../deploy/45_deploy_p2tr_signature_fraud_router"
+import deployP2TRFraudRouter, {
+  BOUNDED_V1_PROTOCOL_ID,
+  BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+  BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+  abortLiveBridgeUpgradeWithoutVettedCompleteV2,
+  isEphemeralLocalNetwork,
+  runFrostCustodyPreflight,
+} from "../../deploy/45_deploy_p2tr_signature_fraud_router"
+import deployFrostWalletRegistry from "../../deploy/48_deploy_frost_wallet_registry"
+import deployRebateAndPrepareTxs from "../../deploy/82_deploy_rebate_and_prepare_txs"
+import deployTIP109GovernanceUpgrade from "../../deploy/85_deploy_tip109_governance_upgrade"
+import deployTIP109Hotfix from "../../deploy/86_deploy_tip109_hotfix"
+
+const expectPreflightFailure = async (
+  promise: Promise<unknown>,
+  message: string
+): Promise<void> => {
+  try {
+    await promise
+    expect.fail("expected FROST custody preflight to fail")
+  } catch (error) {
+    expect((error as Error).message).to.include(message)
+  }
+}
+
+const createPreflightMockHre = (
+  providerOverrides: Record<string, (...args: any[]) => Promise<any>>
+): HardhatRuntimeEnvironment => {
+  const sourceProvider = ethers.provider
+
+  return {
+    ...hre,
+    getChainId: hre.getChainId.bind(hre),
+    ethers: {
+      constants: ethers.constants,
+      utils: ethers.utils,
+      provider: {
+        getBlockNumber: sourceProvider.getBlockNumber.bind(sourceProvider),
+        getBlock: sourceProvider.getBlock.bind(sourceProvider),
+        getStorageAt: sourceProvider.getStorageAt.bind(sourceProvider),
+        getLogs: sourceProvider.getLogs.bind(sourceProvider),
+        ...providerOverrides,
+      },
+    },
+  } as unknown as HardhatRuntimeEnvironment
+}
+
+const createLiveMockHre = (): {
+  hre: HardhatRuntimeEnvironment
+  deployCalls: string[]
+  saveCalls: string[]
+} => {
+  const deployCalls: string[] = []
+  const saveCalls: string[] = []
+  const bridgeAddress = "0x1000000000000000000000000000000000000001"
+  const blockHash = `0x${"ab".repeat(32)}`
+
+  const mock = {
+    network: { name: "sepolia", tags: {} },
+    deployments: {
+      get: async (name: string) => {
+        if (name !== "Bridge") {
+          throw new Error(`unexpected deployment lookup: ${name}`)
+        }
+        return { address: bridgeAddress }
+      },
+      deploy: async (name: string) => {
+        deployCalls.push(name)
+        return { address: bridgeAddress }
+      },
+      save: async (name: string) => {
+        saveCalls.push(name)
+      },
+    },
+    getNamedAccounts: async () => ({
+      deployer: "0x2000000000000000000000000000000000000002",
+    }),
+    getChainId: async () => "11155111",
+    ethers: {
+      ...ethers,
+      constants: ethers.constants,
+      utils: ethers.utils,
+      provider: {
+        getBlockNumber: async () => 100,
+        getBlock: async () => ({ hash: blockHash }),
+        getStorageAt: async () => ethers.constants.HashZero,
+        getLogs: async () => [],
+      },
+    },
+    helpers: {},
+    artifacts: {},
+  } as unknown as HardhatRuntimeEnvironment
+
+  return { hre: mock, deployCalls, saveCalls }
+}
+
+describe("deploy/45 P2TR fraud evidence NO-GO", () => {
+  let bridge: BridgeStub
+
+  beforeEach(async () => {
+    await deployments.fixture()
+    const Bridge = await deployments.get("Bridge")
+    bridge = (await ethers.getContractAt(
+      "BridgeStub",
+      Bridge.address
+    )) as BridgeStub
+    await bridge.resetFrostWalletRegistryForTest(ethers.constants.AddressZero)
+    await bridge.resetP2TRFraudRouterForTest(ethers.constants.AddressZero)
+  })
+
+  it("derives the raw preflight slots from the committed formal layout", () => {
+    const layout = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, "../formal/Bridge.storage-layout.json"),
+        "utf8"
+      )
+    ) as {
+      storage: { label: string; slot: string; type: string }[]
+      types: Record<string, { members?: { label: string; slot: string }[] }>
+    }
+    const self = layout.storage.find(({ label }) => label === "self")!
+    const members = layout.types[self.type].members!
+    const frostRegistry = members.find(
+      ({ label }) => label === "frostWalletRegistry"
+    )!
+    const p2trRouter = members.find(({ label }) => label === "p2trFraudRouter")!
+
+    expect(self.slot).to.equal("51")
+    expect(frostRegistry.slot).to.equal("32")
+    expect(p2trRouter.slot).to.equal("34")
+    expect(Number(self.slot) + Number(frostRegistry.slot)).to.equal(
+      BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT
+    )
+    expect(Number(self.slot) + Number(p2trRouter.slot)).to.equal(
+      BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT
+    )
+  })
+
+  it("keeps the bounded router unwired and persists a pinned zero-state receipt", async () => {
+    const Bridge = await deployments.get("Bridge")
+    const routerDeployment = await deployments.get("P2TRSignatureFraudRouter")
+    const router = (await ethers.getContractAt(
+      "P2TRSignatureFraudRouter",
+      routerDeployment.address
+    )) as P2TRSignatureFraudRouter
+    const receipt = routerDeployment.linkedData
+      ?.frostCustodyPreflight as FrostCustodyPreflightReceipt
+
+    expect(await bridge.p2trFraudRouter()).to.equal(
+      ethers.constants.AddressZero
+    )
+    expect(await router.bridge()).to.equal(Bridge.address)
+    expect(await router.evidenceProtocolID()).to.equal(BOUNDED_V1_PROTOCOL_ID)
+
+    expect(receipt.schemaVersion).to.equal("tbtc/frost-custody-preflight/v1")
+    expect(receipt.networkName).to.equal("hardhat")
+    expect(receipt.chainId).to.equal("31337")
+    expect(receipt.bridge).to.equal(Bridge.address)
+    expect(receipt.scanFromBlock).to.equal(0)
+    expect(receipt.scanToBlock).to.equal(receipt.snapshotBlockNumber)
+    expect(receipt.registrationsFound).to.equal(0)
+    expect(receipt.frostWalletRegistry).to.equal(ethers.constants.AddressZero)
+    expect(receipt.configuredP2TRFraudRouter).to.equal(
+      ethers.constants.AddressZero
+    )
+    expect(receipt.configuredRouterStatus).to.equal("unset")
+    expect(receipt.frostWalletRegistryStorageSlot).to.equal(
+      BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT
+    )
+    expect(receipt.p2trFraudRouterStorageSlot).to.equal(
+      BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT
+    )
+    expect(receipt.storageLayoutEvidence).to.equal(
+      "test/formal/Bridge.storage-layout.json"
+    )
+
+    const snapshotBlock = await ethers.provider.getBlock(
+      receipt.snapshotBlockNumber
+    )
+    expect(snapshotBlock.hash).to.equal(receipt.snapshotBlockHash)
+    expect(
+      await ethers.provider.getStorageAt(
+        Bridge.address,
+        BRIDGE_FROST_WALLET_REGISTRY_STORAGE_SLOT,
+        receipt.snapshotBlockNumber
+      )
+    ).to.equal(ethers.constants.HashZero)
+    expect(
+      await ethers.provider.getStorageAt(
+        Bridge.address,
+        BRIDGE_P2TR_FRAUD_ROUTER_STORAGE_SLOT,
+        receipt.snapshotBlockNumber
+      )
+    ).to.equal(ethers.constants.HashZero)
+  })
+
+  it("fails on a non-zero FROST registry storage word", async () => {
+    await bridge.resetFrostWalletRegistryForTest(
+      (
+        await ethers.getSigners()
+      )[1].address
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "frost registry storage slot"
+    )
+  })
+
+  it("fails on a non-zero P2TR router storage word", async () => {
+    await bridge.resetP2TRFraudRouterForTest(
+      (
+        await ethers.getSigners()
+      )[1].address
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "P2TR router storage slot"
+    )
+  })
+
+  it("fails when NewFrostWalletRegistered exists in history", async () => {
+    await bridge.emitNewFrostWalletRegisteredForTest()
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "prior FROST wallet registration"
+    )
+  })
+
+  it("fails when the zero-ECDSA NewWalletRegisteredV2 marker exists", async () => {
+    await bridge.emitZeroEcdsaWalletRegisteredV2ForTest()
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(hre, bridge.address),
+      "prior FROST wallet registration"
+    )
+  })
+
+  it("fails closed on malformed or unavailable raw storage reads", async () => {
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({ getStorageAt: async () => "0x00" }),
+        bridge.address
+      ),
+      "malformed Bridge storage slot"
+    )
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getStorageAt: async () => {
+            throw new Error("storage RPC unavailable")
+          },
+        }),
+        bridge.address
+      ),
+      "storage RPC unavailable"
+    )
+  })
+
+  it("fails closed when either registration log query fails", async () => {
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getLogs: async () => {
+            throw new Error("NewFrostWalletRegistered RPC unavailable")
+          },
+        }),
+        bridge.address
+      ),
+      "NewFrostWalletRegistered RPC unavailable"
+    )
+
+    let queryCount = 0
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(
+        createPreflightMockHre({
+          getLogs: async () => {
+            queryCount += 1
+            if (queryCount === 2) {
+              throw new Error("NewWalletRegisteredV2 RPC unavailable")
+            }
+            return []
+          },
+        }),
+        bridge.address
+      ),
+      "NewWalletRegisteredV2 RPC unavailable"
+    )
+  })
+
+  it("fails closed when the pinned snapshot hash changes", async () => {
+    const getBlock = ethers.provider.getBlock.bind(ethers.provider)
+    let readCount = 0
+    const reorgedHre = createPreflightMockHre({
+      getBlock: async (...args: unknown[]) => {
+        const block = await getBlock(...(args as [number]))
+        readCount += 1
+        return readCount === 1
+          ? block
+          : { ...block, hash: `0x${"cd".repeat(32)}` }
+      },
+    })
+
+    await expectPreflightFailure(
+      runFrostCustodyPreflight(reorgedHre, bridge.address),
+      "snapshot block reorged"
+    )
+  })
+
+  for (const [upgradePath, deployFunction] of [
+    ["45_deploy_p2tr_signature_fraud_router", deployP2TRFraudRouter],
+    ["48_deploy_frost_wallet_registry", deployFrostWalletRegistry],
+    ["82_deploy_rebate_and_prepare_txs", deployRebateAndPrepareTxs],
+    ["85_deploy_tip109_governance_upgrade", deployTIP109GovernanceUpgrade],
+    ["86_deploy_tip109_hotfix", deployTIP109Hotfix],
+  ] as const) {
+    it(`aborts live ${upgradePath} before writes or calldata output`, async () => {
+      const mock = createLiveMockHre()
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => logs.push(args.join(" "))
+
+      try {
+        await expectPreflightFailure(
+          deployFunction(mock.hre),
+          `NO-GO ${upgradePath}`
+        )
+      } finally {
+        console.log = originalLog
+      }
+
+      expect(mock.deployCalls).to.deep.equal([])
+      expect(mock.saveCalls).to.deep.equal([])
+      expect(logs).to.have.lengthOf(1)
+      expect(logs[0]).to.match(/^FROST_CUSTODY_PREFLIGHT_RECEIPT=/)
+      expect(logs[0]).not.to.include("calldata")
+      expect(logs[0]).not.to.include("SUMMARY")
+    })
+  }
+
+  it("runs the write-free NO-GO dependency first on every active path", () => {
+    for (const deployFunction of [
+      deployP2TRFraudRouter,
+      deployFrostWalletRegistry,
+      deployRebateAndPrepareTxs,
+      deployTIP109GovernanceUpgrade,
+      deployTIP109Hotfix,
+    ]) {
+      expect(deployFunction.dependencies?.[0]).to.equal("FrostCustodyNoGo")
+    }
+  })
+
+  it("default-denies every non-ephemeral network and returns NO-GO", async () => {
+    expect(isEphemeralLocalNetwork("hardhat")).to.equal(true)
+    expect(isEphemeralLocalNetwork("development")).to.equal(true)
+    expect(isEphemeralLocalNetwork("system_tests")).to.equal(true)
+    expect(isEphemeralLocalNetwork("sepolia")).to.equal(false)
+    expect(isEphemeralLocalNetwork("mainnet")).to.equal(false)
+    expect(isEphemeralLocalNetwork("custom-live-network")).to.equal(false)
+
+    await expectPreflightFailure(
+      abortLiveBridgeUpgradeWithoutVettedCompleteV2(hre, "test-upgrade"),
+      "NO-GO test-upgrade"
+    )
+  })
+})

--- a/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
+++ b/solidity/test/deploy/84_upgrade_bridge_c2_1_counter.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { expect } from "chai"
+import { constants, utils } from "ethers"
 import func from "../../deploy/84_upgrade_bridge_c2_1_counter"
 
 describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
@@ -41,7 +42,10 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
     options: any
   }
 
-  function createMockHre(networkTags: Record<string, boolean> = {}) {
+  function createMockHre(
+    networkTags: Record<string, boolean> = {},
+    networkName = "hardhat"
+  ) {
     const deployCalls: DeployCall[] = []
     const getCalls: string[] = []
     const logCalls: string[] = []
@@ -53,6 +57,14 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
 
     const mockHre: any = {
       ethers: {
+        constants,
+        utils,
+        provider: {
+          getBlockNumber: async () => 100,
+          getBlock: async () => ({ hash: `0x${"ab".repeat(32)}` }),
+          getStorageAt: async () => constants.HashZero,
+          getLogs: async () => [],
+        },
         getSigner: async (address: string) => {
           expect(address).to.equal(DEPLOYER_ADDRESS)
           return signer
@@ -61,6 +73,9 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       deployments: {
         get: async (name: string) => {
           getCalls.push(name)
+          if (name === "Bridge") {
+            return { address: BRIDGE_ADDRESS }
+          }
           const address = dependencyAddresses[name]
           if (!address) {
             throw new Error(`Unexpected deployment lookup: ${name}`)
@@ -83,6 +98,7 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
         deployer: DEPLOYER_ADDRESS,
         treasury: TREASURY_ADDRESS,
       }),
+      getChainId: async () => "11155111",
       helpers: {
         upgrades: {
           upgradeProxy: async (...args: any[]) => {
@@ -99,7 +115,7 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
           },
         },
       },
-      network: { tags: networkTags },
+      network: { name: networkName, tags: networkTags },
       tenderly: {
         verify: async (deployment: any) => {
           tenderlyVerifyCalls.push(deployment)
@@ -202,5 +218,24 @@ describe("Deploy Script 84: Bridge C-2.1a Counter Upgrade", () => {
       { name: "MovingFunds", address: MOVING_FUNDS_ADDRESS },
       { name: "Bridge", address: BRIDGE_ADDRESS },
     ])
+  })
+
+  it("aborts a live-network upgrade before deployment or proxy mutation", async () => {
+    const { mockHre, deployCalls, upgradeProxyCalls } = createMockHre(
+      {},
+      "sepolia"
+    )
+
+    try {
+      await func(mockHre)
+      expect.fail("expected live Bridge upgrade NO-GO")
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        "NO-GO 84_upgrade_bridge_c2_1_counter"
+      )
+    }
+
+    expect(deployCalls).to.deep.equal([])
+    expect(upgradeProxyCalls).to.deep.equal([])
   })
 })

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -209,9 +209,10 @@ export default async function bridgeFixture(): Promise<{
   // Deploy + wire the two fraud router sidecars. EcdsaFraudRouter
   // hosts the ECDSA fraud lifecycle (was inlined on Bridge);
   // P2TRSignatureFraudRouter is the sister sidecar for the P2TR
-  // signature-fraud lifecycle. Both routers are pinned to the
-  // Bridge address at construction and wired via the one-time
-  // setters on Bridge.
+  // signature-fraud lifecycle. Production BOUNDED_V1 is intentionally
+  // not wired because it cannot activate FROST custody. Tests use an
+  // explicit handshake-only COMPLETE_V2 stub. It is not evidence that a
+  // production COMPLETE_V2 implementation exists.
   const existingEcdsaFraudRouter = await bridge.ecdsaFraudRouter()
   let ecdsaFraudRouter: EcdsaFraudRouter
   if (existingEcdsaFraudRouter === ethers.constants.AddressZero) {
@@ -237,7 +238,7 @@ export default async function bridgeFixture(): Promise<{
   let p2trFraudRouter: P2TRSignatureFraudRouter
   if (existingP2TRFraudRouter === ethers.constants.AddressZero) {
     const P2TRFraudRouterFactory = await ethers.getContractFactory(
-      "P2TRSignatureFraudRouter",
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
       deployer
     )
     p2trFraudRouter = (await P2TRFraudRouterFactory.deploy(

--- a/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.EdgeCases.test.ts
@@ -86,6 +86,21 @@ describe("FrostWalletRegistry DKG edge cases (B-1.5 slice 4)", () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ deployer, bridge } = await waffle.loadFixture(bridgeFixture))
 
+    // This suite deliberately exercises the registry -> Bridge FROST callback.
+    // Install the handshake-only COMPLETE_V2 test stub explicitly so the test
+    // never depends on whichever bounded production router another full-suite
+    // fixture left in Bridge storage. The stub is not a functional fraud router
+    // and is never used by deployment code.
+    const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+      deployer
+    )
+    const completeP2TRFraudRouter = await CompleteP2TRFraudRouterFactory.deploy(
+      bridge.address
+    )
+    await completeP2TRFraudRouter.deployed()
+    await bridge.resetP2TRFraudRouterForTest(completeP2TRFraudRouter.address)
+
     const t = await deployments.get("T")
     randomBeacon = await smock.fake<IRandomBeacon>("IRandomBeacon")
 

--- a/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
+++ b/solidity/test/frost-registry/FrostWalletRegistry.HappyPath.test.ts
@@ -58,6 +58,21 @@ describe("FrostWalletRegistry full-cycle DKG happy path (B-1.5 slice 3)", () => 
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;({ deployer, bridge } = await waffle.loadFixture(bridgeFixture))
 
+    // This suite deliberately exercises the registry -> Bridge FROST callback.
+    // Install the handshake-only COMPLETE_V2 test stub explicitly so the test
+    // never depends on whichever bounded production router another full-suite
+    // fixture left in Bridge storage. The stub is not a functional fraud router
+    // and is never used by deployment code.
+    const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+      "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+      deployer
+    )
+    const completeP2TRFraudRouter = await CompleteP2TRFraudRouterFactory.deploy(
+      bridge.address
+    )
+    await completeP2TRFraudRouter.deployed()
+    await bridge.resetP2TRFraudRouterForTest(completeP2TRFraudRouter.address)
+
     const t = await deployments.get("T")
 
     randomBeacon = await smock.fake<IRandomBeacon>("IRandomBeacon")

--- a/solidity/test/integration/utils/fixture.ts
+++ b/solidity/test/integration/utils/fixture.ts
@@ -128,9 +128,10 @@ export const fixture = deployments.createFixture(
     // the unit-test bridgeFixture). The deploy scripts at
     // deploy/44_deploy_ecdsa_fraud_router.ts and
     // deploy/45_deploy_p2tr_signature_fraud_router.ts run during
-    // deployments.fixture() above; this block calls the one-time
-    // governance setters so the routers are usable for integration
-    // tests that exercise fraud paths through MaintainerProxy.
+    // deployments.fixture() above. Production BOUNDED_V1 deliberately stays
+    // unwired; integration tests substitute a handshake-only COMPLETE_V2 stub.
+    // The stub is not evidence that a production COMPLETE_V2 implementation
+    // exists.
     const existingEcdsaFraudRouter = await bridge.ecdsaFraudRouter()
     let ecdsaFraudRouter: EcdsaFraudRouter
     if (existingEcdsaFraudRouter === ethers.constants.AddressZero) {
@@ -150,10 +151,14 @@ export const fixture = deployments.createFixture(
     const existingP2TRFraudRouter = await bridge.p2trFraudRouter()
     let p2trFraudRouter: P2TRSignatureFraudRouter
     if (existingP2TRFraudRouter === ethers.constants.AddressZero) {
-      p2trFraudRouter =
-        await helpers.contracts.getContract<P2TRSignatureFraudRouter>(
-          "P2TRSignatureFraudRouter"
-        )
+      const CompleteP2TRFraudRouterFactory = await ethers.getContractFactory(
+        "HandshakeOnlyCompleteP2TRSignatureFraudRouterStub",
+        deployer
+      )
+      p2trFraudRouter = (await CompleteP2TRFraudRouterFactory.deploy(
+        bridge.address
+      )) as P2TRSignatureFraudRouter
+      await p2trFraudRouter.deployed()
       await bridgeGovernance
         .connect(governance)
         .setP2TRFraudRouter(p2trFraudRouter.address)


### PR DESCRIPTION
## Summary

- make the current bounded P2TR fraud router inert before decoding evidence, accepting escrow, mutating challenge state, or migrating legacy records
- require an exact Bridge-bound `COMPLETE_V2` evidence-protocol handshake before FROST wallet creation or registration can become reachable
- fail closed in live deployment and upgrade paths, with zero-FROST custody preflight checks, pinned-chain/reorg checks, and canonical receipts
- remove the unsafe outpoint-only defeat path and preserve the legacy ECDSA fraud flow

## Security posture

This PR is a safety boundary. It does **not** make FROST/P2TR fraud handling production-ready, and the stack intentionally contains no production `COMPLETE_V2` router. Live FROST custody remains hard **NO-GO** until authenticated witness data, authoritative prevouts, exact wallet/outpoint identity, all sighash forms, a vetted immutable implementation, and the corresponding operational controls are separately reviewed and deployed.

## Stack

- base: #1028
- depends on: #1027

## Verification

- Solidity build: pass (28 files compiled)
- focused fraud/deployment/FROST regression suites: 125 passing
- formal Bridge storage-layout suite: 2 passing
- Solidity formatting and `git diff --check`: pass

