### PR TITLE
feat(watchtower)!: scope nonce recovery by lane and harden outbox policy

### DIFF
--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -1016,6 +1016,9 @@ CREATE TABLE p2tr_signature_fraud_challenge_nonce_release_request (
         requested_at_unix_ms BETWEEN 0 AND 9007199254740991
     ),
     UNIQUE (record_id, release_request_id),
+    -- Lets the nonce-allocator safety barrier bind a claimed release request to
+    -- its own (chain_id, sender) key declaratively rather than by convention.
+    UNIQUE (chain_id, sender, release_request_id),
     FOREIGN KEY (record_id, generation)
         REFERENCES p2tr_signature_fraud_challenge_outbox(record_id, generation)
         ON DELETE RESTRICT,
@@ -1216,13 +1219,38 @@ SELECT release_request_id, attempt_sequence, outcome
   FROM p2tr_signature_fraud_challenge_nonce_release_resolution
  WHERE outcome IN ('released', 'already-released');
 
+-- A contract mismatch is a statement about the nonce allocator's API
+-- implementation, not about any one account, so it permanently flips this
+-- singleton to no-go for every lane at once and is never cleared.
+-- `incident_epoch` counts the events that set it.
+CREATE TABLE p2tr_signature_fraud_nonce_allocator_global_barrier (
+    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    contract_mismatch_blocked boolean NOT NULL DEFAULT false,
+    incident_epoch bigint NOT NULL DEFAULT 0 CHECK (
+        incident_epoch BETWEEN 0 AND 9007199254740991
+    )
+);
+
+INSERT INTO p2tr_signature_fraud_nonce_allocator_global_barrier (
+    singleton,
+    contract_mismatch_blocked,
+    incident_epoch
+) VALUES (true, false, 0);
+
 -- External nonce-release and signer calls never run inside a database
 -- transaction, so their mutually exclusive durable claims live here. A
 -- release invocation is committed before allocator I/O; a signer claim is
