### PR TITLE
fix(watchtower)!: require a provider tombstone to claim never-invoked

### DIFF
--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -1737,6 +1737,31 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
     signer_invocation_id bytea NOT NULL CHECK (
         octet_length(signer_invocation_id) = 32
     ),
+    -- Proof that the provider itself closed this invocation. Required exactly
+    -- for 'never-invoked': two attesters can report what they observed, but
+    -- nobody can observe the absence of a request still buffered in transit --
+    -- only a fencing write at the provider settles that.
+    provider_tombstone_receipt bytea CHECK (
+        provider_tombstone_receipt IS NULL
+        OR octet_length(provider_tombstone_receipt) BETWEEN 1 AND 2048
+    ),
+    provider_tombstone_at_unix_ms bigint CHECK (
+        provider_tombstone_at_unix_ms IS NULL
+        OR provider_tombstone_at_unix_ms BETWEEN 0 AND 9007199254740991
+    ),
+    CHECK (
+        (outcome = 'never-invoked')
+            = (provider_tombstone_receipt IS NOT NULL)
+    ),
+    CHECK (
+        (provider_tombstone_receipt IS NULL)
+            = (provider_tombstone_at_unix_ms IS NULL)
+    ),
+    CHECK (
+        provider_tombstone_at_unix_ms IS NULL
+        OR provider_tombstone_at_unix_ms
+            BETWEEN boundary_started_at_unix_ms AND resolved_at_unix_ms
+    ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
@@ -1859,9 +1884,15 @@ BEGIN
             'orphaned signer boundary resolution does not name the durable boundary';
     END IF;
 
+    IF NEW.outcome = 'never-invoked'
+       AND NEW.provider_tombstone_receipt IS NULL THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary never-invoked resolution requires a provider tombstone';
+    END IF;
+
     IF NEW.resolution_evidence_digest <> sha256(
            convert_to(
-               'tbtc-p2tr-signer-boundary-independent-resolution-v2',
+               'tbtc-p2tr-signer-boundary-independent-resolution-v3',
                'UTF8'
            )
            || NEW.record_id
@@ -1877,6 +1908,14 @@ BEGIN
                   decode(repeat('00', 32), 'hex')
               )
            || NEW.provider_evidence_digest
+           || CASE WHEN NEW.provider_tombstone_receipt IS NULL
+                   THEN decode(repeat('00', 32), 'hex')
+                   ELSE NEW.signer_invocation_id END
+           || COALESCE(
+                  sha256(NEW.provider_tombstone_receipt),
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(COALESCE(NEW.provider_tombstone_at_unix_ms, 0))
        ) THEN
         RAISE EXCEPTION
             'orphaned signer boundary resolution digest is invalid';

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -762,6 +762,27 @@ export const computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest = (
  * lane. Only an out-of-band, dual-attested observation of what the signer
  * actually did can resolve that, and this is that evidence.
  */
+/**
+ * A provider's proof that it permanently closed one invocation.
+ *
+ * Two independent attesters can observe a great deal, but not the absence of a
+ * request buffered somewhere between the outbox and the key: delivery delay is
+ * unbounded, so a request can still arrive after everyone has looked and found
+ * nothing. Only a WRITE at the provider settles that — a one-shot transition
+ * that both reports "no bytes escaped" and refuses any later arrival of this
+ * invocation. This is the receipt for that write.
+ *
+ * It is expressible only because the boundary now has a deterministic identity
+ * the provider and the outbox can name independently.
+ */
+export type P2TRSignatureFraudSignerInvocationTombstone = {
+  /** Must name the same invocation the resolution speaks for. */
+  signerInvocationID: string
+  /** Provider-authenticated bytes; opaque here, exactly like an attestation. */
+  receipt: string
+  tombstonedAtUnixMs: number
+}
+
 export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
   recordID: string
   /**
@@ -779,6 +800,11 @@ export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
   outcome: "never-invoked" | "signed" | "terminal-unsafe"
   /** Required exactly when the signer is proven to have produced bytes. */
   signedTransactionHash?: string
+  /**
+   * Required exactly for `never-invoked`, and refused otherwise. Without it
+   * that outcome is an assertion nobody is positioned to make.
+   */
+  providerTombstone?: P2TRSignatureFraudSignerInvocationTombstone
   providerEvidenceDigest: string
   evidenceDigest: string
   canonicalAttestations: readonly [
@@ -823,8 +849,14 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
   // Mirrored byte for byte by the PostgreSQL guard trigger. The invocation ID
   // replaces the boundary start as the identity term; v1 hashed a wall-clock
   // tuple, so the domain moves with the layout.
+  const tombstone = resolution.providerTombstone
+  if ((resolution.outcome === "never-invoked") !== (tombstone !== undefined)) {
+    throw new Error(
+      "Signer-boundary resolution names a provider tombstone only for a never-invoked outcome"
+    )
+  }
   return `0x${createHash("sha256")
-    .update("tbtc-p2tr-signer-boundary-independent-resolution-v2", "utf8")
+    .update("tbtc-p2tr-signer-boundary-independent-resolution-v3", "utf8")
     .update(
       Buffer.from(
         normalizeBytes32(
@@ -894,6 +926,38 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
         "hex"
       )
     )
+    .update(
+      tombstone === undefined
+        ? Buffer.alloc(32)
+        : Buffer.from(
+            normalizeBytes32(
+              tombstone.signerInvocationID,
+              "Signer-boundary tombstone invocation ID"
+            ).slice(2),
+            "hex"
+          )
+    )
+    .update(
+      tombstone === undefined
+        ? Buffer.alloc(32)
+        : createHash("sha256")
+            .update(
+              Buffer.from(
+                normalizeHexData(
+                  tombstone.receipt,
+                  "Signer-boundary tombstone receipt"
+                ).slice(2),
+                "hex"
+              )
+            )
+            .digest()
+    )
+    .update(
+      uint64(
+        tombstone === undefined ? 0 : tombstone.tombstonedAtUnixMs,
+        "Signer-boundary tombstone time"
+      )
+    )
     .digest("hex")}`
 }
 
@@ -905,6 +969,7 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
 export type P2TRSignatureFraudNormalizedSignerBoundaryResolution = {
   recordID: string
   signerInvocationID: string
+  providerTombstone?: P2TRSignatureFraudSignerInvocationTombstone
   boundaryStartedAtUnixMs: number
   preparationAttempts: number
   nonceReservationID: string
@@ -932,6 +997,39 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
     resolution.signerInvocationID,
     "Orphaned signer boundary invocation ID"
   )
+  if (
+    (resolution.outcome === "never-invoked") !==
+    (resolution.providerTombstone !== undefined)
+  ) {
+    throw new Error(
+      "Orphaned signer boundary resolution requires a provider tombstone exactly for a never-invoked outcome"
+    )
+  }
+  const providerTombstone =
+    resolution.providerTombstone === undefined
+      ? undefined
+      : {
+          signerInvocationID: normalizeBytes32(
+            resolution.providerTombstone.signerInvocationID,
+            "Orphaned signer boundary tombstone invocation ID"
+          ),
+          receipt: normalizeHexData(
+            resolution.providerTombstone.receipt,
+            "Orphaned signer boundary tombstone receipt"
+          ),
+          tombstonedAtUnixMs: requireUnixMilliseconds(
+            resolution.providerTombstone.tombstonedAtUnixMs,
+            "Orphaned signer boundary tombstone time"
+          ),
+        }
+  if (
+    providerTombstone !== undefined &&
+    providerTombstone.signerInvocationID !== signerInvocationID
+  ) {
+    throw new Error(
+      "Orphaned signer boundary tombstone names another invocation"
+    )
+  }
   const boundaryStartedAtUnixMs = requireUnixMilliseconds(
     resolution.boundaryStartedAtUnixMs,
     "Orphaned signer boundary start"
@@ -996,6 +1094,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
       invokedAtUnixMs,
       outcome: resolution.outcome,
       signedTransactionHash,
+      providerTombstone,
       providerEvidenceDigest,
     }) !== evidenceDigest
   ) {
@@ -1071,6 +1170,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   return {
     recordID,
     signerInvocationID,
+    ...(providerTombstone === undefined ? {} : { providerTombstone }),
     boundaryStartedAtUnixMs,
     preparationAttempts,
     nonceReservationID,
@@ -1136,6 +1236,19 @@ export const assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership = (
   ) {
     throw new Error(
       "Orphaned signer boundary resolution requires a boundary with no signer escape evidence"
+    )
+  }
+  if (
+    resolution.providerTombstone !== undefined &&
+    // Equal to the record's marker by the ownership check above, and already
+    // validated, so no assertion is needed to reach it.
+    (resolution.providerTombstone.tombstonedAtUnixMs <
+      resolution.boundaryStartedAtUnixMs ||
+      resolution.providerTombstone.tombstonedAtUnixMs >
+        resolution.resolvedAtUnixMs)
+  ) {
+    throw new Error(
+      "Orphaned signer boundary tombstone falls outside the invocation window"
     )
   }
 }

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -1532,14 +1532,17 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           corroborating_trust_domain_id,
           corroborating_independence_domain_id,
           corroborating_evidence_digest, corroborating_attestation,
-          corroborating_attested_at_unix_ms, resolved_at_unix_ms
+          corroborating_attested_at_unix_ms, resolved_at_unix_ms,
+          provider_tombstone_receipt, provider_tombstone_at_unix_ms
        ) VALUES (
           decode($1, 'hex'), decode($2, 'hex'), $3, $4,
           decode($5, 'hex'), $6, $7, $8,
           CASE WHEN $9::text IS NULL THEN NULL ELSE decode($9, 'hex') END,
           decode($10, 'hex'), decode($11, 'hex'), $12, $13,
           decode($11, 'hex'), decode($14, 'hex'), $15, $16, $17,
-          decode($11, 'hex'), decode($18, 'hex'), $19, $20
+          decode($11, 'hex'), decode($18, 'hex'), $19, $20,
+          CASE WHEN $21::text IS NULL THEN NULL ELSE decode($21, 'hex') END,
+          $22
        )`,
       [
         stripHex(normalized.recordID),
@@ -1564,6 +1567,10 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         stripHex(corroborating.attestation),
         corroborating.attestedAtUnixMs,
         normalized.resolvedAtUnixMs,
+        normalized.providerTombstone === undefined
+          ? null
+          : stripHex(normalized.providerTombstone.receipt),
+        normalized.providerTombstone?.tombstonedAtUnixMs ?? null,
       ]
     )
     if (normalized.outcome === "never-invoked") {

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -607,7 +607,7 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution/
   )
-  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v2/)
+  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v3/)
   // The deterministic invocation ID is the row identity, so evidence can never
   // speak for a boundary other than the one it names — and unlike the wall-clock
   // tuple it replaced, it cannot drift while the boundary is open.
@@ -615,6 +615,16 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
   assert.match(
     migration,
     /signer_invocation_id bytea NOT NULL CHECK \( octet_length\(signer_invocation_id\) = 32 \)/
+  )
+  // A never-invoked outcome is inexpressible without a provider fencing
+  // receipt, enforced by the database as well as by the resolver.
+  assert.match(
+    migration,
+    /CHECK \( \(outcome = 'never-invoked'\) = \(provider_tombstone_receipt IS NOT NULL\) \)/
+  )
+  assert.match(
+    migration,
+    /never-invoked resolution requires a provider tombstone/
   )
   assert.match(
     migration,

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -2830,6 +2830,13 @@ type BoundaryAttestationMode =
 type BoundaryResolutionOverrides = {
   recordID?: string
   signerInvocationID?: string
+  providerTombstone?: {
+    signerInvocationID: string
+    receipt: string
+    tombstonedAtUnixMs: number
+  }
+  /** Drops the tombstone an honest never-invoked resolution must carry. */
+  omitProviderTombstone?: boolean
   boundaryStartedAtUnixMs?: number
   preparationAttempts?: number
   nonceReservationID?: string
@@ -2887,12 +2894,23 @@ function boundaryResolution(
   overrides: BoundaryResolutionOverrides = {}
 ): P2TRSignatureFraudIndependentSignerBoundaryResolution {
   const outcome = overrides.outcome ?? "never-invoked"
+  const invocationID =
+    overrides.signerInvocationID ??
+    record.activeSignerInvocationID ??
+    boundaryInvocationID(1_300)
   const binding = {
     recordID: overrides.recordID ?? record.recordID,
-    signerInvocationID:
-      overrides.signerInvocationID ??
-      record.activeSignerInvocationID ??
-      boundaryInvocationID(1_300),
+    signerInvocationID: invocationID,
+    // Only a never-invoked outcome may carry one, and it must carry one.
+    ...(outcome === "never-invoked" && overrides.omitProviderTombstone !== true
+      ? {
+          providerTombstone: overrides.providerTombstone ?? {
+            signerInvocationID: invocationID,
+            receipt: "0xfeed",
+            tombstonedAtUnixMs: 1_305,
+          },
+        }
+      : {}),
     boundaryStartedAtUnixMs:
       overrides.boundaryStartedAtUnixMs ??
       record.activeSignerInvocationStartedAtUnixMs ??
@@ -3162,7 +3180,8 @@ postgresTest(
     const { initial, boundary } = await orphanedSignerBoundary(database, 212)
     const rawInsert = async (
       resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution,
-      evidenceDigest = resolution.evidenceDigest
+      evidenceDigest = resolution.evidenceDigest,
+      omitTombstoneColumns = false
     ): Promise<void> => {
       await database.client.query(
         `INSERT INTO p2tr_signature_fraud_challenge_signer_boundary_resolution (
@@ -3175,7 +3194,8 @@ postgresTest(
             primary_attested_at_unix_ms, corroborating_trust_domain_id,
             corroborating_independence_domain_id,
             corroborating_evidence_digest, corroborating_attestation,
-            corroborating_attested_at_unix_ms, resolved_at_unix_ms
+            corroborating_attested_at_unix_ms, resolved_at_unix_ms,
+            provider_tombstone_receipt, provider_tombstone_at_unix_ms
          ) VALUES (
             decode($1, 'hex'), decode($8, 'hex'), $2, $3,
             decode($4, 'hex'), 'prepare', $5,
@@ -3183,7 +3203,9 @@ postgresTest(
             'signer-primary', 'signer-primary-infra', decode($7, 'hex'),
             decode('01', 'hex'), 2000, 'signer-corroborating',
             'signer-corroborating-infra', decode($7, 'hex'),
-            decode('02', 'hex'), 2000, 2400
+            decode('02', 'hex'), 2000, 2400,
+            CASE WHEN $9::text IS NULL THEN NULL ELSE decode($9, 'hex') END,
+            $10
          )`,
         [
           initial.recordID.replace(/^0x/i, ""),
@@ -3194,6 +3216,12 @@ postgresTest(
           resolution.providerEvidenceDigest.slice(2),
           evidenceDigest.slice(2),
           resolution.signerInvocationID.slice(2),
+          omitTombstoneColumns || resolution.providerTombstone === undefined
+            ? null
+            : resolution.providerTombstone.receipt.slice(2),
+          omitTombstoneColumns
+            ? null
+            : resolution.providerTombstone?.tombstonedAtUnixMs ?? null,
         ]
       )
     }
@@ -3219,6 +3247,13 @@ postgresTest(
         })
       ),
       /does not name the durable boundary/
+    )
+    // Independently of the TypeScript assert: the trigger refuses an uninvoked
+    // outcome whose fencing receipt is absent, even though the caller computed
+    // a digest for one.
+    await assert.rejects(
+      rawInsert(boundaryResolution(boundary), undefined, true),
+      /requires a provider tombstone|violates check constraint/
     )
     await assert.rejects(
       rawInsert(boundaryResolution(boundary), `0x${"ab".repeat(32)}`),
@@ -3611,6 +3646,38 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
       },
     ],
     expected: [CLEARED_ORPHAN, WRONG_BOUNDARY],
+    expectedAlertCodes: [],
+  },
+  {
+    // The whole point of the tombstone: nobody can observe the absence of a
+    // request still in transit, so never-invoked without a provider fencing
+    // write is a claim no attester is positioned to make.
+    name: "refuses an uninvoked claim with no provider tombstone",
+    seed: 240,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [{ omitProviderTombstone: true }],
+    expected: [
+      "error:Signer-boundary resolution names a provider tombstone only for a " +
+        "never-invoked outcome",
+    ],
+    expectedAlertCodes: [],
+  },
+  {
+    name: "refuses a tombstone naming another invocation",
+    seed: 241,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [
+      {
+        providerTombstone: {
+          signerInvocationID: `0x${"f1".repeat(32)}`,
+          receipt: "0xfeed",
+          tombstonedAtUnixMs: 1_305,
+        },
+      },
+    ],
+    expected: [
+      "error:Orphaned signer boundary tombstone names another invocation",
+    ],
     expectedAlertCodes: [],
   },
   {


### PR DESCRIPTION
Stacked on #1045. Fixes a soundness defect in the orphaned-boundary resolver introduced in #1041.

## The defect

`resolveOrphanedSignerBoundary` accepts `never-invoked` on two attestations from distinct trust *and* independence domains. That is the right shape for a claim about something observable — and the wrong shape for this one.

**Nobody can observe the absence of a request.** Delivery delay between the outbox and the key is unbounded: a request can sit in a proxy or a queue and arrive *after* the outbox crashed, after it recovered, and after both attesters inspected the signer and found nothing. Reading provider state cannot settle it at any instant, because the answer can change afterwards.

Only a **write** at the provider settles it — a one-shot transition that both reports "no bytes escaped" and refuses any later arrival of the same invocation.

`never-invoked` matters because it is the outcome that releases the reserved nonce. Getting it wrong while signed bytes exist is exactly the two-transactions-one-nonce failure the whole boundary machinery exists to prevent.

## The fix

`never-invoked` now requires a provider tombstone naming the invocation, and is refused without one.

The two attestations keep their job, but **the proposition they attest changes** — from "the signer was never invoked", which they are not positioned to know, to "the provider produced this receipt", which they can check.

This is expressible only because #1044 gave the boundary a deterministic identity. Before that there was no stable name for a provider to tombstone or for an attester to check a receipt against. That is why the fix lands here rather than in #1041 where the defect is.

## Enforced at three layers, deliberately

1. The **digest function** refuses to produce a digest for the inconsistent shape at all, so a `never-invoked` resolution without a tombstone cannot be constructed.
2. The **resolver** refuses it.
3. The **database** refuses it independently — by trigger and by CHECK — for a caller that bypasses TypeScript entirely.

The tombstone is bound into the resolution evidence digest, so both attestations commit to it and a resolution cannot be re-pointed at another receipt.

## Verification

- Watchtower with PostgreSQL: **400/400 → 402/402**, no title lost.
- Digest domain v2 → v3; TS/SQL mirror verified **byte-for-byte against a live PostgreSQL 16 on both branches** (tombstoned and not).
- Removing *both* database defences leaves the raw-SQL guard test failing, so the layers are independently covered rather than shadowing each other.

## What this does not do

It does not specify the provider contract — that is increment 3b. It makes the *shape* of the requirement explicit and unforgeable-by-omission, so the outcome cannot be claimed without the evidence that would justify it.

The design analysis behind this also produced two things worth their own work:

- **Journal-before-egress, not before key use.** The scope doc's phrasing ("provider journals its result before key use") is incoherent — the result does not exist before key use. The decisive predicate is not "was the key used" but "can bytes for this invocation ever cross the egress boundary". A crash between computing σ and committing is *safe* under the right ordering.
- **Consuming the contested nonce on-chain** dissolves most of this ambiguity rather than resolving it. Ethereum already guarantees at most one transaction confirms per nonce, so a self-transfer at the contested nonce, priced above the authorized envelope's committed cap, terminates every ambiguous case in bounded, chain-observable time with zero provider cooperation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZat6B9TisDJ6oW37AG8qH