### PR TITLE
feat(watchtower)!: settle an orphaned boundary on finalized nonce consumption

### DIFF
--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -1762,6 +1762,67 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         OR provider_tombstone_at_unix_ms
             BETWEEN boundary_started_at_unix_ms AND resolved_at_unix_ms
     ),
+    -- Evidence that the chain, not the provider, settled this boundary: the
+    -- reserved nonce is consumed at finality, so any bytes for it are inert.
+    -- chain_id is carried because nothing else in nonce-consumption evidence
+    -- names a chain, and without it an attestation over (sender, nonce) would
+    -- replay against any record on any chain sharing that pair.
+    nonce_consumption_chain_id numeric(78, 0) CHECK (
+        nonce_consumption_chain_id IS NULL OR nonce_consumption_chain_id > 0
+    ),
+    nonce_consumption_nonce bigint CHECK (
+        nonce_consumption_nonce IS NULL OR nonce_consumption_nonce >= 0
+    ),
+    nonce_consumption_account_nonce bigint CHECK (
+        nonce_consumption_account_nonce IS NULL
+        OR nonce_consumption_account_nonce >= 0
+    ),
+    nonce_consumption_read_at_block bigint CHECK (
+        nonce_consumption_read_at_block IS NULL
+        OR nonce_consumption_read_at_block >= 0
+    ),
+    nonce_consumption_transaction_hash bytea CHECK (
+        nonce_consumption_transaction_hash IS NULL
+        OR octet_length(nonce_consumption_transaction_hash) = 32
+    ),
+    nonce_consumption_finalized_block_number bigint CHECK (
+        nonce_consumption_finalized_block_number IS NULL
+        OR nonce_consumption_finalized_block_number >= 0
+    ),
+    nonce_consumption_finalized_block_hash bytea CHECK (
+        nonce_consumption_finalized_block_hash IS NULL
+        OR octet_length(nonce_consumption_finalized_block_hash) = 32
+    ),
+    CHECK (
+        (outcome = 'nonce-consumed')
+            = (nonce_consumption_transaction_hash IS NOT NULL)
+    ),
+    -- All seven move together or none of them do.
+    CHECK (
+        (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_chain_id IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_nonce IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_account_nonce IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_read_at_block IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_finalized_block_number IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_finalized_block_hash IS NULL)
+    ),
+    -- Strictly past the reserved nonce: equality would mean N is still spendable.
+    CHECK (
+        nonce_consumption_account_nonce IS NULL
+        OR nonce_consumption_account_nonce > nonce_consumption_nonce
+    ),
+    -- Read AT the finality boundary, not at head.
+    CHECK (
+        nonce_consumption_read_at_block IS NULL
+        OR nonce_consumption_read_at_block
+            = nonce_consumption_finalized_block_number
+    ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
@@ -1775,7 +1836,7 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
             AND 9007199254740991
     ),
     outcome text NOT NULL CHECK (outcome IN (
-        'never-invoked', 'signed', 'terminal-unsafe'
+        'never-invoked', 'signed', 'terminal-unsafe', 'nonce-consumed'
     )),
     signed_transaction_hash bytea CHECK (
         signed_transaction_hash IS NULL
@@ -1890,9 +1951,23 @@ BEGIN
             'orphaned signer boundary never-invoked resolution requires a provider tombstone';
     END IF;
 
+    -- The consumed nonce must be the one this boundary actually reserved, on
+    -- the chain the record is bound to.
+    IF NEW.outcome = 'nonce-consumed' THEN
+        IF NEW.nonce_consumption_transaction_hash IS NULL THEN
+            RAISE EXCEPTION
+                'orphaned signer boundary nonce-consumed resolution requires consumption evidence';
+        END IF;
+        IF NEW.nonce_consumption_nonce IS DISTINCT FROM outbox_record.reserved_nonce
+           OR NEW.nonce_consumption_chain_id IS DISTINCT FROM outbox_record.chain_id THEN
+            RAISE EXCEPTION
+                'orphaned signer boundary nonce consumption names another sender lane';
+        END IF;
+    END IF;
+
     IF NEW.resolution_evidence_digest <> sha256(
            convert_to(
-               'tbtc-p2tr-signer-boundary-independent-resolution-v3',
+               'tbtc-p2tr-signer-boundary-independent-resolution-v4',
                'UTF8'
            )
            || NEW.record_id
@@ -1916,6 +1991,21 @@ BEGIN
                   decode(repeat('00', 32), 'hex')
               )
            || int8send(COALESCE(NEW.provider_tombstone_at_unix_ms, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_chain_id, 0)::bigint)
+           || int8send(COALESCE(NEW.nonce_consumption_nonce, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_account_nonce, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_read_at_block, 0))
+           || COALESCE(
+                  NEW.nonce_consumption_transaction_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(
+                  COALESCE(NEW.nonce_consumption_finalized_block_number, 0)
+              )
+           || COALESCE(
+                  NEW.nonce_consumption_finalized_block_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
        ) THEN
         RAISE EXCEPTION
             'orphaned signer boundary resolution digest is invalid';

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -775,6 +775,34 @@ export const computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest = (
  * It is expressible only because the boundary now has a deterministic identity
  * the provider and the outbox can name independently.
  */
+/**
+ * Evidence that the chain, not the provider, settled this boundary.
+ *
+ * Once the reserved nonce is consumed at finality, any signed bytes for that
+ * nonce are permanently inert — they can never confirm. That makes the boundary
+ * decidable from public data, which `never-invoked` is not.
+ *
+ * It is a claim about the BYTES, not about the invocation. The signer may have
+ * signed; it may still be holding an envelope. This outcome says only that
+ * whatever it holds can no longer land, so the record must keep its reservation
+ * and stay able to capture a late artifact.
+ *
+ * `chainID` is bound because nothing else in the nonce-consumption evidence
+ * names a chain: without it, an attestation over "sender S nonce N is consumed"
+ * would replay against any record on any chain sharing that pair.
+ */
+export type P2TRSignatureFraudNonceConsumptionEvidence = {
+  chainID: number
+  sender: string
+  transactionNonce: number
+  finalizedAccountNonce: number
+  accountNonceReadAtBlock: number
+  consumingTransaction: P2TRSignatureFraudCanonicalNonceConsumingTransaction
+  /** The finality boundary every read above was taken at. */
+  finalizedThrough: P2TRSignatureFraudCanonicalBlock
+  observedHead: P2TRSignatureFraudCanonicalBlock
+}
+
 export type P2TRSignatureFraudSignerInvocationTombstone = {
   /** Must name the same invocation the resolution speaks for. */
   signerInvocationID: string
@@ -797,7 +825,7 @@ export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
   nonceReservationID: string
   stage: "prepare" | "replacement"
   invokedAtUnixMs: number
-  outcome: "never-invoked" | "signed" | "terminal-unsafe"
+  outcome: "never-invoked" | "signed" | "terminal-unsafe" | "nonce-consumed"
   /** Required exactly when the signer is proven to have produced bytes. */
   signedTransactionHash?: string
   /**
@@ -805,6 +833,8 @@ export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
    * that outcome is an assertion nobody is positioned to make.
    */
   providerTombstone?: P2TRSignatureFraudSignerInvocationTombstone
+  /** Required exactly for `nonce-consumed`, and refused otherwise. */
+  nonceConsumption?: P2TRSignatureFraudNonceConsumptionEvidence
   providerEvidenceDigest: string
   evidenceDigest: string
   canonicalAttestations: readonly [
@@ -831,7 +861,9 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
     return createHash("sha256").update(normalized, "utf8").digest()
   }
   if (
-    !["never-invoked", "signed", "terminal-unsafe"].includes(resolution.outcome)
+    !["never-invoked", "signed", "terminal-unsafe", "nonce-consumed"].includes(
+      resolution.outcome
+    )
   ) {
     throw new Error("Signer-boundary resolution outcome is invalid")
   }
@@ -855,8 +887,17 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
       "Signer-boundary resolution names a provider tombstone only for a never-invoked outcome"
     )
   }
+  const consumption = resolution.nonceConsumption
+  if (
+    (resolution.outcome === "nonce-consumed") !==
+    (consumption !== undefined)
+  ) {
+    throw new Error(
+      "Signer-boundary resolution names nonce consumption only for a nonce-consumed outcome"
+    )
+  }
   return `0x${createHash("sha256")
-    .update("tbtc-p2tr-signer-boundary-independent-resolution-v3", "utf8")
+    .update("tbtc-p2tr-signer-boundary-independent-resolution-v4", "utf8")
     .update(
       Buffer.from(
         normalizeBytes32(
@@ -958,6 +999,60 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
         "Signer-boundary tombstone time"
       )
     )
+    .update(
+      uint64(
+        consumption === undefined ? 0 : consumption.chainID,
+        "Signer-boundary nonce consumption chain ID"
+      )
+    )
+    .update(
+      uint64(
+        consumption === undefined ? 0 : consumption.transactionNonce,
+        "Signer-boundary nonce consumption nonce"
+      )
+    )
+    .update(
+      uint64(
+        consumption === undefined ? 0 : consumption.finalizedAccountNonce,
+        "Signer-boundary nonce consumption account nonce"
+      )
+    )
+    .update(
+      uint64(
+        consumption === undefined ? 0 : consumption.accountNonceReadAtBlock,
+        "Signer-boundary nonce consumption read block"
+      )
+    )
+    .update(
+      consumption === undefined
+        ? Buffer.alloc(32)
+        : Buffer.from(
+            normalizeBytes32(
+              consumption.consumingTransaction.transactionHash,
+              "Signer-boundary consuming transaction hash"
+            ).slice(2),
+            "hex"
+          )
+    )
+    .update(
+      uint64(
+        consumption === undefined
+          ? 0
+          : consumption.finalizedThrough.blockNumber,
+        "Signer-boundary nonce consumption finality height"
+      )
+    )
+    .update(
+      consumption === undefined
+        ? Buffer.alloc(32)
+        : Buffer.from(
+            normalizeBytes32(
+              consumption.finalizedThrough.blockHash,
+              "Signer-boundary nonce consumption finality hash"
+            ).slice(2),
+            "hex"
+          )
+    )
     .digest("hex")}`
 }
 
@@ -970,12 +1065,13 @@ export type P2TRSignatureFraudNormalizedSignerBoundaryResolution = {
   recordID: string
   signerInvocationID: string
   providerTombstone?: P2TRSignatureFraudSignerInvocationTombstone
+  nonceConsumption?: P2TRSignatureFraudNonceConsumptionEvidence
   boundaryStartedAtUnixMs: number
   preparationAttempts: number
   nonceReservationID: string
   stage: "prepare" | "replacement"
   invokedAtUnixMs: number
-  outcome: "never-invoked" | "signed" | "terminal-unsafe"
+  outcome: "never-invoked" | "signed" | "terminal-unsafe" | "nonce-consumed"
   signedTransactionHash?: string
   providerEvidenceDigest: string
   evidenceDigest: string
@@ -1005,6 +1101,18 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
       "Orphaned signer boundary resolution requires a provider tombstone exactly for a never-invoked outcome"
     )
   }