--- committed before signer I/O. Contract mismatch permanently flips the same singleton
--- to no-go, eliminating stale-snapshot races between unrelated lanes.
+-- committed before signer I/O.
+--
+-- What those two claims mutually exclude is signing against releasing ON THE
+-- SAME ETHEREUM ACCOUNT: a release hands a reserved nonce of that account back
+-- to its allocator, so the claim is keyed by (chain_id, sender) -- the nonce
+-- lane. Keying it that way is what stops one account's outstanding allocator
+-- I/O from wedging signing for every other account; nothing here relates
+-- account A's in-flight release to account B.
 CREATE TABLE p2tr_signature_fraud_nonce_allocator_safety_barrier (
-    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    chain_id numeric(78, 0) NOT NULL CHECK (chain_id > 0),
+    sender bytea NOT NULL CHECK (octet_length(sender) = 20),
     active_release_request_id bytea CHECK (
         active_release_request_id IS NULL
         OR octet_length(active_release_request_id) = 32
@@ -1241,10 +1269,7 @@ CREATE TABLE p2tr_signature_fraud_nonce_allocator_safety_barrier (
     unresolved_release_count integer NOT NULL DEFAULT 0 CHECK (
         unresolved_release_count BETWEEN 0 AND 1000000
     ),
-    contract_mismatch_blocked boolean NOT NULL DEFAULT false,
-    incident_epoch bigint NOT NULL DEFAULT 0 CHECK (
-        incident_epoch BETWEEN 0 AND 9007199254740991
-    ),
+    PRIMARY KEY (chain_id, sender),
     CHECK (
         num_nonnulls(
             active_release_request_id,
@@ -1258,16 +1283,44 @@ CREATE TABLE p2tr_signature_fraud_nonce_allocator_safety_barrier (
     ) REFERENCES p2tr_signature_fraud_challenge_nonce_release_attempt (
         release_request_id,
         attempt_sequence
+    ) DEFERRABLE INITIALLY DEFERRED,
+    -- The attempt reference above carries no lane, so on its own it would let
+    -- one lane's barrier row hold a claim belonging to a different lane. This
+    -- second reference pins the claimed request to THIS row's key.
+    FOREIGN KEY (
+        chain_id,
+        sender,
+        active_release_request_id
+    ) REFERENCES p2tr_signature_fraud_challenge_nonce_release_request (
+        chain_id,
+        sender,
+        release_request_id
     ) DEFERRABLE INITIALLY DEFERRED
 );
 
-INSERT INTO p2tr_signature_fraud_nonce_allocator_safety_barrier (
-    singleton,
-    active_signer_invocation_count,
-    unresolved_release_count,
-    contract_mismatch_blocked,
-    incident_epoch
-) VALUES (true, 0, 0, false, 0);
+-- Lane rows are seeded eagerly when a lane is configured, never lazily on first
+-- use. Every gate below reads a missing row as fail-closed, and the activation
+-- handshake needs the row set to be ground truth rather than a by-product of
+-- traffic. Rows deliberately outlive the manifest that introduced them, so a
+-- lane rotated out of the current manifest keeps its barrier state.
+CREATE FUNCTION p2tr_signature_fraud_seed_nonce_allocator_lane_barrier()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO p2tr_signature_fraud_nonce_allocator_safety_barrier (
+        chain_id,
+        sender
+    ) VALUES (NEW.chain_id, NEW.sender)
+    ON CONFLICT (chain_id, sender) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER p2tr_signature_fraud_seed_nonce_allocator_lane_barrier_trigger
+AFTER INSERT ON p2tr_signature_fraud_signer_lane_configuration
+FOR EACH ROW EXECUTE FUNCTION
+    p2tr_signature_fraud_seed_nonce_allocator_lane_barrier();
 
 CREATE INDEX p2tr_signature_fraud_pending_nonce_release_idx
     ON p2tr_signature_fraud_challenge_nonce_release_request (release_request_id);
@@ -1633,7 +1686,7 @@ CREATE TABLE p2tr_signature_fraud_challenge_provenance_incident (
 -- call outstanding". That ambiguity is resolvable only by the boundary's own
 -- owner, which is the single witness that authorization failed before any
 -- signer I/O. The same first-person observation is already trusted to clear the
--- singleton signer barrier, so it is equally sufficient to retire the incident.
+-- lane's signer barrier, so it is equally sufficient to retire the incident.
 --
 -- A lease timeout is NOT such evidence and can never produce a row here.
 CREATE TABLE p2tr_signature_fraud_challenge_provenance_incident_resolution (
@@ -1718,9 +1771,9 @@ EXECUTE FUNCTION p2tr_signature_fraud_guard_provenance_incident_resolution();
 --
 -- `active_signer_invocation_started_at_unix_ms` is committed BEFORE boundary
 -- authorization and therefore before the signer RPC, so a lost owner leaves the
--- singleton `active_signer_invocation_count` at one. That blocks every
--- nonce-release invocation store-wide and freezes challenge signing on every
--- lane. Lease expiry is not evidence and can never produce a row here; only an
+-- lane's `active_signer_invocation_count` at one. That blocks every
+-- nonce-release invocation on that lane and freezes challenge signing for that
+-- account. Lease expiry is not evidence and can never produce a row here; only an
 -- out-of-band observation of what the signer actually did, carrying two
 -- attestations from distinct trust AND independence domains, may.
 --
@@ -3096,9 +3149,10 @@ AS $$
 BEGIN
     UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
        SET unresolved_release_count = unresolved_release_count + 1
-     WHERE singleton = true;
+     WHERE chain_id = NEW.chain_id
+       AND sender = NEW.sender;
     IF NOT FOUND THEN
-        RAISE EXCEPTION 'nonce allocator safety barrier is missing';
+        RAISE EXCEPTION 'nonce allocator safety barrier is missing for the lane';
     END IF;
     RETURN NEW;
 END;
@@ -3120,7 +3174,7 @@ DECLARE
 BEGIN
     IF COALESCE((
         SELECT contract_mismatch_blocked
-        FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+        FROM p2tr_signature_fraud_nonce_allocator_global_barrier
         WHERE singleton = true
     ), true) THEN
         RETURN NULL;
@@ -3190,6 +3244,9 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
     attempt p2tr_signature_fraud_challenge_nonce_release_attempt%ROWTYPE;
+    lane_chain_id numeric(78, 0);
+    lane_sender bytea;
+    globally_blocked boolean;
 BEGIN
     SELECT * INTO attempt
     FROM p2tr_signature_fraud_challenge_nonce_release_attempt
@@ -3215,22 +3272,38 @@ BEGIN
         RAISE EXCEPTION 'nonce-release invocation lacks its exact live attempt';
     END IF;
 
+    SELECT chain_id, sender INTO lane_chain_id, lane_sender
+      FROM p2tr_signature_fraud_challenge_nonce_release_request
+     WHERE release_request_id = NEW.release_request_id;
+
+    SELECT contract_mismatch_blocked INTO globally_blocked
+      FROM p2tr_signature_fraud_nonce_allocator_global_barrier
+     WHERE singleton = true;
+    IF globally_blocked IS NULL THEN
+        RAISE EXCEPTION 'nonce allocator global barrier is missing';
+    END IF;
+
+    -- The claim excludes signing on THIS account only. A different account's
+    -- signer boundary is not a reason to withhold this account's nonce from
+    -- its allocator.
     UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
        SET active_release_request_id = NEW.release_request_id,
            active_release_attempt_sequence = NEW.attempt_sequence,
            active_release_expires_at_unix_ms = attempt.expires_at_unix_ms
-     WHERE singleton = true
+     WHERE chain_id = lane_chain_id
+       AND sender = lane_sender
        AND active_release_request_id IS NULL
        AND active_signer_invocation_count = 0
        AND unresolved_release_count > 0
-       AND NOT contract_mismatch_blocked;
+       AND NOT globally_blocked;
     IF NOT FOUND THEN
         IF NOT EXISTS (
             SELECT 1
             FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
-            WHERE singleton = true
+            WHERE chain_id = lane_chain_id
+              AND sender = lane_sender
         ) THEN
-            RAISE EXCEPTION 'nonce allocator safety barrier is missing';
+            RAISE EXCEPTION 'nonce allocator safety barrier is missing for the lane';
         END IF;
         -- Contention is not malformed state. Suppress this append so the same
         -- uninvoked attempt can retry after the current signer/release exits.
@@ -3329,11 +3402,18 @@ DECLARE
     barrier_release_request bytea;
     barrier_release_sequence integer;
     invocation_exists boolean;
+    lane_chain_id numeric(78, 0);
+    lane_sender bytea;
 BEGIN
+    SELECT chain_id, sender INTO lane_chain_id, lane_sender
+      FROM p2tr_signature_fraud_challenge_nonce_release_request
+     WHERE release_request_id = NEW.release_request_id;
+
     SELECT active_release_request_id, active_release_attempt_sequence
       INTO barrier_release_request, barrier_release_sequence
       FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
-     WHERE singleton = true
+     WHERE chain_id = lane_chain_id
+       AND sender = lane_sender
      FOR UPDATE;
 
     SELECT EXISTS (
@@ -3386,24 +3466,30 @@ BEGIN
                     ) THEN NULL
                ELSE active_release_expires_at_unix_ms
            END,
-           contract_mismatch_blocked =
-               contract_mismatch_blocked
-               OR NEW.result_kind = 'contract-mismatch',
            unresolved_release_count = unresolved_release_count - CASE
                WHEN NEW.result_kind IN ('released', 'already-released') THEN 1
                ELSE 0
-           END,
-           incident_epoch = incident_epoch + CASE
-               WHEN NEW.result_kind = 'contract-mismatch' THEN 1
-               ELSE 0
            END
-     WHERE singleton = true
+     WHERE chain_id = lane_chain_id
+       AND sender = lane_sender
        AND (
            NEW.result_kind NOT IN ('released', 'already-released')
            OR unresolved_release_count > 0
        );
     IF NOT FOUND THEN
         RAISE EXCEPTION 'nonce-release safety barrier counter underflow';
+    END IF;
+
+    -- A malformed allocator response condemns the allocator, not the account,
+    -- so it lands on the global barrier and blocks every lane.
+    IF NEW.result_kind = 'contract-mismatch' THEN
+        UPDATE p2tr_signature_fraud_nonce_allocator_global_barrier
+           SET contract_mismatch_blocked = true,
+               incident_epoch = incident_epoch + 1
+         WHERE singleton = true;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'nonce allocator global barrier is missing';
+        END IF;
     END IF;
     RETURN NEW;
 END;
@@ -3423,7 +3509,13 @@ DECLARE
     ambiguous_result p2tr_signature_fraud_challenge_nonce_release_result%ROWTYPE;
     barrier_request bytea;
     barrier_sequence integer;
+    lane_chain_id numeric(78, 0);
+    lane_sender bytea;
 BEGIN
+    SELECT chain_id, sender INTO lane_chain_id, lane_sender
+      FROM p2tr_signature_fraud_challenge_nonce_release_request
+     WHERE release_request_id = NEW.release_request_id;
+
     SELECT * INTO attempt
     FROM p2tr_signature_fraud_challenge_nonce_release_attempt
     WHERE release_request_id = NEW.release_request_id
@@ -3443,7 +3535,8 @@ BEGIN
     SELECT active_release_request_id, active_release_attempt_sequence
       INTO barrier_request, barrier_sequence
       FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
-     WHERE singleton = true
+     WHERE chain_id = lane_chain_id
+       AND sender = lane_sender
      FOR UPDATE;
 
     IF attempt.release_request_id IS NULL
@@ -3496,7 +3589,14 @@ CREATE FUNCTION p2tr_signature_fraud_apply_nonce_release_resolution_barrier()
 RETURNS trigger
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    lane_chain_id numeric(78, 0);
+    lane_sender bytea;
 BEGIN
+    SELECT chain_id, sender INTO lane_chain_id, lane_sender
+      FROM p2tr_signature_fraud_challenge_nonce_release_request
+     WHERE release_request_id = NEW.release_request_id;
+
     UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
        SET active_release_request_id = NULL,
            active_release_attempt_sequence = NULL,
@@ -3504,15 +3604,9 @@ BEGIN
            unresolved_release_count = unresolved_release_count - CASE
                WHEN NEW.outcome IN ('released', 'already-released') THEN 1
                ELSE 0
-           END,
-           contract_mismatch_blocked =
-               contract_mismatch_blocked
-               OR NEW.outcome = 'terminal-unsafe',
-           incident_epoch = incident_epoch + CASE
-               WHEN NEW.outcome = 'terminal-unsafe' THEN 1
-               ELSE 0
            END
-     WHERE singleton = true
+     WHERE chain_id = lane_chain_id
+       AND sender = lane_sender
        AND active_release_request_id = NEW.release_request_id
        AND active_release_attempt_sequence = NEW.attempt_sequence
        AND (
@@ -3521,6 +3615,18 @@ BEGIN
        );
     IF NOT FOUND THEN
         RAISE EXCEPTION 'independent nonce-release resolution lost its durable barrier';
+    END IF;
+
+    -- A terminally unsafe release means the allocator's state can no longer be
+    -- reasoned about at all, which is a global condemnation, not a lane one.
+    IF NEW.outcome = 'terminal-unsafe' THEN
+        UPDATE p2tr_signature_fraud_nonce_allocator_global_barrier
+           SET contract_mismatch_blocked = true,
+               incident_epoch = incident_epoch + 1
+         WHERE singleton = true;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'nonce allocator global barrier is missing';
+        END IF;
     END IF;
     RETURN NEW;
 END;
@@ -4347,22 +4453,48 @@ BEGIN
             RAISE EXCEPTION 'nonce allocator contract mismatch globally blocks signer invocation';
         END IF;
 
+        IF (
+            SELECT contract_mismatch_blocked
+            FROM p2tr_signature_fraud_nonce_allocator_global_barrier
+            WHERE singleton = true
+        ) IS DISTINCT FROM false THEN
+            RAISE EXCEPTION 'nonce allocator contract mismatch globally blocks signer invocation';
+        END IF;
+
+        -- Only this account's own allocator I/O excludes this signer boundary.
+        -- The same-lane check above (an unacknowledged release on this lane)
+        -- already covers the case that matters; what the key removes is one
+        -- account's pending release freezing every other account's signer.
         UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
            SET active_signer_invocation_count =
                    active_signer_invocation_count + 1
-         WHERE singleton = true
+         WHERE chain_id = NEW.chain_id
+           AND sender = NEW.selected_sender
            AND active_release_request_id IS NULL
-           AND unresolved_release_count = 0
-           AND NOT contract_mismatch_blocked;
+           AND unresolved_release_count = 0;
         IF NOT FOUND THEN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+                WHERE chain_id = NEW.chain_id
+                  AND sender = NEW.selected_sender
+            ) THEN
+                RAISE EXCEPTION 'nonce allocator safety barrier is missing for the lane';
+            END IF;
             RAISE EXCEPTION 'signer invocation is blocked by active nonce-release I/O';
         END IF;
     ELSIF OLD.active_signer_invocation_started_at_unix_ms IS NOT NULL
        AND NEW.active_signer_invocation_started_at_unix_ms IS NULL THEN
+        -- Key off OLD, which is by construction the lane that was incremented.
+        -- NEW is equal to it today only because the lane-change guard above
+        -- refuses to clear a selection whose reservation is neither null nor
+        -- voided, and a live marker makes that reservation unvoidable. Reading
+        -- OLD does not depend on that argument holding.
         UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
            SET active_signer_invocation_count =
                    active_signer_invocation_count - 1
-         WHERE singleton = true
+         WHERE chain_id = OLD.chain_id
+           AND sender = OLD.selected_sender
            AND active_signer_invocation_count > 0;
         IF NOT FOUND THEN
             RAISE EXCEPTION 'active signer invocation barrier counter underflow';

--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -1846,19 +1846,11 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         nonce_consumption_finalized_block_hash IS NULL
         OR octet_length(nonce_consumption_finalized_block_hash) = 32
     ),
-    nonce_consumption_observed_head_block_number bigint CHECK (
-        nonce_consumption_observed_head_block_number IS NULL
-        OR nonce_consumption_observed_head_block_number >= 0
-    ),
-    nonce_consumption_observed_head_block_hash bytea CHECK (
-        nonce_consumption_observed_head_block_hash IS NULL
-        OR octet_length(nonce_consumption_observed_head_block_hash) = 32
-    ),
     CHECK (
         (outcome = 'nonce-consumed')
             = (nonce_consumption_transaction_hash IS NOT NULL)
     ),
-    -- All nonce-consumption fields move together or none of them do.
+    -- All seven move together or none of them do.
     CHECK (
         (nonce_consumption_transaction_hash IS NULL)
             = (nonce_consumption_chain_id IS NULL)
@@ -1872,10 +1864,6 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
             = (nonce_consumption_finalized_block_number IS NULL)
         AND (nonce_consumption_transaction_hash IS NULL)
             = (nonce_consumption_finalized_block_hash IS NULL)
-        AND (nonce_consumption_transaction_hash IS NULL)
-            = (nonce_consumption_observed_head_block_number IS NULL)
-        AND (nonce_consumption_transaction_hash IS NULL)
-            = (nonce_consumption_observed_head_block_hash IS NULL)
     ),
     -- Strictly past the reserved nonce: equality would mean N is still spendable.
     CHECK (
@@ -1887,13 +1875,6 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         nonce_consumption_read_at_block IS NULL
         OR nonce_consumption_read_at_block
             = nonce_consumption_finalized_block_number
-    ),
-    -- The observed head is attestation-bound and must put the state-read
-    -- boundary at least two epochs behind it before nonce bytes become inert.
-    CHECK (
-        nonce_consumption_observed_head_block_number IS NULL
-        OR nonce_consumption_observed_head_block_number
-            - nonce_consumption_finalized_block_number >= 64
     ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
@@ -2039,7 +2020,7 @@ BEGIN
 
     IF NEW.resolution_evidence_digest <> sha256(
            convert_to(
-               'tbtc-p2tr-signer-boundary-independent-resolution-v5',
+               'tbtc-p2tr-signer-boundary-independent-resolution-v4',
                'UTF8'
            )
            || NEW.record_id
@@ -2076,16 +2057,6 @@ BEGIN
               )
            || COALESCE(
                   NEW.nonce_consumption_finalized_block_hash,
-                  decode(repeat('00', 32), 'hex')
-              )
-           || int8send(
-                  COALESCE(
-                      NEW.nonce_consumption_observed_head_block_number,
-                      0
-                  )
-              )
-           || COALESCE(
-                  NEW.nonce_consumption_observed_head_block_hash,
                   decode(repeat('00', 32), 'hex')
               )
        ) THEN

--- a/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
+++ b/services/watchtower/migrations/003_p2tr_signature_fraud_challenge_outbox.sql
@@ -1846,11 +1846,19 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         nonce_consumption_finalized_block_hash IS NULL
         OR octet_length(nonce_consumption_finalized_block_hash) = 32
     ),
+    nonce_consumption_observed_head_block_number bigint CHECK (
+        nonce_consumption_observed_head_block_number IS NULL
+        OR nonce_consumption_observed_head_block_number >= 0
+    ),
+    nonce_consumption_observed_head_block_hash bytea CHECK (
+        nonce_consumption_observed_head_block_hash IS NULL
+        OR octet_length(nonce_consumption_observed_head_block_hash) = 32
+    ),
     CHECK (
         (outcome = 'nonce-consumed')
             = (nonce_consumption_transaction_hash IS NOT NULL)
     ),
-    -- All seven move together or none of them do.
+    -- All nonce-consumption fields move together or none of them do.
     CHECK (
         (nonce_consumption_transaction_hash IS NULL)
             = (nonce_consumption_chain_id IS NULL)
@@ -1864,6 +1872,10 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
             = (nonce_consumption_finalized_block_number IS NULL)
         AND (nonce_consumption_transaction_hash IS NULL)
             = (nonce_consumption_finalized_block_hash IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_observed_head_block_number IS NULL)
+        AND (nonce_consumption_transaction_hash IS NULL)
+            = (nonce_consumption_observed_head_block_hash IS NULL)
     ),
     -- Strictly past the reserved nonce: equality would mean N is still spendable.
     CHECK (
@@ -1875,6 +1887,13 @@ CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution (
         nonce_consumption_read_at_block IS NULL
         OR nonce_consumption_read_at_block
             = nonce_consumption_finalized_block_number
+    ),
+    -- The observed head is attestation-bound and must put the state-read
+    -- boundary at least two epochs behind it before nonce bytes become inert.
+    CHECK (
+        nonce_consumption_observed_head_block_number IS NULL
+        OR nonce_consumption_observed_head_block_number
+            - nonce_consumption_finalized_block_number >= 64
     ),
     boundary_started_at_unix_ms bigint NOT NULL CHECK (
         boundary_started_at_unix_ms BETWEEN 0 AND 9007199254740991
@@ -2020,7 +2039,7 @@ BEGIN
 
     IF NEW.resolution_evidence_digest <> sha256(
            convert_to(
-               'tbtc-p2tr-signer-boundary-independent-resolution-v4',
+               'tbtc-p2tr-signer-boundary-independent-resolution-v5',
                'UTF8'
            )
            || NEW.record_id
@@ -2057,6 +2076,16 @@ BEGIN
               )
            || COALESCE(
                   NEW.nonce_consumption_finalized_block_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(
+                  COALESCE(
+                      NEW.nonce_consumption_observed_head_block_number,
+                      0
+                  )
+              )
+           || COALESCE(
+                  NEW.nonce_consumption_observed_head_block_hash,
                   decode(repeat('00', 32), 'hex')
               )
        ) THEN

--- a/services/watchtower/migrations/004_p2tr_candidate_enqueue_retry_alerts.sql
+++ b/services/watchtower/migrations/004_p2tr_candidate_enqueue_retry_alerts.sql
@@ -120,12 +120,12 @@ BEGIN
         RAISE EXCEPTION 'candidate enqueue guard is already exhausted';
     END IF;
 
-    SELECT authorization.consumed_at, authorization.outbox_intent_id
+    SELECT granted.consumed_at, granted.outbox_intent_id
       INTO authorization_consumed_at, authorization_outbox_intent_id
-      FROM p2tr_candidate_enqueue_authorizations authorization
-     WHERE authorization.manifest_hash = NEW.manifest_hash
-       AND authorization.token_id = NEW.token_id
-       AND authorization.candidate_digest = NEW.candidate_digest
+      FROM p2tr_candidate_enqueue_authorizations granted
+     WHERE granted.manifest_hash = NEW.manifest_hash
+       AND granted.token_id = NEW.token_id
+       AND granted.candidate_digest = NEW.candidate_digest
      FOR KEY SHARE;
     IF authorization_consumed_at IS NULL
        OR authorization_outbox_intent_id IS DISTINCT FROM NEW.outbox_intent_id THEN

--- a/services/watchtower/migrations/006_p2tr_signer_boundary_nonce_finality.sql
+++ b/services/watchtower/migrations/006_p2tr_signer_boundary_nonce_finality.sql
@@ -3,9 +3,10 @@
 --
 -- Migration 003 is checksum-tracked and may already be present in production,
 -- so this schema evolution must remain append-only. Existing v4 evidence rows
--- cannot be retroactively given an attested observed head; NOT VALID
--- grandfathers those immutable rows while PostgreSQL enforces the complete v5
--- evidence shape for every new insert.
+-- cannot be retroactively given an attested observed head. They are explicitly
+-- marked as version 4 so the runtime can recognize an exact retry, while NOT
+-- VALID constraints grandfather those immutable rows and enforce version 5
+-- plus the complete v5 evidence shape for every new insert.
 
 INSERT INTO p2tr_watchtower_schema_version (component, version)
 VALUES ('signer-boundary-nonce-finality', 1);
@@ -22,9 +23,18 @@ ALTER TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution
         CHECK (
             nonce_consumption_observed_head_block_hash IS NULL
             OR octet_length(nonce_consumption_observed_head_block_hash) = 32
-        );
+        ),
+    -- PostgreSQL fills every pre-existing row with 4 before the default moves
+    -- to 5. The NOT VALID constraint below then refuses an explicitly forged
+    -- v4 marker on every post-migration insert without rewriting old evidence.
+    ADD COLUMN resolution_evidence_version smallint NOT NULL DEFAULT 4;
 
 ALTER TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution
+    ALTER COLUMN resolution_evidence_version SET DEFAULT 5;
+
+ALTER TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution
+    ADD CONSTRAINT p2tr_signer_boundary_evidence_version_v5
+    CHECK (resolution_evidence_version = 5) NOT VALID,
     ADD CONSTRAINT p2tr_signer_boundary_nonce_finality_v5
     CHECK (
         (

--- a/services/watchtower/migrations/006_p2tr_signer_boundary_nonce_finality.sql
+++ b/services/watchtower/migrations/006_p2tr_signer_boundary_nonce_finality.sql
@@ -1,0 +1,187 @@
+-- Bind orphaned signer-boundary nonce-consumption evidence to an observed head
+-- and enforce the same two-epoch finality floor as ordinary reconciliation.
+--
+-- Migration 003 is checksum-tracked and may already be present in production,
+-- so this schema evolution must remain append-only. Existing v4 evidence rows
+-- cannot be retroactively given an attested observed head; NOT VALID
+-- grandfathers those immutable rows while PostgreSQL enforces the complete v5
+-- evidence shape for every new insert.
+
+INSERT INTO p2tr_watchtower_schema_version (component, version)
+VALUES ('signer-boundary-nonce-finality', 1);
+
+ALTER TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution
+    ADD COLUMN nonce_consumption_observed_head_block_number bigint
+        CONSTRAINT p2tr_signer_boundary_observed_head_number_valid
+        CHECK (
+            nonce_consumption_observed_head_block_number IS NULL
+            OR nonce_consumption_observed_head_block_number >= 0
+        ),
+    ADD COLUMN nonce_consumption_observed_head_block_hash bytea
+        CONSTRAINT p2tr_signer_boundary_observed_head_hash_valid
+        CHECK (
+            nonce_consumption_observed_head_block_hash IS NULL
+            OR octet_length(nonce_consumption_observed_head_block_hash) = 32
+        );
+
+ALTER TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution
+    ADD CONSTRAINT p2tr_signer_boundary_nonce_finality_v5
+    CHECK (
+        (
+            nonce_consumption_transaction_hash IS NULL
+            AND nonce_consumption_observed_head_block_number IS NULL
+            AND nonce_consumption_observed_head_block_hash IS NULL
+        )
+        OR (
+            nonce_consumption_transaction_hash IS NOT NULL
+            AND nonce_consumption_observed_head_block_number IS NOT NULL
+            AND nonce_consumption_observed_head_block_hash IS NOT NULL
+            AND nonce_consumption_observed_head_block_number
+                - nonce_consumption_finalized_block_number >= 64
+        )
+    ) NOT VALID;
+
+CREATE OR REPLACE FUNCTION p2tr_signature_fraud_guard_signer_boundary_resolution()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    outbox_record p2tr_signature_fraud_challenge_outbox%ROWTYPE;
+    escaped boolean;
+BEGIN
+    SELECT * INTO outbox_record
+      FROM p2tr_signature_fraud_challenge_outbox
+     WHERE record_id = NEW.record_id
+     FOR SHARE;
+
+    IF outbox_record.record_id IS NULL THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary resolution names an absent outbox record';
+    END IF;
+
+    -- Identity is the invocation ID, compared against the durable column rather
+    -- than re-derived: PostgreSQL cannot recompute it (the binding preimage
+    -- spans three tables and a TypeScript layout), which is the same standard
+    -- nonce_reservation_id already met.
+    --
+    -- The other three remain checked. They are descriptive columns of
+    -- append-only evidence that nothing downstream reads, so leaving them
+    -- unchecked would let a resolution naming the right boundary write
+    -- permanently wrong forensics about it. None can drift while the marker is
+    -- set: the start is immutable in flight and NULL-paired with the ID, the
+    -- reservation cannot be NULLed under an active marker, and every transition
+    -- that bumps the attempt clears the marker in the same swap.
+    IF outbox_record.active_signer_invocation_id
+           IS DISTINCT FROM NEW.signer_invocation_id
+       OR outbox_record.active_signer_invocation_started_at_unix_ms
+           IS DISTINCT FROM NEW.boundary_started_at_unix_ms
+       OR outbox_record.preparation_attempts <> NEW.preparation_attempts
+       OR outbox_record.nonce_reservation_id
+           IS DISTINCT FROM NEW.nonce_reservation_id THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary resolution does not name the durable boundary';
+    END IF;
+
+    IF NEW.outcome = 'never-invoked'
+       AND NEW.provider_tombstone_receipt IS NULL THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary never-invoked resolution requires a provider tombstone';
+    END IF;
+
+    -- The consumed nonce must be the one this boundary actually reserved, on
+    -- the chain the record is bound to.
+    IF NEW.outcome = 'nonce-consumed' THEN
+        IF NEW.nonce_consumption_transaction_hash IS NULL THEN
+            RAISE EXCEPTION
+                'orphaned signer boundary nonce-consumed resolution requires consumption evidence';
+        END IF;
+        IF NEW.nonce_consumption_nonce IS DISTINCT FROM outbox_record.reserved_nonce
+           OR NEW.nonce_consumption_chain_id IS DISTINCT FROM outbox_record.chain_id THEN
+            RAISE EXCEPTION
+                'orphaned signer boundary nonce consumption names another sender lane';
+        END IF;
+    END IF;
+
+    IF NEW.resolution_evidence_digest <> sha256(
+           convert_to(
+               'tbtc-p2tr-signer-boundary-independent-resolution-v5',
+               'UTF8'
+           )
+           || NEW.record_id
+           || NEW.signer_invocation_id
+           || int8send(NEW.boundary_started_at_unix_ms)
+           || int8send(NEW.preparation_attempts::bigint)
+           || NEW.nonce_reservation_id
+           || sha256(convert_to(NEW.stage, 'UTF8'))
+           || int8send(NEW.invoked_at_unix_ms)
+           || sha256(convert_to(NEW.outcome, 'UTF8'))
+           || COALESCE(
+                  NEW.signed_transaction_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+           || NEW.provider_evidence_digest
+           || CASE WHEN NEW.provider_tombstone_receipt IS NULL
+                   THEN decode(repeat('00', 32), 'hex')
+                   ELSE NEW.signer_invocation_id END
+           || COALESCE(
+                  sha256(NEW.provider_tombstone_receipt),
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(COALESCE(NEW.provider_tombstone_at_unix_ms, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_chain_id, 0)::bigint)
+           || int8send(COALESCE(NEW.nonce_consumption_nonce, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_account_nonce, 0))
+           || int8send(COALESCE(NEW.nonce_consumption_read_at_block, 0))
+           || COALESCE(
+                  NEW.nonce_consumption_transaction_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(
+                  COALESCE(NEW.nonce_consumption_finalized_block_number, 0)
+              )
+           || COALESCE(
+                  NEW.nonce_consumption_finalized_block_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+           || int8send(
+                  COALESCE(
+                      NEW.nonce_consumption_observed_head_block_number,
+                      0
+                  )
+              )
+           || COALESCE(
+                  NEW.nonce_consumption_observed_head_block_hash,
+                  decode(repeat('00', 32), 'hex')
+              )
+       ) THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary resolution digest is invalid';
+    END IF;
+
+    IF NEW.primary_attested_at_unix_ms < NEW.invoked_at_unix_ms
+       OR NEW.corroborating_attested_at_unix_ms < NEW.invoked_at_unix_ms
+       OR NEW.primary_attested_at_unix_ms > NEW.resolved_at_unix_ms
+       OR NEW.corroborating_attested_at_unix_ms > NEW.resolved_at_unix_ms THEN
+        RAISE EXCEPTION
+            'orphaned signer boundary attestations fall outside the invocation window';
+    END IF;
+
+    IF NEW.outcome = 'never-invoked' THEN
+        escaped :=
+            outbox_record.signer_invocation_started_at_unix_ms IS NOT NULL
+            OR outbox_record.prepared_transaction_hash IS NOT NULL
+            OR outbox_record.broadcast_attempts > 0
+            OR coalesce(
+                   jsonb_array_length(
+                       outbox_record.record_state -> 'unexpectedSignedArtifacts'
+                   ),
+                   0
+               ) > 0;
+        IF escaped THEN
+            RAISE EXCEPTION
+                'orphaned signer boundary resolution requires a boundary with no signer escape evidence';
+        END IF;
+    END IF;
+    RETURN NEW;
+END
+$$;

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -6764,7 +6764,7 @@ const validateIndependentTransport = (
 }
 
 const requireFinalityConfirmationBlocks = (
-  value: unknown,
+  value: number,
   label: string
 ): number => {
   const depth = requirePositiveSafeInteger(value, label)

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -760,9 +760,9 @@ export const computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest = (
  * authorization and therefore before the signer RPC, so a lost owner leaves a
  * marker that nothing in the process-local recovery path may clear: lease
  * expiry is not proof that a remote call stopped. The marker keeps the
- * singleton `active_signer_invocation_count` at one, which blocks every
- * nonce-release invocation store-wide and freezes challenge signing on every
- * lane. Only an out-of-band, dual-attested observation of what the signer
+ * lane's `active_signer_invocation_count` at one, which blocks every
+ * nonce-release invocation on that lane and freezes challenge signing for that
+ * account. Only an out-of-band, dual-attested observation of what the signer
  * actually did can resolve that, and this is that evidence.
  */
 /**

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -820,10 +820,38 @@ export type P2TRSignatureFraudNonceConsumptionEvidence = {
   observedHead: P2TRSignatureFraudCanonicalBlock
 }
 
+/**
+ * A provider's proof that one signer invocation was permanently closed without
+ * the signer ever being reached. It is the sole basis for a `never-invoked`
+ * outcome, so it is worth stating exactly how far this side can vouch for it.
+ *
+ * What is enforced here: the tombstone must name the same invocation the
+ * resolution speaks for; the receipt bytes are bound into the resolution
+ * evidence digest, so the two independent attestations are attesting to THESE
+ * bytes and not merely to the verdict; the resolution must name the boundary
+ * marker that is still live and clears it in the same transaction, so an
+ * invocation is answered exactly once and a later contradiction has nowhere to
+ * go; and `never-invoked` is refused outright if any signed artifact for the
+ * record has escaped.
+ *
+ * What cannot be enforced here: whether the receipt is TRUE. The bytes are
+ * opaque to this process, so nothing stops a provider that did reach its signer
+ * from issuing a tombstone claiming otherwise. Closing that is an obligation on
+ * the provider, not on this store: it must keep a durable write-once register
+ * keyed by invocation ID, written before the signer is reached, so that its
+ * answer for a given invocation is fixed at the moment of the attempt and it
+ * cannot later be induced to say something else. A provider that answers from
+ * memory, or recomputes an answer on request, does not satisfy this and its
+ * tombstones should not be trusted for `never-invoked`.
+ */
 export type P2TRSignatureFraudSignerInvocationTombstone = {
   /** Must name the same invocation the resolution speaks for. */
   signerInvocationID: string
-  /** Provider-authenticated bytes; opaque here, exactly like an attestation. */
+  /**
+   * Provider-authenticated bytes; opaque here, exactly like an attestation.
+   * Bound into the resolution evidence digest, so both attestors commit to the
+   * exact bytes rather than to the verdict alone.
+   */
   receipt: string
   tombstonedAtUnixMs: number
 }

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -942,7 +942,7 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
     )
   }
   return `0x${createHash("sha256")
-    .update("tbtc-p2tr-signer-boundary-independent-resolution-v4", "utf8")
+    .update("tbtc-p2tr-signer-boundary-independent-resolution-v5", "utf8")
     .update(
       Buffer.from(
         normalizeBytes32(
@@ -1094,6 +1094,23 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
             normalizeBytes32(
               consumption.finalizedThrough.blockHash,
               "Signer-boundary nonce consumption finality hash"
+            ).slice(2),
+            "hex"
+          )
+    )
+    .update(
+      uint64(
+        consumption === undefined ? 0 : consumption.observedHead.blockNumber,
+        "Signer-boundary nonce consumption observed head height"
+      )
+    )
+    .update(
+      consumption === undefined
+        ? Buffer.alloc(32)
+        : Buffer.from(
+            normalizeBytes32(
+              consumption.observedHead.blockHash,
+              "Signer-boundary nonce consumption observed head hash"
             ).slice(2),
             "hex"
           )
@@ -1384,6 +1401,14 @@ const normalizeSignerBoundaryNonceConsumption = (
   if (observedHead.blockNumber < finalizedThrough.blockNumber) {
     throw new Error(
       "Signer-boundary nonce consumption finality boundary is ahead of its observed head"
+    )
+  }
+  if (
+    observedHead.blockNumber - finalizedThrough.blockNumber <
+    P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS
+  ) {
+    throw new Error(
+      `Signer-boundary nonce consumption finality depth must be at least ${P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS} blocks`
     )
   }
   const transactionNonce = requireNonNegativeSafeInteger(
@@ -6660,6 +6685,17 @@ const validatePreparedTransactionFeePolicy = (
       "Prepared challenge priority fee per gas"
     )
   )
+  const manifestGasLimit = BigInt(
+    normalizePositivePolicyUint256(
+      policy.maxGasLimit,
+      "Challenge fee policy gas limit"
+    )
+  )
+  if (gasLimit !== manifestGasLimit) {
+    throw new Error(
+      "Prepared challenge transaction does not use its exact manifest-bound gas limit"
+    )
+  }
   if (
     policy.chainID !== intent.chainID ||
     normalizePolicyUint256(
@@ -6668,7 +6704,6 @@ const validatePreparedTransactionFeePolicy = (
     ) !== normalizePolicyUint256(intent.value, "Challenge intent value") ||
     normalizeAddress(policy.sender, "Challenge fee policy sender") !==
       normalizeAddress(prepared.sender, "Prepared challenge sender") ||
-    gasLimit > BigInt(policy.maxGasLimit) ||
     maxFeePerGas > BigInt(policy.maxFeePerGas) ||
     maxPriorityFeePerGas > BigInt(policy.maxPriorityFeePerGas) ||
     gasLimit * maxFeePerGas > BigInt(policy.maxTotalFeeWei)

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -44,6 +44,20 @@ export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_CURSOR_LENGTH = 512
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_PROTOCOL_ID_LENGTH = 128
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_SIGNED_VARIANTS = 16
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_GENERATIONS = 32
+/**
+ * Floor on the reconciler's declared finality depth.
+ *
+ * The depth gates irreversible conclusions: a canonical resolution retires a
+ * generation, and a finalized nonce-consuming transaction is what lets an
+ * orphaned signer boundary be resolved without asking the signer what it did.
+ * If the reconciler may declare any positive depth, a single-block reorg can
+ * un-consume a nonce that was already recorded as spent. Two epochs is the
+ * point past which a reorg is a consensus failure rather than an ordinary
+ * event, so it is the shallowest depth under which those conclusions hold.
+ *
+ * This is a floor, not a default: an operator may declare more.
+ */
+export const P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS = 64
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_SERIES_ID_DOMAIN =
   "tbtc-p2tr-signature-fraud-outbox-series-v1"
 export const P2TR_SIGNATURE_FRAUD_OUTBOX_RECORD_ID_DOMAIN =
@@ -3872,17 +3886,22 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     ) {
       return current
     }
-    const signerWasInvoked =
-      current.activeSignerInvocationStartedAtUnixMs !== undefined
     const resumeStatus = current.preparationResumeStatus
 
     // The marker is established before asynchronous boundary authorization.
     // Lease expiry cannot prove that another replica's authorization or signer
     // call stopped. Only an independently attested provider outcome may clear
-    // the global signer-I/O barrier, so startup stays deliberately activation-
+    // its lane's signer-I/O barrier, so startup stays deliberately activation-
     // blocked on this record until the store's out-of-band orphaned-boundary
     // resolver (`resolveOrphanedSignerBoundary`) supplies that evidence.
-    if (signerWasInvoked) return current
+    //
+    // Everything below therefore runs only with the marker absent. It used to
+    // branch on it repeatedly; those arms were unreachable and claimed the
+    // orphan path lands in `quarantined`, which is reconcilable -- a false
+    // lead for anyone tracing why an orphan cannot be resolved locally.
+    if (current.activeSignerInvocationStartedAtUnixMs !== undefined) {
+      return current
+    }
 
     // A crash can occur after the non-signing allocator durably reserves a
     // nonce but before this record stores the returned binding. Reservation
@@ -3890,7 +3909,6 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     // recover that exact binding and put it under the SQL nonce guard before
     // recording a pre-sign void.
     if (
-      !signerWasInvoked &&
       resumeStatus === undefined &&
       current.reservedNonce === undefined &&
       current.selectedLaneID !== undefined &&
@@ -3992,16 +4010,14 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     }
 
     const releasableReservation =
-      !signerWasInvoked &&
-      resumeStatus === undefined &&
-      current.reservedNonce !== undefined
+      resumeStatus === undefined && current.reservedNonce !== undefined
         ? current.reservedNonce
         : undefined
     const voidedAt = requireUnixMilliseconds(
       this.now(),
       "Challenge outbox lease recovery time"
     )
-    const retainLane = signerWasInvoked || resumeStatus !== undefined
+    const retainLane = resumeStatus !== undefined
     const voidReason =
       "Preparation lease expired before transaction signer invocation"
     const voidEvidenceDigest =
@@ -4020,23 +4036,14 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       await this.assertVoidedReservationCapacity(current)
     }
     const recovered = nextRecord(current, {
-      // Once the signer boundary is durable, never sign a replacement or
-      // release this lane on lease expiry.
-      status: signerWasInvoked
-        ? "quarantined"
-        : current.provenanceInvalidationEvidence !== undefined
-        ? "cancelled-provenance-invalidated"
-        : resumeStatus ?? "queued",
+      status:
+        current.provenanceInvalidationEvidence !== undefined
+          ? "cancelled-provenance-invalidated"
+          : resumeStatus ?? "queued",
       preparationLease: undefined,
       preparationResumeStatus: undefined,
-      // A lease timeout cannot prove that an external signer call stopped.
-      // Only the worker observing that call return may clear this marker.
-      activeSignerInvocationStartedAtUnixMs: signerWasInvoked
-        ? current.activeSignerInvocationStartedAtUnixMs
-        : undefined,
-      activeSignerInvocationID: signerWasInvoked
-        ? current.activeSignerInvocationID
-        : undefined,
+      activeSignerInvocationStartedAtUnixMs: undefined,
+      activeSignerInvocationID: undefined,
       preparationSender: retainLane ? current.preparationSender : undefined,
       selectedLaneID: retainLane ? current.selectedLaneID : undefined,
       selectedSignerIdentity: retainLane
@@ -4059,22 +4066,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
               },
             ]
           : current.voidedNonceReservations,
-      signerQuarantines:
-        signerWasInvoked && current.reservedNonce !== undefined
-          ? appendSignerQuarantine(
-              current.signerQuarantines,
-              current.reservedNonce,
-              voidedAt,
-              "Preparation lease expired after the durable signer invocation boundary; the returned-byte outcome is ambiguous",
-              "ambiguous-signer-invocation"
-            )
-          : current.signerQuarantines,
+      signerQuarantines: current.signerQuarantines,
       updatedAtUnixMs: voidedAt,
-      lastError: signerWasInvoked
-        ? "Challenge outbox preparation lease expired after the signer boundary; nonce lane retained"
-        : resumeStatus === undefined
-        ? "Challenge outbox preparation lease expired before signer invocation"
-        : "Challenge outbox replacement lease expired before signer invocation; prior variant restored",
+      lastError:
+        resumeStatus === undefined
+          ? "Challenge outbox preparation lease expired before signer invocation"
+          : "Challenge outbox replacement lease expired before signer invocation; prior variant restored",
     })
     if (
       !(await this.store.compareAndSwap(
@@ -6731,11 +6728,24 @@ const validateIndependentTransport = (
       "Challenge broadcasting, recheck, cancellation, reconciliation, and canonical verification require independent provider, trust, and infrastructure domains"
     )
   }
-  requirePositiveSafeInteger(
+  requireFinalityConfirmationBlocks(
     reconciler.finalityConfirmationBlocks,
     "Challenge reconciliation finality confirmation depth"
   )
   validateCanonicalSubmissionSelectors(reconciler.canonicalSubmissionSelectors)
+}
+
+const requireFinalityConfirmationBlocks = (
+  value: unknown,
+  label: string
+): number => {
+  const depth = requirePositiveSafeInteger(value, label)
+  if (depth < P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS) {
+    throw new Error(
+      `${label} must be at least ${P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS} blocks`
+    )
+  }
+  return depth
 }
 
 const normalizeActivationManifestBinding = (

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -889,11 +889,14 @@ export type P2TRSignatureFraudIndependentSignerBoundaryResolution = {
   resolvedAtUnixMs: number
 }
 
-export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
+type P2TRSignatureFraudSignerBoundaryResolutionEvidenceVersion = 4 | 5
+
+const computeVersionedSignerBoundaryResolutionEvidenceDigest = (
   resolution: Omit<
     P2TRSignatureFraudIndependentSignerBoundaryResolution,
     "evidenceDigest" | "canonicalAttestations" | "resolvedAtUnixMs"
-  >
+  >,
+  evidenceVersion: P2TRSignatureFraudSignerBoundaryResolutionEvidenceVersion
 ): string => {
   const uint64 = (value: number, label: string): Buffer => {
     requireNonNegativeSafeInteger(value, label)
@@ -941,8 +944,11 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
       "Signer-boundary resolution names nonce consumption only for a nonce-consumed outcome"
     )
   }
-  return `0x${createHash("sha256")
-    .update("tbtc-p2tr-signer-boundary-independent-resolution-v5", "utf8")
+  const digest = createHash("sha256")
+    .update(
+      `tbtc-p2tr-signer-boundary-independent-resolution-v${evidenceVersion}`,
+      "utf8"
+    )
     .update(
       Buffer.from(
         normalizeBytes32(
@@ -1098,25 +1104,50 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
             "hex"
           )
     )
-    .update(
-      uint64(
-        consumption === undefined ? 0 : consumption.observedHead.blockNumber,
-        "Signer-boundary nonce consumption observed head height"
+  if (evidenceVersion === 5) {
+    digest
+      .update(
+        uint64(
+          consumption === undefined ? 0 : consumption.observedHead.blockNumber,
+          "Signer-boundary nonce consumption observed head height"
+        )
       )
-    )
-    .update(
-      consumption === undefined
-        ? Buffer.alloc(32)
-        : Buffer.from(
-            normalizeBytes32(
-              consumption.observedHead.blockHash,
-              "Signer-boundary nonce consumption observed head hash"
-            ).slice(2),
-            "hex"
-          )
-    )
-    .digest("hex")}`
+      .update(
+        consumption === undefined
+          ? Buffer.alloc(32)
+          : Buffer.from(
+              normalizeBytes32(
+                consumption.observedHead.blockHash,
+                "Signer-boundary nonce consumption observed head hash"
+              ).slice(2),
+              "hex"
+            )
+      )
+  }
+  return `0x${digest.digest("hex")}`
 }
+
+export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
+  resolution: Omit<
+    P2TRSignatureFraudIndependentSignerBoundaryResolution,
+    "evidenceDigest" | "canonicalAttestations" | "resolvedAtUnixMs"
+  >
+): string =>
+  computeVersionedSignerBoundaryResolutionEvidenceDigest(resolution, 5)
+
+/**
+ * Computes the digest accepted before migration 005. This must only be used to
+ * recognize an exact replay of immutable evidence that the migration marked as
+ * version 4; new resolutions must always use the v5 helper above.
+ */
+export const computeP2TRSignatureFraudLegacyV4SignerBoundaryResolutionEvidenceDigest =
+  (
+    resolution: Omit<
+      P2TRSignatureFraudIndependentSignerBoundaryResolution,
+      "evidenceDigest" | "canonicalAttestations" | "resolvedAtUnixMs"
+    >
+  ): string =>
+    computeVersionedSignerBoundaryResolutionEvidenceDigest(resolution, 4)
 
 /**
  * The exact normalized form both the PostgreSQL adapter and the in-memory
@@ -1144,8 +1175,9 @@ export type P2TRSignatureFraudNormalizedSignerBoundaryResolution = {
   resolvedAtUnixMs: number
 }
 
-export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
-  resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution
+const validateVersionedIndependentSignerBoundaryResolution = (
+  resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution,
+  evidenceVersion: P2TRSignatureFraudSignerBoundaryResolutionEvidenceVersion
 ): P2TRSignatureFraudNormalizedSignerBoundaryResolution => {
   const recordID = normalizeBytes32(
     resolution.recordID,
@@ -1174,7 +1206,10 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   const nonceConsumption =
     resolution.nonceConsumption === undefined
       ? undefined
-      : normalizeSignerBoundaryNonceConsumption(resolution.nonceConsumption)
+      : normalizeSignerBoundaryNonceConsumption(
+          resolution.nonceConsumption,
+          evidenceVersion === 5
+        )
   const providerTombstone =
     resolution.providerTombstone === undefined
       ? undefined
@@ -1254,20 +1289,23 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
     "Independent signer-boundary resolution digest"
   )
   if (
-    computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest({
-      recordID,
-      signerInvocationID,
-      boundaryStartedAtUnixMs,
-      preparationAttempts,
-      nonceReservationID,
-      stage: resolution.stage,
-      invokedAtUnixMs,
-      outcome: resolution.outcome,
-      signedTransactionHash,
-      providerTombstone,
-      nonceConsumption,
-      providerEvidenceDigest,
-    }) !== evidenceDigest
+    computeVersionedSignerBoundaryResolutionEvidenceDigest(
+      {
+        recordID,
+        signerInvocationID,
+        boundaryStartedAtUnixMs,
+        preparationAttempts,
+        nonceReservationID,
+        stage: resolution.stage,
+        invokedAtUnixMs,
+        outcome: resolution.outcome,
+        signedTransactionHash,
+        providerTombstone,
+        nonceConsumption,
+        providerEvidenceDigest,
+      },
+      evidenceVersion
+    ) !== evidenceDigest
   ) {
     throw new Error("Independent signer-boundary resolution digest is invalid")
   }
@@ -1357,6 +1395,22 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   }
 }
 
+export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
+  resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution
+): P2TRSignatureFraudNormalizedSignerBoundaryResolution =>
+  validateVersionedIndependentSignerBoundaryResolution(resolution, 5)
+
+/**
+ * Validates the exact evidence contract used before migration 005. The
+ * PostgreSQL adapter invokes this only after finding an immutable row that the
+ * migration explicitly classified as version 4; it is never an insertion path.
+ */
+export const validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay =
+  (
+    resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution
+  ): P2TRSignatureFraudNormalizedSignerBoundaryResolution =>
+    validateVersionedIndependentSignerBoundaryResolution(resolution, 4)
+
 /**
  * The durable-state half of the resolver's precondition, evaluated identically
  * by both stores and re-evaluated independently by the PostgreSQL guard
@@ -1372,7 +1426,8 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
  * same either way — the nonce is spent regardless of who spent it.
  */
 const normalizeSignerBoundaryNonceConsumption = (
-  evidence: P2TRSignatureFraudNonceConsumptionEvidence
+  evidence: P2TRSignatureFraudNonceConsumptionEvidence,
+  enforceFinalityFloor: boolean
 ): P2TRSignatureFraudNonceConsumptionEvidence => {
   // The canonical validators are void-returning assertions, so the normalized
   // shape is rebuilt here from the same helpers they use.
@@ -1404,8 +1459,9 @@ const normalizeSignerBoundaryNonceConsumption = (
     )
   }
   if (
+    enforceFinalityFloor &&
     observedHead.blockNumber - finalizedThrough.blockNumber <
-    P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS
+      P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS
   ) {
     throw new Error(
       `Signer-boundary nonce consumption finality depth must be at least ${P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS} blocks`

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -1515,6 +1515,35 @@ export type P2TRSignatureFraudNonceReleasePageRequest = {
   cursor?: string
 }
 
+/**
+ * One nonce lane: the sending account on one chain. This is the unit the
+ * durable nonce-allocator barrier is keyed by, because a nonce reservation and
+ * its release both belong to exactly one account.
+ */
+export type P2TRSignatureFraudSigningLane = {
+  chainID: number
+  sender: string
+}
+
+/**
+ * The single normalizer both store implementations must route through. A lane
+ * is a lookup key, so a checksummed address and its lower-case spelling have to
+ * collapse to one value; if the two implementations disagreed here, the
+ * in-memory double would report a lane clear while PostgreSQL reported it
+ * blocked, and the divergence would favour signing.
+ */
+export function normalizeP2TRSignatureFraudSigningLane(
+  lane: P2TRSignatureFraudSigningLane
+): P2TRSignatureFraudSigningLane {
+  return {
+    chainID: normalizePositiveSafeIntegerLike(
+      lane.chainID,
+      "Signing lane chain ID"
+    ),
+    sender: normalizeAddress(lane.sender, "Signing lane sender"),
+  }
+}
+
 export type P2TRSignatureFraudNonceReleasePage = {
   requests: P2TRSignatureFraudNonceReleaseRequest[]
   nextCursor?: string
@@ -1888,8 +1917,20 @@ export interface P2TRSignatureFraudChallengeOutboxStore
     seriesID: string
   ): Promise<P2TRSignatureFraudChallengeOutboxRecord | undefined>
   isSignerQuarantined(chainID: number, signerIdentity: string): Promise<boolean>
-  hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean>
-  hasPendingNonceReleases(): Promise<boolean>
+  /**
+   * Omitting the lane asks the store-wide question, which is what decides
+   * whether recovery must be swept. Passing one asks only whether THAT nonce
+   * lane is still unresolved, which is what decides whether signing on it may
+   * proceed. The two are deliberately different questions: a lane is frozen by
+   * its own residue, never by another account's.
+   */
+  hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean>
+  hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean>
   getNonceReleaseRequest(
     releaseRequestID: string
   ): Promise<P2TRSignatureFraudNonceReleaseRequest | undefined>
@@ -1897,8 +1938,11 @@ export interface P2TRSignatureFraudChallengeOutboxStore
     request: P2TRSignatureFraudNonceReleasePageRequest
   ): Promise<P2TRSignatureFraudNonceReleasePage>
   /**
-   * Reconstructs the exact singleton barrier-owned invocation after restart.
-   * A still-live resultless call is not exposed for independent resolution.
+   * Reconstructs a barrier-owned invocation after restart. The durable barrier
+   * is keyed per nonce lane, so several lanes can hold a claim at once; one
+   * recoverable invocation is returned per call and the caller drains the rest
+   * on subsequent passes. A still-live resultless call is not exposed for
+   * independent resolution.
    */
   getActiveAmbiguousNonceReleaseInvocation(
     nowUnixMs: number
@@ -2555,7 +2599,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       return current
     }
     await this.assertVoidedReservationCapacity(current)
-    await this.assertRecoveryBarrier()
+    // No lane is selected yet -- that happens in the candidate loop below -- so
+    // there is nothing to judge here, only recovery to drive. There is
+    // deliberately no per-candidate wedge check: a lane wedged by an orphan is
+    // already held by that orphan under the unique (chain, sender) lane slot,
+    // so its swap fails and the loop moves on, and a lane wedged by an
+    // unacknowledged release or a quarantine is refused by the durable lane
+    // gate in the same swap. The lane that is actually chosen is asserted at
+    // the irreversible boundary, which is the refusal that matters.
+    await this.driveRecoverySweeps()
 
     const nowUnixMs = requireUnixMilliseconds(
       this.now(),
@@ -2754,7 +2806,10 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge outbox signer invocation time"
     )
-    await this.assertRecoveryBarrier()
+    await this.assertRecoveryBarrier({
+      chainID: reserved.intent.chainID,
+      sender: reservation.sender,
+    })
     // Built from the record that is about to be committed: `nextRecord` already
     // carries the post-swap version, and the binding reads no signer marker, so
     // the invocation identity is derivable here and lands in the same swap that
@@ -3008,7 +3063,6 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     ) {
       return current
     }
-    await this.assertRecoveryBarrier()
 
     let variants: readonly P2TRSignatureFraudPreparedTransactionVariant[]
     try {
@@ -3022,12 +3076,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         "Challenge replacement record lacks its authenticated nonce reservation"
       )
     }
-    const selectedPreparer = this.preparerForReservation(current.reservedNonce)
+    // Captured once: the lane cannot change under a replacement, and both the
+    // entry assert and the boundary assert below must name the same one.
+    const replacementReservation = current.reservedNonce
+    const selectedPreparer = this.preparerForReservation(replacementReservation)
     if (
       selectedPreparer === undefined ||
       (await this.store.isSignerQuarantined(
         current.intent.chainID,
-        current.reservedNonce.signerIdentity
+        replacementReservation.signerIdentity
       ))
     ) {
       return this.quarantine(
@@ -3035,6 +3092,12 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
         "Challenge replacement signer lane is unavailable or quarantined"
       )
     }
+    // Asserted here rather than at entry: the replacement's lane is only known
+    // once its reservation and preparer have been resolved just above.
+    await this.assertRecoveryBarrier({
+      chainID: current.intent.chainID,
+      sender: replacementReservation.sender,
+    })
     const selectedFeePolicy = feePolicyForPreparer(current, selectedPreparer)
     if (variants.length >= P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_SIGNED_VARIANTS) {
       await this.store.saveCriticalAlert({
@@ -3120,7 +3183,10 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge outbox replacement signer invocation time"
     )
-    await this.assertRecoveryBarrier()
+    await this.assertRecoveryBarrier({
+      chainID: claimed.intent.chainID,
+      sender: replacementReservation.sender,
+    })
     // As at the initial boundary: build first, so the identity is committed in
     // the same swap as the marker and a build failure leaves nothing durable.
     const pendingBoundary = nextRecord(claimed, {
@@ -4501,15 +4567,39 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
     }
   }
 
-  private async assertRecoveryBarrier(): Promise<void> {
+  /**
+   * Drives recovery without judging any lane. This must stay store-wide: the
+   * sweeps below are the only thing that ever reclaims a `preparing` record
+   * whose lane selection is still NULL -- the window between the claim swap and
+   * the lane swap -- and no per-lane predicate can see such a row, because it
+   * belongs to no lane yet. Narrowing the sweep would strand those records
+   * permanently. Recovering another account's backlog is never harmful; only
+   * REFUSING TO SIGN on another account's behalf is, and that is
+   * `assertRecoveryBarrier`'s job.
+   */
+  private async driveRecoverySweeps(): Promise<void> {
     if (!this.recoveryBarrierEstablished) {
       await this.establishRecoveryBarrier()
     }
+  }
+
+  /**
+   * Refuses to sign on one nonce lane while THAT lane still has unresolved
+   * durable recovery work. The lane is required rather than optional on
+   * purpose: an absent lane would silently mean "no check", which is the same
+   * shape of hole as a barrier row that does not exist reading as a clean lane.
+   */
+  private async assertRecoveryBarrier(
+    lane: P2TRSignatureFraudSigningLane
+  ): Promise<void> {
+    await this.driveRecoverySweeps()
+    const normalized = normalizeP2TRSignatureFraudSigningLane(lane)
     const [expiredPreparationLease, pendingNonceRelease] = await Promise.all([
       this.store.hasExpiredPreparationLeases(
-        requireUnixMilliseconds(this.now(), "Challenge recovery barrier time")
+        requireUnixMilliseconds(this.now(), "Challenge recovery barrier time"),
+        normalized
       ),
-      this.store.hasPendingNonceReleases(),
+      this.store.hasPendingNonceReleases(normalized),
     ])
     if (expiredPreparationLease || pendingNonceRelease) {
       this.recoveryBarrierEstablished = false
@@ -4551,15 +4641,15 @@ export class P2TRSignatureFraudChallengeOutboxDispatcher {
       this.now(),
       "Challenge recovery barrier completion time"
     )
-    if (
-      (await this.store.hasPendingNonceReleases()) ||
-      (await this.store.hasExpiredPreparationLeases(nowUnixMs))
-    ) {
-      throw new Error(
-        "Challenge signing is blocked by unresolved durable recovery work"
-      )
-    }
-    this.recoveryBarrierEstablished = true
+    // Residue left here is no longer fatal. It used to throw, and that throw --
+    // not either message in `assertRecoveryBarrier` -- is what a wedged store
+    // actually raised, because this runs first whenever the flag is unset. One
+    // account's unresolvable residue therefore froze signing on every account.
+    // Whether residue blocks is now the caller's question to ask about its own
+    // lane; all this decides is whether the store-wide fast path may latch.
+    this.recoveryBarrierEstablished =
+      !(await this.store.hasPendingNonceReleases()) &&
+      !(await this.store.hasExpiredPreparationLeases(nowUnixMs))
   }
 
   private async applyPreSignRecheckFailure(

--- a/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
+++ b/services/watchtower/src/P2TRSignatureFraudChallengeOutbox.ts
@@ -1136,7 +1136,7 @@ export const computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest = (
   computeVersionedSignerBoundaryResolutionEvidenceDigest(resolution, 5)
 
 /**
- * Computes the digest accepted before migration 005. This must only be used to
+ * Computes the digest accepted before migration 006. This must only be used to
  * recognize an exact replay of immutable evidence that the migration marked as
  * version 4; new resolutions must always use the v5 helper above.
  */
@@ -1401,7 +1401,7 @@ export const validateP2TRSignatureFraudIndependentSignerBoundaryResolution = (
   validateVersionedIndependentSignerBoundaryResolution(resolution, 5)
 
 /**
- * Validates the exact evidence contract used before migration 005. The
+ * Validates the exact evidence contract used before migration 006. The
  * PostgreSQL adapter invokes this only after finding an immutable row that the
  * migration explicitly classified as version 4; it is never an insertion path.
  */

--- a/services/watchtower/src/P2TRSignatureFraudWatchtowerService.ts
+++ b/services/watchtower/src/P2TRSignatureFraudWatchtowerService.ts
@@ -27,6 +27,7 @@ import type {
   P2TRSignatureFraudWatchtowerStoreProfileProvider,
   P2TRSignatureFraudWatchtowerTransactionCoordinator,
 } from "./types.js"
+import { P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS } from "./P2TRSignatureFraudChallengeOutbox.js"
 
 const DEFAULT_ALERT_DEDUPLICATION_WINDOW_MS = 60_000
 const MAX_ALERT_FAILURE_SUMMARIES = 20
@@ -708,10 +709,11 @@ function requireProductionBroadcastReconciler(
   if (
     typeof finalityConfirmationBlocks !== "number" ||
     !Number.isSafeInteger(finalityConfirmationBlocks) ||
-    finalityConfirmationBlocks <= 0
+    finalityConfirmationBlocks <
+      P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS
   ) {
     throw new Error(
-      "P2TR signature-fraud watchtower challenge broadcast reconciler requires a positive finality confirmation depth"
+      `P2TR signature-fraud watchtower challenge broadcast reconciler requires a finality confirmation depth of at least ${P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS} blocks`
     )
   }
 

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -40,8 +40,10 @@ import {
   computeP2TRSignatureFraudResolutionEvidenceDigest,
   appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
+  normalizeP2TRSignatureFraudSigningLane,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
 } from "./P2TRSignatureFraudChallengeOutbox.js"
+import type { P2TRSignatureFraudSigningLane } from "./P2TRSignatureFraudChallengeOutbox.js"
 import type { P2TRPostgresOutboxTransactionSession } from "./PostgresP2TRSignatureFraudOutboxActivationHandshake.js"
 import type { P2TRSignatureFraudWatchtowerTransactionCoordinator } from "./types.js"
 
@@ -414,30 +416,61 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     return result.rows[0]?.exists === true
   }
 
-  async hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean> {
+  async hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
     if (!this.inTransaction()) {
       return this.runInTransaction(() =>
-        this.hasExpiredPreparationLeases(nowUnixMs)
+        this.hasExpiredPreparationLeases(nowUnixMs, lane)
       )
     }
     this.assertSession()
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
+    // `lane_released_at_unix_ms IS NULL` is not a filter of convenience. A
+    // record that has released its lane is no longer occupying it, so freezing
+    // the lane on its behalf would be wrong -- and the partial unique index on
+    // (chain_id, selected_sender) carries the same predicate, so stating it
+    // keeps this an index lookup instead of a scan.
     const result = await this.options.session.query<{ exists: boolean }>(
       `SELECT EXISTS (
           SELECT 1
             FROM p2tr_signature_fraud_challenge_outbox
            WHERE status = 'preparing'
              AND preparation_lease_expires_at_unix_ms <= $1
+             ${
+               normalized === undefined
+                 ? ""
+                 : `AND chain_id = $2
+             AND selected_sender = decode($3, 'hex')
+             AND lane_released_at_unix_ms IS NULL`
+             }
        ) AS exists`,
-      [unixMilliseconds(nowUnixMs, "Preparation recovery time")]
+      normalized === undefined
+        ? [unixMilliseconds(nowUnixMs, "Preparation recovery time")]
+        : [
+            unixMilliseconds(nowUnixMs, "Preparation recovery time"),
+            normalized.chainID,
+            stripHex(normalized.sender),
+          ]
     )
     return result.rows[0]?.exists === true
   }
 
-  async hasPendingNonceReleases(): Promise<boolean> {
+  async hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
     if (!this.inTransaction()) {
-      return this.runInTransaction(() => this.hasPendingNonceReleases())
+      return this.runInTransaction(() => this.hasPendingNonceReleases(lane))
     }
     this.assertSession()
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
     const result = await this.options.session.query<{ exists: boolean }>(
       `SELECT EXISTS (
           SELECT 1
@@ -447,7 +480,16 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
                    FROM p2tr_signature_fraud_challenge_nonce_release_terminal x
                   WHERE x.release_request_id = r.release_request_id
                )
-       ) AS exists`
+             ${
+               normalized === undefined
+                 ? ""
+                 : `AND r.chain_id = $1
+             AND r.sender = decode($2, 'hex')`
+             }
+       ) AS exists`,
+      normalized === undefined
+        ? []
+        : [normalized.chainID, stripHex(normalized.sender)]
     )
     return result.rows[0]?.exists === true
   }

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -556,13 +556,37 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
          LEFT JOIN p2tr_signature_fraud_challenge_nonce_release_resolution rx
            ON rx.release_request_id = a.release_request_id
           AND rx.attempt_sequence = a.attempt_sequence
-        WHERE b.singleton = true
+        WHERE b.active_release_request_id IS NOT NULL
+        ORDER BY b.chain_id, b.sender
         FOR UPDATE OF b`
     )
-    if (result.rows.length !== 1) {
-      throw new Error("Nonce allocator safety barrier is absent or duplicated")
+    // The barrier is keyed per nonce lane, so several lanes can hold a claim at
+    // once. Every claim is validated — a malformed one throws even if it is not
+    // the claim this call recovers — and the first recoverable one is returned.
+    // The caller drains the rest on subsequent passes.
+    let recoverable: P2TRSignatureFraudAmbiguousNonceReleaseInvocation | undefined
+    for (const row of result.rows) {
+      const candidate = await this.hydrateAmbiguousNonceReleaseInvocation(row, now)
+      if (recoverable === undefined) recoverable = candidate
     }
-    const row = result.rows[0]
+    return recoverable
+  }
+
+  private async hydrateAmbiguousNonceReleaseInvocation(
+    row: {
+      active_release_request_id: Buffer | null
+      active_release_attempt_sequence: string | number | null
+      active_release_expires_at_unix_ms: string | number | null
+      owner: string | null
+      started_at_unix_ms: string | number | null
+      expires_at_unix_ms: string | number | null
+      invoked_at_unix_ms: string | number | null
+      result_kind: string | null
+      response_digest: Buffer | null
+      resolution_outcome: string | null
+    },
+    now: number
+  ): Promise<P2TRSignatureFraudAmbiguousNonceReleaseInvocation | undefined> {
     if (row.active_release_request_id === null) {
       if (
         row.active_release_attempt_sequence !== null ||
@@ -1471,9 +1495,9 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
    * the signer RPC, so nothing inside the process-local recovery path may clear
    * it — `recoverExpiredPreparation` deliberately refuses, because a lease
    * timeout is not proof that a remote call stopped. Meanwhile the marker holds
-   * the singleton `active_signer_invocation_count` at one, which blocks every
-   * nonce-release invocation store-wide and freezes challenge signing on every
-   * lane. Only out-of-band, dual-attested evidence of what the signer actually
+   * the lane's `active_signer_invocation_count` at one, which blocks every
+   * nonce-release invocation on that lane and freezes challenge signing for
+   * that account. Only out-of-band, dual-attested evidence of what the signer actually
    * did can break that, and every effect below lands in one transaction.
    */
   async resolveOrphanedSignerBoundary(
@@ -1742,7 +1766,7 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
    * "stuck in authorization" from "signer call outstanding". Only the
    * boundary's owner witnesses authorization failing before signer I/O, and
    * that same first-person observation is already trusted to clear the
-   * singleton signer barrier. Retirement is therefore performed in the SAME
+   * lane's signer barrier. Retirement is therefore performed in the SAME
    * transaction as the barrier-clearing swap: never resolve-then-clear (which
    * would unblock activation while the barrier is still live) and never
    * clear-then-resolve (which strands a permanently blocking incident).

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -42,6 +42,7 @@ import {
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
   normalizeP2TRSignatureFraudSigningLane,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
+  validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay,
 } from "./P2TRSignatureFraudChallengeOutbox.js"
 import type { P2TRSignatureFraudSigningLane } from "./P2TRSignatureFraudChallengeOutbox.js"
 import type { P2TRPostgresOutboxTransactionSession } from "./PostgresP2TRSignatureFraudOutboxActivationHandshake.js"
@@ -1556,8 +1557,69 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
       )
     }
     this.assertSession()
-    const normalized =
-      validateP2TRSignatureFraudIndependentSignerBoundaryResolution(resolution)
+    type StoredSignerBoundaryResolution = {
+      outcome: "never-invoked" | "signed" | "terminal-unsafe" | "nonce-consumed"
+      resolution_evidence_digest: Buffer
+      resolution_evidence_version: 4 | 5
+    }
+    const loadExisting = async (recordID: string, signerInvocationID: string) =>
+      this.options.session.query<StoredSignerBoundaryResolution>(
+        `SELECT outcome, resolution_evidence_digest,
+                resolution_evidence_version
+           FROM p2tr_signature_fraud_challenge_signer_boundary_resolution
+          WHERE record_id = decode($1, 'hex')
+            AND signer_invocation_id = decode($2, 'hex')`,
+        [stripHex(recordID), stripHex(signerInvocationID)]
+      )
+    const acceptLegacyV4Replay = (
+      existing: StoredSignerBoundaryResolution
+    ): "acknowledged" | "unsafe" => {
+      let legacy
+      try {
+        legacy =
+          validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay(
+            resolution
+          )
+      } catch {
+        throw new Error("Independent signer-boundary resolution conflicts")
+      }
+      if (
+        existing.outcome !== legacy.outcome ||
+        prefixedHex(existing.resolution_evidence_digest) !==
+          legacy.evidenceDigest
+      ) {
+        throw new Error("Independent signer-boundary resolution conflicts")
+      }
+      return legacy.outcome === "terminal-unsafe" ? "unsafe" : "acknowledged"
+    }
+    let normalized
+    try {
+      normalized =
+        validateP2TRSignatureFraudIndependentSignerBoundaryResolution(
+          resolution
+        )
+    } catch (validationError) {
+      // A pre-005 response may be retried after the database committed its v4
+      // evidence but before the caller observed the response. Look up only by
+      // the two bounded identity fields, then accept solely an exact, fully
+      // validated replay of a row migration 005 marked as grandfathered.
+      const recordID = bytes32(
+        resolution.recordID,
+        "Orphaned signer boundary record ID"
+      )
+      const signerInvocationID = bytes32(
+        resolution.signerInvocationID,
+        "Orphaned signer boundary invocation ID"
+      )
+      const existing = await loadExisting(recordID, signerInvocationID)
+      if (
+        existing.rows.length !== 1 ||
+        existing.rows[0].resolution_evidence_version !== 4
+      ) {
+        throw validationError
+      }
+      return acceptLegacyV4Replay(existing.rows[0])
+    }
     const currentRow = await this.lockRecord(normalized.recordID)
     if (currentRow === undefined) {
       throw new Error(
@@ -1565,17 +1627,14 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
       )
     }
     const current = await this.hydrateRow(currentRow)
-    const existing = await this.options.session.query<{
-      outcome: "never-invoked" | "signed" | "terminal-unsafe"
-      resolution_evidence_digest: Buffer
-    }>(
-      `SELECT outcome, resolution_evidence_digest
-         FROM p2tr_signature_fraud_challenge_signer_boundary_resolution
-        WHERE record_id = decode($1, 'hex')
-          AND signer_invocation_id = decode($2, 'hex')`,
-      [stripHex(normalized.recordID), stripHex(normalized.signerInvocationID)]
+    const existing = await loadExisting(
+      normalized.recordID,
+      normalized.signerInvocationID
     )
     if (existing.rows.length === 1) {
+      if (existing.rows[0].resolution_evidence_version === 4) {
+        return acceptLegacyV4Replay(existing.rows[0])
+      }
       if (
         existing.rows[0].outcome !== normalized.outcome ||
         prefixedHex(existing.rows[0].resolution_evidence_digest) !==
@@ -1612,7 +1671,8 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           nonce_consumption_finalized_block_number,
           nonce_consumption_finalized_block_hash,
           nonce_consumption_observed_head_block_number,
-          nonce_consumption_observed_head_block_hash
+          nonce_consumption_observed_head_block_hash,
+          resolution_evidence_version
        ) VALUES (
           decode($1, 'hex'), decode($2, 'hex'), $3, $4,
           decode($5, 'hex'), $6, $7, $8,
@@ -1627,7 +1687,8 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           $28,
           CASE WHEN $29::text IS NULL THEN NULL ELSE decode($29, 'hex') END,
           $30,
-          CASE WHEN $31::text IS NULL THEN NULL ELSE decode($31, 'hex') END
+          CASE WHEN $31::text IS NULL THEN NULL ELSE decode($31, 'hex') END,
+          5
        )`,
       [
         stripHex(normalized.recordID),

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -564,9 +564,14 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
     // once. Every claim is validated — a malformed one throws even if it is not
     // the claim this call recovers — and the first recoverable one is returned.
     // The caller drains the rest on subsequent passes.
-    let recoverable: P2TRSignatureFraudAmbiguousNonceReleaseInvocation | undefined
+    let recoverable:
+      | P2TRSignatureFraudAmbiguousNonceReleaseInvocation
+      | undefined
     for (const row of result.rows) {
-      const candidate = await this.hydrateAmbiguousNonceReleaseInvocation(row, now)
+      const candidate = await this.hydrateAmbiguousNonceReleaseInvocation(
+        row,
+        now
+      )
       if (recoverable === undefined) recoverable = candidate
     }
     return recoverable

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -1599,10 +1599,10 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           resolution
         )
     } catch (validationError) {
-      // A pre-005 response may be retried after the database committed its v4
+      // A pre-006 response may be retried after the database committed its v4
       // evidence but before the caller observed the response. Look up only by
       // the two bounded identity fields, then accept solely an exact, fully
-      // validated replay of a row migration 005 marked as grandfathered.
+      // validated replay of a row migration 006 marked as grandfathered.
       const recordID = bytes32(
         resolution.recordID,
         "Orphaned signer boundary record ID"

--- a/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudChallengeOutboxStore.ts
@@ -1610,7 +1610,9 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           nonce_consumption_account_nonce, nonce_consumption_read_at_block,
           nonce_consumption_transaction_hash,
           nonce_consumption_finalized_block_number,
-          nonce_consumption_finalized_block_hash
+          nonce_consumption_finalized_block_hash,
+          nonce_consumption_observed_head_block_number,
+          nonce_consumption_observed_head_block_hash
        ) VALUES (
           decode($1, 'hex'), decode($2, 'hex'), $3, $4,
           decode($5, 'hex'), $6, $7, $8,
@@ -1623,7 +1625,9 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
           $23, $24, $25, $26,
           CASE WHEN $27::text IS NULL THEN NULL ELSE decode($27, 'hex') END,
           $28,
-          CASE WHEN $29::text IS NULL THEN NULL ELSE decode($29, 'hex') END
+          CASE WHEN $29::text IS NULL THEN NULL ELSE decode($29, 'hex') END,
+          $30,
+          CASE WHEN $31::text IS NULL THEN NULL ELSE decode($31, 'hex') END
        )`,
       [
         stripHex(normalized.recordID),
@@ -1665,6 +1669,10 @@ export class PostgresP2TRSignatureFraudChallengeOutboxStore
         normalized.nonceConsumption === undefined
           ? null
           : stripHex(normalized.nonceConsumption.finalizedThrough.blockHash),
+        normalized.nonceConsumption?.observedHead.blockNumber ?? null,
+        normalized.nonceConsumption === undefined
+          ? null
+          : stripHex(normalized.nonceConsumption.observedHead.blockHash),
       ]
     )
     if (normalized.outcome === "never-invoked") {

--- a/services/watchtower/src/PostgresP2TRSignatureFraudOutboxActivationHandshake.ts
+++ b/services/watchtower/src/PostgresP2TRSignatureFraudOutboxActivationHandshake.ts
@@ -475,85 +475,160 @@ export class PostgresP2TRSignatureFraudOutboxActivationHandshakeProvider {
           WHERE c.singleton = true`,
         [TERMINAL_STATUSES]
       ),
+      // The barrier is keyed per nonce lane, so this audit is a rollup, not a
+      // row read. Activation is a whole-service event: it must refuse if ANY
+      // lane has outstanding allocator or signer I/O, including a lane whose
+      // barrier row is absent entirely. Per-lane equality alone cannot see a
+      // missing row — a lane holding a live signer invocation with no barrier
+      // row would produce zero failing groups and zero counters, and activation
+      // would pass. The whole-store SUM equalities below are what close that:
+      // together with per-lane equality they force any lane without a row to
+      // account for nothing, which is exactly the completeness the old
+      // single-row read got from the singleton.
       session.query<NonceAllocatorBarrierRow>(
-        `SELECT CASE
-                  WHEN b.active_release_request_id IS NULL THEN 0
-                  ELSE 1
-                END::bigint AS active_release_attempt_count,
-                b.active_signer_invocation_count,
-                b.unresolved_release_count,
-                b.contract_mismatch_blocked,
-                CASE
-                  WHEN b.active_signer_invocation_count = (
-                         SELECT count(*)
-                           FROM p2tr_signature_fraud_challenge_outbox o
-                          WHERE o.active_signer_invocation_started_at_unix_ms
-                                IS NOT NULL
-                       )
-                   AND b.unresolved_release_count = (
-                         SELECT count(*)
-                           FROM p2tr_signature_fraud_challenge_nonce_release_request r
-                          WHERE NOT EXISTS (
-                                SELECT 1
-                                  FROM p2tr_signature_fraud_challenge_nonce_release_terminal x
-                                 WHERE x.release_request_id = r.release_request_id
-                          )
-                       )
-                   AND (
-                         (b.active_release_request_id IS NULL
-                          AND b.active_release_attempt_sequence IS NULL
-                          AND b.active_release_expires_at_unix_ms IS NULL)
-                         OR EXISTS (
+        `WITH lane AS (
+             SELECT b.active_release_request_id,
+                    b.active_signer_invocation_count,
+                    b.unresolved_release_count,
+                    (
+                      SELECT count(*)
+                        FROM p2tr_signature_fraud_challenge_outbox o
+                       WHERE o.active_signer_invocation_started_at_unix_ms
+                             IS NOT NULL
+                         AND o.chain_id = b.chain_id
+                         AND o.selected_sender = b.sender
+                    ) AS observed_signer_count,
+                    (
+                      SELECT count(*)
+                        FROM p2tr_signature_fraud_challenge_nonce_release_request r
+                       WHERE r.chain_id = b.chain_id
+                         AND r.sender = b.sender
+                         AND NOT EXISTS (
                              SELECT 1
-                               FROM p2tr_signature_fraud_challenge_nonce_release_attempt a
-                               JOIN p2tr_signature_fraud_challenge_nonce_release_invocation i
-                                 ON i.release_request_id = a.release_request_id
-                                AND i.attempt_sequence = a.attempt_sequence
-                              WHERE a.release_request_id = b.active_release_request_id
-                                AND a.attempt_sequence = b.active_release_attempt_sequence
-                                AND a.expires_at_unix_ms = b.active_release_expires_at_unix_ms
-                                AND NOT EXISTS (
-                                    SELECT 1
-                                      FROM p2tr_signature_fraud_challenge_nonce_release_result x
-                                     WHERE x.release_request_id = a.release_request_id
-                                       AND x.attempt_sequence = a.attempt_sequence
-                                       AND x.result_kind <> 'ambiguous-error'
-                                )
-                                AND NOT EXISTS (
-                                    SELECT 1
-                                      FROM p2tr_signature_fraud_challenge_nonce_release_resolution rx
-                                     WHERE rx.release_request_id = a.release_request_id
-                                       AND rx.attempt_sequence = a.attempt_sequence
-                                )
+                               FROM p2tr_signature_fraud_challenge_nonce_release_terminal x
+                              WHERE x.release_request_id = r.release_request_id
                          )
+                    ) AS observed_unresolved_count,
+                    (
+                      (b.active_release_request_id IS NULL
+                       AND b.active_release_attempt_sequence IS NULL
+                       AND b.active_release_expires_at_unix_ms IS NULL)
+                      OR EXISTS (
+                          SELECT 1
+                            FROM p2tr_signature_fraud_challenge_nonce_release_attempt a
+                            JOIN p2tr_signature_fraud_challenge_nonce_release_invocation i
+                              ON i.release_request_id = a.release_request_id
+                             AND i.attempt_sequence = a.attempt_sequence
+                            JOIN p2tr_signature_fraud_challenge_nonce_release_request rr
+                              ON rr.release_request_id = a.release_request_id
+                           WHERE a.release_request_id = b.active_release_request_id
+                             AND a.attempt_sequence = b.active_release_attempt_sequence
+                             AND a.expires_at_unix_ms = b.active_release_expires_at_unix_ms
+                             AND rr.chain_id = b.chain_id
+                             AND rr.sender = b.sender
+                             AND NOT EXISTS (
+                                 SELECT 1
+                                   FROM p2tr_signature_fraud_challenge_nonce_release_result x
+                                  WHERE x.release_request_id = a.release_request_id
+                                    AND x.attempt_sequence = a.attempt_sequence
+                                    AND x.result_kind <> 'ambiguous-error'
+                             )
+                             AND NOT EXISTS (
+                                 SELECT 1
+                                   FROM p2tr_signature_fraud_challenge_nonce_release_resolution rx
+                                  WHERE rx.release_request_id = a.release_request_id
+                                    AND rx.attempt_sequence = a.attempt_sequence
+                             )
+                      )
+                    ) AS claim_is_live
+               FROM p2tr_signature_fraud_nonce_allocator_safety_barrier b
+         ), rollup AS (
+             SELECT count(*) FILTER (
+                        WHERE active_release_request_id IS NOT NULL
+                    ) AS active_release_attempt_count,
+                    COALESCE(sum(active_signer_invocation_count), 0)
+                        AS active_signer_invocation_count,
+                    COALESCE(sum(unresolved_release_count), 0)
+                        AS unresolved_release_count,
+                    count(*) FILTER (
+                        WHERE observed_signer_count <> active_signer_invocation_count
+                           OR observed_unresolved_count <> unresolved_release_count
+                           OR NOT claim_is_live
+                    ) AS lane_mismatch_count
+               FROM lane
+         ), truth AS (
+             SELECT (
+                      SELECT count(*)
+                        FROM p2tr_signature_fraud_challenge_outbox o
+                       WHERE o.active_signer_invocation_started_at_unix_ms
+                             IS NOT NULL
+                    ) AS total_signer_count,
+                    (
+                      SELECT count(*)
+                        FROM p2tr_signature_fraud_challenge_nonce_release_request r
+                       WHERE NOT EXISTS (
+                             SELECT 1
+                               FROM p2tr_signature_fraud_challenge_nonce_release_terminal x
+                              WHERE x.release_request_id = r.release_request_id
                        )
-                   AND b.contract_mismatch_blocked = (EXISTS (
-                         SELECT 1
-                           FROM p2tr_signature_fraud_challenge_nonce_release_result x
-                          WHERE x.result_kind = 'contract-mismatch'
-                         UNION ALL
-                         SELECT 1
-                           FROM p2tr_signature_fraud_challenge_nonce_release_resolution rx
-                          WHERE rx.outcome = 'terminal-unsafe'
-                       ))
-                   AND b.contract_mismatch_blocked = (EXISTS (
-                         SELECT 1
-                           FROM p2tr_signature_fraud_challenge_critical_alert a
-                          WHERE a.code IN (
-                                'reservation-release-failed',
-                                'nonce-release-terminal-unsafe'
-                            )
-                            AND NOT EXISTS (
-                                SELECT 1
-                                  FROM p2tr_signature_fraud_challenge_critical_alert_resolution ar
-                                 WHERE ar.alert_id = a.alert_id
-                            )
-                       ))
-                  THEN 0
-                  ELSE 1
-                END::bigint AS mismatch_count
-           FROM p2tr_signature_fraud_nonce_allocator_safety_barrier b
-          WHERE b.singleton = true`
+                    ) AS total_unresolved_count
+         ), global AS (
+             SELECT contract_mismatch_blocked
+               FROM p2tr_signature_fraud_nonce_allocator_global_barrier
+              WHERE singleton = true
+         )
+         SELECT rollup.active_release_attempt_count::bigint
+                    AS active_release_attempt_count,
+                rollup.active_signer_invocation_count::bigint
+                    AS active_signer_invocation_count,
+                rollup.unresolved_release_count::bigint
+                    AS unresolved_release_count,
+                (SELECT contract_mismatch_blocked FROM global)
+                    AS contract_mismatch_blocked,
+                (
+                  rollup.lane_mismatch_count
+                  + CASE
+                      WHEN rollup.active_signer_invocation_count
+                           = truth.total_signer_count THEN 0
+                      ELSE 1
+                    END
+                  + CASE
+                      WHEN rollup.unresolved_release_count
+                           = truth.total_unresolved_count THEN 0
+                      ELSE 1
+                    END
+                  + CASE
+                      WHEN (SELECT contract_mismatch_blocked FROM global)
+                           IS NOT DISTINCT FROM (EXISTS (
+                             SELECT 1
+                               FROM p2tr_signature_fraud_challenge_nonce_release_result x
+                              WHERE x.result_kind = 'contract-mismatch'
+                             UNION ALL
+                             SELECT 1
+                               FROM p2tr_signature_fraud_challenge_nonce_release_resolution rx
+                              WHERE rx.outcome = 'terminal-unsafe'
+                           )) THEN 0
+                      ELSE 1
+                    END
+                  + CASE
+                      WHEN (SELECT contract_mismatch_blocked FROM global)
+                           IS NOT DISTINCT FROM (EXISTS (
+                             SELECT 1
+                               FROM p2tr_signature_fraud_challenge_critical_alert a
+                              WHERE a.code IN (
+                                    'reservation-release-failed',
+                                    'nonce-release-terminal-unsafe'
+                                )
+                                AND NOT EXISTS (
+                                    SELECT 1
+                                      FROM p2tr_signature_fraud_challenge_critical_alert_resolution ar
+                                     WHERE ar.alert_id = a.alert_id
+                                )
+                           )) THEN 0
+                      ELSE 1
+                    END
+                )::bigint AS mismatch_count
+           FROM rollup, truth`
       ),
       session.query<CatalogDefinitionRow>(
         `SELECT 'relation'::text AS object_kind,
@@ -688,6 +763,10 @@ export class PostgresP2TRSignatureFraudOutboxActivationHandshakeProvider {
       capacityCounterResult,
       "outbox capacity-counter mismatch count"
     )
+    // The rollup always yields one row, so unlike the singleton read this
+    // replaced, this guard no longer proves the barrier covers every lane —
+    // the SUM equalities inside `mismatch_count` do. It is retained only to
+    // reject a shape the query cannot legitimately produce.
     if (nonceAllocatorBarrierResult.rows.length !== 1) {
       throw new Error("PostgreSQL nonce-allocator safety barrier is invalid")
     }

--- a/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
@@ -32,6 +32,7 @@ import {
   appendSignerQuarantine,
   assertP2TRSignatureFraudOrphanedSignerBoundaryOwnership,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
+  normalizeP2TRSignatureFraudSigningLane,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
 
 /** Mirrors the PostgreSQL adapter's tolerance for an unprefixed `Hex` render. */
@@ -179,19 +180,56 @@ export class InMemoryOutboxStore
     )
   }
 
-  async hasExpiredPreparationLeases(nowUnixMs: number): Promise<boolean> {
+  async hasExpiredPreparationLeases(
+    nowUnixMs: number,
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
     return [...this.records.values()].some(
       (record) =>
         record.status === "preparing" &&
         record.preparationLease !== undefined &&
-        record.preparationLease.expiresAtUnixMs <= nowUnixMs
+        record.preparationLease.expiresAtUnixMs <= nowUnixMs &&
+        (normalized === undefined ||
+          // Mirrors the adapter exactly, including the released-lane exclusion:
+          // a record that surrendered its lane is not occupying it. The
+          // adapter writes `lane_released_at_unix_ms` exactly when
+          // `finalNonceResolution` is set, so this is the same predicate.
+          (record.finalNonceResolution === undefined &&
+            record.preparationSender !== undefined &&
+            normalizeP2TRSignatureFraudSigningLane({
+              chainID: record.intent.chainID,
+              sender: record.preparationSender,
+            }).sender === normalized.sender &&
+            record.intent.chainID === normalized.chainID))
     )
   }
 
-  async hasPendingNonceReleases(): Promise<boolean> {
-    return [...this.nonceReleaseRequests.keys()].some(
-      (id) => !this.releaseAcknowledged(id)
-    )
+  async hasPendingNonceReleases(
+    lane?: P2TRSignatureFraudSigningLane
+  ): Promise<boolean> {
+    const normalized =
+      lane === undefined
+        ? undefined
+        : normalizeP2TRSignatureFraudSigningLane(lane)
+    return [...this.nonceReleaseRequests.entries()].some(([id, request]) => {
+      if (this.releaseAcknowledged(id)) return false
+      if (normalized === undefined) return true
+      // The reservation carries the sender but not the chain, so the chain
+      // comes from the record the release belongs to -- the same join the
+      // adapter gets for free from the release-request row.
+      const chainID = this.records.get(request.recordID)?.intent.chainID
+      return (
+        chainID === normalized.chainID &&
+        normalizeP2TRSignatureFraudSigningLane({
+          chainID: normalized.chainID,
+          sender: request.reservation.sender,
+        }).sender === normalized.sender
+      )
+    })
   }
 
   async getNonceReleaseRequest(

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -73,6 +73,7 @@ import {
   computeP2TRSignatureFraudCanonicalProvenanceInvalidationEvidenceHash,
   computeP2TRSignatureFraudOutboxRecordID,
   computeP2TRSignatureFraudOutboxSeriesID,
+  computeP2TRSignatureFraudLegacyV4SignerBoundaryResolutionEvidenceDigest,
   computeP2TRSignatureFraudNonceReleaseRequestID,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
   computeP2TRSignatureFraudResolutionEvidenceDigest,
@@ -80,6 +81,7 @@ import {
   invalidateP2TRSignatureFraudCanonicalProvenance,
   quarantineLegacyP2TRSignatureFraudSubmissions,
   validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
+  validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
 import {
   computeP2TRSignatureFraudSignerInvocationID,
@@ -4189,5 +4191,60 @@ test("requires consensus finality for direct orphaned-boundary nonce evidence", 
   )
   assert.ok(
     validateP2TRSignatureFraudIndependentSignerBoundaryResolution(build(564))
+  )
+
+  const {
+    evidenceDigest: ignoredCurrentDigest,
+    canonicalAttestations: ignoredCurrentAttestations,
+    resolvedAtUnixMs,
+    ...legacyBinding
+  } = build(512)
+  void ignoredCurrentDigest
+  void ignoredCurrentAttestations
+  const legacyDigest =
+    computeP2TRSignatureFraudLegacyV4SignerBoundaryResolutionEvidenceDigest(
+      legacyBinding
+    )
+  const legacyResolution: P2TRSignatureFraudIndependentSignerBoundaryResolution =
+    {
+      ...legacyBinding,
+      evidenceDigest: legacyDigest,
+      canonicalAttestations: [
+        {
+          trustDomainID: "primary",
+          independenceDomainID: "primary-infra",
+          evidenceDigest: legacyDigest,
+          attestation: "0x01",
+          attestedAtUnixMs: 1_200,
+        },
+        {
+          trustDomainID: "corroborating",
+          independenceDomainID: "corroborating-infra",
+          evidenceDigest: legacyDigest,
+          attestation: "0x02",
+          attestedAtUnixMs: 1_200,
+        },
+      ],
+      resolvedAtUnixMs,
+    }
+  assert.throws(
+    () =>
+      validateP2TRSignatureFraudIndependentSignerBoundaryResolution(
+        legacyResolution
+      ),
+    /finality depth must be at least 64 blocks/
+  )
+  assert.ok(
+    validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay(
+      legacyResolution
+    )
+  )
+  assert.throws(
+    () =>
+      validateP2TRSignatureFraudLegacyV4SignerBoundaryResolutionReplay({
+        ...legacyResolution,
+        providerEvidenceDigest: `0x${"ff".repeat(32)}`,
+      }),
+    /resolution digest is invalid/
   )
 })

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -154,9 +154,10 @@ const completeV2TestCall = (sighash: string) => {
 const signTestChallengeTransaction = (
   calldata: string,
   maxFeePerGas: number,
-  maxPriorityFeePerGas: number
+  maxPriorityFeePerGas: number,
+  signingKey = `0x${"42".repeat(32)}`
 ) => {
-  const wallet = new Wallet(`0x${"42".repeat(32)}`)
+  const wallet = new Wallet(signingKey)
   const transaction = {
     type: 2,
     chainId: 11155111,
@@ -552,7 +553,7 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
       intentID: intent.intentID,
       rawTransaction: this.rawTransaction,
       transactionHash: Hex.from(this.transactionHash),
-      sender: TRANSACTION_SENDER,
+      sender: this.transactionSender,
       nonce: 7,
       invocation:
         this.echoInvocation === undefined
@@ -964,6 +965,58 @@ const createRecord = (
     reconciliationAttempts: 0,
   }
 }
+
+/**
+ * A second nonce lane. `validateSignerLanes` requires a distinct lane ID,
+ * signer identity and sender, and the reservation is EIP-712 signed by the
+ * sender itself, so the lane needs its own wallet and must take its address as
+ * the sender.
+ */
+const SECOND_LANE_SIGNING_KEY = `0x${"43".repeat(32)}`
+const SECOND_LANE_WALLET = new Wallet(SECOND_LANE_SIGNING_KEY)
+// The blob must carry the calldata of the intent it will be bound to, so lane B
+// signs the second test intent's call, not the default one.
+const SECOND_INTENT_SEED = "bb"
+const secondIntentCall = completeV2TestCall(`0x${SECOND_INTENT_SEED.repeat(32)}`)
+const secondLaneSignedTransaction = signTestChallengeTransaction(
+  secondIntentCall.calldata,
+  20,
+  2,
+  SECOND_LANE_SIGNING_KEY
+)
+const secondLaneReplacementTransaction = signTestChallengeTransaction(
+  secondIntentCall.calldata,
+  40,
+  4,
+  SECOND_LANE_SIGNING_KEY
+)
+const SECOND_TRANSACTION_SENDER = SECOND_LANE_WALLET.address
+const SECOND_SIGNER_LANE_ID = "lane.b.test"
+const SECOND_SIGNER_IDENTITY = "signer.b.test"
+
+class SecondLanePreparer extends FixedPreparer {
+  readonly laneID = SECOND_SIGNER_LANE_ID
+  readonly signerIdentity = SECOND_SIGNER_IDENTITY
+  readonly transactionSender = SECOND_TRANSACTION_SENDER
+  readonly wallet = SECOND_LANE_WALLET
+  rawTransaction = secondLaneSignedTransaction.rawTransaction
+  transactionHash = secondLaneSignedTransaction.transactionHash
+  replacementRawTransaction = secondLaneReplacementTransaction.rawTransaction
+  replacementTransactionHash = secondLaneReplacementTransaction.transactionHash
+}
+
+const twoLaneFeePolicyManifest = () =>
+  feePolicyManifest([
+    {
+      laneID: SECOND_SIGNER_LANE_ID,
+      signerIdentity: SECOND_SIGNER_IDENTITY,
+      sender: SECOND_TRANSACTION_SENDER,
+      maxGasLimit: "1000000",
+      maxFeePerGas: "100",
+      maxPriorityFeePerGas: "10",
+      maxTotalFeeWei: "100000000",
+    },
+  ])
 
 const enqueue = async (
   store: InMemoryOutboxStore,
@@ -3835,4 +3888,173 @@ test("refuses a burn that is not a self-transfer of nothing", async () => {
       name
     )
   }
+})
+
+// The whole point of keying the barrier by nonce lane. An orphaned signer
+// boundary is unresolvable without out-of-band evidence, so before this change
+// one such record froze challenge signing on EVERY sending account: the freeze
+// was driven by store-wide `hasExpiredPreparationLeases` /
+// `hasPendingNonceReleases` reads, and the throw that a wedged store actually
+// raised came from `establishRecoveryBarrier`, before any per-record check.
+//
+// Note these tests are the only thing pinning that behaviour in either
+// direction. Nothing in the suite asserted any barrier message before, so a
+// regression here would otherwise ship silently.
+const orphanLaneA = async (
+  store: InMemoryOutboxStore,
+  preparers: readonly P2TRSignatureFraudChallengeTransactionPreparer[]
+): Promise<{ now: () => number; release: () => void }> => {
+  const record = await enqueue(store, createIntent(), twoLaneFeePolicyManifest())
+  const authorizer = new FixedBoundaryAuthorizer()
+  let now = 2_000
+  let markStarted!: () => void
+  let release!: () => void
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve
+  })
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  authorizer.beforeAuthorize = async () => {
+    markStarted()
+    await gate
+  }
+  authorizer.rejectAuthorization = new Error("worker restarted")
+  const original = dispatcher(
+    store,
+    preparers as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => now,
+    100,
+    undefined,
+    authorizer
+  )
+  void original.prepare(record.recordID, "worker-a").catch(() => undefined)
+  await started
+  // Past the lease, the boundary is an orphan: the marker stands and no
+  // process-local recovery may clear it.
+  now = 40_001
+  return { now: () => now, release }
+}
+
+test("an orphaned boundary on one lane no longer freezes signing on another", async () => {
+  const store = new InMemoryOutboxStore()
+  const laneA = new FixedPreparer()
+  const laneB = new SecondLanePreparer()
+  const { now, release } = await orphanLaneA(store, [laneA, laneB])
+
+  assert.equal(
+    await store.hasExpiredPreparationLeases(now(), {
+      chainID: 11155111,
+      sender: TRANSACTION_SENDER,
+    }),
+    true
+  )
+  assert.equal(
+    await store.hasExpiredPreparationLeases(now(), {
+      chainID: 11155111,
+      sender: SECOND_TRANSACTION_SENDER,
+    }),
+    false
+  )
+
+  const second = await enqueue(
+    store,
+    createIntent(SECOND_INTENT_SEED),
+    twoLaneFeePolicyManifest()
+  )
+  const restarted = dispatcher(
+    store,
+    [laneA, laneB] as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    now
+  )
+  const prepared = await restarted.prepare(second.recordID, "worker-b")
+
+  // Lane A is skipped as unavailable rather than fatal, and lane B signs.
+  assert.equal(prepared.status, "prepared")
+  assert.equal(
+    prepared.preparationSender?.toLowerCase(),
+    SECOND_TRANSACTION_SENDER.toLowerCase()
+  )
+  assert.equal(laneA.calls, 0)
+  assert.equal(prepared.selectedLaneID, SECOND_SIGNER_LANE_ID)
+  assert.equal(laneB.calls, 1)
+  release()
+})
+
+test("an orphaned boundary still freezes signing on its own lane", async () => {
+  const store = new InMemoryOutboxStore()
+  const laneA = new FixedPreparer()
+  const { now, release } = await orphanLaneA(store, [laneA])
+
+  const second = await enqueue(
+    store,
+    createIntent(SECOND_INTENT_SEED),
+    twoLaneFeePolicyManifest()
+  )
+  const restarted = dispatcher(
+    store,
+    [laneA] as never,
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    now
+  )
+  // The only configured lane is the wedged one, so no healthy lane exists. The
+  // record is re-queued rather than signed -- it is never handed to the signer.
+  const attempted = await restarted.prepare(second.recordID, "worker-b")
+  assert.equal(attempted.status, "queued")
+  assert.equal(
+    attempted.lastError,
+    "No healthy durable signer lane is currently available"
+  )
+  assert.equal(laneA.calls, 0)
+  release()
+})
+
+// The direct analogue of the activation hole fixed in #1049: a `preparing`
+// record whose lane selection is still NULL belongs to no lane, so no per-lane
+// predicate -- nor a rollup over every lane -- can see it. Only the store-wide
+// sweep reclaims it, which is why the sweep must not gain a lane filter.
+test("recovery still sweeps a preparing record that has selected no lane", async () => {
+  const store = new InMemoryOutboxStore()
+  const record = await enqueue(store)
+  const claimed = await store.compareAndSwap(record.recordID, record.version, {
+    ...record,
+    status: "preparing",
+    version: record.version + 1,
+    preparationAttempts: 1,
+    preparationLease: { owner: "worker-a", expiresAtUnixMs: 3_000 },
+    updatedAtUnixMs: 2_000,
+  })
+  assert.equal(claimed, true)
+  const stranded = await store.get(record.recordID)
+  assert.equal(stranded?.preparationSender, undefined)
+
+  // Invisible to every lane, visible store-wide.
+  assert.equal(
+    await store.hasExpiredPreparationLeases(40_001, {
+      chainID: 11155111,
+      sender: TRANSACTION_SENDER,
+    }),
+    false
+  )
+  assert.equal(await store.hasExpiredPreparationLeases(40_001), true)
+
+  const recovery = dispatcher(
+    store,
+    new FixedPreparer(),
+    new RecordingBroadcaster(),
+    new FixedRechecker(),
+    new FixedReconciler(),
+    () => 40_001
+  )
+  await recovery.recoverExpiredPreparationLeases()
+  assert.equal((await store.get(record.recordID))?.status, "queued")
+  assert.equal(await store.hasExpiredPreparationLeases(40_001), false)
 })

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -43,6 +43,7 @@ import {
   P2TRSignatureFraudChallengeOutboxScheduler,
   P2TRSignatureFraudChallengeOutboxStatus,
   P2TRSignatureFraudChallengeOutboxStore,
+  P2TRSignatureFraudIndependentSignerBoundaryResolution,
   P2TRSignatureFraudLegacySubmissionQuarantine,
   P2TRSignatureFraudIndependentNonceReleaseResolution,
   P2TRSignatureFraudAmbiguousNonceReleaseInvocation,
@@ -75,8 +76,10 @@ import {
   computeP2TRSignatureFraudNonceReleaseRequestID,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
   computeP2TRSignatureFraudResolutionEvidenceDigest,
+  computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest,
   invalidateP2TRSignatureFraudCanonicalProvenance,
   quarantineLegacyP2TRSignatureFraudSubmissions,
+  validateP2TRSignatureFraudIndependentSignerBoundaryResolution,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
 import {
   computeP2TRSignatureFraudSignerInvocationID,
@@ -2955,6 +2958,20 @@ test("enforces manifest-bound fee and exact value caps at every boundary", async
   )
   assert.equal(overGas.status, "quarantined")
 
+  // A low gas limit can be a perfectly valid EIP-1559 envelope while still
+  // guaranteeing an out-of-gas failure after the reserved nonce is consumed.
+  // The signer must use the manifest's exact challenge execution budget.
+  const underGasStore = new InMemoryOutboxStore()
+  const underGasRecord = await enqueue(underGasStore)
+  const underGasPreparer = new DynamicFeePreparer()
+  underGasPreparer.initialGasLimit = 21_000
+  const underGas = await dispatcher(underGasStore, underGasPreparer).prepare(
+    underGasRecord.recordID,
+    "worker"
+  )
+  assert.equal(underGas.status, "quarantined")
+  assert.match(underGas.lastError ?? "", /exact manifest-bound gas limit/)
+
   const wrongValueStore = new InMemoryOutboxStore()
   const wrongValueRecord = await enqueue(wrongValueStore)
   const wrongValuePreparer = new DynamicFeePreparer()
@@ -4100,5 +4117,77 @@ test("refuses a reconciler whose finality depth is below consensus finality", as
       new FixedRechecker(),
       deeper
     )
+  )
+})
+
+test("requires consensus finality for direct orphaned-boundary nonce evidence", () => {
+  const build = (
+    observedHeadBlockNumber: number
+  ): P2TRSignatureFraudIndependentSignerBoundaryResolution => {
+    const binding = {
+      recordID: `0x${"a1".repeat(32)}`,
+      signerInvocationID: `0x${"a2".repeat(32)}`,
+      boundaryStartedAtUnixMs: 1_000,
+      preparationAttempts: 1,
+      nonceReservationID: `0x${"a3".repeat(32)}`,
+      stage: "prepare" as const,
+      invokedAtUnixMs: 1_100,
+      outcome: "nonce-consumed" as const,
+      nonceConsumption: {
+        chainID: 11155111,
+        sender: TRANSACTION_SENDER,
+        transactionNonce: 7,
+        finalizedAccountNonce: 8,
+        accountNonceReadAtBlock: 500,
+        consumingTransaction: {
+          transactionHash: `0x${"a4".repeat(32)}`,
+          sender: TRANSACTION_SENDER,
+          nonce: 7,
+          blockNumber: 480,
+          blockHash: `0x${"a5".repeat(32)}`,
+        },
+        finalizedThrough: {
+          blockNumber: 500,
+          blockHash: `0x${"a6".repeat(32)}`,
+        },
+        observedHead: {
+          blockNumber: observedHeadBlockNumber,
+          blockHash: `0x${"a7".repeat(32)}`,
+        },
+      },
+      providerEvidenceDigest: `0x${"a8".repeat(32)}`,
+    }
+    const evidenceDigest =
+      computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest(binding)
+    return {
+      ...binding,
+      evidenceDigest,
+      canonicalAttestations: [
+        {
+          trustDomainID: "primary",
+          independenceDomainID: "primary-infra",
+          evidenceDigest,
+          attestation: "0x01",
+          attestedAtUnixMs: 1_200,
+        },
+        {
+          trustDomainID: "corroborating",
+          independenceDomainID: "corroborating-infra",
+          evidenceDigest,
+          attestation: "0x02",
+          attestedAtUnixMs: 1_200,
+        },
+      ],
+      resolvedAtUnixMs: 1_300,
+    }
+  }
+
+  assert.throws(
+    () =>
+      validateP2TRSignatureFraudIndependentSignerBoundaryResolution(build(563)),
+    /finality depth must be at least 64 blocks/
+  )
+  assert.ok(
+    validateP2TRSignatureFraudIndependentSignerBoundaryResolution(build(564))
   )
 })

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -4102,4 +4102,3 @@ test("refuses a reconciler whose finality depth is below consensus finality", as
     )
   )
 })
-

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -977,7 +977,9 @@ const SECOND_LANE_WALLET = new Wallet(SECOND_LANE_SIGNING_KEY)
 // The blob must carry the calldata of the intent it will be bound to, so lane B
 // signs the second test intent's call, not the default one.
 const SECOND_INTENT_SEED = "bb"
-const secondIntentCall = completeV2TestCall(`0x${SECOND_INTENT_SEED.repeat(32)}`)
+const secondIntentCall = completeV2TestCall(
+  `0x${SECOND_INTENT_SEED.repeat(32)}`
+)
 const secondLaneSignedTransaction = signTestChallengeTransaction(
   secondIntentCall.calldata,
   20,
@@ -3904,7 +3906,11 @@ const orphanLaneA = async (
   store: InMemoryOutboxStore,
   preparers: readonly P2TRSignatureFraudChallengeTransactionPreparer[]
 ): Promise<{ now: () => number; release: () => void }> => {
-  const record = await enqueue(store, createIntent(), twoLaneFeePolicyManifest())
+  const record = await enqueue(
+    store,
+    createIntent(),
+    twoLaneFeePolicyManifest()
+  )
   const authorizer = new FixedBoundaryAuthorizer()
   let now = 2_000
   let markStarted!: () => void

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -62,6 +62,7 @@ import {
   P2TRSignatureFraudRawTransactionBroadcaster,
   P2TRSignatureFraudSignerQuarantine,
   P2TR_SIGNATURE_FRAUD_OUTBOX_MAX_TRUST_DOMAIN_ID_LENGTH,
+  P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS,
   computeP2TRSignatureFraudEthereumEligibilityReadSetHash,
   computeP2TRSignatureFraudChallengeFeePolicyHash,
   computeP2TRSignatureFraudCancellationEvidenceHash,
@@ -806,7 +807,7 @@ class FixedReconciler implements P2TRSignatureFraudChallengeOutboxReconciler {
   readonly reconciliationTrustDomainID = "reconciliation.test"
   readonly reconciliationIndependenceDomainID = "reconciliation-infra.test"
   readonly providerIdentity = {}
-  readonly finalityConfirmationBlocks = 12
+  readonly finalityConfirmationBlocks = 64
   readonly canonicalSubmissionSelectors = [
     { variant: "router-process" as const, selector: "0xf1f87d85" },
     { variant: "router-direct" as const, selector: "0xa1c114f9" },
@@ -1214,7 +1215,7 @@ const acceptedOwnResolution = (
   withCanonicalAttestations({
     status: "accepted-own",
     observedHead: {
-      blockNumber: 120,
+      blockNumber: 172,
       blockHash: `0x${"12".repeat(32)}`,
     },
     finalizedThrough: {
@@ -3160,7 +3161,7 @@ test("accepts only decoded, finalized canonical own evidence", async () => {
 test("keeps eligible evidence open after finalized nonce disposition", async () => {
   const finalizedEvidence = {
     observedHead: {
-      blockNumber: 120,
+      blockNumber: 172,
       blockHash: `0x${"12".repeat(32)}`,
     },
     finalizedThrough: {
@@ -4064,3 +4065,41 @@ test("recovery still sweeps a preparing record that has selected no lane", async
   assert.equal((await store.get(record.recordID))?.status, "queued")
   assert.equal(await store.hasExpiredPreparationLeases(40_001), false)
 })
+
+// The depth gates irreversible conclusions -- retiring a generation, and
+// treating a nonce as spent so an orphaned signer boundary can be resolved
+// without asking the signer what it did. A reconciler that may declare any
+// positive depth can have a one-block reorg un-consume a nonce already recorded
+// as spent, so the floor is enforced where the reconciler is validated.
+test("refuses a reconciler whose finality depth is below consensus finality", async () => {
+  const store = new InMemoryOutboxStore()
+  const shallow = new FixedReconciler()
+  ;(shallow as unknown as Record<string, unknown>).finalityConfirmationBlocks =
+    P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS - 1
+  assert.throws(
+    () =>
+      dispatcher(
+        store,
+        new FixedPreparer(),
+        new RecordingBroadcaster(),
+        new FixedRechecker(),
+        shallow
+      ),
+    /finality confirmation depth must be at least 64 blocks/
+  )
+
+  // The floor is a minimum, not an equality: more depth stays acceptable.
+  const deeper = new FixedReconciler()
+  ;(deeper as unknown as Record<string, unknown>).finalityConfirmationBlocks =
+    P2TR_SIGNATURE_FRAUD_OUTBOX_MIN_FINALITY_CONFIRMATION_BLOCKS + 1
+  assert.ok(
+    dispatcher(
+      store,
+      new FixedPreparer(),
+      new RecordingBroadcaster(),
+      new FixedRechecker(),
+      deeper
+    )
+  )
+})
+

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -18,6 +18,15 @@ const lateArtifactMigrationSource = readFileSync(
   "utf8"
 )
 const lateArtifactMigration = lateArtifactMigrationSource.replace(/\s+/g, " ")
+const nonceFinalityMigrationURL = new URL(
+  "006_p2tr_signer_boundary_nonce_finality.sql",
+  migrationsURL
+)
+const nonceFinalityMigrationSource = readFileSync(
+  nonceFinalityMigrationURL,
+  "utf8"
+)
+const nonceFinalityMigration = nonceFinalityMigrationSource.replace(/\s+/g, " ")
 const activationHandshakeSource = readFileSync(
   new URL(
     "../src/PostgresP2TRSignatureFraudOutboxActivationHandshake.ts",
@@ -51,9 +60,14 @@ test("leaves transaction ownership to the ordered migration runner", () => {
   const lateArtifactIndex = orderedMigrations.indexOf(
     "005_p2tr_signer_boundary_late_artifact.sql"
   )
+  const nonceFinalityIndex = orderedMigrations.indexOf(
+    "006_p2tr_signer_boundary_nonce_finality.sql"
+  )
   assert.notEqual(challengeOutboxIndex, -1)
   assert.notEqual(lateArtifactIndex, -1)
+  assert.notEqual(nonceFinalityIndex, -1)
   assert.ok(challengeOutboxIndex < lateArtifactIndex)
+  assert.ok(lateArtifactIndex < nonceFinalityIndex)
   if (canonicalJournalIndex !== -1) {
     assert.ok(canonicalJournalIndex < challengeOutboxIndex)
   }
@@ -661,7 +675,27 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution/
   )
-  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v5/)
+  // Migration 003 is immutable because the runner checksum-tracks its exact
+  // published bytes. The v5 digest and its observed-head columns are appended
+  // by migration 006 for both fresh databases and upgrades.
+  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v4/)
+  assert.doesNotMatch(migration, /nonce_consumption_observed_head/)
+  assert.match(
+    nonceFinalityMigration,
+    /ADD COLUMN nonce_consumption_observed_head_block_number bigint/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /ADD COLUMN nonce_consumption_observed_head_block_hash bytea/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /CREATE OR REPLACE FUNCTION p2tr_signature_fraud_guard_signer_boundary_resolution\(\)/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /tbtc-p2tr-signer-boundary-independent-resolution-v5/
+  )
   // The deterministic invocation ID is the row identity, so evidence can never
   // speak for a boundary other than the one it names — and unlike the wall-clock
   // tuple it replaced, it cannot drift while the boundary is open.
@@ -692,8 +726,12 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
   )
   assert.match(migration, /nonce consumption names another sender lane/)
   assert.match(
-    migration,
+    nonceFinalityMigration,
     /nonce_consumption_observed_head_block_number\s+- nonce_consumption_finalized_block_number >= 64/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /p2tr_signer_boundary_nonce_finality_v5[\s\S]*NOT VALID/
   )
   assert.match(
     migration,

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -690,6 +690,18 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
   )
   assert.match(
     nonceFinalityMigration,
+    /ADD COLUMN resolution_evidence_version smallint NOT NULL DEFAULT 4/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /ALTER COLUMN resolution_evidence_version SET DEFAULT 5/
+  )
+  assert.match(
+    nonceFinalityMigration,
+    /ADD CONSTRAINT p2tr_signer_boundary_evidence_version_v5\s+CHECK \(resolution_evidence_version = 5\) NOT VALID/
+  )
+  assert.match(
+    nonceFinalityMigration,
     /CREATE OR REPLACE FUNCTION p2tr_signature_fraud_guard_signer_boundary_resolution\(\)/
   )
   assert.match(

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -164,7 +164,7 @@ test("never expires a resultless allocator invocation by wall clock", () => {
   )
   assert.match(
     migration,
-    /active_release_request_id IS NULL AND active_signer_invocation_count = 0/
+    /WHERE chain_id = lane_chain_id AND sender = lane_sender AND active_release_request_id IS NULL AND active_signer_invocation_count = 0/
   )
   assert.match(
     migration,
@@ -621,7 +621,38 @@ test("serializes nonce-release and signer I/O through a durable barrier", () => 
   )
   assert.match(
     migration,
-    /contract_mismatch_blocked = contract_mismatch_blocked OR NEW.result_kind = 'contract-mismatch'/
+    /CREATE TABLE p2tr_signature_fraud_nonce_allocator_global_barrier/
+  )
+  // The lane barrier is keyed by the nonce lane -- the sending account -- so
+  // one account's outstanding allocator I/O cannot freeze signing on another.
+  assert.match(
+    migration,
+    /CREATE TABLE p2tr_signature_fraud_nonce_allocator_safety_barrier \( chain_id numeric\(78, 0\) NOT NULL CHECK \(chain_id > 0\), sender bytea NOT NULL CHECK \(octet_length\(sender\) = 20\),/
+  )
+  assert.match(migration, /PRIMARY KEY \(chain_id, sender\),/)
+  // Without this the attempt reference carries no lane and one lane's row
+  // could hold another lane's claim.
+  assert.match(
+    migration,
+    /FOREIGN KEY \( chain_id, sender, active_release_request_id \) REFERENCES p2tr_signature_fraud_challenge_nonce_release_request \( chain_id, sender, release_request_id \)/
+  )
+  // Rows are seeded eagerly, because every gate reads a missing row as
+  // fail-closed and the activation rollup needs the row set to be ground truth.
+  assert.match(
+    migration,
+    /p2tr_signature_fraud_seed_nonce_allocator_lane_barrier_trigger AFTER INSERT ON p2tr_signature_fraud_signer_lane_configuration/
+  )
+  // The decrement must key off OLD: the update that clears the marker can clear
+  // the lane selection at the same time.
+  assert.match(
+    migration,
+    /active_signer_invocation_count - 1 WHERE chain_id = OLD.chain_id AND sender = OLD.selected_sender/
+  )
+  // A contract mismatch condemns the allocator, not one account, so it stays
+  // global and blocks every lane.
+  assert.match(
+    migration,
+    /UPDATE p2tr_signature_fraud_nonce_allocator_global_barrier SET contract_mismatch_blocked = true, incident_epoch = incident_epoch \+ 1/
   )
 })
 

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutboxMigration.test.ts
@@ -661,7 +661,7 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     migration,
     /CREATE TABLE p2tr_signature_fraud_challenge_signer_boundary_resolution/
   )
-  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v4/)
+  assert.match(migration, /tbtc-p2tr-signer-boundary-independent-resolution-v5/)
   // The deterministic invocation ID is the row identity, so evidence can never
   // speak for a boundary other than the one it names — and unlike the wall-clock
   // tuple it replaced, it cannot drift while the boundary is open.
@@ -691,6 +691,10 @@ test("resolves an orphaned signer boundary only on dual-attested evidence", () =
     /CHECK \( \(outcome = 'nonce-consumed'\) = \(nonce_consumption_transaction_hash IS NOT NULL\) \)/
   )
   assert.match(migration, /nonce consumption names another sender lane/)
+  assert.match(
+    migration,
+    /nonce_consumption_observed_head_block_number\s+- nonce_consumption_finalized_block_number >= 64/
+  )
   assert.match(
     migration,
     /CHECK \(\(outcome = 'signed'\) = \(signed_transaction_hash IS NOT NULL\)\)/

--- a/services/watchtower/test/P2TRSignatureFraudWatchtowerService.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudWatchtowerService.test.ts
@@ -214,7 +214,7 @@ class FakeSubmitter
   readonly p2trSignatureFraudWatchtowerIdempotentSubmissions = true
   readonly submissionTrustDomainID = "submitter.test"
   readonly reconciliationTrustDomainID = "reconciler.test"
-  readonly finalityConfirmationBlocks = 12
+  readonly finalityConfirmationBlocks = 64
   submissionCount = 0
   private readonly submittedChallenges = new Map<string, string>()
 
@@ -248,7 +248,7 @@ class FakeSubmitter
 const acceptedChallengeBroadcastReconciler: P2TRSignatureFraudChallengeBroadcastReconciler =
   {
     reconciliationTrustDomainID: "reconciler.test",
-    finalityConfirmationBlocks: 12,
+    finalityConfirmationBlocks: 64,
     async reconcileSignatureFraudChallengeBroadcast() {
       return { status: "accepted" }
     },

--- a/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
+++ b/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
+import { readdirSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { describe, it } from "node:test"
+import pg from "pg"
 import {
   runP2TRWatchtowerMigrations,
   validateP2TRWatchtowerMigrationBody,
@@ -240,3 +242,48 @@ class MigrationClient implements P2TRWatchtowerMigrationClient {
     this.releasedWith = error
   }
 }
+
+// Every assertion above reads the migrations as TEXT. That cannot see a
+// statement PostgreSQL refuses to parse, and one shipped undetected: migration
+// 004 aliased a table `authorization`, a reserved key word, so the whole file
+// failed at the first reference to it and the tables, foreign keys and
+// append-only triggers it declares existed in no database. Nothing else applies
+// 004 -- the adapter suites stop at 003 -- so this is the only test that would
+// have caught it. It applies every migration, in order, to a real server.
+describe("P2TR watchtower migrations apply to PostgreSQL", () => {
+  const postgresURL = process.env.P2TR_WATCHTOWER_TEST_POSTGRES_URL
+  const postgresIt = postgresURL === undefined ? it.skip : it
+
+  postgresIt("applies every migration in order to a fresh schema", async () => {
+    const migrationsURL = new URL("../migrations/", import.meta.url)
+    const ordered = readdirSync(migrationsURL)
+      .filter((name) => /^\d{3}_.+\.sql$/.test(name))
+      .sort()
+    assert.ok(ordered.length >= 4, "expected the full migration set")
+
+    const client = new pg.Client({ connectionString: postgresURL })
+    await client.connect()
+    const schema = `p2tr_migrations_${process.pid}_${Date.now()}`
+    try {
+      await client.query(`CREATE SCHEMA ${schema}`)
+      await client.query(`SET search_path TO ${schema}`)
+      for (const name of ordered) {
+        const body = await readFile(new URL(name, migrationsURL), "utf8")
+        // The runner validates each body before it reaches the server; hold
+        // this test to the same contract so the two cannot drift.
+        assert.doesNotThrow(
+          () => validateP2TRWatchtowerMigrationBody(body),
+          `${name} is not a valid migration body`
+        )
+        try {
+          await client.query(body)
+        } catch (error) {
+          assert.fail(`${name} failed to apply: ${(error as Error).message}`)
+        }
+      }
+    } finally {
+      await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      await client.end()
+    }
+  })
+})

--- a/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
+++ b/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
@@ -350,7 +350,8 @@ describe("P2TR watchtower migrations apply to PostgreSQL", () => {
                   'p2tr_signature_fraud_challenge_signer_boundary_resolution'
               AND column_name IN (
                   'nonce_consumption_observed_head_block_number',
-                  'nonce_consumption_observed_head_block_hash'
+                  'nonce_consumption_observed_head_block_hash',
+                  'resolution_evidence_version'
               )
             ORDER BY column_name`,
           [schema]
@@ -360,17 +361,47 @@ describe("P2TR watchtower migrations apply to PostgreSQL", () => {
           [
             "nonce_consumption_observed_head_block_hash",
             "nonce_consumption_observed_head_block_number",
+            "resolution_evidence_version",
           ]
         )
 
-        const constraint = await client.query<{ convalidated: boolean }>(
-          `SELECT convalidated
-             FROM pg_constraint
-            WHERE conname = 'p2tr_signer_boundary_nonce_finality_v5'
-              AND connamespace = $1::regnamespace`,
+        const evidenceVersionDefault = await client.query<{
+          column_default: string
+        }>(
+          `SELECT column_default
+             FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name =
+                  'p2tr_signature_fraud_challenge_signer_boundary_resolution'
+              AND column_name = 'resolution_evidence_version'`,
           [schema]
         )
-        assert.deepEqual(constraint.rows, [{ convalidated: false }])
+        assert.match(evidenceVersionDefault.rows[0].column_default, /5/)
+
+        const constraints = await client.query<{
+          conname: string
+          convalidated: boolean
+        }>(
+          `SELECT conname, convalidated
+             FROM pg_constraint
+            WHERE conname IN (
+                      'p2tr_signer_boundary_evidence_version_v5',
+                      'p2tr_signer_boundary_nonce_finality_v5'
+                  )
+              AND connamespace = $1::regnamespace
+            ORDER BY conname`,
+          [schema]
+        )
+        assert.deepEqual(constraints.rows, [
+          {
+            conname: "p2tr_signer_boundary_evidence_version_v5",
+            convalidated: false,
+          },
+          {
+            conname: "p2tr_signer_boundary_nonce_finality_v5",
+            convalidated: false,
+          },
+        ])
 
         const guard = await client.query<{ definition: string }>(
           `SELECT pg_get_functiondef(

--- a/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
+++ b/services/watchtower/test/P2TRWatchtowerMigrations.test.ts
@@ -2,16 +2,35 @@ import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
 import { readdirSync } from "node:fs"
 import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
 import { describe, it } from "node:test"
 import pg from "pg"
 import {
+  loadP2TRWatchtowerMigrations,
   runP2TRWatchtowerMigrations,
   validateP2TRWatchtowerMigrationBody,
   type P2TRWatchtowerMigration,
   type P2TRWatchtowerMigrationClient,
 } from "../src/P2TRWatchtowerMigrations.js"
 
+const PUBLISHED_OUTBOX_MIGRATION_CHECKSUM =
+  "e6887e75e5c2baa0a97a6c68d911c604c4c5750cbc0c250dad2502739e8b88bc"
+
 describe("P2TR watchtower migration bodies", () => {
+  it("preserves the published migration 003 checksum", async () => {
+    const migration = await readFile(
+      new URL(
+        "../migrations/003_p2tr_signature_fraud_challenge_outbox.sql",
+        import.meta.url
+      )
+    )
+
+    assert.equal(
+      createHash("sha256").update(migration).digest("hex"),
+      PUBLISHED_OUTBOX_MIGRATION_CHECKSUM
+    )
+  })
+
   it("rejects every top-level transaction-control token", () => {
     for (const control of [
       "BEGIN",
@@ -247,9 +266,10 @@ class MigrationClient implements P2TRWatchtowerMigrationClient {
 // statement PostgreSQL refuses to parse, and one shipped undetected: migration
 // 004 aliased a table `authorization`, a reserved key word, so the whole file
 // failed at the first reference to it and the tables, foreign keys and
-// append-only triggers it declares existed in no database. Nothing else applies
-// 004 -- the adapter suites stop at 003 -- so this is the only test that would
-// have caught it. It applies every migration, in order, to a real server.
+// append-only triggers it declares existed in no database. The outbox adapter
+// suite applies the complete schema but does not directly exercise 004's retry
+// journal, so this remains the test that applies every migration in order and
+// verifies the ordered upgrade path on a real server.
 describe("P2TR watchtower migrations apply to PostgreSQL", () => {
   const postgresURL = process.env.P2TR_WATCHTOWER_TEST_POSTGRES_URL
   const postgresIt = postgresURL === undefined ? it.skip : it
@@ -259,7 +279,7 @@ describe("P2TR watchtower migrations apply to PostgreSQL", () => {
     const ordered = readdirSync(migrationsURL)
       .filter((name) => /^\d{3}_.+\.sql$/.test(name))
       .sort()
-    assert.ok(ordered.length >= 4, "expected the full migration set")
+    assert.ok(ordered.length >= 6, "expected the full migration set")
 
     const client = new pg.Client({ connectionString: postgresURL })
     await client.connect()
@@ -286,4 +306,105 @@ describe("P2TR watchtower migrations apply to PostgreSQL", () => {
       await client.end()
     }
   })
+
+  postgresIt(
+    "upgrades a checksum-tracked migration 003 database through migration 006",
+    async () => {
+      const migrationsURL = new URL("../migrations/", import.meta.url)
+      const migrations = await loadP2TRWatchtowerMigrations(
+        fileURLToPath(migrationsURL)
+      )
+      assert.equal(migrations[2].checksum, PUBLISHED_OUTBOX_MIGRATION_CHECKSUM)
+
+      const client = new pg.Client({ connectionString: postgresURL })
+      await client.connect()
+      const schema = `p2tr_migration_upgrade_${process.pid}_${Date.now()}`
+      try {
+        await client.query(`CREATE SCHEMA ${schema}`)
+        await client.query(`SET search_path TO ${schema}`)
+        const pool = {
+          connect: async () => postgresMigrationClient(client),
+        }
+
+        const installed = await runP2TRWatchtowerMigrations(
+          pool,
+          migrations.slice(0, 4)
+        )
+        assert.deepEqual(
+          installed.applied.map(({ version }) => version),
+          [1, 2, 3, 4]
+        )
+
+        const upgraded = await runP2TRWatchtowerMigrations(pool, migrations)
+        assert.deepEqual(
+          upgraded.applied.map(({ version }) => version),
+          [5, 6]
+        )
+        assert.equal(upgraded.current.length, 6)
+
+        const columns = await client.query<{ column_name: string }>(
+          `SELECT column_name
+             FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name =
+                  'p2tr_signature_fraud_challenge_signer_boundary_resolution'
+              AND column_name IN (
+                  'nonce_consumption_observed_head_block_number',
+                  'nonce_consumption_observed_head_block_hash'
+              )
+            ORDER BY column_name`,
+          [schema]
+        )
+        assert.deepEqual(
+          columns.rows.map(({ column_name }) => column_name),
+          [
+            "nonce_consumption_observed_head_block_hash",
+            "nonce_consumption_observed_head_block_number",
+          ]
+        )
+
+        const constraint = await client.query<{ convalidated: boolean }>(
+          `SELECT convalidated
+             FROM pg_constraint
+            WHERE conname = 'p2tr_signer_boundary_nonce_finality_v5'
+              AND connamespace = $1::regnamespace`,
+          [schema]
+        )
+        assert.deepEqual(constraint.rows, [{ convalidated: false }])
+
+        const guard = await client.query<{ definition: string }>(
+          `SELECT pg_get_functiondef(
+                    'p2tr_signature_fraud_guard_signer_boundary_resolution()'
+                    ::regprocedure
+                  ) AS definition`
+        )
+        assert.match(
+          guard.rows[0].definition,
+          /tbtc-p2tr-signer-boundary-independent-resolution-v5/
+        )
+        assert.match(
+          guard.rows[0].definition,
+          /nonce_consumption_observed_head_block_number/
+        )
+      } finally {
+        await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+        await client.end()
+      }
+    }
+  )
 })
+
+function postgresMigrationClient(
+  client: pg.Client
+): P2TRWatchtowerMigrationClient {
+  return {
+    async query(text, values) {
+      const result = await client.query(
+        text,
+        values === undefined ? undefined : [...values]
+      )
+      return { rows: result.rows, rowCount: result.rowCount }
+    },
+    release() {},
+  }
+}

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -2946,7 +2946,7 @@ function boundaryResolution(
               blockHash: `0x${"c3".repeat(32)}`,
             },
             observedHead: {
-              blockNumber: 512,
+              blockNumber: 564,
               blockHash: `0x${"c4".repeat(32)}`,
             },
           },
@@ -3797,6 +3797,45 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
     expectedAlertCodes: [],
   },
   {
+    // A nonce that appears consumed near the head can become live again in an
+    // ordinary reorg. Direct boundary evidence therefore uses the same
+    // consensus-finality floor as ordinary reconciliation.
+    name: "refuses shallow nonce-consumption finality",
+    seed: 245,
+    boundary: orphanedBoundaryOnly,
+    resolutions: [
+      {
+        outcome: "nonce-consumed",
+        nonceConsumption: {
+          chainID: CHAIN_ID,
+          sender: WALLET.address,
+          transactionNonce: 7,
+          finalizedAccountNonce: 8,
+          accountNonceReadAtBlock: 500,
+          consumingTransaction: {
+            transactionHash: `0x${"c1".repeat(32)}`,
+            sender: WALLET.address,
+            nonce: 7,
+            blockNumber: 480,
+            blockHash: `0x${"c2".repeat(32)}`,
+          },
+          finalizedThrough: {
+            blockNumber: 500,
+            blockHash: `0x${"c3".repeat(32)}`,
+          },
+          observedHead: {
+            blockNumber: 563,
+            blockHash: `0x${"c4".repeat(32)}`,
+          },
+        },
+      },
+    ],
+    expected: [
+      "error:Signer-boundary nonce consumption finality depth must be at least 64 blocks",
+    ],
+    expectedAlertCodes: [],
+  },
+  {
     // Permitted precisely BECAUSE bytes may have escaped -- that is what nonce
     // consumption makes harmless. never-invoked refuses this same record.
     name: "settles a nonce-consumed boundary that carries escape evidence",
@@ -3845,7 +3884,7 @@ const orphanedBoundaryParityScenarios: OrphanedBoundaryScenario[] = [
             blockHash: `0x${"c3".repeat(32)}`,
           },
           observedHead: {
-            blockNumber: 512,
+            blockNumber: 564,
             blockHash: `0x${"c4".repeat(32)}`,
           },
         },

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -4331,3 +4331,55 @@ postgresTest(
     await database.client.end()
   }
 )
+
+// The one-shot property, which is what makes a provider's answer binding.
+// `never-invoked` rests on a provider receipt the watchtower cannot verify --
+// the bytes are opaque to it -- so the guarantee it CAN offer is that an
+// invocation is answered exactly once: the resolution must name the live
+// marker, and it clears that marker in the same transaction. A provider that
+// later contradicts itself has nowhere to put the second answer.
+postgresTest(
+  "answers each signer invocation exactly once, whatever the second answer says",
+  async () => {
+    const database = await createTestDatabase()
+    const { boundary } = await orphanedSignerBoundary(database, 222)
+
+    await begin(database.client)
+    assert.equal(
+      await database.store.resolveOrphanedSignerBoundary(
+        boundaryResolution(boundary)
+      ),
+      "acknowledged"
+    )
+    await commit(database.client)
+
+    // Same invocation, opposite claim. The marker it would have to name is
+    // gone, so there is no way to record a contradiction.
+    await assert.rejects(
+      database.store.resolveOrphanedSignerBoundary(
+        boundaryResolution(boundary, {
+          outcome: "signed",
+          signedTransactionHash: `0x${"5e".repeat(32)}`,
+        })
+      ),
+      /Independent signer-boundary resolution conflicts/
+    )
+
+    // Replaying the identical answer is not a contradiction, so it stays
+    // idempotent rather than becoming a second, conflicting record.
+    await begin(database.client)
+    assert.equal(
+      await database.store.resolveOrphanedSignerBoundary(
+        boundaryResolution(boundary)
+      ),
+      "acknowledged"
+    )
+    await commit(database.client)
+    const stored = await database.client.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM p2tr_signature_fraud_challenge_signer_boundary_resolution`
+    )
+    assert.equal(stored.rows[0].count, "1")
+    await database.client.end()
+  }
+)

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -74,7 +74,7 @@ type TestDatabase = {
 
 async function createTestDatabase(
   maxActiveOutboxRecords = 1_024,
-  migrationCount = 5
+  migrationCount = 6
 ): Promise<TestDatabase> {
   const client = new Client({ connectionString: postgresURL })
   await client.connect()
@@ -3162,7 +3162,7 @@ async function orphanedSignerBoundary(
 }
 
 postgresTest(
-  "replays grandfathered v4 signer-boundary evidence after migration 005",
+  "replays grandfathered v4 signer-boundary evidence after migration 006",
   async () => {
     const database = await createTestDatabase(1_024, 4)
     const { boundary } = await orphanedSignerBoundary(database, 209)
@@ -3187,7 +3187,7 @@ postgresTest(
     await database.client.query(
       await readFile(
         new URL(
-          "../migrations/005_p2tr_signer_boundary_nonce_finality.sql",
+          "../migrations/006_p2tr_signer_boundary_nonce_finality.sql",
           import.meta.url
         ),
         "utf8"

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -29,6 +29,7 @@ import {
   computeP2TRSignatureFraudCanonicalProvenanceFingerprint,
   computeP2TRSignatureFraudCanonicalProvenanceInvalidationEvidenceHash,
   computeP2TRSignatureFraudChallengeFeePolicyHash,
+  computeP2TRSignatureFraudLegacyV4SignerBoundaryResolutionEvidenceDigest,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
   computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest,
 } from "../src/P2TRSignatureFraudChallengeOutbox.js"
@@ -72,7 +73,8 @@ type TestDatabase = {
 }
 
 async function createTestDatabase(
-  maxActiveOutboxRecords = 1_024
+  maxActiveOutboxRecords = 1_024,
+  migrationCount = 5
 ): Promise<TestDatabase> {
   const client = new Client({ connectionString: postgresURL })
   await client.connect()
@@ -109,7 +111,7 @@ async function createTestDatabase(
       "../migrations/006_p2tr_signer_boundary_nonce_finality.sql",
       import.meta.url
     ),
-  ]) {
+  ].slice(0, migrationCount)) {
     await client.query(await readFile(migration, "utf8"))
   }
   await seedCanonicalPoint(client, maxActiveOutboxRecords)
@@ -2922,7 +2924,8 @@ function boundaryAttestations(
  */
 function boundaryResolution(
   record: P2TRSignatureFraudChallengeOutboxRecord,
-  overrides: BoundaryResolutionOverrides = {}
+  overrides: BoundaryResolutionOverrides = {},
+  computeEvidenceDigest = computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest
 ): P2TRSignatureFraudIndependentSignerBoundaryResolution {
   const outcome = overrides.outcome ?? "never-invoked"
   const invocationID =
@@ -2992,8 +2995,7 @@ function boundaryResolution(
       overrides.providerEvidenceDigest ?? BOUNDARY_PROVIDER_DIGEST,
   }
   const evidenceDigest =
-    overrides.evidenceDigest ??
-    computeP2TRSignatureFraudSignerBoundaryResolutionEvidenceDigest(binding)
+    overrides.evidenceDigest ?? computeEvidenceDigest(binding)
   const resolvedAtUnixMs = overrides.resolvedAtUnixMs ?? 2_400
   return {
     ...binding,
@@ -3005,6 +3007,89 @@ function boundaryResolution(
     ),
     resolvedAtUnixMs,
   }
+}
+
+function legacyV4BoundaryResolution(
+  record: P2TRSignatureFraudChallengeOutboxRecord,
+  overrides: BoundaryResolutionOverrides = {}
+): P2TRSignatureFraudIndependentSignerBoundaryResolution {
+  return boundaryResolution(
+    record,
+    overrides,
+    computeP2TRSignatureFraudLegacyV4SignerBoundaryResolutionEvidenceDigest
+  )
+}
+
+async function insertLegacyV4BoundaryResolution(
+  database: TestDatabase,
+  resolution: P2TRSignatureFraudIndependentSignerBoundaryResolution
+): Promise<void> {
+  const [primary, corroborating] = resolution.canonicalAttestations
+  await database.client.query(
+    `INSERT INTO p2tr_signature_fraud_challenge_signer_boundary_resolution (
+        record_id, signer_invocation_id, boundary_started_at_unix_ms,
+        preparation_attempts, nonce_reservation_id, stage,
+        invoked_at_unix_ms, outcome, signed_transaction_hash,
+        provider_evidence_digest, resolution_evidence_digest,
+        primary_trust_domain_id, primary_independence_domain_id,
+        primary_evidence_digest, primary_attestation,
+        primary_attested_at_unix_ms, corroborating_trust_domain_id,
+        corroborating_independence_domain_id,
+        corroborating_evidence_digest, corroborating_attestation,
+        corroborating_attested_at_unix_ms, resolved_at_unix_ms,
+        provider_tombstone_receipt, provider_tombstone_at_unix_ms,
+        nonce_consumption_chain_id, nonce_consumption_nonce,
+        nonce_consumption_account_nonce, nonce_consumption_read_at_block,
+        nonce_consumption_transaction_hash,
+        nonce_consumption_finalized_block_number,
+        nonce_consumption_finalized_block_hash
+     ) VALUES (
+        decode($1, 'hex'), decode($2, 'hex'), $3, $4,
+        decode($5, 'hex'), $6, $7, $8,
+        CASE WHEN $9::text IS NULL THEN NULL ELSE decode($9, 'hex') END,
+        decode($10, 'hex'), decode($11, 'hex'), $12, $13,
+        decode($11, 'hex'), decode($14, 'hex'), $15, $16, $17,
+        decode($11, 'hex'), decode($18, 'hex'), $19, $20,
+        CASE WHEN $21::text IS NULL THEN NULL ELSE decode($21, 'hex') END,
+        $22, $23, $24, $25, $26,
+        CASE WHEN $27::text IS NULL THEN NULL ELSE decode($27, 'hex') END,
+        $28,
+        CASE WHEN $29::text IS NULL THEN NULL ELSE decode($29, 'hex') END
+     )`,
+    [
+      resolution.recordID.slice(2),
+      resolution.signerInvocationID.slice(2),
+      resolution.boundaryStartedAtUnixMs,
+      resolution.preparationAttempts,
+      resolution.nonceReservationID.slice(2),
+      resolution.stage,
+      resolution.invokedAtUnixMs,
+      resolution.outcome,
+      resolution.signedTransactionHash?.slice(2) ?? null,
+      resolution.providerEvidenceDigest.slice(2),
+      resolution.evidenceDigest.slice(2),
+      primary.trustDomainID,
+      primary.independenceDomainID,
+      primary.attestation.slice(2),
+      primary.attestedAtUnixMs,
+      corroborating.trustDomainID,
+      corroborating.independenceDomainID,
+      corroborating.attestation.slice(2),
+      corroborating.attestedAtUnixMs,
+      resolution.resolvedAtUnixMs,
+      resolution.providerTombstone?.receipt.slice(2) ?? null,
+      resolution.providerTombstone?.tombstonedAtUnixMs ?? null,
+      resolution.nonceConsumption?.chainID ?? null,
+      resolution.nonceConsumption?.transactionNonce ?? null,
+      resolution.nonceConsumption?.finalizedAccountNonce ?? null,
+      resolution.nonceConsumption?.accountNonceReadAtBlock ?? null,
+      resolution.nonceConsumption?.consumingTransaction.transactionHash.slice(
+        2
+      ) ?? null,
+      resolution.nonceConsumption?.finalizedThrough.blockNumber ?? null,
+      resolution.nonceConsumption?.finalizedThrough.blockHash.slice(2) ?? null,
+    ]
+  )
 }
 
 // The barrier is keyed per nonce lane, so the store-wide quantity these tests
@@ -3075,6 +3160,95 @@ async function orphanedSignerBoundary(
   await commit(database.client)
   return { initial, boundary }
 }
+
+postgresTest(
+  "replays grandfathered v4 signer-boundary evidence after migration 005",
+  async () => {
+    const database = await createTestDatabase(1_024, 4)
+    const { boundary } = await orphanedSignerBoundary(database, 209)
+    const currentConsumption = boundaryResolution(boundary, {
+      outcome: "nonce-consumed",
+    }).nonceConsumption!
+    const legacyResolution = legacyV4BoundaryResolution(boundary, {
+      outcome: "nonce-consumed",
+      nonceConsumption: {
+        ...currentConsumption,
+        observedHead: {
+          blockNumber: 512,
+          blockHash: currentConsumption.observedHead.blockHash,
+        },
+      },
+    })
+
+    await begin(database.client)
+    await insertLegacyV4BoundaryResolution(database, legacyResolution)
+    await commit(database.client)
+
+    await database.client.query(
+      await readFile(
+        new URL(
+          "../migrations/005_p2tr_signer_boundary_nonce_finality.sql",
+          import.meta.url
+        ),
+        "utf8"
+      )
+    )
+    const grandfathered = await database.client.query<{
+      resolution_evidence_version: number
+    }>(
+      `SELECT resolution_evidence_version
+         FROM p2tr_signature_fraud_challenge_signer_boundary_resolution
+        WHERE record_id = decode($1, 'hex')`,
+      [legacyResolution.recordID.slice(2)]
+    )
+    assert.deepEqual(grandfathered.rows, [{ resolution_evidence_version: 4 }])
+
+    // This exact pre-upgrade payload has only twelve observed-head blocks. The
+    // current v5 validator rejects it, but the immutable v4 row must still make
+    // a lost-response retry idempotent rather than a permanent false conflict.
+    await begin(database.client)
+    assert.equal(
+      await database.store.resolveOrphanedSignerBoundary(legacyResolution),
+      "acknowledged"
+    )
+    await commit(database.client)
+
+    await begin(database.client)
+    await assert.rejects(
+      database.store.resolveOrphanedSignerBoundary({
+        ...legacyResolution,
+        providerEvidenceDigest: `0x${"ab".repeat(32)}`,
+      }),
+      /Independent signer-boundary resolution conflicts/
+    )
+    await database.client.query("ROLLBACK")
+    await database.client.end()
+
+    // The compatibility branch is not an insertion escape hatch: ordinary
+    // post-upgrade resolutions continue to use and persist evidence version 5.
+    const currentDatabase = await createTestDatabase()
+    const { boundary: currentBoundary } = await orphanedSignerBoundary(
+      currentDatabase,
+      210
+    )
+    await begin(currentDatabase.client)
+    assert.equal(
+      await currentDatabase.store.resolveOrphanedSignerBoundary(
+        boundaryResolution(currentBoundary, { outcome: "nonce-consumed" })
+      ),
+      "acknowledged"
+    )
+    await commit(currentDatabase.client)
+    const versions = await currentDatabase.client.query<{
+      resolution_evidence_version: number
+    }>(
+      `SELECT resolution_evidence_version
+         FROM p2tr_signature_fraud_challenge_signer_boundary_resolution`
+    )
+    assert.deepEqual(versions.rows, [{ resolution_evidence_version: 5 }])
+    await currentDatabase.client.end()
+  }
+)
 
 postgresTest(
   "clears an orphaned signer boundary and reopens store-wide nonce-release I/O",

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -4260,48 +4260,45 @@ postgresTest(
 // other test executes. Without this, the adapter could filter on the wrong
 // column, or not filter at all, and every dispatcher-level test would still
 // pass -- they bind to the in-memory double.
-postgresTest(
-  "scopes the recovery predicates to one nonce lane",
-  async () => {
-    const database = await createTestDatabase()
-    await orphanedSignerBoundary(database, 220)
-    const afterLease = 10_000_000
-    const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
-    const otherSender = {
-      chainID: CHAIN_ID,
-      sender: `0x${"cd".repeat(20)}`,
-    }
-    const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
-
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease),
-      true
-    )
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
-      true
-    )
-    // A different account on the same chain, and the same account on a
-    // different chain, are both unaffected.
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
-      false
-    )
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
-      false
-    )
-    // The sender is a lookup key, so its spelling must not matter.
-    assert.equal(
-      await database.store.hasExpiredPreparationLeases(afterLease, {
-        chainID: CHAIN_ID,
-        sender: WALLET.address.toLowerCase(),
-      }),
-      true
-    )
-    await database.client.end()
+postgresTest("scopes the recovery predicates to one nonce lane", async () => {
+  const database = await createTestDatabase()
+  await orphanedSignerBoundary(database, 220)
+  const afterLease = 10_000_000
+  const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
+  const otherSender = {
+    chainID: CHAIN_ID,
+    sender: `0x${"cd".repeat(20)}`,
   }
-)
+  const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
+
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease),
+    true
+  )
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
+    true
+  )
+  // A different account on the same chain, and the same account on a
+  // different chain, are both unaffected.
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
+    false
+  )
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
+    false
+  )
+  // The sender is a lookup key, so its spelling must not matter.
+  assert.equal(
+    await database.store.hasExpiredPreparationLeases(afterLease, {
+      chainID: CHAIN_ID,
+      sender: WALLET.address.toLowerCase(),
+    }),
+    true
+  )
+  await database.client.end()
+})
 
 postgresTest(
   "scopes the pending nonce-release predicate to one nonce lane",

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -1431,10 +1431,13 @@ postgresTest(
       active: Buffer | null
       unresolved: number
     }>(
-      `SELECT active_release_request_id AS active,
-              unresolved_release_count AS unresolved
-         FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
-        WHERE singleton = true`
+      `SELECT (SELECT active_release_request_id
+                 FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+                WHERE active_release_request_id IS NOT NULL
+                LIMIT 1) AS active,
+              (SELECT COALESCE(sum(unresolved_release_count), 0)::integer
+                 FROM p2tr_signature_fraud_nonce_allocator_safety_barrier)
+                AS unresolved`
     )
     assert.deepEqual(barrier.rows[0], { active: null, unresolved: 0 })
 
@@ -2996,15 +2999,32 @@ function boundaryResolution(
   }
 }
 
+// The barrier is keyed per nonce lane, so the store-wide quantity these tests
+// reason about -- "is any lane holding an irreversible signer boundary" -- is
+// the sum across lanes. That is the same rollup the activation handshake reads.
 async function barrierSignerInvocationCount(
   database: TestDatabase
 ): Promise<number> {
   const result = await database.client.query<{ count: string }>(
-    `SELECT active_signer_invocation_count::text AS count
-       FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
-      WHERE singleton = true`
+    `SELECT COALESCE(sum(active_signer_invocation_count), 0)::text AS count
+       FROM p2tr_signature_fraud_nonce_allocator_safety_barrier`
   )
   return Number(result.rows[0].count)
+}
+
+async function laneBarrierSignerInvocationCount(
+  database: TestDatabase,
+  chainID: number,
+  sender: string
+): Promise<number | undefined> {
+  const result = await database.client.query<{ count: string }>(
+    `SELECT active_signer_invocation_count::text AS count
+       FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+      WHERE chain_id = $1::numeric
+        AND sender = $2::bytea`,
+    [String(chainID), Buffer.from(sender.replace(/^0x/, ""), "hex")]
+  )
+  return result.rows.length === 0 ? undefined : Number(result.rows[0].count)
 }
 
 async function blockingProvenanceIncidents(
@@ -4069,3 +4089,168 @@ for (const scenario of orphanedBoundaryParityScenarios) {
     }
   )
 }
+
+// Activation is a whole-service event, so narrowing the barrier's key must not
+// narrow activation safety: the handshake must still refuse if ANY lane has
+// outstanding allocator or signer I/O. Per-lane equality alone cannot see that,
+// because a lane with no barrier row contributes no failing group and no
+// counters -- it reads exactly like a clean store. The four tests below drive
+// the barrier audit to a positive mismatch, which nothing else in the suite
+// does; without them a rollup that silently reports zero passes every test.
+postgresTest(
+  "blocks activation when a lane holding a signer boundary has no barrier row",
+  async () => {
+    const database = await createTestDatabase()
+    await orphanedSignerBoundary(database, 216)
+    assert.equal(await barrierSignerInvocationCount(database), 1)
+
+    // Ground truth (the outbox marker) survives; only the barrier row that
+    // accounts for it is gone.
+    await database.client.query(
+      `DELETE FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+        WHERE active_signer_invocation_count > 0`
+    )
+    assert.equal(await barrierSignerInvocationCount(database), 0)
+
+    await beginSerializable(database.client)
+    const response = await activationProvider(
+      database.client,
+      () => 5_000
+    ).attestActivationChallenge(activationRequest)
+    await commit(database.client)
+
+    assert.equal(response.payload.state.activeSignerInvocationCount, 0)
+    assert.equal(response.payload.state.nonceAllocatorBarrierMismatchCount, 1)
+    assert.equal(response.payload.state.activationBlocked, true)
+    assert.equal(
+      response.payload.state.activationBlockingReasons.includes(
+        "nonce-allocator-barrier-mismatch"
+      ),
+      true
+    )
+    await database.client.end()
+  }
+)
+
+postgresTest(
+  "blocks activation when the barrier table is empty and I/O is outstanding",
+  async () => {
+    const database = await createTestDatabase()
+    await orphanedSignerBoundary(database, 217)
+
+    await database.client.query(
+      `DELETE FROM p2tr_signature_fraud_nonce_allocator_safety_barrier`
+    )
+
+    await beginSerializable(database.client)
+    const response = await activationProvider(
+      database.client,
+      () => 5_000
+    ).attestActivationChallenge(activationRequest)
+    await commit(database.client)
+
+    // Every counter reads clean, which is precisely the failure mode: only the
+    // whole-store sum equality distinguishes this from an idle service.
+    assert.equal(response.payload.state.activeSignerInvocationCount, 0)
+    assert.equal(response.payload.state.activeNonceReleaseAttemptCount, 0)
+    assert.equal(response.payload.state.nonceAllocatorBarrierMismatchCount, 1)
+    assert.equal(response.payload.state.activationBlocked, true)
+    assert.equal(
+      response.payload.state.activationBlockingReasons.includes(
+        "nonce-allocator-barrier-mismatch"
+      ),
+      true
+    )
+    await database.client.end()
+  }
+)
+
+postgresTest(
+  "blocks activation when lane counters drift but their total still agrees",
+  async () => {
+    const database = await createTestDatabase()
+    await orphanedSignerBoundary(database, 218)
+    const decoySender = Buffer.alloc(20, 0xff)
+
+    // Move the boundary's count onto a second, unrelated lane. The sum is still
+    // 1 and still equals ground truth, so only the per-lane grouped equality
+    // can see that both lanes are now misattributed.
+    await database.client.query(
+      `INSERT INTO p2tr_signature_fraud_nonce_allocator_safety_barrier (
+           chain_id, sender, active_signer_invocation_count
+       ) VALUES (
+           (SELECT chain_id
+              FROM p2tr_signature_fraud_nonce_allocator_safety_barrier
+             WHERE active_signer_invocation_count > 0),
+           $1::bytea,
+           1
+       )`,
+      [decoySender]
+    )
+    await database.client.query(
+      `UPDATE p2tr_signature_fraud_nonce_allocator_safety_barrier
+          SET active_signer_invocation_count = 0
+        WHERE sender <> $1::bytea`,
+      [decoySender]
+    )
+    assert.equal(await barrierSignerInvocationCount(database), 1)
+
+    await beginSerializable(database.client)
+    const response = await activationProvider(
+      database.client,
+      () => 5_000
+    ).attestActivationChallenge(activationRequest)
+    await commit(database.client)
+
+    assert.equal(response.payload.state.activeSignerInvocationCount, 1)
+    assert.equal(response.payload.state.nonceAllocatorBarrierMismatchCount, 2)
+    assert.equal(response.payload.state.activationBlocked, true)
+    assert.equal(
+      response.payload.state.activationBlockingReasons.includes(
+        "nonce-allocator-barrier-mismatch"
+      ),
+      true
+    )
+    await database.client.end()
+  }
+)
+
+postgresTest(
+  "blocks activation when the global mismatch flag has no supporting evidence",
+  async () => {
+    const database = await createTestDatabase()
+    await insertRecord(database, outboxRecord(219))
+
+    // The flag is a statement about the allocator implementation rather than
+    // any one account, so it survives lane keying on its own singleton and both
+    // consistency invariants over it stay whole-store. Only this direction is
+    // testable: the opposite one -- an unresolved `reservation-release-failed`
+    // alert while the flag reads false -- cannot be built, because the alert
+    // trigger demands the contract-mismatch result that sets the flag.
+    await database.client.query(
+      `UPDATE p2tr_signature_fraud_nonce_allocator_global_barrier
+          SET contract_mismatch_blocked = true
+        WHERE singleton = true`
+    )
+
+    await beginSerializable(database.client)
+    const response = await activationProvider(
+      database.client,
+      () => 5_000
+    ).attestActivationChallenge(activationRequest)
+    await commit(database.client)
+
+    assert.equal(
+      response.payload.state.nonceAllocatorContractMismatchBlocked,
+      true
+    )
+    assert.equal(response.payload.state.nonceAllocatorBarrierMismatchCount, 2)
+    assert.equal(
+      response.payload.state.activationBlockingReasons.includes(
+        "nonce-allocator-barrier-mismatch"
+      ),
+      true
+    )
+    await database.client.end()
+  }
+)

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -98,7 +98,15 @@ async function createTestDatabase(
       import.meta.url
     ),
     new URL(
+      "../migrations/004_p2tr_candidate_enqueue_retry_alerts.sql",
+      import.meta.url
+    ),
+    new URL(
       "../migrations/005_p2tr_signer_boundary_late_artifact.sql",
+      import.meta.url
+    ),
+    new URL(
+      "../migrations/006_p2tr_signer_boundary_nonce_finality.sql",
       import.meta.url
     ),
   ]) {

--- a/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
+++ b/services/watchtower/test/PostgresP2TRSignatureFraudChallengeOutboxStore.test.ts
@@ -4254,3 +4254,83 @@ postgresTest(
     await database.client.end()
   }
 )
+
+// The lane-scoped variants of these two predicates decide whether challenge
+// signing is refused on one nonce lane, and both are implemented in SQL that no
+// other test executes. Without this, the adapter could filter on the wrong
+// column, or not filter at all, and every dispatcher-level test would still
+// pass -- they bind to the in-memory double.
+postgresTest(
+  "scopes the recovery predicates to one nonce lane",
+  async () => {
+    const database = await createTestDatabase()
+    await orphanedSignerBoundary(database, 220)
+    const afterLease = 10_000_000
+    const ownLane = { chainID: CHAIN_ID, sender: WALLET.address }
+    const otherSender = {
+      chainID: CHAIN_ID,
+      sender: `0x${"cd".repeat(20)}`,
+    }
+    const otherChain = { chainID: CHAIN_ID + 1, sender: WALLET.address }
+
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease),
+      true
+    )
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, ownLane),
+      true
+    )
+    // A different account on the same chain, and the same account on a
+    // different chain, are both unaffected.
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, otherSender),
+      false
+    )
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, otherChain),
+      false
+    )
+    // The sender is a lookup key, so its spelling must not matter.
+    assert.equal(
+      await database.store.hasExpiredPreparationLeases(afterLease, {
+        chainID: CHAIN_ID,
+        sender: WALLET.address.toLowerCase(),
+      }),
+      true
+    )
+    await database.client.end()
+  }
+)
+
+postgresTest(
+  "scopes the pending nonce-release predicate to one nonce lane",
+  async () => {
+    const database = await createTestDatabase()
+    await createPendingNonceRelease(database, 221)
+
+    assert.equal(await database.store.hasPendingNonceReleases(), true)
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID,
+        sender: WALLET.address,
+      }),
+      true
+    )
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID,
+        sender: `0x${"cd".repeat(20)}`,
+      }),
+      false
+    )
+    assert.equal(
+      await database.store.hasPendingNonceReleases({
+        chainID: CHAIN_ID + 1,
+        sender: WALLET.address,
+      }),
+      false
+    )
+    await database.client.end()
+  }
+)

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -897,7 +897,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:835](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L835)
+[src/services/maintenance/p2tr-signature-fraud.ts:840](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L840)
 
 ___
 
