### PR TITLE
feat(watchtower)!: refuse signing per nonce lane, not store-wide

### DIFF
--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -1515,6 +1515,35 @@ export type P2TRSignatureFraudNonceReleasePageRequest = {
   cursor?: string
 }
 
+/**
+ * One nonce lane: the sending account on one chain. This is the unit the
+ * durable nonce-allocator barrier is keyed by, because a nonce reservation and
+ * its release both belong to exactly one account.
+ */
+export type P2TRSignatureFraudSigningLane = {
+  chainID: number
+  sender: string
+}
+
+/**
+ * The single normalizer both store implementations must route through. A lane
+ * is a lookup key, so a checksummed address and its lower-case spelling have to
+ * collapse to one value; if the two implementations disagreed here, the
+ * in-memory double would report a lane clear while PostgreSQL reported it
+ * blocked, and the divergence would favour signing.
+ */
+export function normalizeP2TRSignatureFraudSigningLane(
+  lane: P2TRSignatureFraudSigningLane
+): P2TRSignatureFraudSigningLane {
+  return {
+    chainID: normalizePositiveSafeIntegerLike(
+      lane.chainID,
+      "Signing lane chain ID"
+    ),
+    sender: normalizeAddress(lane.sender, "Signing lane sender"),
+  }
+}
+
 export type P2TRSignatureFraudNonceReleasePage = {
   requests: P2TRSignatureFraudNonceReleaseRequest[]
   nextCursor?: string
@@ -1888,8 +1917,20 @@ export interface P2TRSignatureFraudChallengeOutboxStore
     seriesID: string
   ): Promise<P2TRSignatureFraudChallengeOutboxRecord | undefined>
   isSignerQuarantined(chainID: number, signerIdentity: string): Promise<boolean>
-  hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean>
-  hasPendingNonceReleases(): Promise<boolean>
+  /**
+   * Omitting the lane asks the store-wide question, which is what decides
+   * whether recovery must be swept. Passing one asks only whether THAT nonce
+   * lane is still unresolved, which is what decides whether signing on it may
+   * proceed. The two are deliberately different questions: a lane is frozen by
+   * its own residue, never by another account's.
+   */
+  hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean>
+  hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean>
   getNonceReleaseRequest(
     releaseRequestID: string
   ): Promise<P2TRSignatureFraudNonceReleaseRequest | undefined>
@@ -1897,8 +1938,11 @@ export interface P2TRSignatureFraudChallengeOutboxStore
     request: P2TRSignatureFraudNonceReleasePageRequest
   ): Promise<P2TRSignatureFraudNonceReleasePage>
   /**
-   * Reconstructs the exact singleton barrier-owned invocation after restart.
-   * A still-live resultless call is not exposed for independent resolution.
+   * Reconstructs a barrier-owned invocation after restart. The durable barrier
+   * is keyed per nonce lane, so several lanes can hold a claim at once; one
+   * recoverable invocation is returned per call and the caller drains the rest
+   * on subsequent passes. A still-live resultless call is not exposed for
+   * independent resolution.
    */
   getActiveAmbiguousNonceReleaseInvocation(
     nowUnixMs: number
@@ -2555,7 +2599,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       return current
     }
     await this.assertVoidedReservationCapacity(current)
-    await this.assertRecoveryBarrier()
+    // No lane is selected yet -- that happens in the candidate loop below -- so
+    // there is nothing to judge here, only recovery to drive. There is
+    // deliberately no per-candidate wedge check: a lane wedged by an orphan is
+    // already held by that orphan under the unique (chain, sender) lane slot,
+    // so its swap fails and the loop moves on, and a lane wedged by an
+    // unacknowledged release or a quarantine is refused by the durable lane
+    // gate in the same swap. The lane that is actually chosen is asserted at
+    // the irreversible boundary, which is the refusal that matters.
+    await this.driveRecoverySweeps()
 
     const nowUnixMs = requireUnixMilliseconds(
       this.now(),
@@ -2754,7 +2806,10 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge outbox signer invocation time"
     )
