### PR TITLE
test: prototype replacing smock fakes with Solidity stubs (1 of 29 files)

### DIFF
--- a/solidity/contracts/test/ReimbursementPoolStub.sol
+++ b/solidity/contracts/test/ReimbursementPoolStub.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+/// @notice Test-only stand-in for `@keep-network/random-beacon`'s
+///         ReimbursementPool.
+/// @dev Replaces `smock.fake<ReimbursementPool>("ReimbursementPool")`.
+///
+///      smock is archived upstream (`wonderland-archive/smock`, no further
+///      support or security patches) and it is the reason this package cannot
+///      move past hardhat 2.19.x, which in turn caps the toolchain at Node 22.
+///      A plain Solidity stub carries none of that: it has no JavaScript
+///      dependency, so it survives hardhat 2 -> 3, ethers -> viem, and a move
+///      to Foundry.
+///
+///      Behaviour is deliberately the subset the tests use, not the whole
+///      contract:
+///
+///      - `refund` records every call instead of transferring anything. The
+///        recorded calls replace smock's `refund.getCall(n).args` and the
+///        `calledOnce` / `calledTwice` matchers, via `refundCallCount()` and
+///        `refundCall(i)`.
+///      - `maxGasPrice`, `staticGas`, `owner` and `isAuthorized` return values
+///        the test sets, replacing smock's `.returns(...)`.
+///      - `resetRefundCalls()` replaces `refund.reset()`.
+///
+///      Assertions become state reads rather than spy matchers, which is why
+///      this needs no chai plugin.
+contract ReimbursementPoolStub {
+    struct RefundCall {
+        uint256 gasSpent;
+        address receiver;
+    }
+
+    RefundCall[] internal refundCalls;
+
+    uint256 public maxGasPrice = 20000000000;
+    uint256 public staticGas = 40800;
+    address public owner;
+    bool internal authorizedDefault = true;
+
+    mapping(address => bool) internal authorizedOverride;
+    mapping(address => bool) internal authorizedOverrideSet;
+
+    /// @notice Records the call. The production contract would transfer ETH;
+    ///         every test that uses this stub asserts on the call, not on a
+    ///         balance change.
+    function refund(uint256 gasSpent, address receiver) external {
+        refundCalls.push(RefundCall(gasSpent, receiver));
+    }
+
+    function isAuthorized(address account) external view returns (bool) {
+        if (authorizedOverrideSet[account]) {
+            return authorizedOverride[account];
+        }
+        return authorizedDefault;
+    }
+
+    // --- test controls -----------------------------------------------------
+
+    function refundCallCount() external view returns (uint256) {
+        return refundCalls.length;
+    }
+
+    /// @notice Arguments of the i-th `refund` call, replacing smock's
+    ///         `refund.getCall(i).args`.
+    function refundCall(uint256 index)
+        external
+        view
+        returns (uint256 gasSpent, address receiver)
+    {
+        RefundCall storage call = refundCalls[index];
+        return (call.gasSpent, call.receiver);
+    }
+
+    function resetRefundCalls() external {
+        delete refundCalls;
+    }
+
+    function setMaxGasPrice(uint256 _maxGasPrice) external {
+        maxGasPrice = _maxGasPrice;
+    }
+
+    function setStaticGas(uint256 _staticGas) external {
+        staticGas = _staticGas;
+    }
+
+    function setOwner(address _owner) external {
+        owner = _owner;
+    }
+
+    function setAuthorized(address account, bool value) external {
+        authorizedOverride[account] = value;
+        authorizedOverrideSet[account] = true;
+    }
+
+    function setAuthorizedDefault(bool value) external {
+        authorizedDefault = value;
+    }
+
+    /// @notice Lets a test fund the stub so it can be the target of value
+    ///         transfers if a future case needs it.
+    receive() external payable {}
+}

--- a/solidity/test/cross-chain/wormhole/L1BTCDepositorNtt.ntt.test.ts
+++ b/solidity/test/cross-chain/wormhole/L1BTCDepositorNtt.ntt.test.ts
@@ -8,7 +8,7 @@ import {
   IBridge,
   ITBTCVault,
   L1BTCDepositorNtt,
-  ReimbursementPool,
+  ReimbursementPoolStub,
   TestERC20,
 } from "../../../typechain"
 
