### PR TITLE
chore(ci): move off end-of-life Node to 22 LTS

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       - name: Enable Corepack (Yarn from lockfile)
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       - name: Enable Corepack (Yarn from lockfile)
         run: |
@@ -150,7 +150,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - name: Enable Corepack (Yarn from lockfile)
@@ -250,7 +250,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       - name: Enable Corepack (Yarn from lockfile)
         run: |
@@ -302,7 +302,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - name: Enable Corepack (Yarn from lockfile)
@@ -373,7 +373,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       # IMPORTANT: Keep this root `yarn install` **before** `corepack prepare
       # yarn@4`. The repo root uses Yarn Classic (Frozen v1 lockfile); `solidity/`
@@ -425,7 +425,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       - name: Enable Corepack (Yarn from lockfile)
         run: |

--- a/.github/workflows/cross-chain-arbitrum.yml
+++ b/.github/workflows/cross-chain-arbitrum.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: cross-chain/arbitrum/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: cross-chain/arbitrum/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -118,7 +118,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: cross-chain/arbitrum/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -156,7 +156,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: cross-chain/arbitrum/yarn.lock
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/cross-chain-bob.yml
+++ b/.github/workflows/cross-chain-bob.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/bob/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/bob/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/bob/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/bob/yarn.lock
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/cross-chain-optimism.yml
+++ b/.github/workflows/cross-chain-optimism.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/optimism/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/optimism/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/optimism/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/optimism/yarn.lock
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/cross-chain-polygon.yml
+++ b/.github/workflows/cross-chain-polygon.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/polygon/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/polygon/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/polygon/yarn.lock
 
       # A workaround for transitive dependencies that use the obsolete git://
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "22.x"
           cache-dependency-path: cross-chain/polygon/yarn.lock
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/deployment-artifacts.yml
+++ b/.github/workflows/deployment-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: solidity/yarn.lock
 
       - name: Configure git protocol

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: monitoring/yarn.lock
 
       - name: Configure git to don't use unauthenticated protocol
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: monitoring/yarn.lock
 
       - name: Configure git to don't use unauthenticated protocol

--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache-dependency-path: solidity/yarn.lock
 

--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache-dependency-path: typescript/yarn.lock
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: system-tests/yarn.lock
 
       - name: Enable Corepack
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: system-tests/yarn.lock
 
       - name: Enable Corepack

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: typescript/yarn.lock
 
       # We need this step because the `@keep-network/tbtc-v2` which we update in
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: typescript/yarn.lock
 
       # We need this step because the `@keep-network/tbtc-v2` which we update in
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache-dependency-path: typescript/yarn.lock
 
       - name: Configure git to don't use unauthenticated protocol

--- a/.github/workflows/yearn.yml
+++ b/.github/workflows/yearn.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: yearn/yarn.lock
 
       - name: Enable Corepack
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.19.0"
+          node-version: "22.23.1"
           cache-dependency-path: yearn/yarn.lock
 
       # Below step is a workaround. Eslint executed in `yearn` directory

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:22-alpine as builder
 
 # Add packages necessary to perform the build process.
 RUN apk add --update --no-cache \
@@ -36,7 +36,7 @@ RUN yarn install --production --frozen-lockfile --ignore-scripts
 # Prune other unnecessary files from dependencies using node-prune.
 RUN node-prune
 
-FROM node:18-alpine as runner
+FROM node:22-alpine as runner
 
 WORKDIR /monitoring
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -83,6 +83,6 @@
     "@openzeppelin/upgrades-core": "1.20.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -113,7 +113,7 @@
     "@solana/web3.js": "1.97.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=22.0.0"
   },
   "packageManager": "yarn@4.12.0",
   "repository": {


### PR DESCRIPTION
> **Corrected from Node 24 → 22.** The branch name still says `24`; the content
> and title are 22. See "Why 22, not 24" below — the first revision was verified
> against a warm local solc cache and did not survive CI's cold cache.

Every Node version this repo builds and tests on is past end of life.

| Node | EOL | workflows |
| --- | --- | --- |
| 14 | **2023-04-30** | cross-chain-optimism, cross-chain-polygon |
| 18 | **2025-04-30** | monitoring, npm-contracts, npm-typescript, system-tests, typescript |
| 20 | **2026-04-30** | contracts, cross-chain-arbitrum, cross-chain-bob, deployment-artifacts, format, yearn |

Including `20.19.0`, the newest pin in the tree, which went EOL three months ago.

## Why 22, not 24

24 has 21 months of support against 22's 9, and was the first choice. It does not
work here. Measured, cold solc cache, one variable at a time:

| hardhat | node | result |
| --- | --- | --- |
| 2.12.5 | **22** | compiles, **2949 passing** |
| 2.12.5 | **24** | `HH502` — `InvalidArgumentError: maxRedirections is not supported` |
| 2.29.0 | 24 | compiles |
| 2.29.0 + smock 2.3.4 | 18 | **34 failing** — `reading 'bind'` |

Hardhat's `undici` call is incompatible with Node 24 until ~2.20, and
`@defi-wonderland/smock` breaks on hardhat >= 2.20. **The two windows do not
overlap.** Node 22 is the ceiling until smock is replaced — and smock is archived
upstream (`wonderland-archive/smock`, `archived=true`), so that is a project of
its own rather than a bump.

The 9-month window is therefore a *consequence* of the smock pin, not a reason to
prefer 22 on its merits.

## On the cold cache

The first revision of this PR claimed Node 24 worked. It did — locally, against a
warm 295 MB solc cache. CI starts cold, cannot download the compiler, and dies.
Every number above was re-measured with the cache cleared.

## Verified

Node v22.23.1, cold cache, no dependency changes:

```
solidity     2949 passing, 31 pending, 0 failing
typescript    738 passing,  63 pending, 0 failing
```

## Scope

- 13 workflows → Node 22. Pin style preserved: exact pins become `22.23.1`,
  ranges become `22.x`.
- `engines.node` raised in `solidity` (`>=18.0.0`) and `typescript` (`>=16`).
- `monitoring/Dockerfile` off the EOL `node:18-alpine`.

## Related

`actions/checkout@v3` (39 uses) and `actions/setup-node@v3` (21 uses) run on the
deprecated Node 20 *actions* runtime; latest are v7. Separate pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized CI/build, deployment dry-run, verification, formatting, and analysis workflows to Node.js **22.x / 22.23.1**.
  - Updated the monitoring container image to **node:22-alpine**.
- **Compatibility**
  - Raised the minimum supported Node.js versions:
    - Solidity: `engines.node` to **>=22.0.0**
    - TypeScript: `engines.node` to **>=22.0.0**
  - Ensures more consistent builds and checks across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->