-    await this.assertRecoveryBarrier()
+    await this.assertRecoveryBarrier({
+      chainID: reserved.intent.chainID,
+      sender: reservation.sender,
+    })
     // Built from the record that is about to be committed: `nextRecord` already
     // carries the post-swap version, and the binding reads no signer marker, so
     // the invocation identity is derivable here and lands in the same swap that
@@ -3008,7 +3063,6 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     ) {
       return current
     }
-    await this.assertRecoveryBarrier()
 
     let variants: readonly P2TRSignatureFraudPreparedTransactionVariant[]
     try {
@@ -3022,12 +3076,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         "Challenge replacement record lacks its authenticated nonce reservation"
       )
     }
-    const selectedPreparer = this.preparerForReservation(current.reservedNonce)
+    // Captured once: the lane cannot change under a replacement, and both the
+    // entry assert and the boundary assert below must name the same one.
+    const replacementReservation = current.reservedNonce
+    const selectedPreparer = this.preparerForReservation(replacementReservation)
     if (
       selectedPreparer === undefined ||
       (await this.store.isSignerQuarantined(
         current.intent.chainID,
-        current.reservedNonce.signerIdentity
+        replacementReservation.signerIdentity
       ))
     ) {
       return this.quarantine(
@@ -3035,6 +3092,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         "Challenge replacement signer lane is unavailable or quarantined"
       )
     }