@@ -1031,7 +1031,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2166](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2166)
+[src/services/maintenance/p2tr-signature-fraud.ts:2182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2182)
 
 ___
 
@@ -1049,7 +1049,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2150](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2150)
+[src/services/maintenance/p2tr-signature-fraud.ts:2166](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2166)
 
 ___
 
@@ -1066,7 +1066,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2161](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2161)
+[src/services/maintenance/p2tr-signature-fraud.ts:2177](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2177)
 
 ___
 
@@ -1083,7 +1083,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2156)
+[src/services/maintenance/p2tr-signature-fraud.ts:2172](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2172)
 
 ___
 
@@ -1100,7 +1100,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2246](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2246)
+[src/services/maintenance/p2tr-signature-fraud.ts:2262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2262)
 
 ___
 
@@ -1120,7 +1120,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2198](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2198)
+[src/services/maintenance/p2tr-signature-fraud.ts:2214](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2214)
 
 ___
 
@@ -1137,7 +1137,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2207](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2207)
+[src/services/maintenance/p2tr-signature-fraud.ts:2223](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2223)
 
 ___
 
@@ -1153,7 +1153,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2203)
+[src/services/maintenance/p2tr-signature-fraud.ts:2219](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2219)
 
 ___
 
@@ -1199,7 +1199,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2251](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2251)
+[src/services/maintenance/p2tr-signature-fraud.ts:2267](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2267)
 
 ___
 
