### PR TITLE
fix(watchtower): make migration 004 applicable to PostgreSQL

### DIFF
--- a/services/watchtower/migrations/004_p2tr_candidate_enqueue_retry_alerts.sql
+++ b/services/watchtower/migrations/004_p2tr_candidate_enqueue_retry_alerts.sql
@@ -120,12 +120,12 @@ BEGIN
         RAISE EXCEPTION 'candidate enqueue guard is already exhausted';
     END IF;
 
-    SELECT authorization.consumed_at, authorization.outbox_intent_id
+    SELECT granted.consumed_at, granted.outbox_intent_id
       INTO authorization_consumed_at, authorization_outbox_intent_id
-      FROM p2tr_candidate_enqueue_authorizations authorization
-     WHERE authorization.manifest_hash = NEW.manifest_hash
-       AND authorization.token_id = NEW.token_id
-       AND authorization.candidate_digest = NEW.candidate_digest
+      FROM p2tr_candidate_enqueue_authorizations granted
+     WHERE granted.manifest_hash = NEW.manifest_hash
+       AND granted.token_id = NEW.token_id
+       AND granted.candidate_digest = NEW.candidate_digest
      FOR KEY SHARE;
     IF authorization_consumed_at IS NULL
        OR authorization_outbox_intent_id IS DISTINCT FROM NEW.outbox_intent_id THEN

--- a/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
+++ b/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
+import { readdirSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { describe, it } from "node:test"
+import pg from "pg"
 import {
   runP2TRWatchtowerMigrations,
   validateP2TRWatchtowerMigrationBody,
@@ -240,3 +242,48 @@ class MigrationClient implements P2TRWatchtowerMigrationClient {
     this.releasedWith = error
   }
 }
+
+// Every assertion above reads the migrations as TEXT. That cannot see a
+// statement PostgreSQL refuses to parse, and one shipped undetected: migration
+// 004 aliased a table `authorization`, a reserved key word, so the whole file
+// failed at the first reference to it and the tables, foreign keys and
+// append-only triggers it declares existed in no database. Nothing else applies
+// 004 -- the adapter suites stop at 003 -- so this is the only test that would
+// have caught it. It applies every migration, in order, to a real server.
+describe("P2TR watchtower migrations apply to PostgreSQL", () => {
+  const postgresURL = process.env.P2TR_WATCHTOWER_TEST_POSTGRES_URL
+  const postgresIt = postgresURL === undefined ? it.skip : it
+
+  postgresIt("applies every migration in order to a fresh schema", async () => {
+    const migrationsURL = new URL("../migrations/", import.meta.url)
+    const ordered = readdirSync(migrationsURL)
+      .filter((name) => /^\d{3}_.+\.sql$/.test(name))
+      .sort()
+    assert.ok(ordered.length >= 4, "expected the full migration set")
+
+    const client = new pg.Client({ connectionString: postgresURL })
+    await client.connect()
+    const schema = `p2tr_migrations_${process.pid}_${Date.now()}`
+    try {
+      await client.query(`CREATE SCHEMA ${schema}`)
+      await client.query(`SET search_path TO ${schema}`)
+      for (const name of ordered) {
+        const body = await readFile(new URL(name, migrationsURL), "utf8")
+        // The runner validates each body before it reaches the server; hold
+        // this test to the same contract so the two cannot drift.
+        assert.doesNotThrow(
+          () => validateP2TRWatchtowerMigrationBody(body),
+          `${name} is not a valid migration body`
+        )
+        try {
+          await client.query(body)
+        } catch (error) {
+          assert.fail(`${name} failed to apply: ${(error as Error).message}`)
+        }
+      }
+    } finally {
+      await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      await client.end()
+    }
+  })
+})


### PR DESCRIPTION
Stacked on #1049.

Migration 004 has never applied to a database. It aliases a table `authorization` in the candidate-enqueue resolution trigger:

```sql
FROM p2tr_candidate_enqueue_authorizations authorization
WHERE authorization.manifest_hash = NEW.manifest_hash
```

`AUTHORIZATION` is a reserved key word, so PostgreSQL rejects the first qualified reference and with it the whole file:

```
ERROR:  syntax error at or near "."
```

The effect is that everything migration 004 declares is absent from every database: the exact-authority key, the outbox-intent foreign key, `p2tr_candidate_enqueue_transaction_guard`, `p2tr_candidate_enqueue_transaction_resolution`, `p2tr_candidate_enqueue_retry_exhaustion_alert`, and their append-only triggers.

## Why no test caught it

Nothing applies it. Every assertion over migration 004 reads the file as **text** — regexes over table names and error strings, plus a lexer-level quote validator — and the adapter suites build their schemas from 001 through 003 only. Under those tests a file the server will not parse is indistinguishable from a correct one.

## The fix

The alias becomes `granted` (one statement, lines 123–128). With that, all four migrations apply cleanly — it was the only defect in the file.

The durable half is a new test that applies **every** migration in directory order to a real server, holding each body to the same `validateP2TRWatchtowerMigrationBody` contract the runner uses so the two cannot drift. It is gated on `P2TR_WATCHTOWER_TEST_POSTGRES_URL` like the other Postgres suites.

Verified by reverting the alias: the new test fails with the original `syntax error at or near "."`, naming the file.

**413/413** (412 + this test).