+  if (
+    (resolution.outcome === "nonce-consumed") !==
+    (resolution.nonceConsumption !== undefined)
+  ) {
+    throw new Error(
+      "Orphaned signer boundary resolution requires nonce consumption evidence exactly for a nonce-consumed outcome"
+    )
+  }
+  const nonceConsumption =
+    resolution.nonceConsumption === undefined
+      ? undefined
+      : normalizeSignerBoundaryNonceConsumption(resolution.nonceConsumption)
   const providerTombstone =
     resolution.providerTombstone === undefined
       ? undefined
@@ -1053,7 +1161,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   if (
     invokedAtUnixMs < boundaryStartedAtUnixMs ||
     resolvedAtUnixMs < invokedAtUnixMs ||
-    !["never-invoked", "signed", "terminal-unsafe"].includes(
+    !["never-invoked", "signed", "terminal-unsafe", "nonce-consumed"].includes(
       resolution.outcome
     ) ||
     !["prepare", "replacement"].includes(resolution.stage)
@@ -1095,6 +1203,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
       outcome: resolution.outcome,
       signedTransactionHash,
       providerTombstone,
+      nonceConsumption,
       providerEvidenceDigest,
     }) !== evidenceDigest
   ) {
@@ -1171,6 +1280,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
     recordID,
     signerInvocationID,
     ...(providerTombstone === undefined ? {} : { providerTombstone }),
+    ...(nonceConsumption === undefined ? {} : { nonceConsumption }),
     boundaryStartedAtUnixMs,
     preparationAttempts,
     nonceReservationID,
@@ -1192,6 +1302,117 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
  * owns, and `never-invoked` may only be claimed for a record that carries no
  * signer escape evidence whatsoever.
  */
+/**
+ * Reuses the canonical consuming-transaction validator rather than restating
+ * it. The one check deliberately NOT imported from the terminal-disposition
+ * path is "the consuming transaction is not one of ours": for an orphan the
+ * prepared-hash set is empty, so it would be vacuous, and the recovery is the
+ * same either way — the nonce is spent regardless of who spent it.
+ */
+const normalizeSignerBoundaryNonceConsumption = (
+  evidence: P2TRSignatureFraudNonceConsumptionEvidence
+): P2TRSignatureFraudNonceConsumptionEvidence => {
+  // The canonical validators are void-returning assertions, so the normalized
+  // shape is rebuilt here from the same helpers they use.
+  validateCanonicalBlock(
+    evidence.finalizedThrough,
+    "Signer-boundary nonce consumption finality"
+  )
+  validateCanonicalBlock(
+    evidence.observedHead,
+    "Signer-boundary nonce consumption observed head"
+  )
+  const finalizedThrough = {
+    blockNumber: evidence.finalizedThrough.blockNumber,
+    blockHash: normalizeBytes32(
+      evidence.finalizedThrough.blockHash,
+      "Signer-boundary nonce consumption finality hash"
+    ),
+  }
+  const observedHead = {
+    blockNumber: evidence.observedHead.blockNumber,
+    blockHash: normalizeBytes32(
+      evidence.observedHead.blockHash,
+      "Signer-boundary nonce consumption observed head hash"
+    ),
+  }
+  if (observedHead.blockNumber < finalizedThrough.blockNumber) {
+    throw new Error(
+      "Signer-boundary nonce consumption finality boundary is ahead of its observed head"
+    )
+  }
+  const transactionNonce = requireNonNegativeSafeInteger(
+    evidence.transactionNonce,
+    "Signer-boundary nonce consumption nonce"
+  )
+  const finalizedAccountNonce = requireNonNegativeSafeInteger(
+    evidence.finalizedAccountNonce,
+    "Signer-boundary nonce consumption account nonce"
+  )
+  // Strictly past the reserved nonce: equality would mean N is still spendable.
+  if (finalizedAccountNonce <= transactionNonce) {
+    throw new Error(
+      "Signer-boundary nonce consumption requires an account nonce past the reserved nonce"
+    )
+  }
+  const accountNonceReadAtBlock = requireNonNegativeSafeInteger(
+    evidence.accountNonceReadAtBlock,
+    "Signer-boundary nonce consumption read block"
+  )
+  // Read AT the finality boundary, not at head, or the account nonce could be
+  // reorganised away underneath the resolution.
+  if (accountNonceReadAtBlock !== finalizedThrough.blockNumber) {
+    throw new Error(
+      "Signer-boundary nonce consumption account nonce was not read at its finality boundary"
+    )
+  }
+  validateCanonicalNonceConsumingTransaction(
+    evidence.consumingTransaction,
+    finalizedThrough
+  )
+  const consumingTransaction = {
+    transactionHash: normalizeBytes32(
+      evidence.consumingTransaction.transactionHash,
+      "Signer-boundary consuming transaction hash"
+    ),
+    sender: normalizeAddress(
+      evidence.consumingTransaction.sender,
+      "Signer-boundary consuming transaction sender"
+    ),
+    nonce: evidence.consumingTransaction.nonce,
+    blockNumber: evidence.consumingTransaction.blockNumber,
+    blockHash: normalizeBytes32(
+      evidence.consumingTransaction.blockHash,
+      "Signer-boundary consuming transaction block hash"
+    ),
+  }
+  const sender = normalizeAddress(
+    evidence.sender,
+    "Signer-boundary nonce consumption sender"
+  )
+  if (
+    consumingTransaction.sender !== sender ||
+    consumingTransaction.nonce !== transactionNonce
+  ) {
+    throw new Error(
+      "Signer-boundary nonce consumption names another sender lane"
+    )
+  }
+  return {
+    chainID: requirePositiveSafeInteger(
+      evidence.chainID,
+      "Signer-boundary nonce consumption chain ID"
+    ),
+    sender,
+    transactionNonce,
+    finalizedAccountNonce,
+    accountNonceReadAtBlock,
+    consumingTransaction,
+    finalizedThrough,
+    observedHead,
+  }
+}
+
 export const assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership = (
   record: P2TRSignatureFraudChallengeOutboxRecord,
   resolution: P2TRSignatureFraudNormalizedSignerBoundaryResolution
@@ -1237,6 +1458,39 @@ export const assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership = (
     throw new Error(
       "Orphaned signer boundary resolution requires a boundary with no signer escape evidence"
     )
+  }
+  // The consumption evidence must name THIS record's lane and chain. Without
+  // this, two attestations over "sender S nonce N is consumed" would replay
+  // against any record on any chain sharing that pair.
+  if (resolution.nonceConsumption !== undefined) {
+    if (
+      record.reservedNonce === undefined ||
+      normalizeAddress(
+        resolution.nonceConsumption.sender,
+        "Nonce consumption sender"
+      ) !==
+        normalizeAddress(
+          record.reservedNonce.sender,
+          "Durable reserved sender"
+        ) ||
+      resolution.nonceConsumption.transactionNonce !==
+        record.reservedNonce.nonce
+    ) {
+      throw new Error(
+        "Orphaned signer boundary nonce consumption names another sender lane"
+      )
+    }
+    if (
+      resolution.nonceConsumption.chainID !==
+      requirePositiveSafeInteger(
+        record.intent.chainID,
+        "Durable challenge chain ID"
+      )
+    ) {
+      throw new Error(
+        "Orphaned signer boundary nonce consumption names another chain"
+      )
+    }
   }
   if (
     resolution.providerTombstone !== undefined &&
@@ -8767,7 +9021,7 @@ const replaceLatestPreparedVariant = (
   replacement,
 ]
 
-const appendSignerQuarantine = (
+export const appendSignerQuarantine = (
   existing: readonly P2TRSignatureFraudSignerQuarantine[] | undefined,
   identity: Pick<
     P2TRSignatureFraudBoundNonceReservation,

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -38,6 +38,7 @@ import {
   computeP2TRSignatureFraudNonceReleaseRequestID,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
   computeP2TRSignatureFraudResolutionEvidenceDigest,
+  appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
 } from "./P2TRSignatureFraudChallengeOutbox.js"
@@ -1533,7 +1534,12 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           corroborating_independence_domain_id,
           corroborating_evidence_digest, corroborating_attestation,
           corroborating_attested_at_unix_ms, resolved_at_unix_ms,
-          provider_tombstone_receipt, provider_tombstone_at_unix_ms
+          provider_tombstone_receipt, provider_tombstone_at_unix_ms,
+          nonce_consumption_chain_id, nonce_consumption_nonce,
+          nonce_consumption_account_nonce, nonce_consumption_read_at_block,
+          nonce_consumption_transaction_hash,
+          nonce_consumption_finalized_block_number,
+          nonce_consumption_finalized_block_hash
        ) VALUES (
           decode($1, 'hex'), decode($2, 'hex'), $3, $4,
           decode($5, 'hex'), $6, $7, $8,
@@ -1542,7 +1548,11 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           decode($11, 'hex'), decode($14, 'hex'), $15, $16, $17,
           decode($11, 'hex'), decode($18, 'hex'), $19, $20,
           CASE WHEN $21::text IS NULL THEN NULL ELSE decode($21, 'hex') END,
-          $22
+          $22,
+          $23, $24, $25, $26,
+          CASE WHEN $27::text IS NULL THEN NULL ELSE decode($27, 'hex') END,
+          $28,
+          CASE WHEN $29::text IS NULL THEN NULL ELSE decode($29, 'hex') END
        )`,
       [
         stripHex(normalized.recordID),
@@ -1571,6 +1581,19 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           ? null
           : stripHex(normalized.providerTombstone.receipt),
         normalized.providerTombstone?.tombstonedAtUnixMs ?? null,
+        normalized.nonceConsumption?.chainID ?? null,
+        normalized.nonceConsumption?.transactionNonce ?? null,
+        normalized.nonceConsumption?.finalizedAccountNonce ?? null,
+        normalized.nonceConsumption?.accountNonceReadAtBlock ?? null,
+        normalized.nonceConsumption === undefined
+          ? null
+          : stripHex(
+              normalized.nonceConsumption.consumingTransaction.transactionHash
+            ),
+        normalized.nonceConsumption?.finalizedThrough.blockNumber ?? null,
+        normalized.nonceConsumption === undefined
+          ? null
+          : stripHex(normalized.nonceConsumption.finalizedThrough.blockHash),
       ]
     )
     if (normalized.outcome === "never-invoked") {
@@ -1605,6 +1628,71 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
       ) {
         throw new Error(
           "Orphaned signer boundary resolution lost its barrier-clearing swap"
+        )
+      }
+      return "acknowledged"
+    }
+    if (normalized.outcome === "nonce-consumed") {
+      const consumption = normalized.nonceConsumption
+      if (consumption === undefined) {
+        throw new Error(
+          "Nonce-consumed signer boundary resolution lost its consumption evidence"
+        )
+      }
+      // NOT the never-invoked shape. Clearing the marker and stopping would
+      // leave the record in `preparing` with a live reservation, which lease
+      // recovery treats as pre-signer: it would void the nonce guard and hand
+      // the nonce back to the allocator, dropping the partial-unique index that
+      // stops a second reservation at it. The whole claim is that the nonce is
+      // SPENT, not free. So the record moves to `generation-required`, a status
+      // the guard-void trigger permanently refuses to free a nonce from, while
+      // the reservation is retained so a late signer envelope stays capturable.
+      //
+      // `quarantined`, not `generation-required`: the latter requires a linked
+      // nonce-disposition row, and producing one from here would mean
+      // reconciling a record whose signer may still be live. `quarantined` is
+      // itself reconcilable, so the ordinary reconcile loop takes it to a
+      // disposition and a successor generation through the normal path — this
+      // resolution only has to clear the barrier and keep the nonce unfreeable.
+      const settled: P2TRSignatureFraudChallengeOutboxRecord = {
+        ...current,
+        version: current.version + 1,
+        status: "quarantined",
+        // `quarantined` with a returned-signer marker requires a signer
+        // quarantine, and the honest one is ambiguity: the signer was invoked
+        // and nothing here establishes what it did. The chain settled the
+        // NONCE, not the signer's behaviour.
+        signerQuarantines:
+          current.signerInvocationStartedAtUnixMs === undefined ||
+          current.reservedNonce === undefined
+            ? current.signerQuarantines
+            : appendSignerQuarantine(
+                current.signerQuarantines,
+                current.reservedNonce,
+                normalized.resolvedAtUnixMs,
+                "The reserved nonce was consumed at finality while this signer invocation was unresolved",
+                "ambiguous-signer-invocation"
+              ),
+        preparationLease: undefined,
+        preparationResumeStatus: undefined,
+        activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
+        updatedAtUnixMs: Math.max(
+          current.updatedAtUnixMs,
+          normalized.resolvedAtUnixMs
+        ),
+        lastError:
+          "The reserved nonce was consumed at finality, so any signer bytes for it are inert",
+      }
+      if (
+        !(await this.compareAndSwapLocked(
+          normalized.recordID,
+          current.version,
+          settled
+        ))
+      ) {
+        throw new Error(
+          "Nonce-consumed signer boundary resolution lost its barrier-clearing swap"
         )
       }
       return "acknowledged"
@@ -1854,15 +1942,24 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
       current,
       artifact.preparedTransaction.transactionHash.toPrefixedString()
     )
+    // A boundary resolved as nonce-consumed has cleared its marker but still
+    // retains the reservation, precisely so a late envelope stays capturable:
+    // the bytes are inert once the nonce is spent, but losing the RECORD of a
+    // signer that leaked them is not acceptable.
+    const retainsResolvedBoundary =
+      current.status === "generation-required" &&
+      current.reservedNonce !== undefined
     if (
       alreadyCaptured &&
-      current.activeSignerInvocationStartedAtUnixMs === undefined
+      current.activeSignerInvocationStartedAtUnixMs === undefined &&
+      !retainsResolvedBoundary
     ) {
       return current
     }
     if (
       current.reservedNonce === undefined ||
-      current.activeSignerInvocationStartedAtUnixMs === undefined ||
+      (current.activeSignerInvocationStartedAtUnixMs === undefined &&
+        !retainsResolvedBoundary) ||
       bytes32(
         current.reservedNonce.reservationID.toPrefixedString(),
         "Stored signer-boundary reservation ID"

--- a/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
@@ -29,6 +29,7 @@ import {
   P2TRSignatureFraudSignerQuarantine,
   computeP2TRSignatureFraudNonceReleaseRequestID,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
+  appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
@@ -535,6 +536,54 @@ export class InMemoryOutboxStore
         signedTransactionHash: normalized.signedTransactionHash,
         resolvedAtUnixMs: normalized.resolvedAtUnixMs,
       })
+    }
+    if (normalized.outcome === "nonce-consumed") {
+      // Mirrors the adapter exactly: move to a status the guard-void trigger
+      // refuses to free a nonce from, retain the reservation as the capture
+      // anchor, and clear the marker.
+      const settled: P2TRSignatureFraudChallengeOutboxRecord = {
+        ...current,
+        version: current.version + 1,
+        status: "quarantined",
+        // `quarantined` with a returned-signer marker requires a signer
+        // quarantine, and the honest one is ambiguity: the signer was invoked
+        // and nothing here establishes what it did. The chain settled the
+        // NONCE, not the signer's behaviour.
+        signerQuarantines:
+          current.signerInvocationStartedAtUnixMs === undefined ||
+          current.reservedNonce === undefined
+            ? current.signerQuarantines
+            : appendSignerQuarantine(
+                current.signerQuarantines,
+                current.reservedNonce,
+                normalized.resolvedAtUnixMs,
+                "The reserved nonce was consumed at finality while this signer invocation was unresolved",
+                "ambiguous-signer-invocation"
+              ),
+        preparationLease: undefined,
+        preparationResumeStatus: undefined,
+        activeSignerInvocationStartedAtUnixMs: undefined,
+        activeSignerInvocationID: undefined,
+        updatedAtUnixMs: Math.max(
+          current.updatedAtUnixMs,
+          normalized.resolvedAtUnixMs
+        ),
+        lastError:
+          "The reserved nonce was consumed at finality, so any signer bytes for it are inert",
+      }
+      if (
+        !(await this.compareAndSwap(
+          normalized.recordID,
+          current.version,
+          settled
+        ))
+      ) {
+        throw new Error(
+          "Nonce-consumed signer boundary resolution lost its barrier-clearing swap"
+        )
+      }
+      appendEvidence()
+      return "acknowledged"
     }
     if (normalized.outcome === "never-invoked") {
       const cleared: P2TRSignatureFraudChallengeOutboxRecord = {

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -607,7 +607,7 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution/
   )
-  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v3/)
+  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v4/)
   // The deterministic invocation ID is the row identity, so evidence can never
   // speak for a boundary other than the one it names — and unlike the wall-clock
   // tuple it replaced, it cannot drift while the boundary is open.
@@ -626,6 +626,17 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /never-invoked resolution requires a provider tombstone/
   )
+  // The chain settles this outcome, so the database demands the consumption
+  // evidence and checks it names this record's own lane and chain.
+  assert.match(
+    migration,
+    /'never-invoked', 'signed', 'terminal-unsafe', 'nonce-consumed'/
+  )
+  assert.match(
+    migration,
+    /CHECK \( \(outcome = 'nonce-consumed'\) = \(nonce_consumption_transaction_hash IS NOT NULL\) \)/
+  )
+  assert.match(migration, /nonce consumption names another sender lane/)
   assert.match(
     migration,
     /CHECK \(\(outcome = 'signed'\) = \(signed_transaction_hash IS NOT NULL\)\)/

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -2830,6 +2830,22 @@ type BoundaryAttestationMode =
 type BoundaryResolutionOverrides = {
   recordID?: string
   signerInvocationID?: string
+  nonceConsumption?: {
+    chainID: number
+    sender: string
+    transactionNonce: number
+    finalizedAccountNonce: number
+    accountNonceReadAtBlock: number
+    consumingTransaction: {
+      transactionHash: string
+      sender: string
+      nonce: number
+      blockNumber: number
+      blockHash: string
+    }
+    finalizedThrough: { blockNumber: number; blockHash: string }
+    observedHead: { blockNumber: number; blockHash: string }
+  }
   providerTombstone?: {
     signerInvocationID: string
     receipt: string
@@ -2842,7 +2858,7 @@ type BoundaryResolutionOverrides = {
   nonceReservationID?: string
   stage?: "prepare" | "replacement"
   invokedAtUnixMs?: number
-  outcome?: "never-invoked" | "signed" | "terminal-unsafe"
+  outcome?: "never-invoked" | "signed" | "terminal-unsafe" | "nonce-consumed"
   signedTransactionHash?: string
   providerEvidenceDigest?: string
   resolvedAtUnixMs?: number
@@ -2901,6 +2917,34 @@ function boundaryResolution(
   const binding = {
     recordID: overrides.recordID ?? record.recordID,
     signerInvocationID: invocationID,
+    // Only a nonce-consumed outcome may carry consumption evidence, and it
+    // must carry it. Defaults name this record's own lane and chain.
+    ...(outcome === "nonce-consumed"
+      ? {
+          nonceConsumption: overrides.nonceConsumption ?? {
+            chainID: record.intent.chainID,
+            sender: record.reservedNonce!.sender,
+            transactionNonce: record.reservedNonce!.nonce,
+            finalizedAccountNonce: record.reservedNonce!.nonce + 1,
+            accountNonceReadAtBlock: 500,
+            consumingTransaction: {
+              transactionHash: `0x${"c1".repeat(32)}`,
+              sender: record.reservedNonce!.sender,
+              nonce: record.reservedNonce!.nonce,
+              blockNumber: 480,
+              blockHash: `0x${"c2".repeat(32)}`,
+            },
+            finalizedThrough: {
+              blockNumber: 500,
+              blockHash: `0x${"c3".repeat(32)}`,
+            },
+            observedHead: {
+              blockNumber: 512,
+              blockHash: `0x${"c4".repeat(32)}`,
+            },
+          },
+        }
+      : {}),
     // Only a never-invoked outcome may carry one, and it must carry one.
     ...(outcome === "never-invoked" && overrides.omitProviderTombstone !== true
       ? {
@@ -3646,6 +3690,80 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
       },
     ],
     expected: [CLEARED_ORPHAN, WRONG_BOUNDARY],
+    expectedAlertCodes: [],
+  },
+  {
+    // The chain settled it: marker cleared, but the record moves to
+    // generation-required rather than back to preparing, so lease recovery
+    // cannot void the guard and hand the spent nonce back to the allocator.
+    name: "settles a boundary whose nonce was consumed at finality",
+    seed: 242,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [{ outcome: "nonce-consumed" }],
+    expected: [
+      "acknowledged status=quarantined active=none activeID=none " +
+        "signer=none signerID=none artifacts=0",
+    ],
+    expectedAlertCodes: [],
+  },
+  {
+    // Permitted precisely BECAUSE bytes may have escaped -- that is what nonce
+    // consumption makes harmless. never-invoked refuses this same record.
+    name: "settles a nonce-consumed boundary that carries escape evidence",
+    seed: 243,
+    boundary: (reserved) => [
+      {
+        ...activeInitialSignerBoundary(reserved),
+        signerInvocationStartedAtUnixMs: 1_300,
+      },
+    ],
+    resolutions: [{ outcome: "nonce-consumed" }],
+    expected: [
+      "acknowledged status=quarantined active=none activeID=none " +
+        "signer=1300 signerID=none artifacts=0",
+    ],
+    // The escape evidence is NOT laundered away by the resolution: the record
+    // still raises its activation-blocking signed-state alert. Nonce
+    // consumption makes the bytes inert, not the incident invisible.
+    expectedAlertCodes: ["signed-state-quarantined"],
+  },
+  {
+    // Nothing else in nonce-consumption evidence names a chain, so without the
+    // binding two attestations over "sender S nonce N is consumed" would replay
+    // against any record on any chain sharing that pair.
+    name: "refuses nonce consumption that names another chain",
+    seed: 244,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [
+      {
+        outcome: "nonce-consumed",
+        nonceConsumption: {
+          chainID: 999,
+          sender: WALLET.address,
+          transactionNonce: 7,
+          finalizedAccountNonce: 8,
+          accountNonceReadAtBlock: 500,
+          consumingTransaction: {
+            transactionHash: `0x${"c1".repeat(32)}`,
+            sender: WALLET.address,
+            nonce: 7,
+            blockNumber: 480,
+            blockHash: `0x${"c2".repeat(32)}`,
+          },
+          finalizedThrough: {
+            blockNumber: 500,
+            blockHash: `0x${"c3".repeat(32)}`,
+          },
+          observedHead: {
+            blockNumber: 512,
+            blockHash: `0x${"c4".repeat(32)}`,
+          },
+        },
+      },
+    ],
+    expected: [
+      "error:Orphaned signer boundary nonce consumption names another chain",
+    ],
     expectedAlertCodes: [],
   },
   {


### PR DESCRIPTION
Blocker A, increment 3b-i. Stacked on #1046.

## Why

#1046 gated `never-invoked` on a provider tombstone, correctly — nobody can observe the absence of a request still in transit. But no provider implements tombstones, so that outcome is unreachable, and one orphan wedges challenge signing on **every lane** until an operator writes `terminal-unsafe`.

There is a fourth exit that needs nobody's cooperation. Once the reserved nonce is consumed on-chain at finality, any signed bytes for it are permanently inert — they can never confirm. The chain has already settled the question. That is a **decidable base case**, which `never-invoked` is not.

## What it claims, precisely

A statement about the **bytes**, not the invocation. The signer may have signed and may still hold an envelope; this says only that whatever it holds can no longer land. Three consequences, each a requirement rather than a refinement:

**The record moves to `quarantined`, not back to `preparing`.** Clearing the marker and stopping would leave a live reservation in the state lease recovery treats as pre-signer — it would void the nonce guard and hand the nonce back to the allocator, dropping the `(chain_id, sender, nonce)` partial-unique index that stops a second reservation at it. The whole claim is that the nonce is **spent, not free**.

`generation-required` would be more informative but requires a linked disposition row, and producing one here means reconciling a record whose signer may still be live. `quarantined` is itself reconcilable, so the ordinary loop carries it onward through the normal path.

**The reservation is retained and `captureEscapedSignedArtifact` is re-anchored on it.** The live marker was its only authorization; clear it without this and a late-returning envelope is dropped with no alert and no escaped-envelope row. The bytes are harmless once the nonce is spent — the silence is not.

**It inherits none of `never-invoked`'s privileges.** No zero-escape precondition — it is permitted *precisely because* bytes may have escaped — and no incident retirement. Anyone who can transact from the sender can force this outcome with a fee bump, so if it also asserted cleanliness, a boundary where bytes escaped could be laundered clean using only the fee market. A record carrying signed state still raises its activation-blocking alert; a returned-signer marker still records an `ambiguous-signer-invocation` quarantine.

## Evidence

Binds `chainID`, which **nothing in the existing nonce-consumption evidence names** — without it two attestations over "sender S nonce N is consumed" would replay against any record on any chain sharing that pair.

Reuses `validateCanonicalNonceConsumingTransaction` unchanged, and deliberately does *not* import the terminal path's "the consuming transaction is not one of ours" check: the prepared-hash set is empty for an orphan, so it would be vacuous, and the recovery is identical either way.

## Breaking change

Digest domain → `tbtc-p2tr-signer-boundary-independent-resolution-v4`; outcome enum gains `nonce-consumed`. Migration 003 gains seven consumption columns with a biconditional CHECK against the outcome, an all-or-none CHECK across the seven, a strictly-past-the-nonce CHECK, and a read-at-the-finality-boundary CHECK. The guard additionally verifies the consumed nonce and chain against the durable outbox row.

## Verification

- Watchtower with PostgreSQL: **402/402 → 405/405**, no title lost.
- TS/SQL digest parity verified byte-for-byte against a live PostgreSQL 16 on both branches.
- Two mutants caught: leaving the record in `preparing`, and dropping the chain binding. The second one initially **survived** — the scenario that kills it had silently failed to insert, which is exactly what mutation testing is for.

## Known limitations

- Finality is a configured depth (`observedHead - finalizedThrough >= finalityConfirmationBlocks`), not a finalized tag, with no floor and no per-chain minimum. If this outcome is what unwedges a global barrier, that number deserves one.
- A deep reorg below the claimed finality is not retractable: both tables are append-only. The honest worst case is a liveness failure, not a double-submit.
- The lane is not released here; the sender stays pinned to this record until the ordinary reconcile loop produces a disposition. Safe, slightly less live than routing through the disposition machinery directly.

Next in the sequence is the burn itself (3b-ii), which produces this evidence automatically instead of waiting for someone to consume the nonce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZat6B9TisDJ6oW37AG8qH