@@ -43,7 +43,7 @@ describe("L1BTCDepositorNtt NTT Integration", () => {
   let tbtcToken: TestERC20
   let tbtcVault: FakeContract<ITBTCVault>
   let nttManager: Record<string, unknown>
-  let reimbursementPool: FakeContract<ReimbursementPool>
+  let reimbursementPool: ReimbursementPoolStub
   let l1BtcDepositorNtt: L1BTCDepositorNtt
 
   const contractsFixture = async () => {
@@ -57,7 +57,9 @@ describe("L1BTCDepositorNtt NTT Integration", () => {
     // Mock contracts
     bridge = await smock.fake<IBridge>("IBridge")
     tbtcVault = await smock.fake<ITBTCVault>("ITBTCVault")
-    reimbursementPool = await smock.fake<ReimbursementPool>("ReimbursementPool")
+    reimbursementPool = (await (
+      await ethers.getContractFactory("ReimbursementPoolStub")
+    ).deploy()) as ReimbursementPoolStub
 
     // Create manual mock for NTT Manager
     nttManager = {


### PR DESCRIPTION
**Draft — pattern-setter.** One type, one file, so the per-type cost of removing
smock is measured rather than estimated before committing to the other 14.

## Why remove smock at all

`@defi-wonderland/smock` is **archived upstream** — the repo is now
`wonderland-archive/smock`, `archived=true`, with a README banner: *"no longer
maintained… may contain outdated, insecure, or vulnerable code… No support,
updates, or security patches."* The npm package carries no `deprecated` flag, so
installs say nothing.

It is also load-bearing on the toolchain. One dependency, three constraints:

| | |
| --- | --- |
| smock breaks on hardhat >= 2.20 | `Cannot read properties of undefined (reading 'bind')` |
| hardhat < ~2.20 cannot run Node 24 | `InvalidArgumentError: maxRedirections is not supported` |
| ⇒ | CI is capped at **Node 22** (9 months of support) instead of 24, and Hardhat 3 is unreachable |

## Why a hand-written stub rather than a library

Every third-party option is dead or incompatible:

| candidate | last publish | verdict |
| --- | --- | --- |
| `@ethereum-waffle/mock-contract` | 2023-10 | part of abandoned waffle |
| `@gnosis.pm/mock-contract` | 2022-04 | 4 years stale |
| `@clrfund/waffle-mock-contract` | 2024-05 | needs **ethers v6** — which smock is what blocks |

The category is dead because the ecosystem moved to Foundry, where mocking is
native. A plain Solidity stub has **no JavaScript dependency**, so it survives
hardhat 2 → 3, ethers → viem, and a Foundry move.

## The migration is the tractable half of smock

Across 29 files: **78 `smock.fake` calls over 15 distinct types**, and **zero**
uses of `smock.mock`, `setVariable` or `getVariable` — the storage-manipulation
APIs with no equivalent. Everything is interface fakes with programmable
returns, which is exactly what a stub contract is. Four types cover 41 of the 78
sites.

## The translation

`ReimbursementPoolStub` records `refund` calls instead of transferring, so
smock's spy matchers become state reads:

| smock | stub |
| --- | --- |
| `refund.getCall(0).args` | `refundCall(0)` |
| `expect(refund).to.have.been.calledTwice` | `refundCallCount() == 2` |
| `refund.reset()` | `resetRefundCalls()` |
| `maxGasPrice.returns(x)` | `setMaxGasPrice(x)` |

That also removes the need for `smock.matchers` in files that only fake this type.

## Result

`L1BTCDepositorNtt.ntt.test.ts`: **14 passing, 0 failing**. Three edited lines
plus one new contract. The other 8 `ReimbursementPool` call sites follow the same
shape and are left for follow-ups so this stays reviewable.

Draft because the sequencing is yours: 29 files is a wide test-only change and
the 13-PR watchtower chain is currently green against main.