### PR TITLE
feat(watchtower)!: identify a signer invocation deterministically

### DIFF
--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -315,9 +315,33 @@ CREATE TABLE p2tr_signature_fraud_challenge_outbox (
         signer_invocation_started_at_unix_ms IS NULL
         OR signer_invocation_started_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
+    -- Deterministic identity of the boundary the marker below names, committed
+    -- in the same swap. The activation barrier counts outstanding invocations
+    -- by the marker's NULL transitions alone, so the two must be NULL together
+    -- or the counter stops meaning "a signer call may be outstanding".
+    signer_invocation_id bytea CHECK (
+        signer_invocation_id IS NULL
+        OR octet_length(signer_invocation_id) = 32
+    ),
     active_signer_invocation_started_at_unix_ms bigint CHECK (
         active_signer_invocation_started_at_unix_ms IS NULL
         OR active_signer_invocation_started_at_unix_ms BETWEEN 0 AND 9007199254740991
+    ),
+    active_signer_invocation_id bytea CHECK (
+        active_signer_invocation_id IS NULL
+        OR octet_length(active_signer_invocation_id) = 32
+    ),
+    CHECK (
+        (active_signer_invocation_started_at_unix_ms IS NULL)
+            = (active_signer_invocation_id IS NULL)
+    ),
+    -- The historical pair is deliberately NOT required to agree. The active
+    -- pair drives the barrier counter and must be exact; the historical marker
+    -- is proof that some signer call began, and a failure record may have to
+    -- assert that from a fallback clock when no identity survived.
+    CHECK (
+        signer_invocation_id IS NULL
+        OR signer_invocation_started_at_unix_ms IS NOT NULL
     ),
     latest_variant_sequence smallint CHECK (
         latest_variant_sequence IS NULL
@@ -1619,7 +1643,12 @@ CREATE TABLE p2tr_signature_fraud_challenge_provenance_incident_resolution (
     record_id bytea NOT NULL,
     provenance_invalidation_id bytea NOT NULL,
     -- The exact boundary this resolution speaks for. Retiring an incident
-    -- raised over a different boundary must be impossible.
+    -- raised over a different boundary must be impossible. Carries the same
+    -- deterministic identity as the signer-boundary resolution committed in the
+    -- same transaction, so one retirement cannot name two boundaries.
+    signer_invocation_id bytea NOT NULL CHECK (
+        octet_length(signer_invocation_id) = 32
+    ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
@@ -1702,7 +1731,12 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         REFERENCES p2tr_signature_fraud_challenge_outbox(record_id)
         ON DELETE RESTRICT,
     -- The exact boundary this resolution speaks for. Resolving a boundary the
-    -- durable row does not currently own must be impossible.
+    -- durable row does not currently own must be impossible. The identity is
+    -- the invocation ID; the three fields after it are operator-facing detail,
+    -- bound into the evidence digest but no longer deciding ownership.
+    signer_invocation_id bytea NOT NULL CHECK (
+        octet_length(signer_invocation_id) = 32
+    ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
@@ -1761,12 +1795,10 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
     resolved_at_unix_ms bigint NOT NULL CHECK (
         resolved_at_unix_ms BETWEEN invoked_at_unix_ms AND 9007199254740991
     ),
-    PRIMARY KEY (
-        record_id,
-        boundary_started_at_unix_ms,
-        preparation_attempts,
-        nonce_reservation_id
-    ),
+    -- Keyed on the deterministic invocation identity, not the wall-clock tuple
+    -- it replaces. `record_id` stays as the leading column because this is the
+    -- table's only index and two queries filter on it alone.
+    PRIMARY KEY (record_id, signer_invocation_id),
     -- Signed bytes are named exactly when, and only when, the signer is proven
     -- to have produced them.
     CHECK ((outcome = 'signed') = (signed_transaction_hash IS NOT NULL)),
@@ -1804,7 +1836,21 @@ BEGIN
             'orphaned signer boundary resolution names an absent outbox record';
     END IF;
 
-    IF outbox_record.active_signer_invocation_started_at_unix_ms
+    -- Identity is the invocation ID, compared against the durable column rather
+    -- than re-derived: PostgreSQL cannot recompute it (the binding preimage
+    -- spans three tables and a TypeScript layout), which is the same standard
+    -- nonce_reservation_id already met.
+    --
+    -- The other three remain checked. They are descriptive columns of
+    -- append-only evidence that nothing downstream reads, so leaving them
+    -- unchecked would let a resolution naming the right boundary write
+    -- permanently wrong forensics about it. None can drift while the marker is
+    -- set: the start is immutable in flight and NULL-paired with the ID, the
+    -- reservation cannot be NULLed under an active marker, and every transition
+    -- that bumps the attempt clears the marker in the same swap.
+    IF outbox_record.active_signer_invocation_id
+           IS DISTINCT FROM NEW.signer_invocation_id
+       OR outbox_record.active_signer_invocation_started_at_unix_ms
            IS DISTINCT FROM NEW.boundary_started_at_unix_ms
        OR outbox_record.preparation_attempts <> NEW.preparation_attempts
        OR outbox_record.nonce_reservation_id
@@ -1815,10 +1861,11 @@ BEGIN
 
     IF NEW.resolution_evidence_digest <> sha256(
            convert_to(
-               'tbtc-p2tr-signer-boundary-independent-resolution-v1',
+               'tbtc-p2tr-signer-boundary-independent-resolution-v2',
                'UTF8'
            )
            || NEW.record_id
+           || NEW.signer_invocation_id
            || int8send(NEW.boundary_started_at_unix_ms)
            || int8send(NEW.preparation_attempts::bigint)
            || NEW.nonce_reservation_id
@@ -4094,10 +4141,20 @@ BEGIN
            OLD.signer_invocation_started_at_unix_ms THEN
         RAISE EXCEPTION 'P2TR challenge signer invocation boundary is immutable';
     END IF;
+    IF OLD.signer_invocation_id IS NOT NULL
+       AND NEW.signer_invocation_id IS DISTINCT FROM OLD.signer_invocation_id THEN
+        RAISE EXCEPTION 'P2TR challenge signer invocation boundary is immutable';
+    END IF;
     IF OLD.active_signer_invocation_started_at_unix_ms IS NOT NULL
        AND NEW.active_signer_invocation_started_at_unix_ms IS NOT NULL
        AND NEW.active_signer_invocation_started_at_unix_ms IS DISTINCT FROM
            OLD.active_signer_invocation_started_at_unix_ms THEN
+        RAISE EXCEPTION 'active signer invocation boundary cannot be replaced in flight';
+    END IF;
+    IF OLD.active_signer_invocation_id IS NOT NULL
+       AND NEW.active_signer_invocation_id IS NOT NULL
+       AND NEW.active_signer_invocation_id IS DISTINCT FROM
+           OLD.active_signer_invocation_id THEN
         RAISE EXCEPTION 'active signer invocation boundary cannot be replaced in flight';
     END IF;
     IF OLD.active_signer_invocation_started_at_unix_ms IS NULL

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -28,6 +28,9 @@ import {
   validateP2TRSignatureFraudWitnessObservationConsistency,
 } from "@keep-network/tbtc-v2.ts"
 
+// A value import, unlike the authorization module's type-only import of this
+// file, so the dependency runs one way at run time and there is no cycle.
+import { computeP2TRSignatureFraudSignerInvocationID } from "./P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
 import type { P2TRSignatureFraudWatchtowerStoreProfileProvider } from "./types.js"
 
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_PAGE_SIZE = 1_000
@@ -761,7 +764,13 @@ export const computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest = (
  */
 export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
   recordID: string
-  /** The exact boundary, byte for byte. A different boundary is refused. */
+  /**
+   * The exact boundary. This is the identity: a deterministic digest over the
+   * whole boundary binding, frozen by the swap that set the marker. The three
+   * fields below remain as operator-facing detail and are bound into the
+   * evidence digest, but they no longer decide which boundary is named.
+   */
+  signerInvocationID: string
   boundaryStartedAtUnixMs: number
   preparationAttempts: number
   nonceReservationID: string
@@ -811,13 +820,25 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
       "Signer-boundary resolution names signed bytes only for a signed outcome"
     )
   }
+  // Mirrored byte for byte by the PostgreSQL guard trigger. The invocation ID
+  // replaces the boundary start as the identity term; v1 hashed a wall-clock
+  // tuple, so the domain moves with the layout.
   return `0x${createHash("sha256")
-    .update("tbtc-p2tr-signer-boundary-independent-resolution-v1", "utf8")
+    .update("tbtc-p2tr-signer-boundary-independent-resolution-v2", "utf8")
     .update(
       Buffer.from(
         normalizeBytes32(
           resolution.recordID,
           "Signer-boundary resolution record ID"
+        ).slice(2),
+        "hex"
+      )
+    )
+    .update(
+      Buffer.from(
+        normalizeBytes32(
+          resolution.signerInvocationID,
+          "Signer-boundary resolution invocation ID"
         ).slice(2),
         "hex"
       )
@@ -883,6 +904,7 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
  */
 export type P2TRSignatureFraudNormalizedSignerBoundaryResolution = {
   recordID: string
+  signerInvocationID: string
   boundaryStartedAtUnixMs: number
   preparationAttempts: number
   nonceReservationID: string
@@ -905,6 +927,10 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   const recordID = normalizeBytes32(
     resolution.recordID,
     "Orphaned signer boundary record ID"
+  )
+  const signerInvocationID = normalizeBytes32(
+    resolution.signerInvocationID,
+    "Orphaned signer boundary invocation ID"
   )
   const boundaryStartedAtUnixMs = requireUnixMilliseconds(
     resolution.boundaryStartedAtUnixMs,
@@ -962,6 +988,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   if (
     computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest({
       recordID,
+      signerInvocationID,
       boundaryStartedAtUnixMs,
       preparationAttempts,
       nonceReservationID,
@@ -1043,6 +1070,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   }
   return {
     recordID,
+    signerInvocationID,
     boundaryStartedAtUnixMs,
     preparationAttempts,
     nonceReservationID,
@@ -1068,7 +1096,24 @@ export const assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership = (
   record: P2TRSignatureFraudChallengeOutboxRecord,
   resolution: P2TRSignatureFraudNormalizedSignerBoundaryResolution
 ): void => {
+  // The invocation ID decides identity: it is a digest over the whole boundary
+  // binding and is frozen by the swap that set the marker, so it is what a
+  // provider can journal and what the primary key indexes.
+  //
+  // The other three are still compared against the durable row. They are
+  // descriptive columns of append-only evidence, and nothing downstream reads
+  // them, so leaving them unchecked would let a resolution that names the right
+  // boundary write permanently wrong forensics about it. None of them can drift
+  // while the marker is set — the start is immutable in flight and NULL-paired
+  // with the ID, the reservation cannot be NULLed under an active marker, and
+  // every transition that bumps the attempt clears the marker in the same swap —
+  // so checking them costs nothing.
   if (
+    record.activeSignerInvocationID === undefined ||
+    normalizeBytes32(
+      record.activeSignerInvocationID,
+      "Durable active signer invocation ID"
+    ) !== resolution.signerInvocationID ||
     record.activeSignerInvocationStartedAtUnixMs !==
       resolution.boundaryStartedAtUnixMs ||
     record.preparationAttempts !== resolution.preparationAttempts ||
@@ -1192,8 +1237,17 @@ export type P2TRSignatureFraudChallengeOutboxRecord = {
   preparationResumeStatus?: "prepared" | "broadcast-pending"
   /** Durable boundary for the currently active signer call. */
   activeSignerInvocationStartedAtUnixMs?: number
+  /**
+   * Deterministic identity of that boundary, committed in the same swap that
+   * sets the marker above. Present exactly when the marker is: the activation
+   * barrier counts invocations by the marker's null transitions, so the two
+   * must never disagree about whether a signer call may be outstanding.
+   */
+  activeSignerInvocationID?: string
   /** Historical proof that at least one signer invocation began. */
   signerInvocationStartedAtUnixMs?: number
+  /** Identity of the last boundary that reached a signer. */
+  signerInvocationID?: string
   preparedTransaction?: P2TRSignatureFraudPreparedChallengeTransaction
   /** Append-only signed identities; the singular field aliases the last item. */
   preparedTransactionVariants?: readonly P2TRSignatureFraudPreparedTransactionVariant[]
@@ -1537,6 +1591,8 @@ export interface P2TRSignatureFraudChallengeOutboxStore
     expectedVersion: number,
     next: P2TRSignatureFraudChallengeOutboxRecord,
     boundary: {
+      /** The identity; the fields below are retained detail. */
+      signerInvocationID: string
       startedAtUnixMs: number
       preparationAttempts: number
       nonceReservationID: string
@@ -2308,13 +2364,38 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       "Challenge outbox signer invocation time"
     )
     await this.assertRecoveryBarrier()
-    const signerBoundary = nextRecord(reserved, {
+    // Built from the record that is about to be committed: `nextRecord` already
+    // carries the post-swap version, and the binding reads no signer marker, so
+    // the invocation identity is derivable here and lands in the same swap that
+    // sets the marker. Building before the swap also means a failure strands
+    // nothing — there is no durable marker yet to pin the activation barrier.
+    const pendingBoundary = nextRecord(reserved, {
       activeSignerInvocationStartedAtUnixMs: signerBoundaryTime,
       lastPreBroadcastRecheckAtUnixMs: signerBoundaryTime,
       lastPreBroadcastRecheckStatus: "eligible",
       updatedAtUnixMs: signerBoundaryTime,
       lastError: undefined,
     })
+    let signerAuthorizationBinding: P2TRSignatureFraudIrreversibleBoundaryBinding
+    try {
+      signerAuthorizationBinding = this.buildIrreversibleBoundaryBinding(
+        pendingBoundary,
+        "prepare",
+        pendingBoundary.preparationAttempts,
+        selectedFeePolicy
+      )
+    } catch (error) {
+      return this.abandonUnboundPreparationClaim(
+        reserved,
+        `Initial signer authorization failed: ${errorMessage(error)}`
+      )
+    }
+    const signerBoundary: P2TRSignatureFraudChallengeOutboxRecord = {
+      ...pendingBoundary,
+      activeSignerInvocationID: computeP2TRSignatureFraudSignerInvocationID(
+        signerAuthorizationBinding
+      ),
+    }
     if (
       !(await this.store.compareAndSwapWithCurrentCanonicalProvenance(
         key,
@@ -2326,20 +2407,8 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       return this.requireRecord(key)
     }
 
-    let signerAuthorizationBinding: P2TRSignatureFraudIrreversibleBoundaryBinding
     let signerAuthorization: P2TRSignatureFraudIrreversibleBoundaryAuthorization
     try {
-      // Building the binding is part of authorizing: it recomputes the intent
-      // identity and re-checks the lane against durable state. A failure here
-      // means exactly what a rejected authorization means — no signer was
-      // invoked — so it must clear the pre-I/O marker rather than escape and
-      // strand the record with the marker set.
-      signerAuthorizationBinding = this.buildIrreversibleBoundaryBinding(
-        signerBoundary,
-        "prepare",
-        signerBoundary.preparationAttempts,
-        selectedFeePolicy
-      )
       signerAuthorization =
         await this.irreversibleBoundaryAuthorizer.authorizeP2TRSignatureFraudIrreversibleBoundary(
           signerAuthorizationBinding
@@ -2476,8 +2545,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       ],
       preparationLease: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       signerInvocationStartedAtUnixMs:
         signerBoundary.signerInvocationStartedAtUnixMs ?? signerBoundaryTime,
+      signerInvocationID:
+        signerBoundary.signerInvocationID ??
+        signerBoundary.activeSignerInvocationID,
       updatedAtUnixMs: requireUnixMilliseconds(
         this.now(),
         "Challenge outbox prepared time"
@@ -2599,6 +2672,7 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         expiresAtUnixMs: leaseExpiresAtUnixMs,
       },
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       updatedAtUnixMs: nowUnixMs,
       lastError: undefined,
     })
@@ -2627,6 +2701,7 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         preparationLease: undefined,
         preparationResumeStatus: undefined,
         activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
         lastPreBroadcastRecheckAtUnixMs: recheckTime,
         lastPreBroadcastRecheckStatus: preSignRecheck.status,
         updatedAtUnixMs: recheckTime,
@@ -2644,13 +2719,36 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       "Challenge outbox replacement signer invocation time"
     )
     await this.assertRecoveryBarrier()
-    const signerBoundary = nextRecord(claimed, {
+    // As at the initial boundary: build first, so the identity is committed in
+    // the same swap as the marker and a build failure leaves nothing durable.
+    const pendingBoundary = nextRecord(claimed, {
       activeSignerInvocationStartedAtUnixMs: signerBoundaryTime,
       lastPreBroadcastRecheckAtUnixMs: signerBoundaryTime,
       lastPreBroadcastRecheckStatus: "eligible",
       updatedAtUnixMs: signerBoundaryTime,
       lastError: undefined,
     })
+    let signerAuthorizationBinding: P2TRSignatureFraudIrreversibleBoundaryBinding
+    try {
+      signerAuthorizationBinding = this.buildIrreversibleBoundaryBinding(
+        pendingBoundary,
+        "replacement",
+        pendingBoundary.preparationAttempts,
+        selectedFeePolicy,
+        previous.transactionHash
+      )
+    } catch (error) {
+      return this.abandonUnboundPreparationClaim(
+        claimed,
+        `Replacement signer authorization failed: ${errorMessage(error)}`
+      )
+    }
+    const signerBoundary: P2TRSignatureFraudChallengeOutboxRecord = {
+      ...pendingBoundary,
+      activeSignerInvocationID: computeP2TRSignatureFraudSignerInvocationID(
+        signerAuthorizationBinding
+      ),
+    }
     if (
       !(await this.store.compareAndSwapWithCurrentCanonicalProvenance(
         key,
@@ -2662,18 +2760,8 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       return this.requireRecord(key)
     }
 
-    let signerAuthorizationBinding: P2TRSignatureFraudIrreversibleBoundaryBinding
     let signerAuthorization: P2TRSignatureFraudIrreversibleBoundaryAuthorization
     try {
-      // As in the initial boundary: a binding that cannot be built names no
-      // invoked signer, so it clears the marker instead of stranding the record.
-      signerAuthorizationBinding = this.buildIrreversibleBoundaryBinding(
-        signerBoundary,
-        "replacement",
-        signerBoundary.preparationAttempts,
-        selectedFeePolicy,
-        previous.transactionHash
-      )
       signerAuthorization =
         await this.irreversibleBoundaryAuthorizer.authorizeP2TRSignatureFraudIrreversibleBoundary(
           signerAuthorizationBinding
@@ -2836,8 +2924,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       preparationLease: undefined,
       preparationResumeStatus: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       signerInvocationStartedAtUnixMs:
         signerBoundary.signerInvocationStartedAtUnixMs ?? signerBoundaryTime,
+      signerInvocationID:
+        signerBoundary.signerInvocationID ??
+        signerBoundary.activeSignerInvocationID,
       updatedAtUnixMs: requireUnixMilliseconds(
         this.now(),
         "Challenge outbox replacement prepared time"
@@ -3462,6 +3554,9 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       // Only the worker observing that call return may clear this marker.
       activeSignerInvocationStartedAtUnixMs: signerWasInvoked
         ? current.activeSignerInvocationStartedAtUnixMs
+        : undefined,
+      activeSignerInvocationID: signerWasInvoked
+        ? current.activeSignerInvocationID
         : undefined,
       preparationSender: retainLane ? current.preparationSender : undefined,
       selectedLaneID: retainLane ? current.selectedLaneID : undefined,
@@ -4296,11 +4391,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       preparationLease: undefined,
       preparationResumeStatus: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       signerInvocationStartedAtUnixMs: signerInvoked
         ? current.signerInvocationStartedAtUnixMs ??
           current.activeSignerInvocationStartedAtUnixMs ??
           nowUnixMs
         : current.signerInvocationStartedAtUnixMs,
+      signerInvocationID: signerInvoked
+        ? current.signerInvocationID ?? current.activeSignerInvocationID
+        : current.signerInvocationID,
       preparationSender:
         signerInvoked || hasPriorVariant
           ? current.preparationSender
@@ -4491,6 +4590,28 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
   }
 
   /**
+   * Records why a boundary binding could not be built, for a claim that never
+   * reached the durable marker. There is nothing to clear — the invocation
+   * identity is derived before the swap that would set the marker, so a failure
+   * here leaves the activation barrier untouched and the reservation is
+   * released by ordinary lease recovery.
+   */
+  private async abandonUnboundPreparationClaim(
+    claimed: P2TRSignatureFraudChallengeOutboxRecord,
+    reason: string
+  ): Promise<P2TRSignatureFraudChallengeOutboxRecord> {
+    const unbound = nextRecord(claimed, {
+      updatedAtUnixMs: requireUnixMilliseconds(
+        this.now(),
+        "Challenge outbox unbound boundary time"
+      ),
+      lastError: requireReason(reason, "Boundary binding failure reason"),
+    })
+    await this.store.compareAndSwap(claimed.recordID, claimed.version, unbound)
+    return this.requireRecord(claimed.recordID)
+  }
+
+  /**
    * Clears the exact durable pre-I/O marker when authorization failed before
    * the signer function was called. Concurrent canonical invalidation may
    * change status, but it must not turn a known-uninvoked signer into an
@@ -4566,6 +4687,7 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
             ? undefined
             : durable.preparationResumeStatus,
         activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
         updatedAtUnixMs: requireUnixMilliseconds(
           this.now(),
           "Signer authorization failure completion time"
@@ -4583,8 +4705,10 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         provenanceWasInvalidated &&
         !hasPriorSignedState &&
         durable.reservedNonce !== undefined &&
-        durable.activeSignerInvocationStartedAtUnixMs !== undefined
+        durable.activeSignerInvocationStartedAtUnixMs !== undefined &&
+        durable.activeSignerInvocationID !== undefined
           ? {
+              signerInvocationID: durable.activeSignerInvocationID,
               startedAtUnixMs: durable.activeSignerInvocationStartedAtUnixMs,
               preparationAttempts: durable.preparationAttempts,
               nonceReservationID:
@@ -4730,6 +4854,7 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       preparationLease: undefined,
       preparationResumeStatus: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       preparationSender: signerBoundary ? current.preparationSender : undefined,
       selectedLaneID: signerBoundary ? current.selectedLaneID : undefined,
       selectedSignerIdentity: signerBoundary

--- a/services/watchtower/src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.ts
+++ b/services/watchtower/src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto"
+
 import {
   assertP2TRVerifiedLiveCoreCandidateEvidence,
   type P2TRVerifiedLiveCoreCandidateEvidence,
@@ -64,6 +66,46 @@ const boundaryAndRequestBindingKeysAgree: MutuallyAssignable<
   Exclude<keyof P2TRReconcilerRequestBinding, "recordGeneration">
 > = true
 void boundaryAndRequestBindingKeysAgree
+
+export const P2TR_SIGNATURE_FRAUD_SIGNER_INVOCATION_DOMAIN =
+  "tbtc-p2tr-signature-fraud-signer-invocation-v1"
+
+/**
+ * The deterministic identity of one signer invocation.
+ *
+ * It is derived from the request-binding digest rather than by walking the
+ * binding again, for two reasons. The binding is already canonicalized in
+ * exactly one place, and a second walk would need a third canonicalizer — the
+ * precise failure `boundaryAndRequestBindingKeysAgree` above exists to prevent,
+ * since a field added to the binding but missed by that walk would drop out of
+ * the identity with no compile error. And the input is normalized first, so two
+ * spellings of the same durable boundary cannot yield two identities.
+ *
+ * The domain must differ from the request-binding domain: without it this value
+ * would be byte-identical to a digest that travels to an external attester, and
+ * it is about to become a durable primary key.
+ *
+ * Deterministic means reproducible, not constant: `recordVersion` is part of the
+ * binding and increments on every successful compare-and-swap, so two distinct
+ * boundaries can never share an identity, while replaying the same durable
+ * attempt always reproduces it.
+ */
+export function computeP2TRSignatureFraudSignerInvocationID(
+  binding: P2TRSignatureFraudIrreversibleBoundaryBinding
+): string {
+  const requestBindingDigest = computeP2TRReconcilerRequestBindingDigest(
+    reconcilerRequestBinding(normalizeBoundaryBinding(binding))
+  )
+  return `0x${createHash("sha256")
+    .update(P2TR_SIGNATURE_FRAUD_SIGNER_INVOCATION_DOMAIN, "utf8")
+    .update(
+      Buffer.from(
+        bytes32(requestBindingDigest, "Request binding digest"),
+        "hex"
+      )
+    )
+    .digest("hex")}`
+}
 
 type PendingAuthorization = {
   binding: NormalizedBoundaryBinding

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -147,7 +147,9 @@ type StoredOutboxRow = {
   selected_sender: Buffer | null
   nonce_reservation_id: Buffer | null
   signer_invocation_started_at_unix_ms: string | number | null
+  signer_invocation_id: Buffer | null
   active_signer_invocation_started_at_unix_ms: string | number | null
+  active_signer_invocation_id: Buffer | null
   last_broadcast_at_unix_ms: string | number | null
   last_reconciliation_at_unix_ms: string | number | null
   last_pre_broadcast_recheck_at_unix_ms: string | number | null
@@ -205,8 +207,8 @@ const STORED_ROW_COLUMNS = `
   preparation_lease_owner, preparation_lease_expires_at_unix_ms,
   preparation_resume_status, selected_signer_lane_id,
   selected_signer_identity, selected_sender, nonce_reservation_id,
-  signer_invocation_started_at_unix_ms,
-  active_signer_invocation_started_at_unix_ms,
+  signer_invocation_started_at_unix_ms, signer_invocation_id,
+  active_signer_invocation_started_at_unix_ms, active_signer_invocation_id,
   last_broadcast_at_unix_ms, last_reconciliation_at_unix_ms,
   last_pre_broadcast_recheck_at_unix_ms,
   last_pre_broadcast_recheck_status, last_resolution_status, last_error,
@@ -1498,15 +1500,8 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
       `SELECT outcome, resolution_evidence_digest
          FROM p2tr_signature_fraud_challenge_signer_boundary_resolution
         WHERE record_id = decode($1, 'hex')
-          AND boundary_started_at_unix_ms = $2
-          AND preparation_attempts = $3
-          AND nonce_reservation_id = decode($4, 'hex')`,
-      [
-        stripHex(normalized.recordID),
-        normalized.boundaryStartedAtUnixMs,
-        normalized.preparationAttempts,
-        stripHex(normalized.nonceReservationID),
-      ]
+          AND signer_invocation_id = decode($2, 'hex')`,
+      [stripHex(normalized.recordID), stripHex(normalized.signerInvocationID)]
     )
     if (existing.rows.length === 1) {
       if (
@@ -1527,7 +1522,8 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     // evidence claiming a boundary was resolved.
     await this.options.session.query(
       `INSERT INTO p2tr_signature_fraud_challenge_signer_boundary_resolution (
-          record_id, boundary_started_at_unix_ms, preparation_attempts,
+          record_id, signer_invocation_id, boundary_started_at_unix_ms,
+          preparation_attempts,
           nonce_reservation_id, stage, invoked_at_unix_ms, outcome,
           signed_transaction_hash, provider_evidence_digest,
           resolution_evidence_digest, primary_trust_domain_id,
@@ -1538,14 +1534,16 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           corroborating_evidence_digest, corroborating_attestation,
           corroborating_attested_at_unix_ms, resolved_at_unix_ms
        ) VALUES (
-          decode($1, 'hex'), $2, $3, decode($4, 'hex'), $5, $6, $7,
-          CASE WHEN $8::text IS NULL THEN NULL ELSE decode($8, 'hex') END,
-          decode($9, 'hex'), decode($10, 'hex'), $11, $12,
-          decode($10, 'hex'), decode($13, 'hex'), $14, $15, $16,
-          decode($10, 'hex'), decode($17, 'hex'), $18, $19
+          decode($1, 'hex'), decode($2, 'hex'), $3, $4,
+          decode($5, 'hex'), $6, $7, $8,
+          CASE WHEN $9::text IS NULL THEN NULL ELSE decode($9, 'hex') END,
+          decode($10, 'hex'), decode($11, 'hex'), $12, $13,
+          decode($11, 'hex'), decode($14, 'hex'), $15, $16, $17,
+          decode($11, 'hex'), decode($18, 'hex'), $19, $20
        )`,
       [
         stripHex(normalized.recordID),
+        stripHex(normalized.signerInvocationID),
         normalized.boundaryStartedAtUnixMs,
         normalized.preparationAttempts,
         stripHex(normalized.nonceReservationID),
@@ -1576,6 +1574,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         ...current,
         version: current.version + 1,
         activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
         updatedAtUnixMs: Math.max(
           current.updatedAtUnixMs,
           normalized.resolvedAtUnixMs
@@ -1589,6 +1588,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           current.version,
           cleared,
           {
+            signerInvocationID: normalized.signerInvocationID,
             startedAtUnixMs: normalized.boundaryStartedAtUnixMs,
             preparationAttempts: normalized.preparationAttempts,
             nonceReservationID: normalized.nonceReservationID,
@@ -1660,6 +1660,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     expectedVersion: number,
     next: P2TRSignatureFraudChallengeOutboxRecord,
     boundary: {
+      signerInvocationID: string
       startedAtUnixMs: number
       preparationAttempts: number
       nonceReservationID: string
@@ -1695,6 +1696,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
   private async retireUninvokedBoundaryIncidents(
     recordID: string,
     boundary: {
+      signerInvocationID: string
       startedAtUnixMs: number
       preparationAttempts: number
       nonceReservationID: string
@@ -1726,9 +1728,19 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         : `0x${boundary.nonceReservationID}`,
       "Uninvoked boundary nonce reservation ID"
     )
+    const signerInvocationID = bytes32(
+      boundary.signerInvocationID.startsWith("0x")
+        ? boundary.signerInvocationID
+        : `0x${boundary.signerInvocationID}`,
+      "Uninvoked boundary signer invocation ID"
+    )
+    // v2 binds the invocation ID, so both halves of one retirement — this
+    // incident row and the signer-boundary resolution committed in the same
+    // transaction — name the same boundary identity.
     const resolutionDigest = hashStructured({
-      domain: "tbtc-p2tr-signature-fraud-provenance-incident-resolution-v1",
+      domain: "tbtc-p2tr-signature-fraud-provenance-incident-resolution-v2",
       recordID: normalizedRecordID,
+      signerInvocationID,
       boundaryStartedAtUnixMs: startedAtUnixMs,
       preparationAttempts: boundary.preparationAttempts,
       nonceReservationID,
@@ -1736,13 +1748,15 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     await this.options.session.query(
       `INSERT INTO p2tr_signature_fraud_challenge_provenance_incident_resolution (
           incident_id, record_id, provenance_invalidation_id,
+          signer_invocation_id,
           boundary_started_at_unix_ms, preparation_attempts,
           nonce_reservation_id, resolution_digest, resolved_at_unix_ms
        )
        SELECT incident.incident_id,
               incident.record_id,
               incident.provenance_invalidation_id,
-              $2, $3, decode($4, 'hex'), decode($5, 'hex'), $6
+              decode($7, 'hex'), $2, $3, decode($4, 'hex'),
+              decode($5, 'hex'), $6
          FROM p2tr_signature_fraud_challenge_provenance_incident incident
         WHERE incident.record_id = decode($1, 'hex')
           AND incident.incident_kind IN (
@@ -1760,6 +1774,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           resolvedAtUnixMs,
           "Uninvoked boundary retirement time"
         ),
+        stripHex(signerInvocationID),
       ]
     )
   }
@@ -1914,9 +1929,12 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         artifact.capturedAtUnixMs
       ),
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       signerInvocationStartedAtUnixMs:
         current.signerInvocationStartedAtUnixMs ??
         current.activeSignerInvocationStartedAtUnixMs,
+      signerInvocationID:
+        current.signerInvocationID ?? current.activeSignerInvocationID,
       unexpectedSignedArtifacts: alreadyCaptured
         ? artifacts
         : [...artifacts, artifact],
@@ -2070,6 +2088,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         // atomically journals its signed bytes or failure disposition.
         activeSignerInvocationStartedAtUnixMs:
           current.activeSignerInvocationStartedAtUnixMs,
+        activeSignerInvocationID: current.activeSignerInvocationID,
         updatedAtUnixMs: Math.max(
           current.updatedAtUnixMs,
           evidence.invalidatedAtUnixMs
@@ -2740,8 +2759,22 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     )
     setOptional(
       state,
+      "signerInvocationID",
+      row.signer_invocation_id === null
+        ? undefined
+        : prefixedHex(row.signer_invocation_id)
+    )
+    setOptional(
+      state,
       "activeSignerInvocationStartedAtUnixMs",
       optionalDatabaseInteger(row.active_signer_invocation_started_at_unix_ms)
+    )
+    setOptional(
+      state,
+      "activeSignerInvocationID",
+      row.active_signer_invocation_id === null
+        ? undefined
+        : prefixedHex(row.active_signer_invocation_id)
     )
     setOptional(
       state,
@@ -4118,7 +4151,9 @@ const DURABLE_OUTBOX_RECORD_KEYS = new Set([
   "preparationLease",
   "preparationResumeStatus",
   "activeSignerInvocationStartedAtUnixMs",
+  "activeSignerInvocationID",
   "signerInvocationStartedAtUnixMs",
+  "signerInvocationID",
   "preparedTransaction",
   "preparedTransactionVariants",
   "lastBroadcastAtUnixMs",
@@ -5224,8 +5259,12 @@ function outboxMutableColumns(
     nonce_reserved_at_unix_ms: record.nonceReservedAtUnixMs ?? null,
     signer_invocation_started_at_unix_ms:
       record.signerInvocationStartedAtUnixMs ?? null,
+    signer_invocation_id: optionalDatabaseBytes(record.signerInvocationID),
     active_signer_invocation_started_at_unix_ms:
       record.activeSignerInvocationStartedAtUnixMs ?? null,
+    active_signer_invocation_id: optionalDatabaseBytes(
+      record.activeSignerInvocationID
+    ),
     latest_variant_sequence: latestVariant?.sequence ?? null,
     prepared_transaction_hash:
       latestVariant === undefined

--- a/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
@@ -82,6 +82,7 @@ export class InMemoryOutboxStore
   /** Append-only retirement evidence, mirroring the PostgreSQL table. */
   readonly retiredProvenanceIncidents: {
     recordID: string
+    signerInvocationID: string
     boundaryStartedAtUnixMs: number
     preparationAttempts: number
     nonceReservationID: string
@@ -505,11 +506,12 @@ export class InMemoryOutboxStore
         "Orphaned signer boundary resolution names an absent outbox record"
       )
     }
+    // Mirrors the PRIMARY KEY (record_id, signer_invocation_id) the adapter
+    // now probes. Keying on anything else lets the double accept a second
+    // resolution PostgreSQL would reject as a duplicate, or vice versa.
     const key = [
       normalizeKey(normalized.recordID),
-      normalized.boundaryStartedAtUnixMs,
-      normalized.preparationAttempts,
-      normalized.nonceReservationID,
+      normalizeKey(normalized.signerInvocationID),
     ].join(":")
     const existing = this.signerBoundaryResolutions.get(key)
     if (existing !== undefined) {
@@ -539,6 +541,7 @@ export class InMemoryOutboxStore
         ...current,
         version: current.version + 1,
         activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
         updatedAtUnixMs: Math.max(
           current.updatedAtUnixMs,
           normalized.resolvedAtUnixMs
@@ -552,6 +555,7 @@ export class InMemoryOutboxStore
           current.version,
           cleared,
           {
+            signerInvocationID: normalized.signerInvocationID,
             startedAtUnixMs: normalized.boundaryStartedAtUnixMs,
             preparationAttempts: normalized.preparationAttempts,
             nonceReservationID: normalized.nonceReservationID,
@@ -642,6 +646,7 @@ export class InMemoryOutboxStore
     expectedVersion: number,
     next: P2TRSignatureFraudChallengeOutboxRecord,
     boundary: {
+      signerInvocationID: string
       startedAtUnixMs: number
       preparationAttempts: number
       nonceReservationID: string
@@ -663,7 +668,13 @@ export class InMemoryOutboxStore
         "provenance incident resolution requires a boundary with no signer escape evidence"
       )
     }
+    // The same predicate the re-keyed database guard enforces: identity by
+    // invocation ID, with the descriptive columns still checked so append-only
+    // retirement evidence cannot record a boundary that never existed.
     if (
+      durable.activeSignerInvocationID === undefined ||
+      prefixedReservationID(durable.activeSignerInvocationID) !==
+        prefixedReservationID(boundary.signerInvocationID) ||
       durable.activeSignerInvocationStartedAtUnixMs !==
         boundary.startedAtUnixMs ||
       durable.preparationAttempts !== boundary.preparationAttempts ||
@@ -680,6 +691,7 @@ export class InMemoryOutboxStore
     }
     this.retiredProvenanceIncidents.push({
       recordID: next.recordID,
+      signerInvocationID: boundary.signerInvocationID,
       boundaryStartedAtUnixMs: boundary.startedAtUnixMs,
       preparationAttempts: boundary.preparationAttempts,
       nonceReservationID: boundary.nonceReservationID,
@@ -834,9 +846,12 @@ export class InMemoryOutboxStore
           ? current.preparationResumeStatus
           : undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       signerInvocationStartedAtUnixMs:
         current.signerInvocationStartedAtUnixMs ??
         current.activeSignerInvocationStartedAtUnixMs,
+      signerInvocationID:
+        current.signerInvocationID ?? current.activeSignerInvocationID,
       signerQuarantines,
       unexpectedSignedArtifacts: alreadyCaptured
         ? artifacts
@@ -956,6 +971,7 @@ export class InMemoryOutboxStore
           : undefined,
         activeSignerInvocationStartedAtUnixMs:
           current.activeSignerInvocationStartedAtUnixMs,
+        activeSignerInvocationID: current.activeSignerInvocationID,
         updatedAtUnixMs: evidence.invalidatedAtUnixMs,
         lastError: evidence.reason,
       }

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -74,6 +74,7 @@ import {
   invalidateP2TRSignatureFraudCanonicalProvenance,
   quarantineLegacyP2TRSignatureFraudSubmissions,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
+import { computeP2TRSignatureFraudSignerInvocationID } from "../src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
 import {
   InMemoryOutboxStore,
   RollbackAwareInMemoryOutboxStore,
@@ -3334,4 +3335,114 @@ test("binds the reserved lane's envelope, not the manifest's first lane", async 
   assert.equal(binding.maxFeePerGas, "100")
   assert.equal(binding.maxPriorityFeePerGas, "10")
   assert.equal(binding.maxTotalFeeWei, "100000000")
+})
+
+test("commits a deterministic invocation identity with the signer marker", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const preparer = new FixedPreparer()
+  const authorizer = new FixedBoundaryAuthorizer()
+  // Observed at the instant the signer is called, i.e. strictly after the swap
+  // that made the boundary durable.
+  let atSignerCall: P2TRSignatureFraudChallengeOutboxRecord | undefined
+  preparer.afterInitialSign = async () => {
+    atSignerCall = await store.get(record.recordID)
+  }
+  const outbox = dispatcher(
+    store,
+    preparer,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 2_000,
+    100,
+    undefined,
+    authorizer
+  )
+
+  assert.equal(
+    (await outbox.prepare(record.recordID, "worker-a")).status,
+    "prepared"
+  )
+  const [binding] = authorizer.bindings
+  assert.ok(binding)
+  const expected = computeP2TRSignatureFraudSignerInvocationID(binding)
+
+  // The identity is durable before the signer runs, not written afterwards.
+  assert.equal(atSignerCall?.activeSignerInvocationStartedAtUnixMs, 2_000)
+  assert.equal(atSignerCall?.activeSignerInvocationID, expected)
+
+  // Deterministic: recomputing from the same binding reproduces it exactly,
+  // while any different boundary yields a different identity.
+  assert.equal(computeP2TRSignatureFraudSignerInvocationID(binding), expected)
+  assert.notEqual(
+    computeP2TRSignatureFraudSignerInvocationID({
+      ...binding,
+      attempt: binding.attempt + 1,
+    }),
+    expected
+  )
+
+  // Cleared with the marker once the signer returns, and promoted to the
+  // historical identity so the boundary that ran stays nameable.
+  const prepared = await store.get(record.recordID)
+  assert.equal(prepared?.activeSignerInvocationStartedAtUnixMs, undefined)
+  assert.equal(prepared?.activeSignerInvocationID, undefined)
+  assert.equal(prepared?.signerInvocationID, expected)
+})
+
+test("gives the replacement boundary its own committed identity", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const preparer = new FixedPreparer()
+  const authorizer = new FixedBoundaryAuthorizer()
+  const durableAtSign: (P2TRSignatureFraudChallengeOutboxRecord | undefined)[] =
+    []
+  preparer.afterInitialSign = async () => {
+    durableAtSign.push(await store.get(record.recordID))
+  }
+  preparer.afterReplacementSign = async () => {
+    durableAtSign.push(await store.get(record.recordID))
+  }
+  const outbox = dispatcher(
+    store,
+    preparer,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 2_000,
+    100,
+    undefined,
+    authorizer
+  )
+
+  assert.equal(
+    (await outbox.prepare(record.recordID, "worker-a")).status,
+    "prepared"
+  )
+  assert.equal(
+    (await outbox.prepareReplacement(record.recordID, "worker-b")).status,
+    "prepared"
+  )
+
+  const [prepareBinding, replacementBinding] = authorizer.bindings
+  assert.ok(prepareBinding)
+  assert.ok(replacementBinding)
+  const prepareID = computeP2TRSignatureFraudSignerInvocationID(prepareBinding)
+  const replacementID =
+    computeP2TRSignatureFraudSignerInvocationID(replacementBinding)
+
+  // Two boundaries on one record are two identities, each durable before its
+  // own signer call.
+  assert.notEqual(prepareID, replacementID)
+  assert.equal(durableAtSign[0]?.activeSignerInvocationID, prepareID)
+  assert.equal(durableAtSign[1]?.activeSignerInvocationID, replacementID)
+
+  // The historical identity names the FIRST boundary that reached a signer,
+  // matching the `??` semantics of signerInvocationStartedAtUnixMs beside it —
+  // it is proof that some signer call began, not a pointer to the latest.
+  const durable = await store.get(record.recordID)
+  assert.equal(durable?.activeSignerInvocationID, undefined)
+  assert.equal(durable?.signerInvocationID, prepareID)
+  assert.equal(durable?.signerInvocationStartedAtUnixMs, 2_000)
 })

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -607,12 +607,14 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution/
   )
-  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v1/)
-  // The boundary tuple is the row identity, so evidence can never speak for a
-  // boundary other than the one it names.
+  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v2/)
+  // The deterministic invocation ID is the row identity, so evidence can never
+  // speak for a boundary other than the one it names — and unlike the wall-clock
+  // tuple it replaced, it cannot drift while the boundary is open.
+  assert.match(migration, /PRIMARY KEY \(record_id, signer_invocation_id\)/)
   assert.match(
     migration,
-    /PRIMARY KEY \( record_id, boundary_started_at_unix_ms, preparation_attempts, nonce_reservation_id \)/
+    /signer_invocation_id bytea NOT NULL CHECK \( octet_length\(signer_invocation_id\) = 32 \)/
   )
   assert.match(
     migration,

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -1213,6 +1213,7 @@ postgresTest(
       updatedAtUnixMs: 1_300,
       signerInvocationStartedAtUnixMs: 1_300,
       activeSignerInvocationStartedAtUnixMs: 1_300,
+      activeSignerInvocationID: boundaryInvocationID(1_300),
     }
     assert.equal(
       await database.store.compareAndSwap(
@@ -1451,6 +1452,7 @@ postgresTest(
       updatedAtUnixMs: 1_300,
       signerInvocationStartedAtUnixMs: 1_300,
       activeSignerInvocationStartedAtUnixMs: 1_300,
+      activeSignerInvocationID: boundaryInvocationID(1_300),
     }
     await begin(database.client)
     assert.equal(
@@ -1472,6 +1474,7 @@ postgresTest(
       // may clear it, and the capture below is that observation.
       activeSignerInvocationStartedAtUnixMs:
         signerBoundary.activeSignerInvocationStartedAtUnixMs,
+      activeSignerInvocationID: signerBoundary.activeSignerInvocationID,
       signerQuarantines: [
         {
           laneID: LANE_ID,
@@ -1571,6 +1574,7 @@ postgresTest(
       updatedAtUnixMs: 1_300,
       signerInvocationStartedAtUnixMs: 1_300,
       activeSignerInvocationStartedAtUnixMs: 1_300,
+      activeSignerInvocationID: boundaryInvocationID(1_300),
     }
     assert.equal(
       await database.store.compareAndSwap(
@@ -1607,6 +1611,7 @@ postgresTest(
       updatedAtUnixMs: 1_400,
       preparationLease: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       preparedTransaction,
       preparedTransactionVariants: [
         {
@@ -1964,6 +1969,7 @@ function activeInitialSignerBoundary(
     version: reserved.version + 1,
     updatedAtUnixMs: now,
     activeSignerInvocationStartedAtUnixMs: now,
+    activeSignerInvocationID: boundaryInvocationID(now),
   }
 }
 
@@ -1982,6 +1988,7 @@ function reconciliationTransition(
     preparationLease: undefined,
     preparationResumeStatus: undefined,
     activeSignerInvocationStartedAtUnixMs: undefined,
+    activeSignerInvocationID: undefined,
     signerInvocationStartedAtUnixMs:
       current.signerInvocationStartedAtUnixMs ??
       current.activeSignerInvocationStartedAtUnixMs,
@@ -2024,9 +2031,14 @@ async function forceDurableReconciliation(
             preparation_lease_expires_at_unix_ms = NULL,
             preparation_resume_status = NULL,
             active_signer_invocation_started_at_unix_ms = NULL,
+            active_signer_invocation_id = NULL,
             signer_invocation_started_at_unix_ms = coalesce(
                 signer_invocation_started_at_unix_ms,
                 active_signer_invocation_started_at_unix_ms
+            ),
+            signer_invocation_id = coalesce(
+                signer_invocation_id,
+                active_signer_invocation_id
             ),
             updated_at_unix_ms = updated_at_unix_ms + 1,
             record_state = jsonb_set(
@@ -2160,6 +2172,7 @@ postgresTest(
 
     assert.ok(invalidated.reservedNonce)
     const retiredBoundary = {
+      signerInvocationID: boundaryInvocationID(1_300),
       startedAtUnixMs: 1_300,
       preparationAttempts: invalidated.preparationAttempts,
       nonceReservationID: invalidated.reservedNonce.reservationID.toString(),
@@ -2173,6 +2186,7 @@ postgresTest(
           ...invalidated,
           version: invalidated.version + 1,
           activeSignerInvocationStartedAtUnixMs: undefined,
+          activeSignerInvocationID: undefined,
           updatedAtUnixMs: 2_400,
         },
         retiredBoundary,
@@ -2611,6 +2625,7 @@ function signerBoundaryRecord(
     updatedAtUnixMs: 1_300,
     signerInvocationStartedAtUnixMs: 1_300,
     activeSignerInvocationStartedAtUnixMs: 1_300,
+    activeSignerInvocationID: boundaryInvocationID(1_300),
   }
 }
 
@@ -2655,6 +2670,7 @@ async function replacementSignerBoundary(
     updatedAtUnixMs: 1_400,
     preparationLease: undefined,
     activeSignerInvocationStartedAtUnixMs: undefined,
+    activeSignerInvocationID: undefined,
     preparedTransaction,
     preparedTransactionVariants: [
       {
@@ -2673,6 +2689,7 @@ async function replacementSignerBoundary(
       version: prepared.version + 1,
       updatedAtUnixMs: 1_500,
       activeSignerInvocationStartedAtUnixMs: 1_500,
+      activeSignerInvocationID: boundaryInvocationID(1_500),
     },
   ]
 }
@@ -2744,6 +2761,7 @@ const escapedCaptureParityScenarios: EscapedCaptureParityScenario[] = [
       {
         ...signerBoundaryRecord(reserved),
         activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
       },
     ],
     captures: [{ capturedAtUnixMs: 2_100 }],
@@ -2792,6 +2810,14 @@ for (const scenario of escapedCaptureParityScenarios) {
 // ---------------------------------------------------------------------------
 
 const BOUNDARY_PROVIDER_DIGEST = `0x${"c7".repeat(32)}`
+/**
+ * A deterministic stand-in for computeP2TRSignatureFraudSignerInvocationID.
+ * The production value is a digest over the whole boundary binding; these
+ * suites only need distinct markers to yield distinct identities.
+ */
+const boundaryInvocationID = (marker: number): string =>
+  `0x${marker.toString(16).padStart(64, "0")}`
+
 const BOUNDARY_SIGNED_HASH = `0x${"5a".repeat(32)}`
 
 type BoundaryAttestationMode =
@@ -2803,6 +2829,7 @@ type BoundaryAttestationMode =
 
 type BoundaryResolutionOverrides = {
   recordID?: string
+  signerInvocationID?: string
   boundaryStartedAtUnixMs?: number
   preparationAttempts?: number
   nonceReservationID?: string
@@ -2862,6 +2889,10 @@ function boundaryResolution(
   const outcome = overrides.outcome ?? "never-invoked"
   const binding = {
     recordID: overrides.recordID ?? record.recordID,
+    signerInvocationID:
+      overrides.signerInvocationID ??
+      record.activeSignerInvocationID ??
+      boundaryInvocationID(1_300),
     boundaryStartedAtUnixMs:
       overrides.boundaryStartedAtUnixMs ??
       record.activeSignerInvocationStartedAtUnixMs ??
@@ -2984,6 +3015,7 @@ postgresTest(
       reservedNonce: undefined,
       nonceReservedAtUnixMs: undefined,
       activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       voidedNonceReservations: [
         {
           reservation: boundary.reservedNonce!,
@@ -3134,7 +3166,8 @@ postgresTest(
     ): Promise<void> => {
       await database.client.query(
         `INSERT INTO p2tr_signature_fraud_challenge_signer_boundary_resolution (
-            record_id, boundary_started_at_unix_ms, preparation_attempts,
+            record_id, signer_invocation_id, boundary_started_at_unix_ms,
+            preparation_attempts,
             nonce_reservation_id, stage, invoked_at_unix_ms, outcome,
             provider_evidence_digest, resolution_evidence_digest,
             primary_trust_domain_id, primary_independence_domain_id,
@@ -3144,7 +3177,8 @@ postgresTest(
             corroborating_evidence_digest, corroborating_attestation,
             corroborating_attested_at_unix_ms, resolved_at_unix_ms
          ) VALUES (
-            decode($1, 'hex'), $2, $3, decode($4, 'hex'), 'prepare', $5,
+            decode($1, 'hex'), decode($8, 'hex'), $2, $3,
+            decode($4, 'hex'), 'prepare', $5,
             'never-invoked', decode($6, 'hex'), decode($7, 'hex'),
             'signer-primary', 'signer-primary-infra', decode($7, 'hex'),
             decode('01', 'hex'), 2000, 'signer-corroborating',
@@ -3159,6 +3193,7 @@ postgresTest(
           resolution.invokedAtUnixMs,
           resolution.providerEvidenceDigest.slice(2),
           evidenceDigest.slice(2),
+          resolution.signerInvocationID.slice(2),
         ]
       )
     }
@@ -3168,8 +3203,19 @@ postgresTest(
     await assert.rejects(
       rawInsert(
         boundaryResolution(boundary, {
-          boundaryStartedAtUnixMs: 1_299,
+          signerInvocationID: `0x${"e2".repeat(32)}`,
           invokedAtUnixMs: 1_310,
+        })
+      ),
+      /does not name the durable boundary/
+    )
+    // Both halves of the guard's ownership predicate, from raw SQL: the
+    // identity, and a descriptive column that no longer matches the durable row.
+    await assert.rejects(
+      rawInsert(
+        boundaryResolution(boundary, {
+          boundaryStartedAtUnixMs: 1_290,
+          invokedAtUnixMs: 1_299,
         })
       ),
       /does not name the durable boundary/
@@ -3408,7 +3454,9 @@ function orphanedBoundaryResult(
         outcome,
         `status=${record?.status ?? "missing"}`,
         `active=${record?.activeSignerInvocationStartedAtUnixMs ?? "none"}`,
+        `activeID=${record?.activeSignerInvocationID ?? "none"}`,
         `signer=${record?.signerInvocationStartedAtUnixMs ?? "none"}`,
+        `signerID=${record?.signerInvocationID ?? "none"}`,
         `artifacts=${record?.unexpectedSignedArtifacts?.length ?? 0}`,
       ].join(" ")
 }
@@ -3518,11 +3566,14 @@ function orphanedBoundaryOnly(
 }
 
 const CLEARED_ORPHAN =
-  "acknowledged status=preparing active=none signer=none artifacts=0"
+  "acknowledged status=preparing active=none activeID=none signer=none " +
+  "signerID=none artifacts=0"
 const RETAINED_ORPHAN =
-  "acknowledged status=preparing active=1300 signer=none artifacts=0"
+  "acknowledged status=preparing active=1300 activeID=0x0000000000000000000000000000000000000000000000000000000000000514 " +
+  "signer=none signerID=none artifacts=0"
 const UNSAFE_ORPHAN =
-  "unsafe status=preparing active=1300 signer=none artifacts=0"
+  "unsafe status=preparing active=1300 activeID=0x0000000000000000000000000000000000000000000000000000000000000514 signer=none " +
+  "signerID=none artifacts=0"
 const WRONG_BOUNDARY =
   "error:Orphaned signer boundary resolution does not name the durable boundary"
 
@@ -3544,8 +3595,35 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
     expectedAlertCodes: [],
   },
   {
-    name: "rejects a different boundary start",
+    // No scenario anywhere resolved two DISTINCT boundaries on one record, so
+    // the row identity was under-tested: keying the in-memory map on the record
+    // alone would have passed everything while diverging from the PostgreSQL
+    // primary key. Two resolutions, two identities, one record.
+    name: "keeps two distinct boundaries on one record apart",
+    seed: 238,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [
+      {},
+      {
+        signerInvocationID: `0x${"e3".repeat(32)}`,
+        boundaryStartedAtUnixMs: 1_301,
+        invokedAtUnixMs: 1_311,
+      },
+    ],
+    expected: [CLEARED_ORPHAN, WRONG_BOUNDARY],
+    expectedAlertCodes: [],
+  },
+  {
+    name: "rejects a different signer invocation ID",
     seed: 222,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [{ signerInvocationID: `0x${"e1".repeat(32)}` }],
+    expected: [WRONG_BOUNDARY],
+    expectedAlertCodes: [],
+  },
+  {
+    name: "rejects a different boundary start",
+    seed: 239,
     boundary: orphanedBoundaryOnly,
     resolutions: [{ boundaryStartedAtUnixMs: 1_299 }],
     expected: [WRONG_BOUNDARY],
@@ -3715,7 +3793,10 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
         outcome: "terminal-unsafe",
       },
     ],
-    expected: ["unsafe status=prepared active=1500 signer=1300 artifacts=0"],
+    expected: [
+      "unsafe status=prepared active=1500 activeID=0x00000000000000000000000000000000000000000000000000000000000005dc signer=1300 " +
+        "signerID=none artifacts=0",
+    ],
     expectedAlertCodes: ["signer-boundary-terminal-unsafe"],
   },
 ]


### PR DESCRIPTION
Blocker A, increment 2 of `BLOCKER-A-SCOPE.md`. Stacked on #1043.

## What it does

A signer boundary had no identity. What served as one was a wall-clock tuple — `(record_id, boundary_started_at_unix_ms, preparation_attempts, nonce_reservation_id)` — that was the primary key of the orphaned-boundary resolution table. It embedded `this.now()`, it was never sent to the signer, and it was not a digest, so a provider could not journal or dedupe per invocation.

`computeP2TRSignatureFraudSignerInvocationID` is a domain-separated digest **derived from the request-binding digest** rather than by walking the binding a second time. A second walk would need a third canonicalizer — precisely the silent-drop failure the key-set assertion from #1043 guards against — so deriving it means the identity inherits the binding's field coverage for free. The domain must differ, or the value would be byte-identical to a digest that already travels to an external attester and is about to become a durable primary key.

It is committed **in the same swap that sets the pre-I/O marker**. That is possible because the binding reads no marker and is built from the record `nextRecord` already produced, which carries the post-swap version. Building before the swap also inverts the failure for the better: a binding that cannot be built now strands nothing, because no durable marker exists yet.

## What the identity does *not* replace

The boundary start, the preparation attempt and the nonce reservation are still compared against the durable row, in both the TypeScript assert and the PostgreSQL guard.

An earlier revision of this branch dropped them on the theory that matching `preparation_attempts` was racy. That was wrong, and an adversarial review disproved it by reproduction: the attempt cannot drift while the marker is set (`prepare` requires status `queued`, `prepareReplacement` clears the marker in the same swap, `recoverExpiredPreparation` retains it only when quarantined), the start is immutable in flight and NULL-paired with the ID, and the reservation cannot be NULLed under an active marker. All three were race-free and free to keep — and dropping them let a resolution carrying the correct ID but fabricated start / attempt / reservation be **accepted**, writing permanently wrong forensics into two append-only tables.

PostgreSQL compares the identity against the durable column rather than re-deriving it: the binding preimage spans three tables and a TypeScript layout. That is the same standard `nonce_reservation_id` already met.

## Breaking change

Migration 003 gains `active_signer_invocation_id` and `signer_invocation_id`, re-keys the boundary resolution onto `PRIMARY KEY (record_id, signer_invocation_id)`, and moves the resolution evidence digest to `tbtc-p2tr-signer-boundary-independent-resolution-v2`. 003 is not on `main` and the table is append-only, so this is an in-place edit with no data-migration path.

A CHECK pairs the **active** marker and its identity as NULL-together: the activation barrier counts outstanding invocations by that marker's null transitions alone, and would otherwise count an invocation with no identity. The **historical** pair is deliberately not paired — a failure record may have to assert that some signer call began from a fallback clock when no identity survived.

`record_id` stays the leading PK column because the PK is the table's only index and two queries filter on it alone.

Both halves of one retirement move together: the provenance-incident resolution is written in the same transaction, so it carries the same identity and its digest moves to v2. Leaving it on the wall clock would give one boundary two identities.

## Verification

Watchtower suite with PostgreSQL: **393/393 → 397/397**, no existing title lost.

TS/SQL digest parity verified byte-for-byte on two vectors against a live PostgreSQL 16 under the v2 layout.

Three mutants each killed by exactly the intended test: writing the identity after the swap instead of within it, keying the in-memory double on the record alone, and dropping the three restored equalities.

New coverage fills gaps the review located rather than the suite: the identity is committed with the marker and promoted on completion; the replacement boundary gets its **own** distinct identity (deleting that line previously left 183/183 green); and two distinct boundaries on one record stay apart — nothing tested that before, so re-keying the in-memory map to `recordID` alone would have passed the whole suite while diverging from the primary key.

## Known, out of scope

The broadcast boundary gets no invocation ID: it owns no signer marker and has no resolution table, so an ID would have nowhere to live.

Separately noted while verifying the DDL: migration **004 does not apply to PostgreSQL at all** — `ERROR: syntax error at or near "authorization"`, a reserved word used as a table alias. Pre-existing; nothing executes 004 because the migration test only regex-matches file text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZat6B9TisDJ6oW37AG8qH