@@ -1211,19 +1211,19 @@ Immutable activation-manifest fee/value envelope for one signer lane.
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `activationManifestHash` | [`Hex`](classes/Hex.md) |
-| `chainID` | `number` |
-| `challengeValueWei` | `string` |
-| `laneID` | `string` |
-| `maxFeePerGas` | `string` |
-| `maxGasLimit` | `string` |
-| `maxPriorityFeePerGas` | `string` |
-| `maxTotalFeeWei` | `string` |
-| `policyHash` | [`Hex`](classes/Hex.md) |
-| `sender` | `string` |
-| `signerIdentity` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `activationManifestHash` | [`Hex`](classes/Hex.md) | - |
+| `chainID` | `number` | - |
+| `challengeValueWei` | `string` | - |
+| `laneID` | `string` | - |
+| `maxFeePerGas` | `string` | - |
+| `maxGasLimit` | `string` | Exact gas budget for challenge calls. The manifest uses a cap-shaped field so it also bounds cost, but preparers must not lower it and create a nonce-consuming transaction that is guaranteed to run out of gas. |
+| `maxPriorityFeePerGas` | `string` | - |
+| `maxTotalFeeWei` | `string` | - |
+| `policyHash` | [`Hex`](classes/Hex.md) | - |
+| `sender` | `string` | - |
+| `signerIdentity` | `string` | - |
 
 #### Defined in
 
