### PR TITLE
fix(typescript): generate TypeChain bindings in refund.sh

### DIFF
--- a/typescript/scripts/refund.sh
+++ b/typescript/scripts/refund.sh
@@ -134,6 +134,9 @@ fi
 printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
 yarn install
 
+printf "${LOG_START}Generating TypeChain bindings...${LOG_END}"
+npm run typechain
+
 # Run script
 printf "${LOG_START}Recovering BTC...${LOG_END}"
 

--- a/typescript/scripts/refund.sh
+++ b/typescript/scripts/refund.sh
@@ -135,6 +135,8 @@ printf "${LOG_START}Installing yarn dependencies...${LOG_END}"
 yarn install
 
 printf "${LOG_START}Generating TypeChain bindings...${LOG_END}"
+# Invoked via npm because the pinned Yarn 4 portable shell cannot execute the
+# typechain script's sh for-loop; the package's own build script does the same.
 npm run typechain
 
 # Run script


### PR DESCRIPTION
Fixes #910.

## What

On a fresh checkout, `typescript/scripts/refund.sh` runs `yarn install` and then invokes the refund script directly via ts-node, which fails to compile with the exact error reported in the issue:

```
TS2307: Cannot find module '../../../typechain/Bridge'
```

The generated `./typechain` directory doesn't exist until the package's `typechain` script runs. This PR adds the missing generation step between `yarn install` and the refund invocation.

The step is invoked via `npm run typechain` rather than `yarn typechain` because the pinned Yarn 4 portable shell cannot execute the `typechain` script (an `sh` for-loop over `$npm_package_config_contracts`); the package's own `build` script already invokes it the same way.

## Verification

Reproduced end-to-end on a fresh worktree with Node 18:

- **Before**: `./typescript/scripts/refund.sh <complete dummy args>` → `TS2307: Cannot find module '../../../typechain/Bridge'`.
- **After**: TypeChain bindings are generated, ts-node compiles, and the run proceeds into the script proper (failing later only on the intentionally bogus dummy arguments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxCWMXfUdFygLaGaS2SPhg
