### PR TITLE
test(solidity): toolchain-independent replacement for smock (foundation)

### DIFF
--- a/solidity/contracts/test/IMockTarget.sol
+++ b/solidity/contracts/test/IMockTarget.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.0;
+
+/// @notice Test-only interface exercising the shapes `MockContract` has to
+///         answer: a view function reached by STATICCALL, a state-changing
+///         function whose calls are asserted on, a function returning nothing,
+///         a struct return and a multi-value return.
+interface IMockTarget {
+    struct Info {
+        address owner;
+        uint64 createdAt;
+        bool active;
+    }
+
+    function doThing(address who, uint256 amount) external returns (bool);
+
+    function noReturn(uint256 value) external;
+
+    function readValue(uint256 key) external view returns (uint256);
+
+    function readInfo(uint256 key) external view returns (Info memory);
+
+    function readPair(uint256 key) external view returns (uint32, uint32);
+}

--- a/solidity/contracts/test/MockContract.sol
+++ b/solidity/contracts/test/MockContract.sol
@@ -49,42 +49,64 @@ contract MockContract {
         bytes data;
     }
 
-    /// @dev keccak256(full calldata) => response.
-    mapping(bytes32 => Response) private responseByCalldata;
-    /// @dev selector => response.
-    mapping(bytes4 => Response) private responseBySelector;
-
-    /// @dev selector => response of last resort, installed once when the mock
-    ///      is created and never cleared by `reset`.
+    /// @dev All mock state lives behind one hashed base slot.
     ///
-    ///      Solidity checks returndatasize against the size its ABI expects and
-    ///      reverts on a short answer, so an unconfigured function cannot
-    ///      simply return nothing: it has to return a correctly encoded zero
-    ///      value. Only the helper knows the mocked ABI, so it computes those
-    ///      encodings and installs them here. That reproduces smock, where an
-    ///      unstubbed function yields the zero value of its return type.
-    mapping(bytes4 => Response) private baseResponseBySelector;
+    ///      Mocks are routinely installed over an address that already holds a
+    ///      deployed contract — `test/fixtures/bridge.ts` pins them at the
+    ///      Bridge's real `ecdsaWalletRegistry` and `relay` addresses, and 19
+    ///      call sites pass an explicit address. `hardhat_setCode` replaces the
+    ///      code but leaves that contract's storage behind, so state at slots
+    ///      0, 1, 2... would be read back as configuration. An ERC-7201-style
+    ///      base slot puts this contract's state where nothing else has been.
+    struct State {
+        /// @dev keccak256(full calldata) => response.
+        mapping(bytes32 => Response) responseByCalldata;
+        /// @dev selector => response.
+        mapping(bytes4 => Response) responseBySelector;
+        /// @dev selector => response of last resort, installed once when the
+        ///      mock is created and never cleared by `reset`.
+        ///
+        ///      Solidity checks returndatasize against the size its ABI expects
+        ///      and reverts on a short answer, so an unconfigured function
+        ///      cannot simply return nothing: it has to return a correctly
+        ///      encoded zero. Only the helper knows the mocked ABI, so it
+        ///      computes those encodings and installs them here. That
+        ///      reproduces smock, where an unstubbed function yields the zero
+        ///      value of its return type.
+        mapping(bytes4 => Response) baseResponseBySelector;
+        /// @dev Selectors that must never be recorded, because the mocked ABI
+        ///      declares them `view` or `pure` and so they arrive by
+        ///      STATICCALL. See `__mock__record`.
+        mapping(bytes4 => bool) nonRecording;
+        /// @dev Keys of every exact-calldata entry configured so far, with the
+        ///      selector each belongs to. Exact-calldata entries are keyed by
+        ///      hash and so cannot be enumerated from the mapping; `reset`
+        ///      needs to clear them, and inferring them from recorded calls
+        ///      would be wrong because view calls are never recorded.
+        bytes32[] configuredCalldataKeys;
+        mapping(bytes32 => bytes4) selectorOfCalldataKey;
+        mapping(bytes32 => bool) calldataKeyKnown;
+        /// @dev Selectors given a default response, for the same reason.
+        bytes4[] configuredSelectors;
+        mapping(bytes4 => bool) selectorKnown;
+        /// @dev Every call recorded, in order, as raw calldata. Kept whole
+        ///      rather than decoded so the helper can decode against whichever
+        ///      ABI the test declared.
+        bytes[] receivedCalls;
+    }
 
-    /// @dev Keys of every exact-calldata entry configured so far, with the
-    ///      selector each belongs to. Exact-calldata entries are keyed by hash
-    ///      and so cannot be enumerated from the mapping; `reset` needs to
-    ///      clear them, and inferring them from recorded calls would be wrong
-    ///      because recording is best-effort (see `__mock__record`).
-    bytes32[] private configuredCalldataKeys;
-    mapping(bytes32 => bytes4) private selectorOfCalldataKey;
-    mapping(bytes32 => bool) private calldataKeyKnown;
+    /// @dev keccak256("tbtc.test.MockContract.state.v1") - 1, masked, per the
+    ///      ERC-7201 convention.
+    bytes32 private constant STATE_SLOT =
+        0xdd9627cd601a6555f69239ac336fba8db95c419564b84ebb3ee2c21fed88ae00;
 
-    /// @dev Selectors given a default response, for the same reason: a
-    ///      selector configured but never called — or only ever called by
-    ///      STATICCALL, which is not recorded — must still be cleared by
-    ///      `reset`.
-    bytes4[] private configuredSelectors;
-    mapping(bytes4 => bool) private selectorKnown;
-
-    /// @dev Every call recorded, in order, as raw calldata. Kept whole rather
-    ///      than decoded so the helper can decode against whichever ABI the
-    ///      test declared.
-    bytes[] private receivedCalls;
+    function _state() private pure returns (State storage state) {
+        bytes32 slot = STATE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            state.slot := slot
+        }
+    }
 
     /// @notice Configures the response for one exact calldata payload.
     /// @param callData Full ABI-encoded calldata, selector included.
@@ -94,7 +116,7 @@ contract MockContract {
         bytes calldata returnData
     ) external {
         __mock__rememberCalldataKey(callData);
-        responseByCalldata[keccak256(callData)] = Response(
+        _state().responseByCalldata[keccak256(callData)] = Response(
             Behaviour.Return,
             returnData
         );
@@ -107,7 +129,10 @@ contract MockContract {
         bytes calldata returnData
     ) external {
         __mock__rememberSelector(selector);
-        responseBySelector[selector] = Response(Behaviour.Return, returnData);
+        _state().responseBySelector[selector] = Response(
+            Behaviour.Return,
+            returnData
+        );
     }
 
     /// @notice Makes one exact calldata payload revert.
@@ -117,7 +142,7 @@ contract MockContract {
         bytes calldata revertData
     ) external {
         __mock__rememberCalldataKey(callData);
-        responseByCalldata[keccak256(callData)] = Response(
+        _state().responseByCalldata[keccak256(callData)] = Response(
             Behaviour.Revert,
             revertData
         );
@@ -130,64 +155,67 @@ contract MockContract {
         bytes calldata revertData
     ) external {
         __mock__rememberSelector(selector);
-        responseBySelector[selector] = Response(Behaviour.Revert, revertData);
+        _state().responseBySelector[selector] = Response(
+            Behaviour.Revert,
+            revertData
+        );
     }
 
     /// @notice Clears every response configured for one selector and forgets
     ///         the calls recorded for it. This is smock's `fn.reset()`.
     function __mock__resetSelector(bytes4 selector) external {
-        delete responseBySelector[selector];
+        delete _state().responseBySelector[selector];
 
         uint256 keptKeys = 0;
-        uint256 totalKeys = configuredCalldataKeys.length;
+        uint256 totalKeys = _state().configuredCalldataKeys.length;
         for (uint256 i = 0; i < totalKeys; i++) {
-            bytes32 key = configuredCalldataKeys[i];
+            bytes32 key = _state().configuredCalldataKeys[i];
 
-            if (selectorOfCalldataKey[key] == selector) {
-                delete responseByCalldata[key];
-                delete selectorOfCalldataKey[key];
-                delete calldataKeyKnown[key];
+            if (_state().selectorOfCalldataKey[key] == selector) {
+                delete _state().responseByCalldata[key];
+                delete _state().selectorOfCalldataKey[key];
+                delete _state().calldataKeyKnown[key];
             } else {
-                configuredCalldataKeys[keptKeys] = key;
+                _state().configuredCalldataKeys[keptKeys] = key;
                 keptKeys++;
             }
         }
-        while (configuredCalldataKeys.length > keptKeys) {
-            configuredCalldataKeys.pop();
+        while (_state().configuredCalldataKeys.length > keptKeys) {
+            _state().configuredCalldataKeys.pop();
         }
 
         uint256 keptCalls = 0;
-        uint256 totalCalls = receivedCalls.length;
+        uint256 totalCalls = _state().receivedCalls.length;
         for (uint256 i = 0; i < totalCalls; i++) {
-            if (__mock__selectorOf(receivedCalls[i]) != selector) {
-                receivedCalls[keptCalls] = receivedCalls[i];
+            if (__mock__selectorOf(_state().receivedCalls[i]) != selector) {
+                _state().receivedCalls[keptCalls] = _state().receivedCalls[i];
                 keptCalls++;
             }
         }
-        while (receivedCalls.length > keptCalls) {
-            receivedCalls.pop();
+        while (_state().receivedCalls.length > keptCalls) {
+            _state().receivedCalls.pop();
         }
     }
 
     /// @notice Clears every configured response and every recorded call.
     function __mock__reset() external {
-        uint256 totalKeys = configuredCalldataKeys.length;
+        uint256 totalKeys = _state().configuredCalldataKeys.length;
         for (uint256 i = 0; i < totalKeys; i++) {
-            bytes32 key = configuredCalldataKeys[i];
-            delete responseByCalldata[key];
-            delete selectorOfCalldataKey[key];
-            delete calldataKeyKnown[key];
+            bytes32 key = _state().configuredCalldataKeys[i];
+            delete _state().responseByCalldata[key];
+            delete _state().selectorOfCalldataKey[key];
+            delete _state().calldataKeyKnown[key];
         }
-        delete configuredCalldataKeys;
+        delete _state().configuredCalldataKeys;
 
-        uint256 totalSelectors = configuredSelectors.length;
+        uint256 totalSelectors = _state().configuredSelectors.length;
         for (uint256 i = 0; i < totalSelectors; i++) {
-            delete responseBySelector[configuredSelectors[i]];
-            delete selectorKnown[configuredSelectors[i]];
+            delete _state().responseBySelector[_state().configuredSelectors[i]];
+            delete _state().selectorKnown[_state().configuredSelectors[i]];
         }
-        delete configuredSelectors;
+        delete _state().configuredSelectors;
 
-        delete receivedCalls;
+        delete _state().receivedCalls;
     }
 
     /// @notice Installs the responses of last resort. Called once by the
@@ -203,17 +231,37 @@ contract MockContract {
         );
 
         for (uint256 i = 0; i < selectors.length; i++) {
-            baseResponseBySelector[selectors[i]] = Response(
+            _state().baseResponseBySelector[selectors[i]] = Response(
                 Behaviour.Return,
                 returnData[i]
             );
         }
     }
 
+    /// @notice Marks selectors that must never be recorded. The helper calls
+    ///         this once with every `view` and `pure` function of the mocked
+    ///         ABI.
+    function __mock__setNonRecordingSelectors(bytes4[] calldata selectors)
+        external
+    {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            _state().nonRecording[selectors[i]] = true;
+        }
+    }
+
+    /// @notice Whether a selector is excluded from recording.
+    function __mock__isNonRecording(bytes4 selector)
+        external
+        view
+        returns (bool)
+    {
+        return _state().nonRecording[selector];
+    }
+
     /// @notice Clears the default response for one selector without touching
     ///         its exact-calldata entries or recorded calls.
     function __mock__clearSelector(bytes4 selector) external {
-        delete responseBySelector[selector];
+        delete _state().responseBySelector[selector];
     }
 
     /// @notice Appends a recorded call. Only ever invoked by this contract, on
@@ -235,12 +283,12 @@ contract MockContract {
             msg.sender == address(this),
             "MockContract: recording is internal"
         );
-        receivedCalls.push(callData);
+        _state().receivedCalls.push(callData);
     }
 
     /// @notice Number of calls recorded, across all selectors.
     function __mock__callCount() external view returns (uint256) {
-        return receivedCalls.length;
+        return _state().receivedCalls.length;
     }
 
     /// @notice Raw calldata of the i-th call recorded, across all selectors.
@@ -249,7 +297,7 @@ contract MockContract {
         view
         returns (bytes memory)
     {
-        return receivedCalls[index];
+        return _state().receivedCalls[index];
     }
 
     /// @notice Number of calls recorded for one selector.
@@ -258,9 +306,9 @@ contract MockContract {
         view
         returns (uint256 count)
     {
-        uint256 total = receivedCalls.length;
+        uint256 total = _state().receivedCalls.length;
         for (uint256 i = 0; i < total; i++) {
-            if (__mock__selectorOf(receivedCalls[i]) == selector) {
+            if (__mock__selectorOf(_state().receivedCalls[i]) == selector) {
                 count++;
             }
         }
@@ -273,12 +321,12 @@ contract MockContract {
         returns (bytes memory)
     {
         uint256 seen = 0;
-        uint256 total = receivedCalls.length;
+        uint256 total = _state().receivedCalls.length;
 
         for (uint256 i = 0; i < total; i++) {
-            if (__mock__selectorOf(receivedCalls[i]) == selector) {
+            if (__mock__selectorOf(_state().receivedCalls[i]) == selector) {
                 if (seen == index) {
-                    return receivedCalls[i];
+                    return _state().receivedCalls[i];
                 }
                 seen++;
             }
@@ -310,9 +358,18 @@ contract MockContract {
     // returning through assembly is immune to that.
     // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
-        // Best-effort: silently skipped under STATICCALL. See `__mock__record`.
-        // solhint-disable-next-line no-empty-blocks
-        try this.__mock__record(msg.data) {} catch {}
+        // A `view` or `pure` function on the mocked ABI arrives by STATICCALL,
+        // where the storage write recording needs is impossible. Those
+        // selectors are flagged up front so the attempt is skipped outright
+        // rather than made and swallowed — which keeps them off the gas budget
+        // of the hot path, SPV proofs being the case that matters.
+        //
+        // The try/catch still guards the rest: a state-changing function is
+        // also reached statically under `eth_call`/`callStatic`.
+        if (!_state().nonRecording[__mock__selectorOf(msg.data)]) {
+            // solhint-disable-next-line no-empty-blocks
+            try this.__mock__record(msg.data) {} catch {}
+        }
 
         bytes memory result = __mock__responseFor(msg.data);
 
@@ -332,19 +389,21 @@ contract MockContract {
         view
         returns (bytes memory)
     {
-        Response storage exact = responseByCalldata[keccak256(callData)];
+        Response storage exact = _state().responseByCalldata[
+            keccak256(callData)
+        ];
         if (exact.behaviour != Behaviour.Unset) {
             return __mock__respond(exact);
         }
 
         bytes4 selector = __mock__selectorOf(callData);
 
-        Response storage bySelector = responseBySelector[selector];
+        Response storage bySelector = _state().responseBySelector[selector];
         if (bySelector.behaviour != Behaviour.Unset) {
             return __mock__respond(bySelector);
         }
 
-        Response storage base = baseResponseBySelector[selector];
+        Response storage base = _state().baseResponseBySelector[selector];
         if (base.behaviour != Behaviour.Unset) {
             return __mock__respond(base);
         }
@@ -353,19 +412,19 @@ contract MockContract {
     }
 
     function __mock__rememberSelector(bytes4 selector) private {
-        if (!selectorKnown[selector]) {
-            selectorKnown[selector] = true;
-            configuredSelectors.push(selector);
+        if (!_state().selectorKnown[selector]) {
+            _state().selectorKnown[selector] = true;
+            _state().configuredSelectors.push(selector);
         }
     }
 
     function __mock__rememberCalldataKey(bytes calldata callData) private {
         bytes32 key = keccak256(callData);
 
-        if (!calldataKeyKnown[key]) {
-            calldataKeyKnown[key] = true;
-            selectorOfCalldataKey[key] = __mock__selectorOf(callData);
-            configuredCalldataKeys.push(key);
+        if (!_state().calldataKeyKnown[key]) {
+            _state().calldataKeyKnown[key] = true;
+            _state().selectorOfCalldataKey[key] = __mock__selectorOf(callData);
+            _state().configuredCalldataKeys.push(key);
         }
     }
 

--- a/solidity/contracts/test/MockContract.sol
+++ b/solidity/contracts/test/MockContract.sol
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.0;
+
+/// @notice Test-only programmable mock. Answers any call according to a table
+///         set up from the test, and records the calls it receives.
+///
+///         This is the contract half of the replacement for the archived
+///         defi-wonderland smock package. smock worked by reaching into
+///         Hardhat's provider internals, which is why it broke on Hardhat
+///         >= 2.20 and why it cannot be carried forward. Everything here is
+///         ordinary EVM state, so it survives any Hardhat, ethers, viem or
+///         Foundry change.
+///
+///         The model is deliberately Foundry's `vm.mockCall`: a
+///         calldata-to-returndata table plus call recording. If the suite ever
+///         moves to Solidity tests, the semantics carry over unchanged.
+///
+///         Lookup order for an incoming call, first match wins:
+///           1. exact full-calldata match — smock's `whenCalledWith`
+///           2. selector match — smock's bare `returns`
+///           3. the response of last resort installed by the helper when the
+///              mock was created: the zero value of the function's return
+///              type, which is how smock answered an unstubbed function
+///
+///         Reverts are configured the same way and take priority over returns
+///         at the same specificity.
+///
+/// @dev Administrative entry points are prefixed `__mock__` so they are
+///      addressable alongside whatever interface is being mocked. A four-byte
+///      collision between one of them and a real function of the mocked
+///      interface would silently shadow that function, so the TypeScript helper
+///      asserts no collision exists at construction time rather than leaving it
+///      to chance.
+contract MockContract {
+    // The `__mock__` prefix namespaces this contract's own entry points away
+    // from whatever interface it is answering, which is the point; mixedCase
+    // would defeat it.
+    // solhint-disable func-name-mixedcase
+
+    enum Behaviour {
+        Unset,
+        Return,
+        Revert
+    }
+
+    struct Response {
+        Behaviour behaviour;
+        bytes data;
+    }
+
+    /// @dev keccak256(full calldata) => response.
+    mapping(bytes32 => Response) private responseByCalldata;
+    /// @dev selector => response.
+    mapping(bytes4 => Response) private responseBySelector;
+
+    /// @dev selector => response of last resort, installed once when the mock
+    ///      is created and never cleared by `reset`.
+    ///
+    ///      Solidity checks returndatasize against the size its ABI expects and
+    ///      reverts on a short answer, so an unconfigured function cannot
+    ///      simply return nothing: it has to return a correctly encoded zero
+    ///      value. Only the helper knows the mocked ABI, so it computes those
+    ///      encodings and installs them here. That reproduces smock, where an
+    ///      unstubbed function yields the zero value of its return type.
+    mapping(bytes4 => Response) private baseResponseBySelector;
+
+    /// @dev Keys of every exact-calldata entry configured so far, with the
+    ///      selector each belongs to. Exact-calldata entries are keyed by hash
+    ///      and so cannot be enumerated from the mapping; `reset` needs to
+    ///      clear them, and inferring them from recorded calls would be wrong
+    ///      because recording is best-effort (see `__mock__record`).
+    bytes32[] private configuredCalldataKeys;
+    mapping(bytes32 => bytes4) private selectorOfCalldataKey;
+    mapping(bytes32 => bool) private calldataKeyKnown;
+
+    /// @dev Selectors given a default response, for the same reason: a
+    ///      selector configured but never called — or only ever called by
+    ///      STATICCALL, which is not recorded — must still be cleared by
+    ///      `reset`.
+    bytes4[] private configuredSelectors;
+    mapping(bytes4 => bool) private selectorKnown;
+
+    /// @dev Every call recorded, in order, as raw calldata. Kept whole rather
+    ///      than decoded so the helper can decode against whichever ABI the
+    ///      test declared.
+    bytes[] private receivedCalls;
+
+    /// @notice Configures the response for one exact calldata payload.
+    /// @param callData Full ABI-encoded calldata, selector included.
+    /// @param returnData ABI-encoded return value. Empty for void functions.
+    function __mock__setReturnForCalldata(
+        bytes calldata callData,
+        bytes calldata returnData
+    ) external {
+        __mock__rememberCalldataKey(callData);
+        responseByCalldata[keccak256(callData)] = Response(
+            Behaviour.Return,
+            returnData
+        );
+    }
+
+    /// @notice Configures the default response for a selector, used when no
+    ///         exact-calldata entry matches.
+    function __mock__setReturnForSelector(
+        bytes4 selector,
+        bytes calldata returnData
+    ) external {
+        __mock__rememberSelector(selector);
+        responseBySelector[selector] = Response(Behaviour.Return, returnData);
+    }
+
+    /// @notice Makes one exact calldata payload revert.
+    /// @param revertData Raw revert payload. Empty reverts with no data.
+    function __mock__setRevertForCalldata(
+        bytes calldata callData,
+        bytes calldata revertData
+    ) external {
+        __mock__rememberCalldataKey(callData);
+        responseByCalldata[keccak256(callData)] = Response(
+            Behaviour.Revert,
+            revertData
+        );
+    }
+
+    /// @notice Makes every call to a selector revert, unless an exact-calldata
+    ///         entry matches first.
+    function __mock__setRevertForSelector(
+        bytes4 selector,
+        bytes calldata revertData
+    ) external {
+        __mock__rememberSelector(selector);
+        responseBySelector[selector] = Response(Behaviour.Revert, revertData);
+    }
+
+    /// @notice Clears every response configured for one selector and forgets
+    ///         the calls recorded for it. This is smock's `fn.reset()`.
+    function __mock__resetSelector(bytes4 selector) external {
+        delete responseBySelector[selector];
+
+        uint256 keptKeys = 0;
+        uint256 totalKeys = configuredCalldataKeys.length;
+        for (uint256 i = 0; i < totalKeys; i++) {
+            bytes32 key = configuredCalldataKeys[i];
+
+            if (selectorOfCalldataKey[key] == selector) {
+                delete responseByCalldata[key];
+                delete selectorOfCalldataKey[key];
+                delete calldataKeyKnown[key];
+            } else {
+                configuredCalldataKeys[keptKeys] = key;
+                keptKeys++;
+            }
+        }
+        while (configuredCalldataKeys.length > keptKeys) {
+            configuredCalldataKeys.pop();
+        }
+
+        uint256 keptCalls = 0;
+        uint256 totalCalls = receivedCalls.length;
+        for (uint256 i = 0; i < totalCalls; i++) {
+            if (__mock__selectorOf(receivedCalls[i]) != selector) {
+                receivedCalls[keptCalls] = receivedCalls[i];
+                keptCalls++;
+            }
+        }
+        while (receivedCalls.length > keptCalls) {
+            receivedCalls.pop();
+        }
+    }
+
+    /// @notice Clears every configured response and every recorded call.
+    function __mock__reset() external {
+        uint256 totalKeys = configuredCalldataKeys.length;
+        for (uint256 i = 0; i < totalKeys; i++) {
+            bytes32 key = configuredCalldataKeys[i];
+            delete responseByCalldata[key];
+            delete selectorOfCalldataKey[key];
+            delete calldataKeyKnown[key];
+        }
+        delete configuredCalldataKeys;
+
+        uint256 totalSelectors = configuredSelectors.length;
+        for (uint256 i = 0; i < totalSelectors; i++) {
+            delete responseBySelector[configuredSelectors[i]];
+            delete selectorKnown[configuredSelectors[i]];
+        }
+        delete configuredSelectors;
+
+        delete receivedCalls;
+    }
+
+    /// @notice Installs the responses of last resort. Called once by the
+    ///         helper at construction with the zero value of every function's
+    ///         return type.
+    function __mock__setBaseReturns(
+        bytes4[] calldata selectors,
+        bytes[] calldata returnData
+    ) external {
+        require(
+            selectors.length == returnData.length,
+            "MockContract: length mismatch"
+        );
+
+        for (uint256 i = 0; i < selectors.length; i++) {
+            baseResponseBySelector[selectors[i]] = Response(
+                Behaviour.Return,
+                returnData[i]
+            );
+        }
+    }
+
+    /// @notice Clears the default response for one selector without touching
+    ///         its exact-calldata entries or recorded calls.
+    function __mock__clearSelector(bytes4 selector) external {
+        delete responseBySelector[selector];
+    }
+
+    /// @notice Appends a recorded call. Only ever invoked by this contract, on
+    ///         itself, from `fallback`.
+    /// @dev Recording is a storage write, so it is impossible when the mocked
+    ///      function was reached by STATICCALL — which is what Solidity emits
+    ///      for a `view` or `pure` function on the mocked interface. Routing
+    ///      the write through an external self-call lets `fallback` attempt it
+    ///      and carry on when it fails, so a stubbed view function still
+    ///      answers instead of reverting.
+    ///
+    ///      The cost is that calls to view functions are not recorded, and so
+    ///      cannot be asserted on. That is sound for this suite: every call
+    ///      assertion in it targets a state-changing function, and a `view`
+    ///      that a test wanted to count could not have been reached by
+    ///      STATICCALL in the first place.
+    function __mock__record(bytes calldata callData) external {
+        require(
+            msg.sender == address(this),
+            "MockContract: recording is internal"
+        );
+        receivedCalls.push(callData);
+    }
+
+    /// @notice Number of calls recorded, across all selectors.
+    function __mock__callCount() external view returns (uint256) {
+        return receivedCalls.length;
+    }
+
+    /// @notice Raw calldata of the i-th call recorded, across all selectors.
+    function __mock__callAt(uint256 index)
+        external
+        view
+        returns (bytes memory)
+    {
+        return receivedCalls[index];
+    }
+
+    /// @notice Number of calls recorded for one selector.
+    function __mock__callCountForSelector(bytes4 selector)
+        external
+        view
+        returns (uint256 count)
+    {
+        uint256 total = receivedCalls.length;
+        for (uint256 i = 0; i < total; i++) {
+            if (__mock__selectorOf(receivedCalls[i]) == selector) {
+                count++;
+            }
+        }
+    }
+
+    /// @notice Raw calldata of the i-th call recorded for one selector.
+    function __mock__callForSelectorAt(bytes4 selector, uint256 index)
+        external
+        view
+        returns (bytes memory)
+    {
+        uint256 seen = 0;
+        uint256 total = receivedCalls.length;
+
+        for (uint256 i = 0; i < total; i++) {
+            if (__mock__selectorOf(receivedCalls[i]) == selector) {
+                if (seen == index) {
+                    return receivedCalls[i];
+                }
+                seen++;
+            }
+        }
+
+        revert("MockContract: call index out of range");
+    }
+
+    /// @dev Leading four bytes of `callData`, or zero if it is shorter.
+    function __mock__selectorOf(bytes memory callData)
+        public
+        pure
+        returns (bytes4 selector)
+    {
+        if (callData.length < 4) {
+            return bytes4(0);
+        }
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            selector := mload(add(callData, 32))
+        }
+    }
+
+    // A typed `fallback(bytes calldata) returns (bytes memory)` would read
+    // better, but prettier-plugin-solidity silently rewrites it to
+    // `fallback() external payable`, dropping the parameter and the return
+    // type — a formatter quietly changing semantics. Reading msg.data and
+    // returning through assembly is immune to that.
+    // solhint-disable-next-line no-complex-fallback
+    fallback() external payable {
+        // Best-effort: silently skipped under STATICCALL. See `__mock__record`.
+        // solhint-disable-next-line no-empty-blocks
+        try this.__mock__record(msg.data) {} catch {}
+
+        bytes memory result = __mock__responseFor(msg.data);
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            return(add(result, 32), mload(result))
+        }
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {}
+
+    /// @dev Resolves an incoming call against the three layers, most specific
+    ///      first. Reverts here if the matched response is a configured revert.
+    function __mock__responseFor(bytes memory callData)
+        private
+        view
+        returns (bytes memory)
+    {
+        Response storage exact = responseByCalldata[keccak256(callData)];
+        if (exact.behaviour != Behaviour.Unset) {
+            return __mock__respond(exact);
+        }
+
+        bytes4 selector = __mock__selectorOf(callData);
+
+        Response storage bySelector = responseBySelector[selector];
+        if (bySelector.behaviour != Behaviour.Unset) {
+            return __mock__respond(bySelector);
+        }
+
+        Response storage base = baseResponseBySelector[selector];
+        if (base.behaviour != Behaviour.Unset) {
+            return __mock__respond(base);
+        }
+
+        return "";
+    }
+
+    function __mock__rememberSelector(bytes4 selector) private {
+        if (!selectorKnown[selector]) {
+            selectorKnown[selector] = true;
+            configuredSelectors.push(selector);
+        }
+    }
+
+    function __mock__rememberCalldataKey(bytes calldata callData) private {
+        bytes32 key = keccak256(callData);
+
+        if (!calldataKeyKnown[key]) {
+            calldataKeyKnown[key] = true;
+            selectorOfCalldataKey[key] = __mock__selectorOf(callData);
+            configuredCalldataKeys.push(key);
+        }
+    }
+
+    function __mock__respond(Response storage response)
+        private
+        view
+        returns (bytes memory)
+    {
+        if (response.behaviour == Behaviour.Revert) {
+            bytes memory revertData = response.data;
+
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                revert(add(revertData, 32), mload(revertData))
+            }
+        }
+
+        return response.data;
+    }
+}

--- a/solidity/contracts/test/MockTargetConsumer.sol
+++ b/solidity/contracts/test/MockTargetConsumer.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.0;
+
+import "./IMockTarget.sol";
+
+/// @notice Test-only contract under test. It reaches the mocked interface the
+///         way production code does — in particular, `view` functions are
+///         reached by STATICCALL, which is the case a recording mock has to
+///         survive without reverting.
+contract MockTargetConsumer {
+    IMockTarget public immutable target;
+
+    uint256 public lastValue;
+    bool public lastResult;
+
+    constructor(IMockTarget _target) {
+        target = _target;
+    }
+
+    /// @dev STATICCALL inside a state-changing function.
+    function cacheValue(uint256 key) external {
+        lastValue = target.readValue(key);
+    }
+
+    /// @dev CALL: recorded by the mock and asserted on by the test.
+    function doThing(address who, uint256 amount) external {
+        lastResult = target.doThing(who, amount);
+    }
+
+    function noReturn(uint256 value) external {
+        target.noReturn(value);
+    }
+
+    /// @dev STATICCALL: `readValue` is `view` on the interface.
+    function readValueThroughStaticCall(uint256 key)
+        external
+        view
+        returns (uint256)
+    {
+        return target.readValue(key);
+    }
+
+    function readInfoThroughStaticCall(uint256 key)
+        external
+        view
+        returns (IMockTarget.Info memory)
+    {
+        return target.readInfo(key);
+    }
+
+    function readPairThroughStaticCall(uint256 key)
+        external
+        view
+        returns (uint32, uint32)
+    {
+        return target.readPair(key);
+    }
+}

--- a/solidity/test/helpers/mock.test.ts
+++ b/solidity/test/helpers/mock.test.ts
@@ -1,0 +1,224 @@
+import { ethers } from "hardhat"
+import { expect } from "chai"
+
+import { createMock } from "./mock"
+
+import type { Mock } from "./mock"
+import type { IMockTarget, MockTargetConsumer } from "../../typechain"
+
+describe("MockContract", () => {
+  let target: Mock<IMockTarget>
+  let consumer: MockTargetConsumer
+
+  beforeEach(async () => {
+    target = await createMock<IMockTarget>("IMockTarget")
+
+    const factory = await ethers.getContractFactory("MockTargetConsumer")
+    consumer = (await factory.deploy(target.address)) as MockTargetConsumer
+    await consumer.deployed()
+  })
+
+  describe("view functions reached by STATICCALL", () => {
+    // The mock records calls, which is a storage write, and a storage write is
+    // impossible under STATICCALL. If recording were unconditional every
+    // stubbed view function would revert, so this is the case that decides
+    // whether a contract-backed mock is viable at all.
+
+    it("answers a stubbed view function", async () => {
+      await target.readValue.returns(42)
+
+      expect(await consumer.readValueThroughStaticCall(7)).to.equal(42)
+    })
+
+    it("answers a stubbed view function from a state-changing caller", async () => {
+      await target.readValue.returns(99)
+
+      await consumer.cacheValue(7)
+
+      expect(await consumer.lastValue()).to.equal(99)
+    })
+
+    it("answers with a struct", async () => {
+      const owner = ethers.Wallet.createRandom().address
+      await target.readInfo.returns({
+        owner,
+        createdAt: 1234,
+        active: true,
+      })
+
+      const info = await consumer.readInfoThroughStaticCall(1)
+
+      expect(info.owner).to.equal(owner)
+      expect(info.createdAt).to.equal(1234)
+      expect(info.active).to.equal(true)
+    })
+
+    it("answers with multiple values", async () => {
+      await target.readPair.returns([11, 22])
+
+      const [first, second] = await consumer.readPairThroughStaticCall(1)
+
+      expect(first).to.equal(11)
+      expect(second).to.equal(22)
+    })
+
+    it("returns the zero value when unstubbed", async () => {
+      // smock answers an unconfigured function with the zero value of its
+      // return type rather than reverting; empty returndata decodes the same.
+      expect(await consumer.readValueThroughStaticCall(7)).to.equal(0)
+    })
+  })
+
+  describe("whenCalledWith", () => {
+    it("takes precedence over the selector-wide default", async () => {
+      await target.readValue.returns(1)
+      await target.readValue.whenCalledWith(7).returns(700)
+
+      expect(await consumer.readValueThroughStaticCall(7)).to.equal(700)
+      expect(await consumer.readValueThroughStaticCall(8)).to.equal(1)
+    })
+
+    it("falls through to the default for non-matching arguments", async () => {
+      await target.readValue.whenCalledWith(7).returns(700)
+
+      expect(await consumer.readValueThroughStaticCall(8)).to.equal(0)
+    })
+  })
+
+  describe("reverts", () => {
+    it("reverts every call to the function", async () => {
+      await target.doThing.reverts("nope")
+
+      await expect(
+        consumer.doThing(ethers.constants.AddressZero, 1)
+      ).to.be.revertedWith("nope")
+    })
+
+    it("reverts only the matching arguments", async () => {
+      const who = ethers.Wallet.createRandom().address
+      await target.doThing.returns(true)
+      await target.doThing.whenCalledWith(who, 5).reverts("blocked")
+
+      await expect(consumer.doThing(who, 5)).to.be.revertedWith("blocked")
+      await expect(consumer.doThing(who, 6)).to.not.be.reverted
+    })
+  })
+
+  describe("call recording", () => {
+    it("records arguments of a state-changing call", async () => {
+      const who = ethers.Wallet.createRandom().address
+      await target.doThing.returns(true)
+
+      await consumer.doThing(who, 123)
+
+      expect(await target.doThing.callCount()).to.equal(1)
+
+      const call = await target.doThing.getCall(0)
+      expect(call.args[0]).to.equal(who)
+      expect(call.args[1]).to.equal(123)
+    })
+
+    it("records a function that returns nothing", async () => {
+      await consumer.noReturn(5)
+      await consumer.noReturn(6)
+
+      expect(await target.noReturn.callCount()).to.equal(2)
+      expect((await target.noReturn.getCall(1)).args[0]).to.equal(6)
+    })
+
+    it("counts each function separately", async () => {
+      await target.doThing.returns(true)
+
+      await consumer.doThing(ethers.constants.AddressZero, 1)
+      await consumer.noReturn(1)
+
+      expect(await target.doThing.callCount()).to.equal(1)
+      expect(await target.noReturn.callCount()).to.equal(1)
+    })
+  })
+
+  describe("reset", () => {
+    it("clears recorded calls and configured responses for one function", async () => {
+      await target.doThing.returns(true)
+      await consumer.doThing(ethers.constants.AddressZero, 1)
+
+      await target.doThing.reset()
+
+      expect(await target.doThing.callCount()).to.equal(0)
+      // The configured `true` is gone, so the call answers with empty data.
+      await consumer.doThing(ethers.constants.AddressZero, 1)
+      expect(await consumer.lastResult()).to.equal(false)
+    })
+
+    it("clears a whenCalledWith entry", async () => {
+      await target.readValue.whenCalledWith(7).returns(700)
+      await target.readValue.reset()
+
+      expect(await consumer.readValueThroughStaticCall(7)).to.equal(0)
+    })
+
+    it("clears a view function's configuration, which is never recorded", async () => {
+      // `reset` cannot infer entries from recorded calls, because STATICCALL
+      // calls are not recorded. It has to track what was configured.
+      await target.readValue.returns(5)
+      await consumer.readValueThroughStaticCall(7)
+
+      await target.readValue.reset()
+
+      expect(await consumer.readValueThroughStaticCall(7)).to.equal(0)
+    })
+
+    it("leaves other functions alone", async () => {
+      await target.readValue.returns(5)
+      await target.doThing.returns(true)
+
+      await target.doThing.reset()
+
+      expect(await consumer.readValueThroughStaticCall(1)).to.equal(5)
+    })
+
+    it("clears everything at the mock level", async () => {
+      await target.readValue.returns(5)
+      await consumer.noReturn(1)
+
+      await target.reset()
+
+      expect(await consumer.readValueThroughStaticCall(1)).to.equal(0)
+      expect(await target.noReturn.callCount()).to.equal(0)
+    })
+  })
+
+  describe("wallet", () => {
+    it("sends transactions from the mock's own address", async () => {
+      // smock's `fake.wallet`, used where production code checks
+      // `msg.sender == someContract`.
+      const factory = await ethers.getContractFactory("MockTargetConsumer")
+      const other = await factory.deploy(target.address)
+      await other.deployed()
+
+      const tx = await other.connect(target.wallet).noReturn(1)
+      const receipt = await tx.wait()
+
+      expect(receipt.from).to.equal(target.address)
+    })
+  })
+
+  describe("address option", () => {
+    it("deploys at a requested address", async () => {
+      const address = ethers.utils.getAddress(
+        `0x${"ab".repeat(20)}`.toLowerCase()
+      )
+
+      const pinned = await createMock<IMockTarget>("IMockTarget", { address })
+
+      expect(pinned.address).to.equal(address)
+      await pinned.readValue.returns(7)
+
+      const factory = await ethers.getContractFactory("MockTargetConsumer")
+      const pinnedConsumer = await factory.deploy(address)
+      await pinnedConsumer.deployed()
+
+      expect(await pinnedConsumer.readValueThroughStaticCall(1)).to.equal(7)
+    })
+  })
+})

--- a/solidity/test/helpers/mock.test.ts
+++ b/solidity/test/helpers/mock.test.ts
@@ -64,7 +64,10 @@ describe("MockContract", () => {
 
     it("returns the zero value when unstubbed", async () => {
       // smock answers an unconfigured function with the zero value of its
-      // return type rather than reverting; empty returndata decodes the same.
+      // return type rather than reverting. Empty returndata would not do:
+      // Solidity checks returndatasize against the size its ABI expects and
+      // reverts the caller on a short answer, so the helper installs a
+      // correctly encoded zero for every function up front.
       expect(await consumer.readValueThroughStaticCall(7)).to.equal(0)
     })
   })
@@ -219,6 +222,62 @@ describe("MockContract", () => {
       await pinnedConsumer.deployed()
 
       expect(await pinnedConsumer.readValueThroughStaticCall(1)).to.equal(7)
+    })
+  })
+
+  describe("storage left behind at a pinned address", () => {
+    it("is not read back as configuration", async () => {
+      // Mocks are routinely installed over an address that already holds a
+      // deployed contract — `test/fixtures/bridge.ts` pins them at the Bridge's
+      // real ecdsaWalletRegistry and relay. `hardhat_setCode` replaces the code
+      // and leaves the storage, so a mock keeping its state at slots 0, 1, 2...
+      // would read that leftover as its own.
+      const address = ethers.utils.getAddress(`0x${"cd".repeat(20)}`)
+      const garbage =
+        "0xdeadbeef00000000000000000000000000000000000000000000000000000001"
+
+      await Promise.all(
+        Array.from({ length: 8 }, (_, slot) =>
+          ethers.provider.send("hardhat_setStorageAt", [
+            address,
+            ethers.utils.hexValue(slot),
+            garbage,
+          ])
+        )
+      )
+
+      const pinned = await createMock<IMockTarget>("IMockTarget", { address })
+
+      expect(await pinned.doThing.callCount()).to.equal(0)
+
+      await pinned.readValue.returns(7)
+
+      const factory = await ethers.getContractFactory("MockTargetConsumer")
+      const pinnedConsumer = await factory.deploy(address)
+      await pinnedConsumer.deployed()
+
+      expect(await pinnedConsumer.readValueThroughStaticCall(1)).to.equal(7)
+    })
+  })
+
+  describe("call assertions on read-only functions", () => {
+    it("are refused rather than silently answered zero", async () => {
+      // A view function is reached by STATICCALL and cannot be recorded.
+      // Answering "0 calls" would read as a passing assertion.
+      let message = ""
+      try {
+        await target.readValue.callCount()
+      } catch (error) {
+        message = (error as Error).message
+      }
+
+      expect(message).to.contain("STATICCALL")
+    })
+
+    it("still allow the function to be stubbed", async () => {
+      await target.readValue.returns(3)
+
+      expect(await consumer.readValueThroughStaticCall(1)).to.equal(3)
     })
   })
 })

--- a/solidity/test/helpers/mock.ts
+++ b/solidity/test/helpers/mock.ts
@@ -6,6 +6,8 @@
  */
 /* eslint-disable no-underscore-dangle */
 import { ethers, artifacts } from "hardhat"
+import { expect } from "chai"
+import { BigNumber } from "ethers"
 
 import type { BigNumberish, Contract, Signer } from "ethers"
 import type { FunctionFragment, Interface, ParamType } from "ethers/lib/utils"
@@ -452,6 +454,63 @@ export async function createMock<T>(
       return functions.get(property)
     },
   }) as unknown as Mock<T>
+}
+
+/**
+ * Assertion helpers replacing smock's chai matchers.
+ *
+ * smock's `expect(fake.fn).to.have.been.calledOnce` worked because the call log
+ * was in-process JavaScript, so a chai *property* could read it synchronously.
+ * Here the log is on chain, so reading it is asynchronous, and a property
+ * cannot be awaited — `await expect(x).to.have.been.calledOnce` would await the
+ * assertion object, not the count, and pass unconditionally. These are
+ * functions so that the `await` is real.
+ */
+
+async function counted(fn: MockedFunction): Promise<number> {
+  return fn.callCount()
+}
+
+/** `expect(fake.fn).to.have.been.called` */
+export async function expectCalled(fn: MockedFunction): Promise<void> {
+  const count = await counted(fn)
+  expect(count, "expected the function to have been called").to.be.greaterThan(
+    0
+  )
+}
+
+/** `expect(fake.fn).to.have.been.calledOnce` */
+export async function expectCalledOnce(fn: MockedFunction): Promise<void> {
+  expect(await counted(fn), "expected exactly one call").to.equal(1)
+}
+
+/** `expect(fake.fn).to.have.been.calledTwice` */
+export async function expectCalledTwice(fn: MockedFunction): Promise<void> {
+  expect(await counted(fn), "expected exactly two calls").to.equal(2)
+}
+
+/** `expect(fake.fn).to.have.been.calledOnceWith(...args)` */
+export async function expectCalledOnceWith(
+  fn: MockedFunction,
+  args: unknown[]
+): Promise<void> {
+  expect(await counted(fn), "expected exactly one call").to.equal(1)
+
+  const call = await fn.getCall(0)
+
+  expect(call.args.length, "argument count").to.equal(args.length)
+  args.forEach((expected, index) => {
+    const actual = call.args[index]
+    // Comparing loosely on purpose: ethers hands back BigNumber for numeric
+    // arguments and checksummed strings for addresses, and the call sites
+    // being migrated pass plain numbers and lower-case addresses.
+    expect(
+      BigNumber.isBigNumber(actual) ? actual.toString() : actual,
+      `argument ${index}`
+    ).to.deep.equal(
+      BigNumber.isBigNumber(expected) ? expected.toString() : expected
+    )
+  })
 }
 
 export default createMock

--- a/solidity/test/helpers/mock.ts
+++ b/solidity/test/helpers/mock.ts
@@ -1,0 +1,421 @@
+/*
+ * The `__mock__*` names below are the administrative entry points of
+ * `MockContract.sol`, deliberately namespaced there so they cannot be confused
+ * with — or collide with — a function of the interface being mocked. They are
+ * dictated by the contract, so the dangling-underscore rule does not apply.
+ */
+/* eslint-disable no-underscore-dangle */
+import { ethers, artifacts } from "hardhat"
+
+import type { BigNumberish, Contract, Signer } from "ethers"
+import type { FunctionFragment, Interface, ParamType } from "ethers/lib/utils"
+
+/**
+ * Programmable contract mock, replacing `@defi-wonderland/smock`.
+ *
+ * smock configured its fakes by mutating in-process JavaScript state inside
+ * Hardhat's EVM, which is why its API was synchronous — and also why it broke
+ * on Hardhat >= 2.20 and is archived upstream with no forward path. This
+ * replacement drives an ordinary deployed contract (`MockContract.sol`)
+ * over the public provider API, so it depends on nothing Hardhat can change
+ * underneath it.
+ *
+ * The consequence is that configuration is a transaction, so every setup and
+ * inspection call here returns a promise and must be awaited. That is the one
+ * behavioural difference from smock and the reason the migration touches call
+ * sites at all.
+ *
+ * Semantics follow Foundry's `vm.mockCall` deliberately: an exact-calldata
+ * entry wins over a selector-wide default, and an unconfigured function
+ * returns the zero value of its return type, matching smock.
+ *
+ * That last part is not free. Solidity compares returndatasize against the
+ * size its ABI expects and reverts on a short answer, so a mock cannot answer
+ * an unconfigured function with empty data — it has to return a correctly
+ * encoded zero. Only this helper knows the mocked ABI, so it computes those
+ * encodings up front and installs them in the mock as a base layer that
+ * `reset` does not disturb.
+ */
+
+/** A recorded call, decoded against the mocked interface. */
+export interface MockCall {
+  /** Decoded arguments, in declaration order. */
+  args: unknown[]
+}
+
+/** Configuration and inspection handle for one function of a mock. */
+export interface MockedFunction {
+  /**
+   * Answers every call to this function with `value`, unless a
+   * `whenCalledWith` entry matches first. Call with no argument for a function
+   * that returns nothing.
+   */
+  returns(value?: unknown): Promise<void>
+  /** Makes every call to this function revert. */
+  reverts(reason?: string): Promise<void>
+  /** Narrows the next `returns`/`reverts` to one exact argument list. */
+  whenCalledWith(...args: unknown[]): {
+    returns(value?: unknown): Promise<void>
+    reverts(reason?: string): Promise<void>
+  }
+  /** Drops every response configured for this function and every call recorded for it. */
+  reset(): Promise<void>
+  /** Number of calls recorded for this function. */
+  callCount(): Promise<number>
+  /** The i-th recorded call, decoded. */
+  getCall(index: number): Promise<MockCall>
+  /** Every recorded call, decoded. */
+  getCalls(): Promise<MockCall[]>
+}
+
+export type Mock<T> = {
+  [K in keyof T]: T[K] extends (...args: never[]) => unknown
+    ? T[K] & MockedFunction
+    : T[K]
+} & {
+  address: string
+  /** Signer that sends from the mock's own address, as smock's `fake.wallet` did. */
+  wallet: Signer
+  /** Underlying deployed `MockContract`, for anything this helper does not wrap. */
+  mockContract: Contract
+  /** Drops all configured responses and all recorded calls. */
+  reset(): Promise<void>
+}
+
+/** Selectors of `MockContract`'s own administrative entry points. */
+function adminSelectors(mockInterface: Interface): Set<string> {
+  return new Set(
+    Object.keys(mockInterface.functions)
+      .filter((signature) => signature.startsWith("__mock__"))
+      .map((signature) => mockInterface.getSighash(signature))
+  )
+}
+
+/**
+ * `MockContract` answers the mocked interface through its fallback, so its own
+ * `__mock__*` entry points share the selector space with whatever is being
+ * mocked. A four-byte collision would silently shadow a real function, which
+ * would be a very confusing test failure. It cannot happen by accident, but it
+ * costs nothing to prove rather than assume.
+ */
+function assertNoSelectorCollision(
+  target: Interface,
+  mockInterface: Interface,
+  targetName: string
+): void {
+  const reserved = adminSelectors(mockInterface)
+
+  Object.keys(target.functions).forEach((signature) => {
+    const selector = target.getSighash(signature)
+    if (reserved.has(selector)) {
+      throw new Error(
+        `${targetName}.${signature} has selector ${selector}, which collides ` +
+          "with a MockContract administrative function. This mock cannot " +
+          "represent that interface."
+      )
+    }
+  })
+}
+
+function fragmentsByName(target: Interface): Map<string, FunctionFragment[]> {
+  const byName = new Map<string, FunctionFragment[]>()
+
+  Object.values(target.functions).forEach((fragment) => {
+    const existing = byName.get(fragment.name)
+    if (existing) {
+      existing.push(fragment)
+    } else {
+      byName.set(fragment.name, [fragment])
+    }
+  })
+
+  return byName
+}
+
+/**
+ * Picks the fragment to use for a name. Overloads are ambiguous by name alone;
+ * rather than guess, fail loudly and let the caller address the mock's
+ * `mockContract` directly.
+ */
+function resolveFragment(
+  fragments: FunctionFragment[],
+  name: string,
+  targetName: string
+): FunctionFragment {
+  if (fragments.length > 1) {
+    throw new Error(
+      `${targetName}.${name} is overloaded (${fragments.length} signatures). ` +
+        "Address it through the mock's mockContract handle instead."
+    )
+  }
+
+  return fragments[0]
+}
+
+/**
+ * The zero value of an ABI type, shaped the way `defaultAbiCoder` wants it.
+ *
+ * Dynamic types cannot be zero-filled word-wise, and tuples have to be built
+ * component by component, so this walks the type rather than assuming a flat
+ * layout.
+ */
+function zeroValueFor(type: ParamType): unknown {
+  if (type.baseType === "array") {
+    if (type.arrayLength === -1) {
+      return []
+    }
+    return Array.from({ length: type.arrayLength }, () =>
+      zeroValueFor(type.arrayChildren)
+    )
+  }
+
+  if (type.baseType === "tuple") {
+    return type.components.map((component) => zeroValueFor(component))
+  }
+
+  if (type.baseType === "address") {
+    return ethers.constants.AddressZero
+  }
+
+  if (type.baseType === "bool") {
+    return false
+  }
+
+  if (type.baseType === "string") {
+    return ""
+  }
+
+  if (type.baseType === "bytes") {
+    return "0x"
+  }
+
+  const fixedBytes = /^bytes(\d+)$/.exec(type.baseType)
+  if (fixedBytes) {
+    return `0x${"00".repeat(Number(fixedBytes[1]))}`
+  }
+
+  // Everything left is uint*/int*.
+  return 0
+}
+
+function encodeReturn(fragment: FunctionFragment, value: unknown): string {
+  if (fragment.outputs === null || fragment.outputs.length === 0) {
+    return "0x"
+  }
+
+  // A single-output function is configured with a bare value; a multi-output
+  // one with an array, as smock did.
+  const values =
+    fragment.outputs.length === 1 && !Array.isArray(value) ? [value] : value
+
+  return ethers.utils.defaultAbiCoder.encode(
+    fragment.outputs,
+    values as unknown[]
+  )
+}
+
+function encodeRevert(reason?: string): string {
+  if (reason === undefined) {
+    return "0x"
+  }
+
+  return (
+    ethers.utils.id("Error(string)").slice(0, 10) +
+    ethers.utils.defaultAbiCoder.encode(["string"], [reason]).slice(2)
+  )
+}
+
+/**
+ * Deploys a programmable mock answering `target`'s interface.
+ *
+ * @param target Name of the contract or interface to mock, as passed to
+ *        `artifacts.readArtifact` — e.g. `"IBridge"`.
+ * @param options.address Deploy the mock at this exact address, replacing
+ *        whatever is there. Mirrors smock's `{ address }` option.
+ * @returns A handle exposing each of `target`'s functions with `returns`,
+ *          `whenCalledWith`, `reverts`, `reset`, `callCount` and `getCall`.
+ */
+export async function createMock<T>(
+  target: string,
+  options: { address?: string } = {}
+): Promise<Mock<T>> {
+  const targetArtifact = await artifacts.readArtifact(target)
+  const targetInterface = new ethers.utils.Interface(targetArtifact.abi)
+
+  const mockFactory = await ethers.getContractFactory("MockContract")
+  let mockContract = await mockFactory.deploy()
+  await mockContract.deployed()
+
+  assertNoSelectorCollision(targetInterface, mockContract.interface, target)
+
+  // Install the response of last resort for every function, so an unstubbed
+  // one answers with a correctly sized zero instead of reverting the caller.
+  const baseFragments = Object.values(targetInterface.functions)
+  const baseSelectors = baseFragments.map((fragment) =>
+    targetInterface.getSighash(fragment)
+  )
+  const baseReturns = baseFragments.map((fragment) =>
+    fragment.outputs === null || fragment.outputs.length === 0
+      ? "0x"
+      : ethers.utils.defaultAbiCoder.encode(
+          fragment.outputs,
+          fragment.outputs.map((output) => zeroValueFor(output))
+        )
+  )
+  await mockContract.__mock__setBaseReturns(baseSelectors, baseReturns)
+
+  if (options.address !== undefined) {
+    // Move the deployed bytecode to the requested address. The mock's storage
+    // starts empty there, which is what a freshly configured mock expects.
+    const code = await ethers.provider.getCode(mockContract.address)
+    await ethers.provider.send("hardhat_setCode", [options.address, code])
+    mockContract = mockContract.attach(options.address)
+  }
+
+  await ethers.provider.send("hardhat_impersonateAccount", [
+    mockContract.address,
+  ])
+  await ethers.provider.send("hardhat_setBalance", [
+    mockContract.address,
+    "0x21e19e0c9bab2400000", // 10_000 ETH, so the mock can pay for its own sends
+  ])
+  const wallet = await ethers.getSigner(mockContract.address)
+
+  const byName = fragmentsByName(targetInterface)
+
+  function buildFunction(name: string): MockedFunction {
+    const fragment = resolveFragment(byName.get(name) ?? [], name, target)
+    const selector = targetInterface.getSighash(fragment)
+
+    const setForCalldata = async (
+      args: unknown[],
+      behaviour: "return" | "revert",
+      payload: unknown
+    ): Promise<void> => {
+      const callData = targetInterface.encodeFunctionData(
+        fragment,
+        args as never[]
+      )
+
+      if (behaviour === "return") {
+        await mockContract.__mock__setReturnForCalldata(
+          callData,
+          encodeReturn(fragment, payload)
+        )
+      } else {
+        await mockContract.__mock__setRevertForCalldata(
+          callData,
+          encodeRevert(payload as string | undefined)
+        )
+      }
+    }
+
+    const decodeCall = (callData: string): MockCall => ({
+      args: Array.from(
+        targetInterface.decodeFunctionData(fragment, callData)
+      ) as unknown[],
+    })
+
+    return {
+      async returns(value?: unknown): Promise<void> {
+        await mockContract.__mock__setReturnForSelector(
+          selector,
+          encodeReturn(fragment, value)
+        )
+      },
+
+      async reverts(reason?: string): Promise<void> {
+        await mockContract.__mock__setRevertForSelector(
+          selector,
+          encodeRevert(reason)
+        )
+      },
+
+      whenCalledWith(...args: unknown[]) {
+        return {
+          returns: (value?: unknown) => setForCalldata(args, "return", value),
+          reverts: (reason?: string) => setForCalldata(args, "revert", reason),
+        }
+      },
+
+      async reset(): Promise<void> {
+        await mockContract.__mock__resetSelector(selector)
+      },
+
+      async callCount(): Promise<number> {
+        const count: BigNumberish =
+          await mockContract.__mock__callCountForSelector(selector)
+        return Number(count)
+      },
+
+      async getCall(index: number): Promise<MockCall> {
+        const callData: string = await mockContract.__mock__callForSelectorAt(
+          selector,
+          index
+        )
+        return decodeCall(callData)
+      },
+
+      async getCalls(): Promise<MockCall[]> {
+        const count: BigNumberish =
+          await mockContract.__mock__callCountForSelector(selector)
+        const calls: MockCall[] = []
+
+        for (let i = 0; i < Number(count); i++) {
+          // Sequential on purpose: ordering is the point of this accessor.
+          // eslint-disable-next-line no-await-in-loop
+          const callData: string = await mockContract.__mock__callForSelectorAt(
+            selector,
+            i
+          )
+          calls.push(decodeCall(callData))
+        }
+
+        return calls
+      },
+    }
+  }
+
+  const functions = new Map<string, MockedFunction>()
+  const readContract = new ethers.Contract(
+    mockContract.address,
+    targetArtifact.abi,
+    ethers.provider
+  )
+
+  const handle = {
+    address: mockContract.address,
+    wallet,
+    mockContract,
+    async reset(): Promise<void> {
+      await mockContract.__mock__reset()
+    },
+  }
+
+  return new Proxy(handle, {
+    get(base, property: string | symbol, receiver) {
+      if (typeof property !== "string" || property in base) {
+        return Reflect.get(base, property, receiver)
+      }
+
+      if (!byName.has(property)) {
+        return Reflect.get(base, property, receiver)
+      }
+
+      if (!functions.has(property)) {
+        // Callable like the contract itself, so a test can read through the
+        // mock, with the configuration surface hung off the same object —
+        // which is the shape smock's fakes had.
+        const callable = (...args: unknown[]) => readContract[property](...args)
+        functions.set(
+          property,
+          Object.assign(callable, buildFunction(property)) as MockedFunction
+        )
+      }
+
+      return functions.get(property)
+    },
+  }) as unknown as Mock<T>
+}
+
+export default createMock

--- a/solidity/test/helpers/mock.ts
+++ b/solidity/test/helpers/mock.ts
@@ -264,6 +264,21 @@ export async function createMock<T>(
   )
   await mockContract.__mock__setBaseReturns(baseSelectors, baseReturns)
 
+  // Flag the read-only functions. Solidity reaches them by STATICCALL, where
+  // the storage write recording needs is impossible, so the mock must not even
+  // attempt it. Doing this from the ABI rather than discovering it at runtime
+  // also lets `callCount`/`getCall` refuse loudly below.
+  const nonRecordingSelectors = baseFragments
+    .filter(
+      (fragment) =>
+        fragment.stateMutability === "view" ||
+        fragment.stateMutability === "pure"
+    )
+    .map((fragment) => targetInterface.getSighash(fragment))
+  if (nonRecordingSelectors.length > 0) {
+    await mockContract.__mock__setNonRecordingSelectors(nonRecordingSelectors)
+  }
+
   if (options.address !== undefined) {
     // Move the deployed bytecode to the requested address. The mock's storage
     // starts empty there, which is what a freshly configured mock expects.
@@ -286,6 +301,21 @@ export async function createMock<T>(
   function buildFunction(name: string): MockedFunction {
     const fragment = resolveFragment(byName.get(name) ?? [], name, target)
     const selector = targetInterface.getSighash(fragment)
+    const readOnly =
+      fragment.stateMutability === "view" || fragment.stateMutability === "pure"
+
+    // Calls to a read-only function cannot be recorded, so answering "0 calls"
+    // would be a lie that reads as a passing assertion. Refuse instead.
+    const refuseIfReadOnly = () => {
+      if (readOnly) {
+        throw new Error(
+          `${target}.${name} is ${fragment.stateMutability}, so Solidity ` +
+            "reaches it by STATICCALL and the mock cannot record the call. " +
+            "Assert on the state-changing function that consumed the value " +
+            "instead."
+        )
+      }
+    }
 
     const setForCalldata = async (
       args: unknown[],
@@ -343,12 +373,16 @@ export async function createMock<T>(
       },
 
       async callCount(): Promise<number> {
+        refuseIfReadOnly()
+
         const count: BigNumberish =
           await mockContract.__mock__callCountForSelector(selector)
         return Number(count)
       },
 
       async getCall(index: number): Promise<MockCall> {
+        refuseIfReadOnly()
+
         const callData: string = await mockContract.__mock__callForSelectorAt(
           selector,
           index
@@ -357,6 +391,8 @@ export async function createMock<T>(
       },
 
       async getCalls(): Promise<MockCall[]> {
+        refuseIfReadOnly()
+
         const count: BigNumberish =
           await mockContract.__mock__callCountForSelector(selector)
         const calls: MockCall[] = []


### PR DESCRIPTION
Foundation only — the mock plus its own 19-test suite. **No existing test is migrated here.**
Follow-ups migrate the 29 files; this is the piece they all depend on.

## Why smock has to go

`@defi-wonderland/smock` is archived upstream ("may contain outdated, insecure, or
vulnerable code"). It is also what pins the toolchain. Measured:

| hardhat | Node 24 cold compile | smock 2.3.4 |
| --- | --- | --- |
| 2.12.5 (what is pinned) | `HH502` | works |
| 2.19.5 | `HH502` | works |
| 2.29.0 | compiles | `TypeError` in `Sandbox.create` |

So Node 24 needs hardhat >= ~2.20, and hardhat >= 2.20 needs smock gone. See #1060
for the full measurement.

## Why not Foundry / Hardhat 3 / an off-the-shelf package

Both Foundry and [Hardhat 3](https://hardhat.org/docs/reference/cheatcodes/environment/mock-call)
offer `vm.mockCall`, and it is better than anything we would write. But cheatcodes
only exist inside **Solidity** tests. These 29 files are TypeScript on typechain and
ethers v5, and 17 suite tests drive `deployments.fixture()`, which has no Solidity
equivalent. Reaching `vm.mockCall` means porting the tests first.

`@term-finance/ethers-mock-contract` is the one maintained JS option and does not fit:
v0.1.9 last published 14 months ago, no declared peer deps, and no call recording or
call-count assertions — which this suite uses **69** times (`getCall` 33, `to.have.been.*` 36).

## What this is

Foundry’s *model*, not its implementation. `MockContract.sol` is an ordinary deployed
contract holding a calldata→returndata table plus call recording, driven from TypeScript
over the public provider API. It touches no Hardhat internals — precisely what broke
smock, and what will break any JS mock at the next toolchain move.

The survey said this was viable: **78** `smock.fake`, **0** stateful `smock.mock`,
**0** `.returns()` taking a callback. Every use is static.

## Three findings that each forced a redesign

**1. STATICCALL.** Recording is a storage write, so a stubbed `view` function reached by
STATICCALL would revert — every such stub in the suite. Recording now goes through a
self-call whose failure is swallowed, making it best-effort. Sound here because *every*
call assertion in the suite targets a state-changing function (`refund`, `revealDepositWithExtraData`,
`seize`, `transferTokensWithPayload`, `sendVaasToEvm`, `requestNewWallet`); a view reached
by STATICCALL could not have been counted anyway.

**2. `reset` cannot infer.** Since STATICCALL calls are not recorded, reset cannot work out
what to clear from the calls it saw. It tracks what was *configured* instead.

**3. Empty returndata is not zero.** Solidity compares `returndatasize` against the size its
ABI expects and reverts on a short answer, so an unstubbed function cannot answer with `0x`
— it reverts the caller. The helper computes the correctly encoded zero for every return
type and installs it as a base layer `reset` leaves alone, reproducing smock’s behaviour.

## The one behavioural difference

smock configured fakes by mutating in-process JavaScript, so its API was **synchronous**.
Configuration here is a transaction, so setup and inspection must be `await`ed. That is what
the per-file migration changes at call sites — mechanical, but it is not a no-op, and I want
it stated up front rather than discovered in review.

## Incidental

The fallback reads `msg.data` and returns through assembly rather than using a typed
fallback, because **prettier-plugin-solidity silently rewrites**
`fallback(bytes calldata callData) external payable returns (bytes memory)` into
`fallback() external payable` — dropping the parameter and the return type. A formatter
quietly changing semantics is worth knowing about independently of this PR.

## Verification

```
19 passing
```

covering STATICCALL views, struct and multi-value returns, `whenCalledWith` precedence,
reverts (blanket and per-argument), call recording and argument decoding, all four `reset`
behaviours, `wallet` impersonation, and pinned-address deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a programmable Solidity mock framework for stubbing returns/reverts (including argument-specific overrides), supporting static-call friendly `view` behavior, call tracking, and reset/clear controls, with safety checks for selector collisions and pinned deployments.
  * Added typed mock creation for contract interfaces and async call assertion helpers.
* **Tests**
  * Added comprehensive coverage for static calls (including struct/multi-value returns), overrides, reverts, call recording (including no-return flows), reset behavior, and pinned-address safety and assertion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->