@@ -1444,7 +1444,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2263](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2263)
+[src/services/maintenance/p2tr-signature-fraud.ts:2279](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2279)
 
 ___
 
@@ -1464,7 +1464,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2255](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2255)
+[src/services/maintenance/p2tr-signature-fraud.ts:2271](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2271)
 
 ___
 
@@ -1481,7 +1481,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2267](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2267)
+[src/services/maintenance/p2tr-signature-fraud.ts:2283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2283)
 
 ___
 
@@ -1904,7 +1904,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2272](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2272)
+[src/services/maintenance/p2tr-signature-fraud.ts:2288](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2288)
 
 ___
 
@@ -2062,7 +2062,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2322](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2322)
+[src/services/maintenance/p2tr-signature-fraud.ts:2338](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2338)
 
 ___
 
@@ -2079,7 +2079,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2327](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2327)
+[src/services/maintenance/p2tr-signature-fraud.ts:2343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2343)
 
 ___
 
@@ -2089,7 +2089,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2311](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2311)
+[src/services/maintenance/p2tr-signature-fraud.ts:2327](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2327)
 
 ___
 
@@ -2117,7 +2117,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2414](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2414)
+[src/services/maintenance/p2tr-signature-fraud.ts:2430](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2430)
 
 ___
 
@@ -2155,7 +2155,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2332](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2332)
+[src/services/maintenance/p2tr-signature-fraud.ts:2348](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2348)
 
 ___
 
