### PR TITLE
feat(watchtower)!: make the signer name the request it served

### DIFF
--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -2111,6 +2111,7 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_quarantine (
         'wrong-sender',
         'wrong-nonce',
         'malformed-signed-envelope',
+        'wrong-signer-invocation-request',
         'invalid-replacement-envelope',
         'reservation-binding-mismatch',
         'reservation-provider-failure'

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -30,7 +30,7 @@ import {
 
 // A value import, unlike the authorization module's type-only import of this
 // file, so the dependency runs one way at run time and there is no cycle.
-import { computeP2TRSignatureFraudSignerInvocationID } from "./P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
+import { computeP2TRSignatureFraudSignerInvocationRequest } from "./P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
 import type { P2TRSignatureFraudWatchtowerStoreProfileProvider } from "./types.js"
 
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_PAGE_SIZE = 1_000
@@ -1193,6 +1193,7 @@ export type P2TRSignatureFraudSignerQuarantine = {
     | "wrong-sender"
     | "wrong-nonce"
     | "malformed-signed-envelope"
+    | "wrong-signer-invocation-request"
     | "invalid-replacement-envelope"
     | "reservation-binding-mismatch"
     | "reservation-provider-failure"
@@ -2390,11 +2391,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         `Initial signer authorization failed: ${errorMessage(error)}`
       )
     }
+    const signerInvocation = computeP2TRSignatureFraudSignerInvocationRequest(
+      signerAuthorizationBinding
+    )
     const signerBoundary: P2TRSignatureFraudChallengeOutboxRecord = {
       ...pendingBoundary,
-      activeSignerInvocationID: computeP2TRSignatureFraudSignerInvocationID(
-        signerAuthorizationBinding
-      ),
+      activeSignerInvocationID: signerInvocation.invocationID,
     }
     if (
       !(await this.store.compareAndSwapWithCurrentCanonicalProvenance(
@@ -2447,7 +2449,8 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         await selectedPreparer.prepareSignatureFraudChallengeTransaction(
           signerBoundary.intent,
           reservation,
-          selectedFeePolicy
+          selectedFeePolicy,
+          signerInvocationRequest(signerInvocation)
         )
     } catch (error) {
       const failed = this.signerFailureRecord(
@@ -2495,6 +2498,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         )
       }
       return this.requireRecord(key)
+    }
+    const echoMismatch = signerInvocationEchoMismatch(escaped, signerInvocation)
+    if (echoMismatch !== undefined) {
+      return this.completeWrongInvocationRequest(
+        signerBoundary,
+        selectedPreparer,
+        escaped,
+        echoMismatch
+      )
     }
     try {
       prepared =
@@ -2743,11 +2755,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         `Replacement signer authorization failed: ${errorMessage(error)}`
       )
     }
+    const signerInvocation = computeP2TRSignatureFraudSignerInvocationRequest(
+      signerAuthorizationBinding
+    )
     const signerBoundary: P2TRSignatureFraudChallengeOutboxRecord = {
       ...pendingBoundary,
-      activeSignerInvocationID: computeP2TRSignatureFraudSignerInvocationID(
-        signerAuthorizationBinding
-      ),
+      activeSignerInvocationID: signerInvocation.invocationID,
     }
     if (
       !(await this.store.compareAndSwapWithCurrentCanonicalProvenance(
@@ -2797,7 +2810,8 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
           signerBoundary.intent,
           current.reservedNonce,
           previous,
-          selectedFeePolicy
+          selectedFeePolicy,
+          signerInvocationRequest(signerInvocation)
         )
     } catch (error) {
       const failed = this.signerFailureRecord(
@@ -2845,6 +2859,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         )
       }
       return this.requireRecord(key)
+    }
+    const echoMismatch = signerInvocationEchoMismatch(escaped, signerInvocation)
+    if (echoMismatch !== undefined) {
+      return this.completeWrongInvocationRequest(
+        signerBoundary,
+        selectedPreparer,
+        escaped,
+        echoMismatch
+      )
     }
     try {
       replacement =
@@ -4590,6 +4613,39 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
   }
 
   /**
+   * Completes a boundary whose signer served a different request.
+   *
+   * The bytes are fully authenticated by this point, so they are captured as an
+   * unexpected signed artifact rather than discarded: the signer was invoked,
+   * consumed the reserved nonce, and may hold further bytes we never saw.
+   * Treating this as an uninvoked boundary would be a lie about the nonce.
+   */
+  private async completeWrongInvocationRequest(
+    signerBoundary: P2TRSignatureFraudChallengeOutboxRecord,
+    preparer: P2TRSignatureFraudChallengeTransactionPreparer,
+    escaped: P2TRSignatureFraudPreparedChallengeTransaction,
+    reason: string
+  ): Promise<P2TRSignatureFraudChallengeOutboxRecord> {
+    const failed = this.signerFailureRecord(
+      signerBoundary,
+      preparer,
+      reason,
+      true,
+      escaped,
+      "wrong-signer-invocation-request"
+    )
+    if (!(await this.compareAndSwapSignerCompletion(signerBoundary, failed))) {
+      return this.completeSignerFailureAfterLostCas(
+        signerBoundary,
+        preparer,
+        reason,
+        "wrong-signer-invocation-request"
+      )
+    }
+    return this.requireRecord(signerBoundary.recordID)
+  }
+
+  /**
    * Records why a boundary binding could not be built, for a claim that never
    * reached the durable marker. There is nothing to clear — the invocation
    * identity is derived before the swap that would set the marker, so a failure
@@ -5728,6 +5784,50 @@ const validateRecordFeePolicyManifest = (
     )
   }
 }
+
+/**
+ * Compares the echo the signer returned against the request it was handed.
+ *
+ * Returns a reason on mismatch, `undefined` when they agree. The echo is an
+ * assertion — a signer can copy it beside bytes it signed for something else —
+ * so this catches a response that does not belong to this request, not a signer
+ * that lies. Conformance of the transaction to the request is enforced
+ * separately and field by field by the SDK validators.
+ */
+const signerInvocationEchoMismatch = (
+  prepared: P2TRSignatureFraudPreparedChallengeTransaction,
+  expected: { invocationID: string; requestDigest: string }
+): string | undefined => {
+  const echo = prepared.invocation
+  if (echo === undefined) {
+    return "Signer returned no invocation request echo"
+  }
+  const echoedID = normalizeBytes32(
+    echo.invocationID,
+    "Echoed signer invocation ID"
+  )
+  const echoedDigest = normalizeBytes32(
+    echo.requestDigest,
+    "Echoed signer invocation request digest"
+  )
+  if (
+    echoedID !== normalizeBytes32(expected.invocationID, "Invocation ID") ||
+    echoedDigest !==
+      normalizeBytes32(expected.requestDigest, "Invocation request digest")
+  ) {
+    return "Signer echoed another invocation request"
+  }
+  return undefined
+}
+
+/** Bridges the record's plain-hex identities into the SDK's `Hex` shape. */
+const signerInvocationRequest = (invocation: {
+  invocationID: string
+  requestDigest: string
+}) => ({
+  invocationID: Hex.from(invocation.invocationID),
+  requestDigest: Hex.from(invocation.requestDigest),
+})
 
 const requireReservedNonce = (
   record: P2TRSignatureFraudChallengeOutboxRecord,

--- a/services/watchtower/src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.ts
+++ b/services/watchtower/src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.ts
@@ -93,18 +93,34 @@ export const P2TR_SIGNATURE_FRAUD_SIGNER_INVOCATION_DOMAIN =
 export function computeP2TRSignatureFraudSignerInvocationID(
   binding: P2TRSignatureFraudIrreversibleBoundaryBinding
 ): string {
-  const requestBindingDigest = computeP2TRReconcilerRequestBindingDigest(
-    reconcilerRequestBinding(normalizeBoundaryBinding(binding))
+  return computeP2TRSignatureFraudSignerInvocationRequest(binding).invocationID
+}
+
+/**
+ * The identity AND the digest it commits to, from one canonicalization.
+ *
+ * The signer is handed both: the digest names the request, and the ID is the
+ * caller's durable handle for this invocation, so a provider can journal
+ * against the same value the outbox persisted. Computing them together is what
+ * keeps the outbox off a second canonicalization path — the digest is otherwise
+ * reachable only inside the authorizer.
+ */
+export function computeP2TRSignatureFraudSignerInvocationRequest(
+  binding: P2TRSignatureFraudIrreversibleBoundaryBinding
+): { invocationID: string; requestDigest: string } {
+  const requestDigest = bytes32(
+    computeP2TRReconcilerRequestBindingDigest(
+      reconcilerRequestBinding(normalizeBoundaryBinding(binding))
+    ),
+    "Request binding digest"
   )
-  return `0x${createHash("sha256")
-    .update(P2TR_SIGNATURE_FRAUD_SIGNER_INVOCATION_DOMAIN, "utf8")
-    .update(
-      Buffer.from(
-        bytes32(requestBindingDigest, "Request binding digest"),
-        "hex"
-      )
-    )
-    .digest("hex")}`
+  return {
+    invocationID: `0x${createHash("sha256")
+      .update(P2TR_SIGNATURE_FRAUD_SIGNER_INVOCATION_DOMAIN, "utf8")
+      .update(Buffer.from(requestDigest, "hex"))
+      .digest("hex")}`,
+    requestDigest: `0x${requestDigest}`,
+  }
 }
 
 type PendingAuthorization = {

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -4305,7 +4305,13 @@ const DURABLE_PREPARED_TRANSACTION_KEYS = new Set([
   "transactionHash",
   "sender",
   "nonce",
+  "invocation",
   "eip1559",
+])
+
+const DURABLE_SIGNER_INVOCATION_KEYS = new Set([
+  "invocationID",
+  "requestDigest",
 ])
 
 const DURABLE_EIP1559_KEYS = new Set([
@@ -4542,6 +4548,13 @@ function assertCompactDurableOutboxRecord(
       DURABLE_PREPARED_TRANSACTION_KEYS,
       "prepared transaction"
     )
+    if (transaction.invocation !== undefined) {
+      assertExactKeys(
+        transaction.invocation,
+        DURABLE_SIGNER_INVOCATION_KEYS,
+        "prepared signer invocation request"
+      )
+    }
     if (transaction.eip1559 !== undefined) {
       assertExactKeys(
         transaction.eip1559,
@@ -5619,6 +5632,20 @@ function hydratePreparedTransaction(
   transaction.transactionHash = Hex.from(
     hexValue(transaction.transactionHash, "Stored prepared transaction hash")
   )
+  if (transaction.invocation !== undefined) {
+    transaction.invocation.invocationID = Hex.from(
+      hexValue(
+        transaction.invocation.invocationID,
+        "Stored prepared signer invocation ID"
+      )
+    )
+    transaction.invocation.requestDigest = Hex.from(
+      hexValue(
+        transaction.invocation.requestDigest,
+        "Stored prepared signer invocation request digest"
+      )
+    )
+  }
 }
 
 function serializeJSON(value: unknown): unknown {

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -8,6 +8,7 @@ import {
   P2TRSignatureFraudChallengeTransactionFeePolicy,
   P2TRSignatureFraudChallengeTransactionPreparer,
   P2TRSignatureFraudPreparedChallengeTransaction,
+  P2TRSignatureFraudSignerInvocationRequest,
   P2TRSignatureFraudSubmissionIntent,
   P2TRWatchtowerChallengeRecord,
   P2TR_SIGNATURE_FRAUD_COMPLETE_V2_CHALLENGE_EVIDENCE_ABI_TYPE,
@@ -74,7 +75,10 @@ import {
   invalidateP2TRSignatureFraudCanonicalProvenance,
   quarantineLegacyP2TRSignatureFraudSubmissions,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
-import { computeP2TRSignatureFraudSignerInvocationID } from "../src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
+import {
+  computeP2TRSignatureFraudSignerInvocationID,
+  computeP2TRSignatureFraudSignerInvocationRequest,
+} from "../src/P2TRSignatureFraudIrreversibleBoundaryAuthorization.js"
 import {
   InMemoryOutboxStore,
   RollbackAwareInMemoryOutboxStore,
@@ -420,6 +424,11 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
   reservationCalls = 0
   releasedReservations: string[] = []
   readonly acknowledgedReleaseRequests = new Set<string>()
+  readonly invocations: P2TRSignatureFraudSignerInvocationRequest[] = []
+  /** Lets a test return an echo other than the one the signer was handed. */
+  echoInvocation?: (
+    invocation: P2TRSignatureFraudSignerInvocationRequest
+  ) => P2TRSignatureFraudSignerInvocationRequest | undefined
   releaseError?: Error
   rawTransaction = RAW_TRANSACTION
   transactionHash = TRANSACTION_HASH
@@ -525,9 +534,11 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
   async prepareSignatureFraudChallengeTransaction(
     intent: P2TRSignatureFraudSubmissionIntent,
     _reservation: P2TRSignatureFraudBoundNonceReservation,
-    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy
+    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction> {
     this.calls++
+    this.invocations.push(invocation)
     await Promise.resolve()
     const prepared = {
       intentID: intent.intentID,
@@ -535,6 +546,10 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
       transactionHash: Hex.from(this.transactionHash),
       sender: TRANSACTION_SENDER,
       nonce: 7,
+      invocation:
+        this.echoInvocation === undefined
+          ? invocation
+          : this.echoInvocation(invocation),
     }
     await this.afterInitialSign?.(prepared)
     return prepared
@@ -544,9 +559,11 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
     intent: P2TRSignatureFraudSubmissionIntent,
     _reservation: P2TRSignatureFraudBoundNonceReservation,
     _previous: P2TRSignatureFraudPreparedChallengeTransaction,
-    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy
+    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction> {
     this.replacementCalls++
+    this.invocations.push(invocation)
     await Promise.resolve()
     const prepared = {
       intentID: intent.intentID,
@@ -554,6 +571,10 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
       transactionHash: Hex.from(this.replacementTransactionHash),
       sender: TRANSACTION_SENDER,
       nonce: 7,
+      invocation:
+        this.echoInvocation === undefined
+          ? invocation
+          : this.echoInvocation(invocation),
     }
     await this.afterReplacementSign?.(prepared)
     return prepared
@@ -581,7 +602,8 @@ class DynamicFeePreparer extends FixedPreparer {
     gasLimit: number,
     maxFeePerGas: number,
     maxPriorityFeePerGas: number,
-    value: string
+    value: string,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction> {
     const rawTransaction = await this.wallet.signTransaction({
       type: 2,
@@ -601,11 +623,15 @@ class DynamicFeePreparer extends FixedPreparer {
       transactionHash: Hex.from(parsed.hash!),
       sender: this.wallet.address,
       nonce: 7,
+      invocation,
     }
   }
 
   override async prepareSignatureFraudChallengeTransaction(
-    intent: P2TRSignatureFraudSubmissionIntent
+    intent: P2TRSignatureFraudSubmissionIntent,
+    _reservation: P2TRSignatureFraudBoundNonceReservation,
+    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction> {
     this.calls++
     return this.sign(
@@ -613,12 +639,17 @@ class DynamicFeePreparer extends FixedPreparer {
       this.initialGasLimit,
       this.initialMaxFeePerGas,
       this.initialPriorityFeePerGas,
-      this.initialValue
+      this.initialValue,
+      invocation
     )
   }
 
   override async prepareSignatureFraudChallengeReplacementTransaction(
-    intent: P2TRSignatureFraudSubmissionIntent
+    intent: P2TRSignatureFraudSubmissionIntent,
+    _reservation: P2TRSignatureFraudBoundNonceReservation,
+    _previous: P2TRSignatureFraudPreparedChallengeTransaction,
+    _feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction> {
     this.replacementCalls++
     return this.sign(
@@ -626,7 +657,8 @@ class DynamicFeePreparer extends FixedPreparer {
       this.replacementGasLimit,
       this.replacementMaxFeePerGas,
       this.replacementPriorityFeePerGas,
-      this.initialValue
+      this.initialValue,
+      invocation
     )
   }
 }
@@ -3445,4 +3477,111 @@ test("gives the replacement boundary its own committed identity", async () => {
   assert.equal(durable?.activeSignerInvocationID, undefined)
   assert.equal(durable?.signerInvocationID, prepareID)
   assert.equal(durable?.signerInvocationStartedAtUnixMs, 2_000)
+})
+
+test("hands the signer its invocation request and requires the echo back", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const preparer = new FixedPreparer()
+  const authorizer = new FixedBoundaryAuthorizer()
+  const outbox = dispatcher(
+    store,
+    preparer,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 2_000,
+    100,
+    undefined,
+    authorizer
+  )
+
+  assert.equal(
+    (await outbox.prepare(record.recordID, "worker-a")).status,
+    "prepared"
+  )
+
+  // The signer is handed exactly the identity the outbox committed durably,
+  // and the digest that identity is derived from.
+  const [binding] = authorizer.bindings
+  assert.ok(binding)
+  const expected = computeP2TRSignatureFraudSignerInvocationRequest(binding)
+  assert.equal(preparer.invocations.length, 1)
+  assert.equal(
+    preparer.invocations[0].invocationID.toPrefixedString(),
+    expected.invocationID
+  )
+  assert.equal(
+    preparer.invocations[0].requestDigest.toPrefixedString(),
+    expected.requestDigest
+  )
+
+  // The echo survives validation and the durable round trip.
+  const durable = await store.get(record.recordID)
+  assert.equal(
+    durable?.preparedTransaction?.invocation?.invocationID.toPrefixedString(),
+    expected.invocationID
+  )
+})
+
+test("captures the bytes when the signer serves another invocation request", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const preparer = new FixedPreparer()
+  // A signer that returns a well-formed, correctly signed transaction while
+  // claiming it served a different request.
+  preparer.echoInvocation = (invocation) => ({
+    invocationID: Hex.from(`0x${"e7".repeat(32)}`),
+    requestDigest: invocation.requestDigest,
+  })
+  const authorizer = new FixedBoundaryAuthorizer()
+  const outbox = dispatcher(
+    store,
+    preparer,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 2_000,
+    100,
+    undefined,
+    authorizer
+  )
+
+  const settled = await outbox.prepare(record.recordID, "worker-a")
+
+  // The signer WAS invoked and the nonce may be spent, so the boundary must not
+  // be recorded as uninvoked, and the authenticated bytes must be retained.
+  assert.equal(preparer.calls, 1)
+  assert.equal(settled.preparedTransaction, undefined)
+  assert.ok(settled.signerInvocationStartedAtUnixMs)
+  assert.equal(settled.unexpectedSignedArtifacts?.length, 1)
+  assert.match(String(settled.lastError), /another invocation request/)
+  assert.equal(
+    settled.signerQuarantines?.[0]?.reasonCode,
+    "wrong-signer-invocation-request"
+  )
+})
+
+test("rejects a signer that returns no invocation echo at all", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const preparer = new FixedPreparer()
+  preparer.echoInvocation = () => undefined
+  const authorizer = new FixedBoundaryAuthorizer()
+  const outbox = dispatcher(
+    store,
+    preparer,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 2_000,
+    100,
+    undefined,
+    authorizer
+  )
+
+  const settled = await outbox.prepare(record.recordID, "worker-a")
+  assert.equal(settled.preparedTransaction, undefined)
+  assert.match(String(settled.lastError), /no invocation request echo/)
+  assert.equal(settled.unexpectedSignedArtifacts?.length, 1)
 })

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -177,6 +177,7 @@
 - [P2TRSignatureFraudNonceReleaseAcknowledgement](README.md#p2trsignaturefraudnoncereleaseacknowledgement)
 - [P2TRSignatureFraudPayloadBounds](README.md#p2trsignaturefraudpayloadbounds)
 - [P2TRSignatureFraudPreparedChallengeTransaction](README.md#p2trsignaturefraudpreparedchallengetransaction)
+- [P2TRSignatureFraudSignerInvocationRequest](README.md#p2trsignaturefraudsignerinvocationrequest)
 - [P2TRSignatureFraudSignerLaneIdentity](README.md#p2trsignaturefraudsignerlaneidentity)
 - [P2TRSignatureFraudSpendType](README.md#p2trsignaturefraudspendtype)
 - [P2TRSignatureFraudSpendTypeClassifier](README.md#p2trsignaturefraudspendtypeclassifier)
@@ -892,7 +893,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:763](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L763)
+[src/services/maintenance/p2tr-signature-fraud.ts:791](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L791)
 
 ___
 
@@ -949,7 +950,7 @@ The outbox must persist this object before invoking either signing method.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:652](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L652)
+[src/services/maintenance/p2tr-signature-fraud.ts:678](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L678)
 
 ___
 
@@ -1031,7 +1032,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1894](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1894)
+[src/services/maintenance/p2tr-signature-fraud.ts:1970](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1970)
 
 ___
 
@@ -1049,7 +1050,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1878](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1878)
+[src/services/maintenance/p2tr-signature-fraud.ts:1954](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1954)
 
 ___
 
@@ -1066,7 +1067,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1889](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1889)
+[src/services/maintenance/p2tr-signature-fraud.ts:1965](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1965)
 
 ___
 
@@ -1083,7 +1084,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1884](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1884)
+[src/services/maintenance/p2tr-signature-fraud.ts:1960](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1960)
 
 ___
 
@@ -1100,7 +1101,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1957](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1957)
+[src/services/maintenance/p2tr-signature-fraud.ts:2033](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2033)
 
 ___
 
@@ -1120,7 +1121,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1909](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1909)
+[src/services/maintenance/p2tr-signature-fraud.ts:1985](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1985)
 
 ___
 
@@ -1137,7 +1138,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1918](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1918)
+[src/services/maintenance/p2tr-signature-fraud.ts:1994](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1994)
 
 ___
 
@@ -1153,7 +1154,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1914](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1914)
+[src/services/maintenance/p2tr-signature-fraud.ts:1990](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1990)
 
 ___
 
@@ -1199,7 +1200,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1962](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1962)
+[src/services/maintenance/p2tr-signature-fraud.ts:2038](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2038)
 
 ___
 
@@ -1227,7 +1228,7 @@ Immutable activation-manifest fee/value envelope for one signer lane.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:681](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L681)
+[src/services/maintenance/p2tr-signature-fraud.ts:707](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L707)
 
 ___
 
@@ -1268,7 +1269,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:666](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L666)
+[src/services/maintenance/p2tr-signature-fraud.ts:692](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L692)
 
 ___
 
@@ -1297,22 +1298,48 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `eip1559?` | \{ `gasLimit`: `string` ; `maxFeePerGas`: `string` ; `maxPriorityFeePerGas`: `string` ; `transactionType`: ``2``  } |
-| `eip1559.gasLimit` | `string` |
-| `eip1559.maxFeePerGas` | `string` |
-| `eip1559.maxPriorityFeePerGas` | `string` |
-| `eip1559.transactionType` | ``2`` |
-| `intentID` | [`Hex`](classes/Hex.md) |
-| `nonce` | `number` |
-| `rawTransaction` | `string` |
-| `sender` | `string` |
-| `transactionHash` | [`Hex`](classes/Hex.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eip1559?` | \{ `gasLimit`: `string` ; `maxFeePerGas`: `string` ; `maxPriorityFeePerGas`: `string` ; `transactionType`: ``2``  } | - |
+| `eip1559.gasLimit` | `string` | - |
+| `eip1559.maxFeePerGas` | `string` | - |
+| `eip1559.maxPriorityFeePerGas` | `string` | - |
+| `eip1559.transactionType` | ``2`` | - |
+| `intentID` | [`Hex`](classes/Hex.md) | - |
+| `invocation?` | [`P2TRSignatureFraudSignerInvocationRequest`](README.md#p2trsignaturefraudsignerinvocationrequest) | The request the signer believed it was serving, echoed back. This is an assertion, not evidence: the digest is a plaintext parameter and a signer can copy it beside bytes it signed for something else. Nothing about the signature is proven by it. What it does catch is a response that does not belong to this request — a crossed transport, a cached reply from an earlier attempt, another tenant's queued job, or a signer that silently ignores parameters it does not understand. Conformance of the transaction itself to the request is enforced separately, field by field, below. |
+| `nonce` | `number` | - |
+| `rawTransaction` | `string` | - |
+| `sender` | `string` | - |
+| `transactionHash` | [`Hex`](classes/Hex.md) | - |
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:630](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L630)
+[src/services/maintenance/p2tr-signature-fraud.ts:644](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L644)
+
+___
+
+### P2TRSignatureFraudSignerInvocationRequest
+
+Ƭ **P2TRSignatureFraudSignerInvocationRequest**: `Object`
+
+Names the exact request a signer is being asked to serve.
+
+Deliberately opaque: the caller's boundary binding is an internal record
+shape belonging to the watchtower, and the dependency runs watchtower -> SDK,
+so the SDK carries only the two identities. `invocationID` is the caller's
+durable identity for this invocation; `requestDigest` is the digest of the
+request it authorizes.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `invocationID` | [`Hex`](classes/Hex.md) |
+| `requestDigest` | [`Hex`](classes/Hex.md) |
+
+#### Defined in
+
+[src/services/maintenance/p2tr-signature-fraud.ts:639](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L639)
 
 ___
 
@@ -1330,7 +1357,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:674](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L674)
+[src/services/maintenance/p2tr-signature-fraud.ts:700](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L700)
 
 ___
 
@@ -1364,7 +1391,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1974](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1974)
+[src/services/maintenance/p2tr-signature-fraud.ts:2050](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2050)
 
 ___
 
@@ -1384,7 +1411,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1966](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1966)
+[src/services/maintenance/p2tr-signature-fraud.ts:2042](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2042)
 
 ___
 
@@ -1401,7 +1428,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1978](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1978)
+[src/services/maintenance/p2tr-signature-fraud.ts:2054](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2054)
 
 ___
 
@@ -1824,7 +1851,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1983](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1983)
+[src/services/maintenance/p2tr-signature-fraud.ts:2059](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2059)
 
 ___
 
@@ -1982,7 +2009,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2029](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2029)
+[src/services/maintenance/p2tr-signature-fraud.ts:2105](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2105)
 
 ___
 
@@ -1999,7 +2026,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2034](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2034)
+[src/services/maintenance/p2tr-signature-fraud.ts:2110](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2110)
 
 ___
 
@@ -2009,7 +2036,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2018](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2018)
+[src/services/maintenance/p2tr-signature-fraud.ts:2094](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2094)
 
 ___
 
@@ -2037,7 +2064,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2121](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2121)
+[src/services/maintenance/p2tr-signature-fraud.ts:2197](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2197)
 
 ___
 
@@ -2075,7 +2102,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2039](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2039)
+[src/services/maintenance/p2tr-signature-fraud.ts:2115](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2115)
 
 ___
 
@@ -2113,7 +2140,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2065](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2065)
+[src/services/maintenance/p2tr-signature-fraud.ts:2141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2141)
 
 ___
 
@@ -2133,7 +2160,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2091](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2091)
+[src/services/maintenance/p2tr-signature-fraud.ts:2167](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2167)
 
 ___
 
@@ -2143,7 +2170,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2006](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2006)
+[src/services/maintenance/p2tr-signature-fraud.ts:2082](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2082)
 
 ___
 
@@ -2222,7 +2249,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2024](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2024)
+[src/services/maintenance/p2tr-signature-fraud.ts:2100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2100)
 
 ___
 
@@ -2798,7 +2825,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2000](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2000)
+[src/services/maintenance/p2tr-signature-fraud.ts:2076](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2076)
 
 ___
 
@@ -2808,7 +2835,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2003](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2003)
+[src/services/maintenance/p2tr-signature-fraud.ts:2079](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2079)
 
 ___
 
@@ -2818,7 +2845,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1906](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1906)
+[src/services/maintenance/p2tr-signature-fraud.ts:1982](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1982)
 
 ___
 
@@ -2876,7 +2903,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1997](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1997)
+[src/services/maintenance/p2tr-signature-fraud.ts:2073](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2073)
 
 ___
 
@@ -2886,7 +2913,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:644](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L644)
+[src/services/maintenance/p2tr-signature-fraud.ts:670](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L670)
 
 ___
 
@@ -2983,7 +3010,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1994](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1994)
+[src/services/maintenance/p2tr-signature-fraud.ts:2070](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2070)
 
 ___
 
@@ -3131,7 +3158,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3765](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3765)
+[src/services/maintenance/p2tr-signature-fraud.ts:3841](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3841)
 
 ___
 
@@ -3264,7 +3291,7 @@ The fixed COMPLETE_V2 evidence record for this input.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:827](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L827)
+[src/services/maintenance/p2tr-signature-fraud.ts:855](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L855)
 
 ___
 
@@ -3284,7 +3311,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5049](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5049)
+[src/services/maintenance/p2tr-signature-fraud.ts:5125](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5125)
 
 ___
 
@@ -3310,7 +3337,7 @@ The submission intent, with its derived `intentID`.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1533](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1533)
+[src/services/maintenance/p2tr-signature-fraud.ts:1561](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1561)
 
 ___
 
@@ -3383,7 +3410,7 @@ The 32-byte challenge identity the router will recompute.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:778](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L778)
+[src/services/maintenance/p2tr-signature-fraud.ts:806](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L806)
 
 ___
 
@@ -3412,7 +3439,7 @@ sighash mode, with or without a witness annex.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4605](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4605)
+[src/services/maintenance/p2tr-signature-fraud.ts:4681](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4681)
 
 ___
 
@@ -3441,7 +3468,7 @@ The EIP-712 digest that doubles as the reservation identity.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1394](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1394)
+[src/services/maintenance/p2tr-signature-fraud.ts:1422](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1422)
 
 ___
 
@@ -3471,7 +3498,7 @@ commitment cannot create separate challenge, deposit, or reward records.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4920](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4920)
+[src/services/maintenance/p2tr-signature-fraud.ts:4996](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4996)
 
 ___
 
@@ -3491,7 +3518,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5003](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5003)
+[src/services/maintenance/p2tr-signature-fraud.ts:5079](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5079)
 
 ___
 
@@ -3523,7 +3550,7 @@ harnesses. It is not a final production Bridge challenge key.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4963](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4963)
+[src/services/maintenance/p2tr-signature-fraud.ts:5039](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5039)
 
 ___
 
@@ -3543,7 +3570,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1197](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1197)
+[src/services/maintenance/p2tr-signature-fraud.ts:1225](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1225)
 
 ___
 
@@ -3579,7 +3606,7 @@ the domain-bound Bridge challenge key for record and submission idempotency.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4847](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4847)
+[src/services/maintenance/p2tr-signature-fraud.ts:4923](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4923)
 
 ___
 
@@ -3599,7 +3626,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2503](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2503)
+[src/services/maintenance/p2tr-signature-fraud.ts:2579](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2579)
 
 ___
 
@@ -3619,7 +3646,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2595](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2595)
+[src/services/maintenance/p2tr-signature-fraud.ts:2671](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2671)
 
 ___
 
@@ -3675,7 +3702,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2669](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2669)
+[src/services/maintenance/p2tr-signature-fraud.ts:2745](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2745)
 
 ___
 
@@ -3695,7 +3722,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2856](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2856)
+[src/services/maintenance/p2tr-signature-fraud.ts:2932](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2932)
 
 ___
 
@@ -3752,7 +3779,7 @@ The ABI-encoded challenge payload, rejected unless it is exactly
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:957](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L957)
+[src/services/maintenance/p2tr-signature-fraud.ts:985](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L985)
 
 ___
 
@@ -3777,7 +3804,7 @@ Calldata for the router's `processP2TRSignatureFraudChallenge`
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:991](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L991)
+[src/services/maintenance/p2tr-signature-fraud.ts:1019](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1019)
 
 ___
 
@@ -3797,7 +3824,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5102](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5102)
+[src/services/maintenance/p2tr-signature-fraud.ts:5178](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5178)
 
 ___
 
@@ -3821,7 +3848,7 @@ Use the protocol-specific COMPLETE_V2 encoder.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1004](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1004)
+[src/services/maintenance/p2tr-signature-fraud.ts:1032](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1032)
 
 ___
 
@@ -3943,7 +3970,7 @@ Parsed witness signature for the input, with sighash type resolved.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4328](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4328)
+[src/services/maintenance/p2tr-signature-fraud.ts:4404](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4404)
 
 ___
 
@@ -3970,7 +3997,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5253](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5253)
+[src/services/maintenance/p2tr-signature-fraud.ts:5329](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5329)
 
 ___
 
@@ -3990,7 +4017,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4672](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4672)
+[src/services/maintenance/p2tr-signature-fraud.ts:4748](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4748)
 
 ___
 
@@ -4027,7 +4054,7 @@ Candidate witness records for each input whose prevout script
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4710](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4710)
+[src/services/maintenance/p2tr-signature-fraud.ts:4786](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4786)
 
 ___
 
@@ -4119,7 +4146,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3062](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3062)
+[src/services/maintenance/p2tr-signature-fraud.ts:3138](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3138)
 
 ___
 
@@ -4425,7 +4452,7 @@ Parsed signature with the 64-byte Schnorr signature and the
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4267](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4267)
+[src/services/maintenance/p2tr-signature-fraud.ts:4343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4343)
 
 ___
 
@@ -4446,7 +4473,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4168](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4168)
+[src/services/maintenance/p2tr-signature-fraud.ts:4244](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4244)
 
 ___
 
@@ -4479,7 +4506,7 @@ The updated challenge record after a successful persist.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4230](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4230)
+[src/services/maintenance/p2tr-signature-fraud.ts:4306](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4306)
 
 ___
 
@@ -4500,7 +4527,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4480)
+[src/services/maintenance/p2tr-signature-fraud.ts:4556](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4556)
 
 ___
 
@@ -4522,7 +4549,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3172](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3172)
+[src/services/maintenance/p2tr-signature-fraud.ts:3248](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3248)
 
 ___
 
@@ -4544,7 +4571,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3119](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3119)
+[src/services/maintenance/p2tr-signature-fraud.ts:3195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3195)
 
 ___
 
@@ -4589,7 +4616,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2627](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2627)
+[src/services/maintenance/p2tr-signature-fraud.ts:2703](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2703)
 
 ___
 
@@ -4609,7 +4636,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2821](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2821)
+[src/services/maintenance/p2tr-signature-fraud.ts:2897](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2897)
 
 ___
 
@@ -4655,7 +4682,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4374](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4374)
+[src/services/maintenance/p2tr-signature-fraud.ts:4450](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4450)
 
 ___
 
@@ -4675,7 +4702,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3083](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3083)
+[src/services/maintenance/p2tr-signature-fraud.ts:3159](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3159)
 
 ___
 
@@ -4864,7 +4891,7 @@ An empty return value; throws if the intent is not bound to the
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1016](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1016)
+[src/services/maintenance/p2tr-signature-fraud.ts:1044](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1044)
 
 ___
 
@@ -4891,7 +4918,7 @@ The prevout records in transaction input order, once every entry has
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4530](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4530)
+[src/services/maintenance/p2tr-signature-fraud.ts:4606](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4606)
 
 ___
 
@@ -4922,7 +4949,7 @@ The reservation in normalized form, with its recomputed identity.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1433](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1433)
+[src/services/maintenance/p2tr-signature-fraud.ts:1461](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1461)
 
 ___
 
@@ -4944,7 +4971,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4413)
+[src/services/maintenance/p2tr-signature-fraud.ts:4489](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4489)
 
 ___
 
@@ -4972,13 +4999,13 @@ The validated replacement transaction.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1809](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1809)
+[src/services/maintenance/p2tr-signature-fraud.ts:1885](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1885)
 
 ___
 
 ### validateP2TRSignatureFraudPreparedChallengeTransaction
 
-▸ **validateP2TRSignatureFraudPreparedChallengeTransaction**(`intent`, `prepared`): [`P2TRSignatureFraudPreparedChallengeTransaction`](README.md#p2trsignaturefraudpreparedchallengetransaction)
+▸ **validateP2TRSignatureFraudPreparedChallengeTransaction**(`intent`, `prepared`, `invocation?`): [`P2TRSignatureFraudPreparedChallengeTransaction`](README.md#p2trsignaturefraudpreparedchallengetransaction)
 
 Authenticates a signed transaction against its durable intent and derives
 the canonical hash/sender/nonce from the raw bytes. This validation must run
@@ -4990,6 +5017,7 @@ before the outbox stores the prepared transaction.
 | :------ | :------ | :------ |
 | `intent` | [`P2TRSignatureFraudSubmissionIntent`](README.md#p2trsignaturefraudsubmissionintent) | Durable submission intent the signed bytes must satisfy. |
 | `prepared` | [`P2TRSignatureFraudPreparedChallengeTransaction`](README.md#p2trsignaturefraudpreparedchallengetransaction) | Prepared transaction whose raw bytes are authenticated. |
+| `invocation?` | [`P2TRSignatureFraudSignerInvocationRequest`](README.md#p2trsignaturefraudsignerinvocationrequest) | Signer invocation request the transaction must echo. Optional because the durable variant ledger re-validates historical variants long after their request is gone. Supplied: the echo must match exactly. Omitted: the echo is preserved untouched, never invented. |
 
 #### Returns
 
@@ -5000,7 +5028,7 @@ The prepared transaction with hash, sender and nonce rederived from
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1601](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1601)
+[src/services/maintenance/p2tr-signature-fraud.ts:1634](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1634)
 
 ___
 
@@ -5026,7 +5054,7 @@ The validated EIP-1559 transaction.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1771](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1771)
+[src/services/maintenance/p2tr-signature-fraud.ts:1847](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1847)
 
 ___
 
@@ -5051,7 +5079,7 @@ The validated transaction, extended with its EIP-1559 fee fields.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1728](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1728)
+[src/services/maintenance/p2tr-signature-fraud.ts:1804](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1804)
 
 ___
 
@@ -5072,4 +5100,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5348](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5348)
+[src/services/maintenance/p2tr-signature-fraud.ts:5424](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5424)

--- a/typescript/api-reference/classes/P2TRSignatureFraudBridgeChallengeSubmitter.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudBridgeChallengeSubmitter.md
@@ -46,7 +46,7 @@ a separately reviewed `COMPLETE_V2` protocol and operational controls.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5163)
+[src/services/maintenance/p2tr-signature-fraud.ts:5239](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5239)
 
 ## Properties
 
@@ -62,7 +62,7 @@ The P2TR signature-fraud entry-point contract.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5164)
+[src/services/maintenance/p2tr-signature-fraud.ts:5240](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5240)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5149](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5149)
+[src/services/maintenance/p2tr-signature-fraud.ts:5225](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5225)
 
 ___
 
@@ -88,7 +88,7 @@ Submitter options. If `challengeDepositAmount` is
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5165)
+[src/services/maintenance/p2tr-signature-fraud.ts:5241](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5241)
 
 ## Methods
 
@@ -102,7 +102,7 @@ Submitter options. If `challengeDepositAmount` is
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5225](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5225)
+[src/services/maintenance/p2tr-signature-fraud.ts:5301](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5301)
 
 ___
 
@@ -127,4 +127,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5180](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5180)
+[src/services/maintenance/p2tr-signature-fraud.ts:5256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5256)

--- a/typescript/api-reference/classes/P2TRSignatureFraudWatchtower.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudWatchtower.md
@@ -64,7 +64,7 @@ available without activating the incomplete fraud protocol.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5407](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5407)
+[src/services/maintenance/p2tr-signature-fraud.ts:5483](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5483)
 
 ## Properties
 
@@ -74,7 +74,7 @@ available without activating the incomplete fraud protocol.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5413)
+[src/services/maintenance/p2tr-signature-fraud.ts:5489](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5489)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5410](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5410)
+[src/services/maintenance/p2tr-signature-fraud.ts:5486](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5486)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5412](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5412)
+[src/services/maintenance/p2tr-signature-fraud.ts:5488](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5488)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5405](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5405)
+[src/services/maintenance/p2tr-signature-fraud.ts:5481](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5481)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5411](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5411)
+[src/services/maintenance/p2tr-signature-fraud.ts:5487](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5487)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5408](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5408)
+[src/services/maintenance/p2tr-signature-fraud.ts:5484](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5484)
 
 ## Methods
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5633](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5633)
+[src/services/maintenance/p2tr-signature-fraud.ts:5709](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5709)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5644](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5644)
+[src/services/maintenance/p2tr-signature-fraud.ts:5720](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5720)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5550](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5550)
+[src/services/maintenance/p2tr-signature-fraud.ts:5626](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5626)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5561](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5561)
+[src/services/maintenance/p2tr-signature-fraud.ts:5637](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5637)
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5597](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5597)
+[src/services/maintenance/p2tr-signature-fraud.ts:5673](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5673)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5586](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5586)
+[src/services/maintenance/p2tr-signature-fraud.ts:5662](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5662)
 
 ___
 
@@ -269,7 +269,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5577](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5577)
+[src/services/maintenance/p2tr-signature-fraud.ts:5653](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5653)
 
 ___
 
@@ -290,7 +290,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5539](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5539)
+[src/services/maintenance/p2tr-signature-fraud.ts:5615](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5615)
 
 ___
 
@@ -310,7 +310,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5530](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5530)
+[src/services/maintenance/p2tr-signature-fraud.ts:5606](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5606)
 
 ___
 
@@ -336,7 +336,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5474](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5474)
+[src/services/maintenance/p2tr-signature-fraud.ts:5550](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5550)
 
 ___
 
@@ -362,7 +362,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5510](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5510)
+[src/services/maintenance/p2tr-signature-fraud.ts:5586](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5586)
 
 ___
 
@@ -385,7 +385,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5430](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5430)
+[src/services/maintenance/p2tr-signature-fraud.ts:5506](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5506)
 
 ___
 
@@ -408,7 +408,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5460](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5460)
+[src/services/maintenance/p2tr-signature-fraud.ts:5536](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5536)
 
 ___
 
@@ -430,7 +430,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5620](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5620)
+[src/services/maintenance/p2tr-signature-fraud.ts:5696](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5696)
 
 ___
 
@@ -451,7 +451,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5608](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5608)
+[src/services/maintenance/p2tr-signature-fraud.ts:5684](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5684)
 
 ___
 
@@ -471,7 +471,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5422](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5422)
+[src/services/maintenance/p2tr-signature-fraud.ts:5498](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5498)
 
 ___
 
@@ -501,4 +501,4 @@ A rejected promise while the fraud layer remains bounded/no-go.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5667](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5667)
+[src/services/maintenance/p2tr-signature-fraud.ts:5743](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5743)

--- a/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
@@ -71,7 +71,7 @@ The submission constructor surface is retained for API compatibility, but
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5693](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5693)
+[src/services/maintenance/p2tr-signature-fraud.ts:5769](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5769)
 
 ## Properties
 
@@ -81,7 +81,7 @@ The submission constructor surface is retained for API compatibility, but
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5695](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5695)
+[src/services/maintenance/p2tr-signature-fraud.ts:5771](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5771)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5691](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5691)
+[src/services/maintenance/p2tr-signature-fraud.ts:5767](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5767)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5689](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5689)
+[src/services/maintenance/p2tr-signature-fraud.ts:5765](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5765)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5690](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5690)
+[src/services/maintenance/p2tr-signature-fraud.ts:5766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5766)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5694](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5694)
+[src/services/maintenance/p2tr-signature-fraud.ts:5770](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5770)
 
 ## Methods
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5750](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5750)
+[src/services/maintenance/p2tr-signature-fraud.ts:5826](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5826)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6549](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6549)
+[src/services/maintenance/p2tr-signature-fraud.ts:6625](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6625)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5926](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5926)
+[src/services/maintenance/p2tr-signature-fraud.ts:6002](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6002)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5891](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5891)
+[src/services/maintenance/p2tr-signature-fraud.ts:5967](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5967)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6263](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6263)
+[src/services/maintenance/p2tr-signature-fraud.ts:6339](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6339)
 
 ___
 
@@ -245,7 +245,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6369](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6369)
+[src/services/maintenance/p2tr-signature-fraud.ts:6445](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6445)
 
 ___
 
@@ -266,7 +266,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6306](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6306)
+[src/services/maintenance/p2tr-signature-fraud.ts:6382](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6382)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6611](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6611)
+[src/services/maintenance/p2tr-signature-fraud.ts:6687](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6687)
 
 ___
 
@@ -311,7 +311,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6578](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6578)
+[src/services/maintenance/p2tr-signature-fraud.ts:6654](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6654)
 
 ___
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5815](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5815)
+[src/services/maintenance/p2tr-signature-fraud.ts:5891](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5891)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5853](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5853)
+[src/services/maintenance/p2tr-signature-fraud.ts:5929](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5929)
 
 ___
 
@@ -377,7 +377,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5873](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5873)
+[src/services/maintenance/p2tr-signature-fraud.ts:5949](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5949)
 
 ___
 
@@ -400,7 +400,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5760](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5760)
+[src/services/maintenance/p2tr-signature-fraud.ts:5836](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5836)
 
 ___
 
@@ -420,7 +420,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5783](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5783)
+[src/services/maintenance/p2tr-signature-fraud.ts:5859](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5859)
 
 ___
 
@@ -440,7 +440,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5800](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5800)
+[src/services/maintenance/p2tr-signature-fraud.ts:5876](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5876)
 
 ___
 
@@ -469,7 +469,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6558](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6558)
+[src/services/maintenance/p2tr-signature-fraud.ts:6634](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6634)
 
 ___
 
@@ -490,7 +490,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6192](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6192)
+[src/services/maintenance/p2tr-signature-fraud.ts:6268](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6268)
 
 ___
 
@@ -517,7 +517,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6651](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6651)
+[src/services/maintenance/p2tr-signature-fraud.ts:6727](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6727)
 
 ___
 
@@ -539,7 +539,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6399](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6399)
+[src/services/maintenance/p2tr-signature-fraud.ts:6475](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6475)
 
 ___
 
@@ -559,7 +559,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6020](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6020)
+[src/services/maintenance/p2tr-signature-fraud.ts:6096](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6096)
 
 ___
 
@@ -581,7 +581,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6121](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6121)
+[src/services/maintenance/p2tr-signature-fraud.ts:6197](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6197)
 
 ___
 
@@ -602,7 +602,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6087](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6087)
+[src/services/maintenance/p2tr-signature-fraud.ts:6163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6163)
 
 ___
 
@@ -622,7 +622,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6011](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6011)
+[src/services/maintenance/p2tr-signature-fraud.ts:6087](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6087)
 
 ___
 
@@ -642,7 +642,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5979](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5979)
+[src/services/maintenance/p2tr-signature-fraud.ts:6055](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6055)
 
 ___
 
@@ -663,7 +663,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5985](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5985)
+[src/services/maintenance/p2tr-signature-fraud.ts:6061](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6061)
 
 ___
 
@@ -691,7 +691,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6507](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6507)
+[src/services/maintenance/p2tr-signature-fraud.ts:6583](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6583)
 
 ___
 
@@ -711,4 +711,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6633](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6633)
+[src/services/maintenance/p2tr-signature-fraud.ts:6709](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6709)

--- a/typescript/api-reference/classes/P2TRWatchtowerSerializedChallengeStore.md
+++ b/typescript/api-reference/classes/P2TRWatchtowerSerializedChallengeStore.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3459](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3459)
+[src/services/maintenance/p2tr-signature-fraud.ts:3535](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3535)
 
 ## Properties
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3460](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3460)
+[src/services/maintenance/p2tr-signature-fraud.ts:3536](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3536)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3456](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3456)
+[src/services/maintenance/p2tr-signature-fraud.ts:3532](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3532)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3457](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3457)
+[src/services/maintenance/p2tr-signature-fraud.ts:3533](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3533)
 
 ## Methods
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3463](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3463)
+[src/services/maintenance/p2tr-signature-fraud.ts:3539](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3539)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3489](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3489)
+[src/services/maintenance/p2tr-signature-fraud.ts:3565](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3565)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3495](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3495)
+[src/services/maintenance/p2tr-signature-fraud.ts:3571](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3571)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3521](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3521)
+[src/services/maintenance/p2tr-signature-fraud.ts:3597](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3597)
 
 ___
 
@@ -172,4 +172,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3473](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3473)
+[src/services/maintenance/p2tr-signature-fraud.ts:3549](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3549)

--- a/typescript/api-reference/interfaces/P2TRSignatureFraudBridgeChallengeContract.md
+++ b/typescript/api-reference/interfaces/P2TRSignatureFraudBridgeChallengeContract.md
@@ -40,7 +40,7 @@ in a follow-up SDK breaking-change release.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1948](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1948)
+[src/services/maintenance/p2tr-signature-fraud.ts:2024](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2024)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1949](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1949)
+[src/services/maintenance/p2tr-signature-fraud.ts:2025](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2025)

--- a/typescript/api-reference/interfaces/P2TRSignatureFraudChallengeTransactionPreparer.md
+++ b/typescript/api-reference/interfaces/P2TRSignatureFraudChallengeTransactionPreparer.md
@@ -25,7 +25,7 @@ Stable identities used for durable lane and signer quarantine records.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:697](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L697)
+[src/services/maintenance/p2tr-signature-fraud.ts:723](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L723)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:698](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L698)
+[src/services/maintenance/p2tr-signature-fraud.ts:724](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L724)
 
 ___
 
@@ -47,13 +47,13 @@ Sender whose nonce lane is serialized by the durable outbox store.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:700](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L700)
+[src/services/maintenance/p2tr-signature-fraud.ts:726](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L726)
 
 ## Methods
 
 ### prepareSignatureFraudChallengeReplacementTransaction
 
-▸ **prepareSignatureFraudChallengeReplacementTransaction**(`intent`, `reservation`, `previous`, `feePolicy`): `Promise`\<[`P2TRSignatureFraudPreparedChallengeTransaction`](../README.md#p2trsignaturefraudpreparedchallengetransaction)\>
+▸ **prepareSignatureFraudChallengeReplacementTransaction**(`intent`, `reservation`, `previous`, `feePolicy`, `invocation`): `Promise`\<[`P2TRSignatureFraudPreparedChallengeTransaction`](../README.md#p2trsignaturefraudpreparedchallengetransaction)\>
 
 Signs an EIP-1559 replacement for the same durable intent, sender, and
 nonce. The outbox persists the signer-invocation boundary before calling
@@ -67,6 +67,7 @@ this method and appends the returned raw bytes before any broadcast.
 | `reservation` | [`P2TRSignatureFraudBoundNonceReservation`](../README.md#p2trsignaturefraudboundnoncereservation) |
 | `previous` | [`P2TRSignatureFraudPreparedChallengeTransaction`](../README.md#p2trsignaturefraudpreparedchallengetransaction) |
 | `feePolicy` | [`P2TRSignatureFraudChallengeTransactionFeePolicy`](../README.md#p2trsignaturefraudchallengetransactionfeepolicy) |
+| `invocation` | [`P2TRSignatureFraudSignerInvocationRequest`](../README.md#p2trsignaturefraudsignerinvocationrequest) |
 
 #### Returns
 
@@ -74,13 +75,13 @@ this method and appends the returned raw bytes before any broadcast.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:739](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L739)
+[src/services/maintenance/p2tr-signature-fraud.ts:766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L766)
 
 ___
 
 ### prepareSignatureFraudChallengeTransaction
 
-▸ **prepareSignatureFraudChallengeTransaction**(`intent`, `reservation`, `feePolicy`): `Promise`\<[`P2TRSignatureFraudPreparedChallengeTransaction`](../README.md#p2trsignaturefraudpreparedchallengetransaction)\>
+▸ **prepareSignatureFraudChallengeTransaction**(`intent`, `reservation`, `feePolicy`, `invocation`): `Promise`\<[`P2TRSignatureFraudPreparedChallengeTransaction`](../README.md#p2trsignaturefraudpreparedchallengetransaction)\>
 
 Prepares and signs, but MUST NOT broadcast, an Ethereum transaction for
 the supplied intent and already-persisted reservation. Implementations
@@ -93,6 +94,7 @@ MUST reject a reservation whose binding, sender, or nonce is not exact.
 | `intent` | [`P2TRSignatureFraudSubmissionIntent`](../README.md#p2trsignaturefraudsubmissionintent) |
 | `reservation` | [`P2TRSignatureFraudBoundNonceReservation`](../README.md#p2trsignaturefraudboundnoncereservation) |
 | `feePolicy` | [`P2TRSignatureFraudChallengeTransactionFeePolicy`](../README.md#p2trsignaturefraudchallengetransactionfeepolicy) |
+| `invocation` | [`P2TRSignatureFraudSignerInvocationRequest`](../README.md#p2trsignaturefraudsignerinvocationrequest) |
 
 #### Returns
 
@@ -100,7 +102,7 @@ MUST reject a reservation whose binding, sender, or nonce is not exact.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:728](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L728)
+[src/services/maintenance/p2tr-signature-fraud.ts:754](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L754)
 
 ___
 
@@ -125,7 +127,7 @@ ambiguous response returns `already-released` for the same reservation.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:718](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L718)
+[src/services/maintenance/p2tr-signature-fraud.ts:744](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L744)
 
 ___
 
@@ -151,4 +153,4 @@ bytes. Its EIP-712 binding must recover to `transactionSender`.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:706](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L706)
+[src/services/maintenance/p2tr-signature-fraud.ts:732](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L732)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordPersistence.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordPersistence.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2111](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2111)
+[src/services/maintenance/p2tr-signature-fraud.ts:2187](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2187)
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2112](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2112)
+[src/services/maintenance/p2tr-signature-fraud.ts:2188](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2188)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordSource.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordSource.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2107](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2107)
+[src/services/maintenance/p2tr-signature-fraud.ts:2183](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2183)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeReplayStore.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeReplayStore.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2100)
+[src/services/maintenance/p2tr-signature-fraud.ts:2176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2176)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2107](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2107)
+[src/services/maintenance/p2tr-signature-fraud.ts:2183](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2183)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2103)
+[src/services/maintenance/p2tr-signature-fraud.ts:2179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2179)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeStore.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeStore.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2100)
+[src/services/maintenance/p2tr-signature-fraud.ts:2176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2176)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2103)
+[src/services/maintenance/p2tr-signature-fraud.ts:2179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2179)

--- a/typescript/src/services/maintenance/p2tr-signature-fraud.ts
+++ b/typescript/src/services/maintenance/p2tr-signature-fraud.ts
@@ -1623,17 +1623,17 @@ export const buildP2TRSignatureFraudSubmissionIntent = (
  *
  * @param intent Durable submission intent the signed bytes must satisfy.
  * @param prepared Prepared transaction whose raw bytes are authenticated.
+ * @param invocation Signer invocation request the transaction must echo.
+ *        Optional because the durable variant ledger re-validates historical
+ *        variants long after their request is gone. Supplied: the echo must
+ *        match exactly. Omitted: the echo is preserved untouched, never
+ *        invented.
  * @returns The prepared transaction with hash, sender and nonce rederived from
  *          the raw bytes rather than taken from the caller.
  */
 export const validateP2TRSignatureFraudPreparedChallengeTransaction = (
   intent: P2TRSignatureFraudSubmissionIntent,
   prepared: P2TRSignatureFraudPreparedChallengeTransaction,
-  /**
-   * Optional because the durable variant ledger re-validates historical
-   * variants long after their request is gone. Supplied: the echo must match
-   * exactly. Omitted: the echo is preserved untouched, never invented.
-   */
   invocation?: P2TRSignatureFraudSignerInvocationRequest
 ): P2TRSignatureFraudPreparedChallengeTransaction => {
   validateP2TRCompleteV2SignatureFraudSubmissionIntent(intent)
@@ -1771,7 +1771,13 @@ export const validateP2TRSignatureFraudPreparedChallengeTransaction = (
   }
 }
 
-/** Normalizes an echoed invocation request, or `undefined` when absent. */
+/**
+ * Normalizes an echoed invocation request, or `undefined` when absent.
+ *
+ * @param value Echoed invocation request, if the caller supplied one.
+ * @returns The request with both identifiers normalized to bytes32, or
+ *          `undefined` when there was nothing to echo.
+ */
 const normalizeP2TRSignatureFraudSignerInvocationEcho = (
   value: P2TRSignatureFraudSignerInvocationRequest | undefined
 ): P2TRSignatureFraudSignerInvocationRequest | undefined => {

--- a/typescript/src/services/maintenance/p2tr-signature-fraud.ts
+++ b/typescript/src/services/maintenance/p2tr-signature-fraud.ts
@@ -627,12 +627,38 @@ export type P2TRSignatureFraudSubmissionIntentOptions = {
   challengeDepositAmount: BigNumberish
 }
 
+/**
+ * Names the exact request a signer is being asked to serve.
+ *
+ * Deliberately opaque: the caller's boundary binding is an internal record
+ * shape belonging to the watchtower, and the dependency runs watchtower -> SDK,
+ * so the SDK carries only the two identities. `invocationID` is the caller's
+ * durable identity for this invocation; `requestDigest` is the digest of the
+ * request it authorizes.
+ */
+export type P2TRSignatureFraudSignerInvocationRequest = {
+  invocationID: Hex
+  requestDigest: Hex
+}
+
 export type P2TRSignatureFraudPreparedChallengeTransaction = {
   intentID: Hex
   rawTransaction: string
   transactionHash: Hex
   sender: string
   nonce: number
+  /**
+   * The request the signer believed it was serving, echoed back.
+   *
+   * This is an assertion, not evidence: the digest is a plaintext parameter and
+   * a signer can copy it beside bytes it signed for something else. Nothing
+   * about the signature is proven by it. What it does catch is a response that
+   * does not belong to this request — a crossed transport, a cached reply from
+   * an earlier attempt, another tenant's queued job, or a signer that silently
+   * ignores parameters it does not understand. Conformance of the transaction
+   * itself to the request is enforced separately, field by field, below.
+   */
+  invocation?: P2TRSignatureFraudSignerInvocationRequest
   eip1559?: {
     transactionType: 2
     gasLimit: string
@@ -728,7 +754,8 @@ export interface P2TRSignatureFraudChallengeTransactionPreparer {
   prepareSignatureFraudChallengeTransaction(
     intent: P2TRSignatureFraudSubmissionIntent,
     reservation: P2TRSignatureFraudBoundNonceReservation,
-    feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy
+    feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction>
 
   /**
@@ -740,7 +767,8 @@ export interface P2TRSignatureFraudChallengeTransactionPreparer {
     intent: P2TRSignatureFraudSubmissionIntent,
     reservation: P2TRSignatureFraudBoundNonceReservation,
     previous: P2TRSignatureFraudPreparedChallengeTransaction,
-    feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy
+    feePolicy: P2TRSignatureFraudChallengeTransactionFeePolicy,
+    invocation: P2TRSignatureFraudSignerInvocationRequest
   ): Promise<P2TRSignatureFraudPreparedChallengeTransaction>
 }
 
@@ -1600,9 +1628,33 @@ export const buildP2TRSignatureFraudSubmissionIntent = (
  */
 export const validateP2TRSignatureFraudPreparedChallengeTransaction = (
   intent: P2TRSignatureFraudSubmissionIntent,
-  prepared: P2TRSignatureFraudPreparedChallengeTransaction
+  prepared: P2TRSignatureFraudPreparedChallengeTransaction,
+  /**
+   * Optional because the durable variant ledger re-validates historical
+   * variants long after their request is gone. Supplied: the echo must match
+   * exactly. Omitted: the echo is preserved untouched, never invented.
+   */
+  invocation?: P2TRSignatureFraudSignerInvocationRequest
 ): P2TRSignatureFraudPreparedChallengeTransaction => {
   validateP2TRCompleteV2SignatureFraudSubmissionIntent(intent)
+  const echo = normalizeP2TRSignatureFraudSignerInvocationEcho(
+    prepared.invocation
+  )
+  if (invocation !== undefined) {
+    const expected = normalizeP2TRSignatureFraudSignerInvocationEcho(invocation)
+    if (
+      echo === undefined ||
+      echo.invocationID.toPrefixedString() !==
+        expected!.invocationID.toPrefixedString() ||
+      echo.requestDigest.toPrefixedString() !==
+        expected!.requestDigest.toPrefixedString()
+    ) {
+      throw new P2TRWitnessSignatureError(
+        "invalid-watchtower-state",
+        "Prepared challenge transaction does not echo its signer invocation request"
+      )
+    }
+  }
   const expectedIntentID = computeP2TRSignatureFraudSubmissionIntentID({
     protocol: intent.protocol,
     evidenceProtocolID: intent.evidenceProtocolID,
@@ -1715,6 +1767,24 @@ export const validateP2TRSignatureFraudPreparedChallengeTransaction = (
     transactionHash: parsedHash,
     sender: utils.getAddress(parsed.from),
     nonce: parsed.nonce,
+    ...(echo === undefined ? {} : { invocation: echo }),
+  }
+}
+
+/** Normalizes an echoed invocation request, or `undefined` when absent. */
+const normalizeP2TRSignatureFraudSignerInvocationEcho = (
+  value: P2TRSignatureFraudSignerInvocationRequest | undefined
+): P2TRSignatureFraudSignerInvocationRequest | undefined => {
+  if (value === undefined) return undefined
+  return {
+    invocationID: toBytes32Hex(
+      value.invocationID,
+      "Signer invocation request ID"
+    ),
+    requestDigest: toBytes32Hex(
+      value.requestDigest,
+      "Signer invocation request digest"
+    ),
   }
 }
 


### PR DESCRIPTION
Blocker A, increment 3a of `BLOCKER-A-SCOPE.md`. Stacked on #1044.

## What it does

The request digest was process-local evidence plumbing: computed in the boundary authorizer to match a reconciler attestation, then discarded. Never persisted, never transmitted. The SDK signer interface took `(intent, reservation, feePolicy)` and the prepared transaction echoed nothing, so a response carried no statement about which request produced it.

Both prepare methods now take a `P2TRSignatureFraudSignerInvocationRequest` of `{ invocationID, requestDigest }`, and the prepared transaction carries the echo back. The type is deliberately **opaque** — the caller's boundary binding is a watchtower record shape and the dependency runs watchtower → SDK, so the SDK carries the two identities and nothing else.

## What this actually buys — read this before reviewing

**The echo is an assertion, not evidence.** The digest is a plaintext parameter and a signer can copy it beside bytes it signed for something else. Nothing about the signature is proven by it.

Every argument handed to the signer — intent, reservation, fee policy, previous variant — is *already* reconstructed from the signed bytes and enforced field by field (`validateP2TRSignatureFraudPreparedChallengeTransaction`, `...Reservation`, `validatePreparedTransactionFeePolicy`, the replacement validator). What the echo adds is exactly the coordinates that never appear in a transaction: record version, generation, attempt, stage, provenance fingerprint, reservation ID.

So the honest value is: it catches a response that does not belong to this request — a crossed transport, a cached reply from an earlier attempt, another tenant's queued job, a signer that silently ignores parameters it does not understand — and it makes the request identity a value the **store** and the out-of-band boundary resolver can check, rather than process-local state. That last part is what pays for the increment.

## Classification of a mismatch

A wrong echo is neither `ambiguous-signer-invocation` (the call did not throw) nor `malformed-signed-envelope` (nothing about the bytes is wrong). By that point the transaction is fully authenticated: it parses, recovers to the reserved sender, and consumes the reserved nonce.

So the echo is compared **in the outbox after validation**, not inside the SDK validator — which is what lets the authenticated artifact be captured as an unexpected signed artifact instead of being dropped by the malformed path. The boundary stays marked invoked, because the signer *was* called and may hold further bytes never seen. New reason code `wrong-signer-invocation-request`, added to the durable CHECK enum.

## No new column, no new migration

`activeSignerInvocationID` is already durable, already committed in the same swap as the pre-I/O marker, and is itself `sha256(domain ‖ requestDigest)` — so an echo is verifiable against state that already exists. `computeP2TRSignatureFraudSignerInvocationRequest` returns both identities from one canonicalization, which keeps the outbox off a second canonicalization path; the digest is otherwise reachable only inside the authorizer.

## Why the SDK validator's third parameter is optional

The durable variant ledger re-validates historical variants long after their request is gone. Supplied → the echo must match; omitted → it is preserved untouched and never invented. Preservation is load-bearing: that validator returns a freshly built literal, so a field it does not name is silently dropped.

## Verification

- Watchtower with PostgreSQL: **397/397 → 400/400**, no title lost.
- SDK suite: **983 passing, 1 failing — identical to baseline.** The failure (`Previous transaction raw bytes do not match the requested input txid`) is pre-existing and untouched; the SDK is not modified by #1043 or #1044, so it predates this stack's watchtower work.
- Two mutants each caught: never comparing the echo, and letting the SDK validator drop it from its return literal.
- SDK `dist` rebuild is required for the watchtower to see the new types (`tsc --project tsconfig.build.json`); the watchtower resolves `@keep-network/tbtc-v2.ts` to the built output, not `src`.

## Follow-ups this surfaced, not fixed here

**The EIP-1559 access list is never validated anywhere.** A signer can attach an arbitrary access list today. The fee-policy check bounds the money but not intrinsic gas consumption inside the signer's own `gasLimit`, so a stuffed list can push the call to out-of-gas — a revert that consumes the nonce and drives the record to `terminal-nonce-consumed`. Worth fixing on its own merits.

**Binding the digest into the signed bytes is feasible and would make this evidence rather than assertion.** An EIP-2930 access-list entry `{address, storageKeys:[digest]}` serializes, is covered by the signature (it changes the transaction hash), and round-trips through this repo's ethers 5.5 — verified. Cost is ~4300 intrinsic gas and the digest becomes public on-chain. Calldata is *not* an option: it is committed by `intentID`, which the digest is derived from, so it is circular. Validating the access list is the prerequisite for both, which is why they are worth doing together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZat6B9TisDJ6oW37AG8qH