+    // Asserted here rather than at entry: the replacement's lane is only known
+    // once its reservation and preparer have been resolved just above.
+    await this.assertRecoveryBarrier({
+      chainID: current.intent.chainID,
+      sender: replacementReservation.sender,
+    })
     const selectedFeePolicy = feePolicyForPreparer(current, selectedPreparer)
     if (variants.length >= P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_SIGNED_VARIANTS) {
       await this.store.saveCriticalAlert({
@@ -3120,7 +3183,10 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge outbox replacement signer invocation time"
     )
-    await this.assertRecoveryBarrier()
+    await this.assertRecoveryBarrier({
+      chainID: claimed.intent.chainID,
+      sender: replacementReservation.sender,
+    })
     // As at the initial boundary: build first, so the identity is committed in
     // the same swap as the marker and a build failure leaves nothing durable.
     const pendingBoundary = nextRecord(claimed, {
@@ -4501,15 +4567,39 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     }
   }
 
-  private async assertRecoveryBarrier(): Promise<void> {
+  /**
+   * Drives recovery without judging any lane. This must stay store-wide: the
+   * sweeps below are the only thing that ever reclaims a `preparing` record
+   * whose lane selection is still NULL -- the window between the claim swap and
+   * the lane swap -- and no per-lane predicate can see such a row, because it
+   * belongs to no lane yet. Narrowing the sweep would strand those records
+   * permanently. Recovering another account's backlog is never harmful; only
+   * REFUSING TO SIGN on another account's behalf is, and that is
+   * `assertRecoveryBarrier`'s job.
+   */
+  private async driveRecoverySweeps(): Promise<void> {
     if (!this.recoveryBarrierEstablished) {
       await this.establishRecoveryBarrier()
     }
+  }
+
+  /**
+   * Refuses to sign on one nonce lane while THAT lane still has unresolved
+   * durable recovery work. The lane is required rather than optional on
+   * purpose: an absent lane would silently mean "no check", which is the same
+   * shape of hole as a barrier row that does not exist reading as a clean lane.
+   */
+  private async assertRecoveryBarrier(
+    lane: P2TRSignatureFraudSigningLane
+  ): Promise<void> {
+    await this.driveRecoverySweeps()
+    const normalized = normalizeP2TRSignatureFraudSigningLane(lane)
     const [expiredPreparationLease, pendingNonceRelease] = await Promise.all([
       this.store.hasExpiredPreparationLeases(
-        requireUnixMilliseconds(this.now(), "Challenge recovery barrier time")
+        requireUnixMilliseconds(this.now(), "Challenge recovery barrier time"),
+        normalized
       ),
-      this.store.hasPendingNonceReleases(),
+      this.store.hasPendingNonceReleases(normalized),
     ])
     if (expiredPreparationLease || pendingNonceRelease) {
       this.recoveryBarrierEstablished = false
@@ -4551,15 +4641,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge recovery barrier completion time"
     )
-    if (
-      (await this.store.hasPendingNonceReleases()) ||
-      (await this.store.hasExpiredPreparationLeases(nowUnixMs))
-    ) {
-      throw new Error(
-        "Challenge signing is blocked by unresolved durable recovery work"
-      )
-    }
-    this.recoveryBarrierEstablished = true
+    // Residue left here is no longer fatal. It used to throw, and that throw --
+    // not either message in `assertRecoveryBarrier` -- is what a wedged store
+    // actually raised, because this runs first whenever the flag is unset. One
+    // account's unresolvable residue therefore froze signing on every account.
+    // Whether residue blocks is now the caller's question to ask about its own
+    // lane; all this decides is whether the store-wide fast path may latch.
+    this.recoveryBarrierEstablished =
+      !(await this.store.hasPendingNonceReleases()) &&
+      !(await this.store.hasExpiredPreparationLeases(nowUnixMs))
   }
 
   private async applyPreSignRecheckFailure(

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -40,8 +40,10 @@ import {
   computeP2TRSignatureFraudResolutionEvidenceDigest,
   appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
+  normalizeP2TRSignatureFraudSigningLane,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
 } from "./P2TRSignatureFraudChallengeOutbox.js"
+import type { P2TRSignatureFraudSigningLane } from "./P2TRSignatureFraudChallengeOutbox.js"
 import type { P2TRPostgresOutboxTransactionSession } from "./PostgresP2TRSignatureFraudOutboxActivationHandshake.js"
 import type { P2TRSignatureFraudWatchtowerTransactionCoordinator } from "./types.js"
 
@@ -414,30 +416,61 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     return result.rows[0]?.exists === true
   }
 
-  async hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean> {
+  async hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
     if (!this.inTransaction()) {
       return this.runInTransaction(() =>
-        this.hasExpiredPreparationLeases(nowUnixMs)
+        this.hasExpiredPreparationLeases(nowUnixMs, lane)
       )
     }
     this.assertSession()
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
+    // `lane_released_at_unix_ms IS NULL` is not a filter of convenience. A
+    // record that has released its lane is no longer occupying it, so freezing
+    // the lane on its behalf would be wrong -- and the partial unique index on
+    // (chain_id, selected_sender) carries the same predicate, so stating it
+    // keeps this an index lookup instead of a scan.
     const result = await this.options.session.query<{ exists: boolean }>(
       `SELECT EXISTS (
           SELECT 1
             FROM p2tr_signature_fraud_challenge_outbox
            WHERE status = 'preparing'
              AND preparation_lease_expires_at_unix_ms <= $1
+             ${
+               normalized === undefined
+                 ? ""
+                 : `AND chain_id = $2
+             AND selected_sender = decode($3, 'hex')
+             AND lane_released_at_unix_ms IS NULL`
+             }
        ) AS exists`,
-      [unixMilliseconds(nowUnixMs, "Preparation recovery time")]
+      normalized === undefined
+        ? [unixMilliseconds(nowUnixMs, "Preparation recovery time")]
+        : [
+            unixMilliseconds(nowUnixMs, "Preparation recovery time"),
+            normalized.chainID,
+            stripHex(normalized.sender),
+          ]
     )
     return result.rows[0]?.exists === true
   }
 
-  async hasPendingNonceReleases(): Promise<boolean> {
+  async hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
     if (!this.inTransaction()) {
-      return this.runInTransaction(() => this.hasPendingNonceReleases())
+      return this.runInTransaction(() => this.hasPendingNonceReleases(lane))
     }
     this.assertSession()
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
     const result = await this.options.session.query<{ exists: boolean }>(
       `SELECT EXISTS (
           SELECT 1
@@ -447,7 +480,16 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
                    FROM p2tr_signature_fraud_challenge_nonce_release_terminal x
                   WHERE x.release_request_id = r.release_request_id
                )
-       ) AS exists`
+             ${
+               normalized === undefined
+                 ? ""
+                 : `AND r.chain_id = $1
+             AND r.sender = decode($2, 'hex')`
+             }
+       ) AS exists`,
+      normalized === undefined
+        ? []
+        : [normalized.chainID, stripHex(normalized.sender)]
     )
     return result.rows[0]?.exists === true
   }

--- a/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
@@ -32,6 +32,7 @@ import {
   appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
+  normalizeP2TRSignatureFraudSigningLane,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
 
 /** Mirrors the PostgreSQL adapter's tolerance for an unprefixed `Hex` render. */
@@ -179,19 +180,56 @@ export class InMemoryOutboxStore
     )
   }
 
-  async hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean> {
+  async hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
     return [...this.records.values()].some(
       (record) =>
         record.status === "preparing" &&
         record.preparationLease !== undefined &&
-        record.preparationLease.expiresAtUnixMs <= nowUnixMs
+        record.preparationLease.expiresAtUnixMs <= nowUnixMs &&
+        (normalized === undefined ||
+          // Mirrors the adapter exactly, including the released-lane exclusion:
+          // a record that surrendered its lane is not occupying it. The
+          // adapter writes `lane_released_at_unix_ms` exactly when
+          // `finalNonceResolution` is set, so this is the same predicate.
+          (record.finalNonceResolution === undefined &&
+            record.preparationSender !== undefined &&
+            normalizeP2TRSignatureFraudSigningLane({
+              chainID: record.intent.chainID,
+              sender: record.preparationSender,
+            }).sender === normalized.sender &&
+            record.intent.chainID === normalized.chainID))
     )
   }
 
-  async hasPendingNonceReleases(): Promise<boolean> {
-    return [...this.nonceReleaseRequests.keys()].some(
-      (id) => !this.releaseAcknowledged(id)
-    )
+  async hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
+    return [...this.nonceReleaseRequests.entries()].some(([id, request]) => {
+      if (this.releaseAcknowledged(id)) return false
+      if (normalized === undefined) return true
+      // The reservation carries the sender but not the chain, so the chain
+      // comes from the record the release belongs to -- the same join the
+      // adapter gets for free from the release-request row.
+      const chainID = this.records.get(request.recordID)?.intent.chainID
+      return (
+        chainID === normalized.chainID &&
+        normalizeP2TRSignatureFraudSigningLane({
+          chainID: normalized.chainID,
+          sender: request.reservation.sender,
+        }).sender === normalized.sender
+      )
+    })
   }
 
   async getNonceReleaseRequest(

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -154,9 +154,10 @@ const completeV2TestCall = (sighash: string) => {
 const signTestChallengeTransaction = (
   calldata: string,
   maxFeePerGas: number,
-  maxPriorityFeePerGas: number
+  maxPriorityFeePerGas: number,
+  signingKey = `0x${"42".repeat(32)}`
 ) => {
-  const wallet = new Wallet(`0x${"42".repeat(32)}`)
+  const wallet = new Wallet(signingKey)
   const transaction = {
     type: 2,
     chainId: 11155111,
@@ -552,7 +553,7 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
       intentID: intent.intentID,
       rawTransaction: this.rawTransaction,
       transactionHash: Hex.from(this.transactionHash),
-      sender: TRANSACTION_SENDER,
+      sender: this.transactionSender,
       nonce: 7,
       invocation:
         this.echoInvocation === undefined
@@ -964,6 +965,58 @@ const createRecord = (
     reconciliationAttempts: 0,
   }
 }
+
+/**
+ * A second nonce lane. `validateSignerLanes` requires a distinct lane ID,
+ * signer identity and sender, and the reservation is EIP-712 signed by the
+ * sender itself, so the lane needs its own wallet and must take its address as
+ * the sender.
+ */
+const SECOND_LANE_SIGNING_KEY = `0x${"43".repeat(32)}`
+const SECOND_LANE_WALLET = new Wallet(SECOND_LANE_SIGNING_KEY)
+// The blob must carry the calldata of the intent it will be bound to, so lane B
+// signs the second test intent's call, not the default one.
+const SECOND_INTENT_SEED = "bb"
+const secondIntentCall = completeV2TestCall(`0x${SECOND_INTENT_SEED.repeat(32)}`)
+const secondLaneSignedTransaction = signTestChallengeTransaction(
+  secondIntentCall.calldata,
+  20,
+  2,
+  SECOND_LANE_SIGNING_KEY
+)
+const secondLaneReplacementTransaction = signTestChallengeTransaction(
+  secondIntentCall.calldata,
+  40,
+  4,
+  SECOND_LANE_SIGNING_KEY
+)
+const SECOND_TRANSACTION_SENDER = SECOND_LANE_WALLET.address
+const SECOND_SIGNER_LANE_ID = "lane.b.test"
+const SECOND_SIGNER_IDENTITY = "signer.b.test"
+
+class SecondLanePreparer extends FixedPreparer {
+  readonly laneID = SECOND_SIGNER_LANE_ID
+  readonly signerIdentity = SECOND_SIGNER_IDENTITY
+  readonly transactionSender = SECOND_TRANSACTION_SENDER
+  readonly wallet = SECOND_LANE_WALLET
+  rawTransaction = secondLaneSignedTransaction.rawTransaction
+  transactionHash = secondLaneSignedTransaction.transactionHash
+  replacementRawTransaction = secondLaneReplacementTransaction.rawTransaction
+  replacementTransactionHash = secondLaneReplacementTransaction.transactionHash
+}
+
+const twoLaneFeePolicyManifest = () =>
+  feePolicyManifest([
+    {
+      laneID: SECOND_SIGNER_LANE_ID,
+      signerIdentity: SECOND_SIGNER_IDENTITY,
+      sender: SECOND_TRANSACTION_SENDER,
+      maxGasLimit: "1000000",
+      maxFeePerGas: "100",
+      maxPriorityFeePerGas: "10",
+      maxTotalFeeWei: "100000000",
+    },
+  ])
 
 const enqueue = async (
   store: InMemoryOutboxStore,
@@ -3776,4 +3829,173 @@ test("refuses a burn that is not a self-transfer of nothing", async () => {
       name
     )
   }
+})
+
+// The whole point of keying the barrier by nonce lane. An orphaned signer
+// boundary is unresolvable without out-of-band evidence, so before this change
+// one such record froze challenge signing on EVERY sending account: the freeze
+// was driven by store-wide `hasExpiredPreparationLeases` /
+// `hasPendingNonceReleases` reads, and the throw that a wedged store actually
+// raised came from `establishRecoveryBarrier`, before any per-record check.
+//
+// Note these tests are the only thing pinning that behaviour in either
+// direction. Nothing in the suite asserted any barrier message before, so a
+// regression here would otherwise ship silently.
+const orphanLaneA = async (
+  store: InMemoryOutboxStore,
+  preparers: readonly P2TRSignatureFraudChallengeTransactionPreparer[]
+): Promise<{ now: () => number; release: () => void }> => {
+  const record = await enqueue(store, createIntent(), twoLaneFeePolicyManifest())
+  const authorizer = new FixedBoundaryAuthorizer()
+  let now = 2_000
+  let markStarted!: () => void
+  let release!: () => void
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve
+  })
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  authorizer.beforeAuthorize = async () => {
+    markStarted()
+    await gate
+  }
+  authorizer.rejectAuthorization = new Error("worker restarted")
+  const original = dispatcher(
+    store,
+    preparers as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => now,
+    100,
+    undefined,
+    authorizer
+  )
+  void original.prepare(record.recordID, "worker-a").catch(() => undefined)
+  await started
+  // Past the lease, the boundary is an orphan: the marker stands and no
+  // process-local recovery may clear it.
+  now = 40_001
+  return { now: () => now, release }
+}
+
+test("an orphaned boundary on one lane no longer freezes signing on another", async () => {
+  const store = new InMemoryOutboxStore()
+  const laneA = new FixedPreparer()
+  const laneB = new SecondLanePreparer()
+  const { now, release } = await orphanLaneA(store, [laneA, laneB])
+
+  assert.equal(
+    await store.hasExpiredPreparationLeases(now(), {
+      chainID: 11155111,
+      sender: TRANSACTION_SENDER,
+    }),
+    true
+  )
+  assert.equal(
+    await store.hasExpiredPreparationLeases(now(), {
+      chainID: 11155111,
+      sender: SECOND_TRANSACTION_SENDER,
+    }),
+    false
+  )
+
+  const second = await enqueue(
+    store,
+    createIntent(SECOND_INTENT_SEED),
+    twoLaneFeePolicyManifest()
+  )
+  const restarted = dispatcher(
+    store,
+    [laneA, laneB] as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    now
+  )
+  const prepared = await restarted.prepare(second.recordID, "worker-b")
+
+  // Lane A is skipped as unavailable rather than fatal, and lane B signs.
+  assert.equal(prepared.status, "prepared")
+  assert.equal(
+    prepared.preparationSender?.toLowerCase(),
+    SECOND_TRANSACTION_SENDER.toLowerCase()
+  )
+  assert.equal(laneA.calls, 0)
+  assert.equal(prepared.selectedLaneID, SECOND_SIGNER_LANE_ID)
+  assert.equal(laneB.calls, 1)
+  release()
+})
+
+test("an orphaned boundary still freezes signing on its own lane", async () => {
+  const store = new InMemoryOutboxStore()
+  const laneA = new FixedPreparer()
+  const { now, release } = await orphanLaneA(store, [laneA])
+
+  const second = await enqueue(
+    store,
+    createIntent(SECOND_INTENT_SEED),
+    twoLaneFeePolicyManifest()
+  )
+  const restarted = dispatcher(
+    store,
+    [laneA] as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    now
+  )
+  // The only configured lane is the wedged one, so no healthy lane exists. The
+  // record is re-queued rather than signed -- it is never handed to the signer.
+  const attempted = await restarted.prepare(second.recordID, "worker-b")
+  assert.equal(attempted.status, "queued")
+  assert.equal(
+    attempted.lastError,
+    "No healthy durable signer lane is currently available"
+  )
+  assert.equal(laneA.calls, 0)
+  release()
+})
+
+// The direct analogue of the activation hole fixed in #1049: a `preparing`
+// record whose lane selection is still NULL belongs to no lane, so no per-lane
+// predicate -- nor a rollup over every lane -- can see it. Only the store-wide
+// sweep reclaims it, which is why the sweep must not gain a lane filter.
+test("recovery still sweeps a preparing record that has selected no lane", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const claimed = await store.compareAndSwap(record.recordID, record.version, {
+    ...record,
+    status: "preparing",
+    version: record.version + 1,
+    preparationAttempts: 1,
+    preparationLease: { owner: "worker-a", expiresAtUnixMs: 3_000 },
+    updatedAtUnixMs: 2_000,
+  })
+  assert.equal(claimed, true)
+  const stranded = await store.get(record.recordID)
+  assert.equal(stranded?.preparationSender, undefined)
+
+  // Invisible to every lane, visible store-wide.
+  assert.equal(
+    await store.hasExpiredPreparationLeases(40_001, {
+      chainID: 11155111,
+      sender: TRANSACTION_SENDER,
+    }),
+    false
+  )
+  assert.equal(await store.hasExpiredPreparationLeases(40_001), true)
+
+  const recovery = dispatcher(
+    store,
+    new FixedPreparer(),
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 40_001
+  )
+  await recovery.recoverExpiredPreparationLeases()
+  assert.equal((await store.get(record.recordID))?.status, "queued")
+  assert.equal(await store.hasExpiredPreparationLeases(40_001), false)
 })

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -977,7 +977,9 @@ const SECOND_LANE_WALLET = new Wallet(SECOND_LANE_SIGNING_KEY)
 // The blob must carry the calldata of the intent it will be bound to, so lane B
 // signs the second test intent's call, not the default one.
 const SECOND_INTENT_SEED = "bb"
-const secondIntentCall = completeV2TestCall(`0x${SECOND_INTENT_SEED.repeat(32)}`)
+const secondIntentCall = completeV2TestCall(
+  `0x${SECOND_INTENT_SEED.repeat(32)}`
+)
 const secondLaneSignedTransaction = signTestChallengeTransaction(
   secondIntentCall.calldata,
   20,
@@ -3845,7 +3847,11 @@ const orphanLaneA = async (
   store: InMemoryOutboxStore,
   preparers: readonly P2TRSignatureFraudChallengeTransactionPreparer[]
 ): Promise<{ now: () => number; release: () => void }> => {
-  const record = await enqueue(store, createIntent(), twoLaneFeePolicyManifest())
+  const record = await enqueue(
+    store,
+    createIntent(),
+    twoLaneFeePolicyManifest()
+  )
   const authorizer = new FixedBoundaryAuthorizer()
   let now = 2_000
   let markStarted!: () => void

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -4190,48 +4190,45 @@ postgresTest(
 // other test executes. Without this, the adapter could filter on the wrong
 // column, or not filter at all, and every dispatcher-level test would still
 // pass -- they bind to the in-memory double.
-postgresTest(
-  "scopes the recovery predicates to one nonce lane",
-  async () => {
-    const database = await createTestDatabase()
-    await orphanedSignerBoundary(database, 220)
-    const afterLease = 10_000_000
-    const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
-    const otherSender = {
-      chainID: CHAIN_ID,
-      sender: `0x${"cd".repeat(20)}`,
-    }
-    const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
-
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease),
-      true
-    )
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
-      true
-    )
-    // A different account on the same chain, and the same account on a
-    // different chain, are both unaffected.
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
-      false
-    )
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
-      false
-    )
-    // The sender is a lookup key, so its spelling must not matter.
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, {
-        chainID: CHAIN_ID,
-        sender: WALLET.address.toLowerCase(),
-      }),
-      true
-    )
-    await database.client.end()
+postgresTest("scopes the recovery predicates to one nonce lane", async () => {
+  const database = await createTestDatabase()
+  await orphanedSignerBoundary(database, 220)
+  const afterLease = 10_000_000
+  const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
+  const otherSender = {
+    chainID: CHAIN_ID,
+    sender: `0x${"cd".repeat(20)}`,
   }
-)
+  const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
+
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease),
+    true
+  )
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
+    true
+  )
+  // A different account on the same chain, and the same account on a
+  // different chain, are both unaffected.
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
+    false
+  )
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
+    false
+  )
+  // The sender is a lookup key, so its spelling must not matter.
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, {
+      chainID: CHAIN_ID,
+      sender: WALLET.address.toLowerCase(),
+    }),
+    true
+  )
+  await database.client.end()
+})
 
 postgresTest(
   "scopes the pending nonce-release predicate to one nonce lane",

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -4184,3 +4184,83 @@ postgresTest(
     await database.client.end()
   }
 )
+
+// The lane-scoped variants of these two predicates decide whether challenge
+// signing is refused on one nonce lane, and both are implemented in SQL that no
+// other test executes. Without this, the adapter could filter on the wrong
+// column, or not filter at all, and every dispatcher-level test would still
+// pass -- they bind to the in-memory double.
+postgresTest(
+  "scopes the recovery predicates to one nonce lane",
+  async () => {
+    const database = await createTestDatabase()
+    await orphanedSignerBoundary(database, 220)
+    const afterLease = 10_000_000
+    const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
+    const otherSender = {
+      chainID: CHAIN_ID,
+      sender: `0x${"cd".repeat(20)}`,
+    }
+    const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
+
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease),
+      true
+    )
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
+      true
+    )
+    // A different account on the same chain, and the same account on a
+    // different chain, are both unaffected.
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
+      false
+    )
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
+      false
+    )
+    // The sender is a lookup key, so its spelling must not matter.
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, {
+        chainID: CHAIN_ID,
+        sender: WALLET.address.toLowerCase(),
+      }),
+      true
+    )
+    await database.client.end()
+  }
+)
+
+postgresTest(
+  "scopes the pending nonce-release predicate to one nonce lane",
+  async () => {
+    const database = await createTestDatabase()
+    await createPendingNonceRelease(database, 221)
+
+    assert.equal(await database.store.hasPendingNonceReleases(), true)
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID,
+        sender: WALLET.address,
+      }),
+      true
+    )
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID,
+        sender: `0x${"cd".repeat(20)}`,
+      }),
+      false
+    )
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID + 1,
+        sender: WALLET.address,
+      }),
+      false
+    )
+    await database.client.end()
+  }
+)


### PR DESCRIPTION
Stacked on #1050. Completes the wedge fix begun in #1049.

## What was still broken

#1049 keyed the durable barrier by `(chain_id, sender)`. The JavaScript half stayed store-wide, so one orphaned signer boundary still froze challenge signing on **every** sending account — the practical wedge was untouched.

## The split that makes it work

`assertRecoveryBarrier` was doing two jobs:

1. **Drive recovery** — `establishRecoveryBarrier` pages the whole store, draining pending releases and expired leases until convergence.
2. **Refuse to sign** on anything left over.

Only (2) is harmful across lanes. Recovering account A's backlog while preparing on account B is work that had to happen anyway and touches nothing of B's safety. So the sweep stays store-wide — `listPage` and `listPendingNonceReleases` are **not** touched — and only the refusal moves to the lane.

## Why the sweep must stay global

A `preparing` record whose lane selection is still `NULL` — the window between the claim swap and the lane swap — belongs to **no lane**. No per-lane predicate, and no rollup over every lane, can see it; only the store-wide sweep reclaims it.

This is the same shape as the activation hole fixed in #1049, where a lane with no barrier row read exactly like a clean store. There the fix was whole-store SUM equalities; here it is keeping the sweep global. A test pins it directly.

## The throw that was actually firing

The error a wedged store raised was `establishRecoveryBarrier`'s `"unresolved durable recovery work"` — **not** either message in `assertRecoveryBarrier`. The flag starts `false`, so establish runs first and throws before the assert's live re-read is ever reached. Narrowing only the assert would have unwedged nothing. That throw is gone; residue now only decides whether the store-wide fast path may latch.

No new per-lane cache was needed: `recoveryBarrierEstablished` already means "the sweeps ran and the store is globally clean", which is a sound fast path — globally clean implies no lane is wedged.

## Call sites

- **`prepare()` entry** — asserts nothing; no lane is selected there. It only drives recovery.
- **No per-candidate wedge check**, deliberately. A lane wedged by an orphan is already held by that orphan under the unique `(chain, sender)` lane slot, so its swap fails and the loop moves on; a lane wedged by an unacknowledged release or a quarantine is refused by `lockAndAssertSignerLaneAvailable` in the same swap. I wrote such a check, found a mutation removing it survived every test, confirmed both existing mechanisms cover it, and dropped it rather than ship two queries per candidate of untested defence.
- **Both irreversible boundaries** assert the selected lane. This is the refusal that matters.
- **`prepareReplacement()`** asserts once its reservation and preparer are resolved, not at entry where the lane is not yet known.
- **`burnContestedNonce`** stays exempt — its lane is by definition the wedged one, so asserting there would deadlock the escape hatch.

The unresolved `reservation-release-failed` disjunct in the durable lane gate stays **global** on purpose: it mirrors the SQL gate at `003:4337` and the `contract_mismatch_blocked` singleton kept global in #1049. An allocator whose contract is in doubt condemns every lane, and the alert table carries no lane key.

## Tests

Nothing pinned any of this. No test asserted a barrier message in either direction, the adapter's two predicates were executed by **no** test, and every fixture was single-lane — so a regression here would have shipped silently. Five tests come with it:

| test | mutation it kills |
|---|---|
| orphan on lane A no longer freezes lane B | restoring the store-wide throw |
| orphan still freezes its own lane | restoring the store-wide throw |
| lane-less `preparing` record still swept | neutralising the lane filter |
| both predicates lane-scoped in SQL, across chains and address casing | neutralising the adapter's filter |

Verified by mutation in both directions. A two-lane dispatcher fixture is new — `validateSignerLanes` requires distinct lane/identity/sender and the reservation is EIP-712 signed by the sender, so lane B needs its own wallet and its own signed blob.

**418/418** (413 + 5).

## Notes for review

- `lane_released_at_unix_ms IS NULL` in the lane-scoped lease predicate is not an optimisation: a record that surrendered its lane is not occupying it, so freezing the lane on its behalf would be wrong. It also happens to match the partial unique index.
- Both store implementations route through one `normalizeP2TRSignatureFraudSigningLane`. A lane is a lookup key, and a casing disagreement between the double and the adapter would have failed in the unsafe direction — double reporting clear while PostgreSQL reported blocked.
- The lane is **required** on the dispatcher assert, not optional. An absent lane silently meaning "no check" is the same shape of hole as a missing barrier row reading as a clean lane.