@@ -2193,7 +2193,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2358](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2358)
+[src/services/maintenance/p2tr-signature-fraud.ts:2374](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2374)
 
 ___
 
@@ -2213,7 +2213,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2384](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2384)
+[src/services/maintenance/p2tr-signature-fraud.ts:2400](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2400)
 
 ___
 
@@ -2223,7 +2223,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2299](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2299)
+[src/services/maintenance/p2tr-signature-fraud.ts:2315](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2315)
 
 ___
 
@@ -2302,7 +2302,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2317](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2317)
+[src/services/maintenance/p2tr-signature-fraud.ts:2333](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2333)
 
 ___
 
@@ -2878,7 +2878,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2289](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2289)
+[src/services/maintenance/p2tr-signature-fraud.ts:2305](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2305)
 
 ___
 
@@ -2892,7 +2892,7 @@ COMPLETE_V2 uses its v3 challenge identity directly as the key.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2293)
+[src/services/maintenance/p2tr-signature-fraud.ts:2309](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2309)
 
 ___
 
@@ -2905,7 +2905,7 @@ compatibility. COMPLETE_V2 submissions use fixed-size evidence instead.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2182)
+[src/services/maintenance/p2tr-signature-fraud.ts:2198](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2198)
 
 ___
 
@@ -2963,7 +2963,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2286](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2286)
+[src/services/maintenance/p2tr-signature-fraud.ts:2302](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2302)
 
 ___
 
@@ -3082,7 +3082,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2283](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2283)
+[src/services/maintenance/p2tr-signature-fraud.ts:2299](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2299)
 
 ___
 
@@ -3230,7 +3230,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4055](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4055)
+[src/services/maintenance/p2tr-signature-fraud.ts:4071](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4071)
 
 ___
 
@@ -3363,7 +3363,7 @@ The fixed COMPLETE_V2 evidence record for this input.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:899](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L899)
+[src/services/maintenance/p2tr-signature-fraud.ts:904](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L904)
 
 ___
 
@@ -3383,7 +3383,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5377](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5377)
+[src/services/maintenance/p2tr-signature-fraud.ts:5393](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5393)
 
 ___
 
@@ -3409,7 +3409,7 @@ The submission intent, with its derived `intentID`.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1605](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1605)
+[src/services/maintenance/p2tr-signature-fraud.ts:1610](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1610)
 
 ___
 
@@ -3482,7 +3482,7 @@ The 32-byte challenge identity the router will recompute.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:850](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L850)
+[src/services/maintenance/p2tr-signature-fraud.ts:855](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L855)
 
 ___
 
@@ -3511,7 +3511,7 @@ sighash mode, with or without a witness annex.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4895](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4895)
+[src/services/maintenance/p2tr-signature-fraud.ts:4911](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4911)
 
 ___
 
@@ -3540,7 +3540,7 @@ The EIP-712 digest that doubles as the reservation identity.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1466](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1466)
+[src/services/maintenance/p2tr-signature-fraud.ts:1471](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1471)
 
 ___
 
@@ -3569,7 +3569,7 @@ sighash. COMPLETE_V2 uses this identity directly as its challenge key.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5208](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5208)
+[src/services/maintenance/p2tr-signature-fraud.ts:5224](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5224)
 
 ___
 
@@ -3589,7 +3589,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5344](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5344)
+[src/services/maintenance/p2tr-signature-fraud.ts:5360](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5360)
 
 ___
 
@@ -3621,7 +3621,7 @@ harnesses. It is not a final production Bridge challenge key.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5304](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5304)
+[src/services/maintenance/p2tr-signature-fraud.ts:5320](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5320)
 
 ___
 
@@ -3641,7 +3641,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1269](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1269)
+[src/services/maintenance/p2tr-signature-fraud.ts:1274](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1274)
 
 ___
 
@@ -3677,7 +3677,7 @@ the domain-bound Bridge challenge key for record and submission idempotency.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5137](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5137)
+[src/services/maintenance/p2tr-signature-fraud.ts:5153](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5153)
 
 ___
 
@@ -3697,7 +3697,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2796](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2796)
+[src/services/maintenance/p2tr-signature-fraud.ts:2812](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2812)
 
 ___
 
@@ -3717,7 +3717,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2888](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2888)
+[src/services/maintenance/p2tr-signature-fraud.ts:2904](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2904)
 
 ___
 
@@ -3773,7 +3773,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2962](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2962)
+[src/services/maintenance/p2tr-signature-fraud.ts:2978](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2978)
 
 ___
 
@@ -3793,7 +3793,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3146)
+[src/services/maintenance/p2tr-signature-fraud.ts:3162](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3162)
 
 ___
 
@@ -3850,7 +3850,7 @@ The ABI-encoded challenge payload, rejected unless it is exactly
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1029](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1029)
+[src/services/maintenance/p2tr-signature-fraud.ts:1034](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1034)
 
 ___
 
@@ -3875,7 +3875,7 @@ Calldata for the router's `processP2TRSignatureFraudChallenge`
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1063](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1063)
+[src/services/maintenance/p2tr-signature-fraud.ts:1068](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1068)
 
 ___
 
@@ -3902,7 +3902,7 @@ ABI-encoded COMPLETE_V2 evidence or legacy domainless payload.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5480)
+[src/services/maintenance/p2tr-signature-fraud.ts:5496](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5496)
 
 ___
 
@@ -3926,7 +3926,7 @@ Use the protocol-specific COMPLETE_V2 encoder.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1076](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1076)
+[src/services/maintenance/p2tr-signature-fraud.ts:1081](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1081)
 
 ___
 
@@ -4048,7 +4048,7 @@ Parsed witness signature for the input, with sighash type resolved.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4618](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4618)
+[src/services/maintenance/p2tr-signature-fraud.ts:4634](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4634)
 
 ___
 
@@ -4075,7 +4075,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5649](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5649)
+[src/services/maintenance/p2tr-signature-fraud.ts:5665](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5665)
 
 ___
 
@@ -4095,7 +4095,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4962](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4962)
+[src/services/maintenance/p2tr-signature-fraud.ts:4978](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4978)
 
 ___
 
@@ -4132,7 +4132,7 @@ Candidate witness records for each input whose prevout script
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5000](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5000)
+[src/services/maintenance/p2tr-signature-fraud.ts:5016](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5016)
 
 ___
 
@@ -4224,7 +4224,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3352](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3352)
+[src/services/maintenance/p2tr-signature-fraud.ts:3368](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3368)
 
 ___
 
@@ -4530,7 +4530,7 @@ Parsed signature with the 64-byte Schnorr signature and the
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4557](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4557)
+[src/services/maintenance/p2tr-signature-fraud.ts:4573](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4573)
 
 ___
 
@@ -4551,7 +4551,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4458](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4458)
+[src/services/maintenance/p2tr-signature-fraud.ts:4474](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4474)
 
 ___
 
@@ -4584,7 +4584,7 @@ The updated challenge record after a successful persist.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4520](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4520)
+[src/services/maintenance/p2tr-signature-fraud.ts:4536](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4536)
 
 ___
 
@@ -4605,7 +4605,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4770](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4770)
+[src/services/maintenance/p2tr-signature-fraud.ts:4786](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4786)
 
 ___
 
@@ -4627,7 +4627,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3462](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3462)
+[src/services/maintenance/p2tr-signature-fraud.ts:3478](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3478)
 
 ___
 
@@ -4649,7 +4649,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3409)
+[src/services/maintenance/p2tr-signature-fraud.ts:3425](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3425)
 
 ___
 
@@ -4694,7 +4694,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2920](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2920)
+[src/services/maintenance/p2tr-signature-fraud.ts:2936](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2936)
 
 ___
 
@@ -4714,7 +4714,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3111](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3111)
+[src/services/maintenance/p2tr-signature-fraud.ts:3127](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3127)
 
 ___
 
@@ -4760,7 +4760,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4664](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4664)
+[src/services/maintenance/p2tr-signature-fraud.ts:4680](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4680)
 
 ___
 
@@ -4780,7 +4780,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3373)
+[src/services/maintenance/p2tr-signature-fraud.ts:3389](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3389)
 
 ___
 
@@ -4969,7 +4969,7 @@ An empty return value; throws if the intent is not bound to the
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1088](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1088)
+[src/services/maintenance/p2tr-signature-fraud.ts:1093](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1093)
 
 ___
 
@@ -4996,7 +4996,7 @@ The prevout records in transaction input order, once every entry has
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4820](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4820)
+[src/services/maintenance/p2tr-signature-fraud.ts:4836](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4836)
 
 ___
 
@@ -5027,7 +5027,7 @@ The reservation in normalized form, with its recomputed identity.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1505](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1505)
+[src/services/maintenance/p2tr-signature-fraud.ts:1510](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1510)
 
 ___
 
@@ -5049,7 +5049,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:4703](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4703)
+[src/services/maintenance/p2tr-signature-fraud.ts:4719](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L4719)
 
 ___
 
@@ -5077,7 +5077,7 @@ The validated replacement transaction.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2081](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2081)
+[src/services/maintenance/p2tr-signature-fraud.ts:2097](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2097)
 
 ___
 
@@ -5106,7 +5106,7 @@ The prepared transaction with hash, sender and nonce rederived from
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1678](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1678)
+[src/services/maintenance/p2tr-signature-fraud.ts:1683](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1683)
 
 ___
 
@@ -5132,7 +5132,7 @@ The validated EIP-1559 transaction.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2043](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2043)
+[src/services/maintenance/p2tr-signature-fraud.ts:2059](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2059)
 
 ___
 
@@ -5157,7 +5157,7 @@ The validated transaction, extended with its EIP-1559 fee fields.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2000](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2000)
+[src/services/maintenance/p2tr-signature-fraud.ts:2005](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2005)
 
 ___
 
@@ -5190,7 +5190,7 @@ The burn with hash, sender, nonce and fee fields rederived from the
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:1874](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1874)
+[src/services/maintenance/p2tr-signature-fraud.ts:1879](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L1879)
 
 ___
 
@@ -5211,4 +5211,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5756](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5756)
+[src/services/maintenance/p2tr-signature-fraud.ts:5772](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5772)

--- a/typescript/api-reference/classes/P2TRSignatureFraudBridgeChallengeSubmitter.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudBridgeChallengeSubmitter.md
@@ -48,7 +48,7 @@ a separately reviewed `COMPLETE_V2` protocol and operational controls.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5551](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5551)
+[src/services/maintenance/p2tr-signature-fraud.ts:5567](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5567)
 
 ## Properties
 
@@ -64,7 +64,7 @@ The P2TR signature-fraud entry-point contract.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5552](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5552)
+[src/services/maintenance/p2tr-signature-fraud.ts:5568](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5568)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5537](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5537)
+[src/services/maintenance/p2tr-signature-fraud.ts:5553](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5553)
 
 ___
 
@@ -90,7 +90,7 @@ Submitter options. If `challengeDepositAmount` is
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5553](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5553)
+[src/services/maintenance/p2tr-signature-fraud.ts:5569](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5569)
 
 ## Methods
 
@@ -104,7 +104,7 @@ Submitter options. If `challengeDepositAmount` is
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5621](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5621)
+[src/services/maintenance/p2tr-signature-fraud.ts:5637](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5637)
 
 ___
 
@@ -129,4 +129,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5568](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5568)
+[src/services/maintenance/p2tr-signature-fraud.ts:5584](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5584)

--- a/typescript/api-reference/classes/P2TRSignatureFraudWatchtower.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudWatchtower.md
@@ -64,7 +64,7 @@ available without activating the incomplete fraud protocol.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5815](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5815)
+[src/services/maintenance/p2tr-signature-fraud.ts:5831](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5831)
 
 ## Properties
 
@@ -74,7 +74,7 @@ available without activating the incomplete fraud protocol.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5821](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5821)
+[src/services/maintenance/p2tr-signature-fraud.ts:5837](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5837)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5818](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5818)
+[src/services/maintenance/p2tr-signature-fraud.ts:5834](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5834)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5820](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5820)
+[src/services/maintenance/p2tr-signature-fraud.ts:5836](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5836)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5813](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5813)
+[src/services/maintenance/p2tr-signature-fraud.ts:5829](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5829)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5819](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5819)
+[src/services/maintenance/p2tr-signature-fraud.ts:5835](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5835)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5816](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5816)
+[src/services/maintenance/p2tr-signature-fraud.ts:5832](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5832)
 
 ## Methods
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6041](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6041)
+[src/services/maintenance/p2tr-signature-fraud.ts:6057](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6057)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6052](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6052)
+[src/services/maintenance/p2tr-signature-fraud.ts:6068](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6068)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5958](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5958)
+[src/services/maintenance/p2tr-signature-fraud.ts:5974](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5974)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5969](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5969)
+[src/services/maintenance/p2tr-signature-fraud.ts:5985](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5985)
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6005](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6005)
+[src/services/maintenance/p2tr-signature-fraud.ts:6021](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6021)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5994](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5994)
+[src/services/maintenance/p2tr-signature-fraud.ts:6010](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6010)
 
 ___
 
@@ -269,7 +269,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5985](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5985)
+[src/services/maintenance/p2tr-signature-fraud.ts:6001](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6001)
 
 ___
 
@@ -290,7 +290,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5947](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5947)
+[src/services/maintenance/p2tr-signature-fraud.ts:5963](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5963)
 
 ___
 
@@ -310,7 +310,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5938](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5938)
+[src/services/maintenance/p2tr-signature-fraud.ts:5954](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5954)
 
 ___
 
@@ -336,7 +336,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5882](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5882)
+[src/services/maintenance/p2tr-signature-fraud.ts:5898](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5898)
 
 ___
 
@@ -362,7 +362,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5918](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5918)
+[src/services/maintenance/p2tr-signature-fraud.ts:5934](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5934)
 
 ___
 
@@ -385,7 +385,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5838](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5838)
+[src/services/maintenance/p2tr-signature-fraud.ts:5854](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5854)
 
 ___
 
@@ -408,7 +408,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5868](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5868)
+[src/services/maintenance/p2tr-signature-fraud.ts:5884](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5884)
 
 ___
 
@@ -430,7 +430,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6028](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6028)
+[src/services/maintenance/p2tr-signature-fraud.ts:6044](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6044)
 
 ___
 
@@ -451,7 +451,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6016](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6016)
+[src/services/maintenance/p2tr-signature-fraud.ts:6032](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6032)
 
 ___
 
@@ -471,7 +471,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:5830](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5830)
+[src/services/maintenance/p2tr-signature-fraud.ts:5846](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L5846)
 
 ___
 
@@ -501,4 +501,4 @@ A rejected promise while the fraud layer remains bounded/no-go.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6075](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6075)
+[src/services/maintenance/p2tr-signature-fraud.ts:6091](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6091)

--- a/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
+++ b/typescript/api-reference/classes/P2TRSignatureFraudWatchtowerRunner.md
@@ -71,7 +71,7 @@ The submission constructor surface is retained for API compatibility, but
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6101](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6101)
+[src/services/maintenance/p2tr-signature-fraud.ts:6117](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6117)
 
 ## Properties
 
@@ -81,7 +81,7 @@ The submission constructor surface is retained for API compatibility, but
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6103](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6103)
+[src/services/maintenance/p2tr-signature-fraud.ts:6119](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6119)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6099](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6099)
+[src/services/maintenance/p2tr-signature-fraud.ts:6115](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6115)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6097](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6097)
+[src/services/maintenance/p2tr-signature-fraud.ts:6113](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6113)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6098](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6098)
+[src/services/maintenance/p2tr-signature-fraud.ts:6114](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6114)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6102](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6102)
+[src/services/maintenance/p2tr-signature-fraud.ts:6118](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6118)
 
 ## Methods
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6158](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6158)
+[src/services/maintenance/p2tr-signature-fraud.ts:6174](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6174)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6957](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6957)
+[src/services/maintenance/p2tr-signature-fraud.ts:6973](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6973)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6334](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6334)
+[src/services/maintenance/p2tr-signature-fraud.ts:6350](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6350)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6299](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6299)
+[src/services/maintenance/p2tr-signature-fraud.ts:6315](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6315)
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6671](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6671)
+[src/services/maintenance/p2tr-signature-fraud.ts:6687](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6687)
 
 ___
 
@@ -245,7 +245,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6777](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6777)
+[src/services/maintenance/p2tr-signature-fraud.ts:6793](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6793)
 
 ___
 
@@ -266,7 +266,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6714](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6714)
+[src/services/maintenance/p2tr-signature-fraud.ts:6730](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6730)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:7019](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7019)
+[src/services/maintenance/p2tr-signature-fraud.ts:7035](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7035)
 
 ___
 
@@ -311,7 +311,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6986](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6986)
+[src/services/maintenance/p2tr-signature-fraud.ts:7002](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7002)
 
 ___
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6223](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6223)
+[src/services/maintenance/p2tr-signature-fraud.ts:6239](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6239)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6261](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6261)
+[src/services/maintenance/p2tr-signature-fraud.ts:6277](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6277)
 
 ___
 
@@ -377,7 +377,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6281](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6281)
+[src/services/maintenance/p2tr-signature-fraud.ts:6297](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6297)
 
 ___
 
@@ -400,7 +400,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6168](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6168)
+[src/services/maintenance/p2tr-signature-fraud.ts:6184](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6184)
 
 ___
 
@@ -420,7 +420,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6191](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6191)
+[src/services/maintenance/p2tr-signature-fraud.ts:6207](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6207)
 
 ___
 
@@ -440,7 +440,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6208](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6208)
+[src/services/maintenance/p2tr-signature-fraud.ts:6224](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6224)
 
 ___
 
@@ -469,7 +469,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6966](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6966)
+[src/services/maintenance/p2tr-signature-fraud.ts:6982](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6982)
 
 ___
 
@@ -490,7 +490,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6600](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6600)
+[src/services/maintenance/p2tr-signature-fraud.ts:6616](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6616)
 
 ___
 
@@ -517,7 +517,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:7059](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7059)
+[src/services/maintenance/p2tr-signature-fraud.ts:7075](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7075)
 
 ___
 
@@ -539,7 +539,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6807](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6807)
+[src/services/maintenance/p2tr-signature-fraud.ts:6823](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6823)
 
 ___
 
@@ -559,7 +559,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6428](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6428)
+[src/services/maintenance/p2tr-signature-fraud.ts:6444](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6444)
 
 ___
 
@@ -581,7 +581,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6529](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6529)
+[src/services/maintenance/p2tr-signature-fraud.ts:6545](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6545)
 
 ___
 
@@ -602,7 +602,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6495](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6495)
+[src/services/maintenance/p2tr-signature-fraud.ts:6511](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6511)
 
 ___
 
@@ -622,7 +622,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6419](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6419)
+[src/services/maintenance/p2tr-signature-fraud.ts:6435](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6435)
 
 ___
 
@@ -642,7 +642,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6387](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6387)
+[src/services/maintenance/p2tr-signature-fraud.ts:6403](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6403)
 
 ___
 
@@ -663,7 +663,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6393](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6393)
+[src/services/maintenance/p2tr-signature-fraud.ts:6409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6409)
 
 ___
 
@@ -691,7 +691,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:6915](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6915)
+[src/services/maintenance/p2tr-signature-fraud.ts:6931](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L6931)
 
 ___
 
@@ -711,4 +711,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:7041](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7041)
+[src/services/maintenance/p2tr-signature-fraud.ts:7057](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L7057)

--- a/typescript/api-reference/classes/P2TRWatchtowerSerializedChallengeStore.md
+++ b/typescript/api-reference/classes/P2TRWatchtowerSerializedChallengeStore.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3749](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3749)
+[src/services/maintenance/p2tr-signature-fraud.ts:3765](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3765)
 
 ## Properties
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3750](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3750)
+[src/services/maintenance/p2tr-signature-fraud.ts:3766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3766)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3746](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3746)
+[src/services/maintenance/p2tr-signature-fraud.ts:3762](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3762)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3747](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3747)
+[src/services/maintenance/p2tr-signature-fraud.ts:3763](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3763)
 
 ## Methods
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3753](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3753)
+[src/services/maintenance/p2tr-signature-fraud.ts:3769](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3769)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3779](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3779)
+[src/services/maintenance/p2tr-signature-fraud.ts:3795](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3795)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3785](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3785)
+[src/services/maintenance/p2tr-signature-fraud.ts:3801](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3801)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3811](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3811)
+[src/services/maintenance/p2tr-signature-fraud.ts:3827](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3827)
 
 ___
 
@@ -172,4 +172,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:3763](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3763)
+[src/services/maintenance/p2tr-signature-fraud.ts:3779](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L3779)

--- a/typescript/api-reference/interfaces/P2TRSignatureFraudBridgeChallengeContract.md
+++ b/typescript/api-reference/interfaces/P2TRSignatureFraudBridgeChallengeContract.md
@@ -40,7 +40,7 @@ in a follow-up SDK breaking-change release.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2237](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2237)
+[src/services/maintenance/p2tr-signature-fraud.ts:2253](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2253)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2238](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2238)
+[src/services/maintenance/p2tr-signature-fraud.ts:2254](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2254)

--- a/typescript/api-reference/interfaces/P2TRSignatureFraudChallengeTransactionPreparer.md
+++ b/typescript/api-reference/interfaces/P2TRSignatureFraudChallengeTransactionPreparer.md
@@ -26,7 +26,7 @@ Stable identities used for durable lane and signer quarantine records.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:750](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L750)
+[src/services/maintenance/p2tr-signature-fraud.ts:755](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L755)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:751](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L751)
+[src/services/maintenance/p2tr-signature-fraud.ts:756](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L756)
 
 ___
 
@@ -48,7 +48,7 @@ Sender whose nonce lane is serialized by the durable outbox store.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:753](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L753)
+[src/services/maintenance/p2tr-signature-fraud.ts:758](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L758)
 
 ## Methods
 
@@ -76,7 +76,7 @@ this method and appends the returned raw bytes before any broadcast.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:793](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L793)
+[src/services/maintenance/p2tr-signature-fraud.ts:798](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L798)
 
 ___
 
@@ -103,7 +103,7 @@ MUST reject a reservation whose binding, sender, or nonce is not exact.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:781](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L781)
+[src/services/maintenance/p2tr-signature-fraud.ts:786](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L786)
 
 ___
 
@@ -135,7 +135,7 @@ reservation spends the same nonce on the same nothing.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:812](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L812)
+[src/services/maintenance/p2tr-signature-fraud.ts:817](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L817)
 
 ___
 
@@ -160,7 +160,7 @@ ambiguous response returns `already-released` for the same reservation.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:771](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L771)
+[src/services/maintenance/p2tr-signature-fraud.ts:776](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L776)
 
 ___
 
@@ -186,4 +186,4 @@ bytes. Its EIP-712 binding must recover to `transactionSender`.
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:759](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L759)
+[src/services/maintenance/p2tr-signature-fraud.ts:764](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L764)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordPersistence.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordPersistence.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2404](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2404)
+[src/services/maintenance/p2tr-signature-fraud.ts:2420](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2420)
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2405](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2405)
+[src/services/maintenance/p2tr-signature-fraud.ts:2421](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2421)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordSource.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeRecordSource.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2400](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2400)
+[src/services/maintenance/p2tr-signature-fraud.ts:2416](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2416)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeReplayStore.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeReplayStore.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2393](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2393)
+[src/services/maintenance/p2tr-signature-fraud.ts:2409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2409)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2400](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2400)
+[src/services/maintenance/p2tr-signature-fraud.ts:2416](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2416)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2396)
+[src/services/maintenance/p2tr-signature-fraud.ts:2412](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2412)

--- a/typescript/api-reference/interfaces/P2TRWatchtowerChallengeStore.md
+++ b/typescript/api-reference/interfaces/P2TRWatchtowerChallengeStore.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2393](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2393)
+[src/services/maintenance/p2tr-signature-fraud.ts:2409](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2409)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[src/services/maintenance/p2tr-signature-fraud.ts:2396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2396)
+[src/services/maintenance/p2tr-signature-fraud.ts:2412](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/maintenance/p2tr-signature-fraud.ts#L2412)

--- a/typescript/node_modules
+++ b/typescript/node_modules
@@ -1,0 +1,1 @@
+/Users/maclane/Projects/tbtc-v2/typescript/node_modules

--- a/typescript/node_modules
+++ b/typescript/node_modules
@@ -1,1 +1,0 @@
-/Users/maclane/Projects/tbtc-v2/typescript/node_modules

--- a/typescript/src/services/maintenance/p2tr-signature-fraud.ts
+++ b/typescript/src/services/maintenance/p2tr-signature-fraud.ts
@@ -2019,6 +2019,17 @@ export const validateP2TRSignatureFraudPreparedEIP1559ChallengeTransaction = (
       "Durable challenge outbox requires an EIP-1559 transaction envelope"
     )
   }
+  // A challenge is one fixed call to a known Router, so an access list buys it
+  // nothing -- but every entry raises the transaction's intrinsic gas. A signer
+  // free to add entries under a fee-policy-capped gas limit can make the
+  // transaction run out of gas on-chain, which still CONSUMES the reserved
+  // nonce while submitting no challenge. Requiring it empty removes the lever.
+  if (envelope.accessList !== undefined && envelope.accessList.length > 0) {
+    throw new P2TRWitnessSignatureError(
+      "invalid-watchtower-state",
+      "Durable challenge outbox refuses a transaction carrying an access list"
+    )
+  }
   return {
     ...validated,
     eip1559: {

--- a/typescript/src/services/maintenance/p2tr-signature-fraud.ts
+++ b/typescript/src/services/maintenance/p2tr-signature-fraud.ts
@@ -739,6 +739,11 @@ export type P2TRSignatureFraudChallengeTransactionFeePolicy = {
   signerIdentity: string
   sender: string
   challengeValueWei: string
+  /**
+   * Exact gas budget for challenge calls. The manifest uses a cap-shaped field
+   * so it also bounds cost, but preparers must not lower it and create a
+   * nonce-consuming transaction that is guaranteed to run out of gas.
+   */
   maxGasLimit: string
   maxFeePerGas: string
   maxPriorityFeePerGas: string

--- a/typescript/test/services/p2tr-signature-fraud.test.ts
+++ b/typescript/test/services/p2tr-signature-fraud.test.ts
@@ -78,6 +78,7 @@ import {
   validateP2TRSignatureFraudPreparedChallengeTransactionReservation,
   validateP2TRSignatureFraudPreparedChallengeTransaction,
   validateP2TRSignatureFraudPreparedNonceBurnTransaction,
+  validateP2TRSignatureFraudPreparedEIP1559ChallengeTransaction,
   validateP2TRSignatureFraudWitnessObservationConsistency,
 } from "../../src/services/maintenance/p2tr-signature-fraud"
 import { Hex } from "../../src/lib/utils"
@@ -2303,6 +2304,87 @@ describe("P2TR signature-fraud witness parsing", () => {
       expect(exact.maxFeePerGas).to.equal(envelope.maxFeePerGas)
       expect(exact.maxPriorityFeePerGas).to.equal(envelope.maxPriorityFeePerGas)
     })
+  })
+
+  // A challenge is one fixed call to a known Router, so an access list buys it
+  // nothing while raising intrinsic gas. Under a fee-policy-capped gas limit a
+  // signer can use one to push the transaction out of gas on-chain, which still
+  // consumes the reserved nonce and submits no challenge.
+  it("refuses a prepared challenge transaction carrying an access list", async () => {
+    const vector = vectorCorpus.cases[0]
+    const rawTransaction = withInputWitness(
+      vector.unsignedTransactionHex,
+      vector.signedInputIndex,
+      vector.witnessSignatureHex
+    )
+    const [observation] = extractP2TRSignatureFraudWitnessObservations(
+      rawTransaction,
+      toObservationPrevouts(vector),
+      [vector.walletIDHex],
+      undefined,
+      undefined,
+      undefined,
+      bridgeChallengeDomain
+    )
+    const completeEvidence =
+      buildP2TRCompleteV2SignatureFraudChallengeEvidence(
+        observation,
+        bridgeChallengeDomain,
+        {
+          registeredWalletIDs: [vector.walletIDHex],
+          walletInputKeyBindings: [],
+        }
+      )
+    const intent = buildP2TRSignatureFraudSubmissionIntent(completeEvidence, {
+      domainChainID: bridgeChallengeDomain.chainID,
+      chainID: bridgeChallengeDomain.chainID,
+      bridgeAddress: bridgeChallengeDomain.bridgeAddress,
+      routerAddress: "0x2222222222222222222222222222222222222222",
+      challengeDepositAmount: 1234,
+    })
+
+    const wallet = new Wallet(`0x${"42".repeat(32)}`)
+    const build = async (accessList: unknown[]) => {
+      const raw = await wallet.signTransaction({
+        type: 2,
+        to: intent.routerAddress,
+        data: intent.calldata,
+        value: BigNumber.from(intent.value),
+        chainId: intent.chainID,
+        nonce: 7,
+        gasLimit: 1_000_000,
+        maxFeePerGas: 20,
+        maxPriorityFeePerGas: 2,
+        accessList: accessList as never,
+      })
+      return {
+        intentID: intent.intentID,
+        rawTransaction: raw,
+        transactionHash: Hex.from(utils.parseTransaction(raw).hash!),
+        sender: wallet.address,
+        nonce: 7,
+      }
+    }
+
+    const withAccessList = await build([
+      { address: intent.routerAddress, storageKeys: [`0x${"11".repeat(32)}`] },
+    ])
+    expectWitnessError(
+      () =>
+        validateP2TRSignatureFraudPreparedEIP1559ChallengeTransaction(
+          intent,
+          withAccessList
+        ),
+      "invalid-watchtower-state"
+    )
+
+    // The same envelope without the access list is accepted, so the rejection
+    // is attributable to the list and nothing else.
+    const clean = validateP2TRSignatureFraudPreparedEIP1559ChallengeTransaction(
+      intent,
+      await build([])
+    )
+    expect(clean.eip1559?.transactionType).to.equal(2)
   })
 
   it("accepts only strictly increasing same-nonce EIP-1559 replacements", async () => {

--- a/typescript/test/services/p2tr-signature-fraud.test.ts
+++ b/typescript/test/services/p2tr-signature-fraud.test.ts
@@ -2326,15 +2326,14 @@ describe("P2TR signature-fraud witness parsing", () => {
       undefined,
       bridgeChallengeDomain
     )
-    const completeEvidence =
-      buildP2TRCompleteV2SignatureFraudChallengeEvidence(
-        observation,
-        bridgeChallengeDomain,
-        {
-          registeredWalletIDs: [vector.walletIDHex],
-          walletInputKeyBindings: [],
-        }
-      )
+    const completeEvidence = buildP2TRCompleteV2SignatureFraudChallengeEvidence(
+      observation,
+      bridgeChallengeDomain,
+      {
+        registeredWalletIDs: [vector.walletIDHex],
+        walletInputKeyBindings: [],
+      }
+    )
     const intent = buildP2TRSignatureFraudSubmissionIntent(completeEvidence, {
       domainChainID: bridgeChallengeDomain.chainID,
       chainID: bridgeChallengeDomain.chainID,


### PR DESCRIPTION
## Review stack

**4 of 4**, based directly on #1048. This is the final cumulative layer.

This is the consolidated review unit for the former #1049–#1052 sequence. Their
commits remain in this branch's history; the intermediate PRs are closed only to
remove duplicate review surfaces.

## Consolidated scope

- **#1049:** key the nonce-allocator barrier by nonce lane
- **#1050:** make migration 004 apply cleanly to PostgreSQL
- **#1051:** scope signing refusal and recovery to the affected nonce lane
- **#1052:** close the remaining outbox policy and recovery gaps

## Hardening included here

- A fault in one nonce lane no longer freezes unrelated lanes
- Signer invocations are answered at most once, independent of the second answer
- Challenge and burn access lists must be empty
- Prepared challenge gas must exactly match the signed manifest
- Irreversible nonce-consumption evidence requires at least 64 confirmations
- The same finality floor applies to direct orphaned-boundary resolution
- Finality attestations bind the observed chain head
- PostgreSQL storage and migration constraints preserve those evidence fields
- Unreachable recovery branches are removed and the live invariant is explicit

The exact-gas and direct-finality fixes are in `9fa0658f8`.

## Review focus

- lane isolation and recovery-barrier accounting
- migration 004 on an existing PostgreSQL deployment
- exact manifest-to-transaction policy binding
- observed-head/finality evidence and reorg safety
- one-shot signer invocation semantics
- in-memory/PostgreSQL parity

## Verification

- SDK build: pass
- SDK tests: **990 passing, 63 pending, 0 failing**
- Watchtower source and test TypeScript builds: pass
- Watchtower tests: **339 passing, 73 integration skips, 0 failing**
- `git diff --check`: clean

The PostgreSQL-only tests are skipped when their integration environment is not
configured; the non-PostgreSQL suite and all compile-time database contracts pass.
