### PR TITLE
chore(watchtower): typecheck the tests the typecheck claimed to cover

### DIFF
--- a/services/watchtower/test/EsploraP2TRSignatureFraudTransactionSource.regression.test.ts
+++ b/services/watchtower/test/EsploraP2TRSignatureFraudTransactionSource.regression.test.ts
@@ -10,6 +10,7 @@ import {
   Hex,
   P2TR_SIGNATURE_FRAUD_SPEND_TYPE_REDEMPTION,
 } from "@keep-network/tbtc-v2.ts"
+import type { P2TRSignatureFraudWatchtowerBridgeLifecycleEventSource } from "@keep-network/tbtc-v2.ts"
 
 import {
   deriveP2TRWalletAddress,
@@ -25,6 +26,22 @@ import type {
   P2TRTaprootDepositBindingInventory,
   P2TRTaprootDepositRevealSource,
 } from "../src/index.js"
+
+/**
+ * Committing the bridge-lifecycle cursor is an optional capability: the service
+ * discovers it structurally (`hasBridgeLifecycleScanCommitter`) rather than
+ * requiring it on the source interface. A double that provides it has to say so
+ * in its type, or the excess-property check rejects the literal and the
+ * contextual type never reaches `spendType`.
+ */
+type CommittingBridgeLifecycleEventSource =
+  P2TRSignatureFraudWatchtowerBridgeLifecycleEventSource & {
+    commitBridgeLifecycleScan(): Promise<void>
+  }
+
+const committingBridgeLifecycleSource = (
+  source: CommittingBridgeLifecycleEventSource
+): CommittingBridgeLifecycleEventSource => source
 
 const walletID =
   "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
@@ -496,7 +513,7 @@ test("does not claim a multi-cycle outspend view is complete when an early bindi
     outspendLimit: 1,
   })
   let committedBridgeLifecycleScan = false
-  const lifecycleSource = {
+  const lifecycleSource: CommittingBridgeLifecycleEventSource = {
     async listBridgeLifecycleEvents() {
       return [
         {
@@ -563,7 +580,7 @@ test("does not certify an empty Esplora inventory or drop an unmatched lifecycle
     {
       bitcoinClient: {} as never,
       transactionSource: source,
-      bridgeLifecycleEventSource: {
+      bridgeLifecycleEventSource: committingBridgeLifecycleSource({
         async listBridgeLifecycleEvents() {
           lifecycleListCount++
           return [
@@ -577,7 +594,7 @@ test("does not certify an empty Esplora inventory or drop an unmatched lifecycle
         async commitBridgeLifecycleScan() {
           lifecycleCommitCount++
         },
-      },
+      }),
       persistence: {
         async loadChallengeRecords() {
           return []

--- a/services/watchtower/test/EsploraP2TRSignatureFraudTransactionSource.test.ts
+++ b/services/watchtower/test/EsploraP2TRSignatureFraudTransactionSource.test.ts
@@ -561,7 +561,9 @@ test("rejects a partial confirmed view when a raw transaction is unavailable", a
       taprootDepositRevealSource: taprootDepositRevealSource([
         taprootDepositEvent(),
       ]),
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({
         [addressConfirmedPath(address)]: [
           confirmedSummary(confirmedTxid, blockHash, 123),
@@ -613,7 +615,9 @@ test("reports every deposit binding when a shared raw transaction is unavailable
           fundingOutputIndex: 3,
         }),
       ]),
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch(
         {
           [addressMempoolPath(address)]: [{ txid: mempoolTxid }],
@@ -668,7 +672,9 @@ test("rejects raw transaction failures for wallet-only candidates", async () => 
     [walletID],
     {
       taprootDepositRevealSource: emptyTaprootDepositRevealSource,
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({
         [addressMempoolPath(address)]: [
           { txid: mempoolTxid },
@@ -701,7 +707,7 @@ test("rejects a failed deposit request after scanning honest siblings", async ()
     fundingOutputIndex: 3,
   })
   const failures: P2TRDepositScanFailure[] = []
-  const revealSource: P2TRTaprootDepositRevealSource = {
+  const revealSource: TestEsploraOptions["taprootDepositRevealSource"] = {
     async getTaprootDepositRevealedEvents() {
       return [firstEvent, secondEvent] as never[]
     },
@@ -725,7 +731,9 @@ test("rejects a failed deposit request after scanning honest siblings", async ()
     [walletID],
     {
       taprootDepositRevealSource: revealSource,
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({
         [addressMempoolPath(address)]: [],
         [depositOutspendPath(secondFundingTxid, 3)]: {
@@ -771,7 +779,9 @@ test("rejects a failed deposit commitment read", async () => {
           throw new Error("unexpected deposit request read")
         },
       },
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({
         [addressMempoolPath(address)]: [{ txid: mempoolTxid }],
         [`/tx/${mempoolTxid}/hex`]: rawMempoolTx,
@@ -819,7 +829,9 @@ test("rejects a fulfilled reveal-history omission against the independent source
       confirmedHistoryCursorStore: new MemoryConfirmedHistoryCursorStore(),
       taprootDepositRevealChainID: "31337",
       taprootDepositRevealBridgeAddress: `0x${"11".repeat(20)}`,
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({ [addressMempoolPath(address)]: [] }, requestedPaths),
     }
   )
@@ -901,7 +913,9 @@ test("rejects the transaction view when reveal-history retrieval fails", async (
           throw new Error("unexpected deposit read")
         },
       },
-      onDepositScanFailure: (failure) => failures.push(failure),
+      onDepositScanFailure: (failure) => {
+        failures.push(failure)
+      },
       fetchFn: fakeFetch({
         [addressMempoolPath(address)]: [{ txid: mempoolTxid }],
         [`/tx/${mempoolTxid}/hex`]: rawMempoolTx,

--- a/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
+++ b/services/watchtower/test/InMemoryP2TRSignatureFraudChallengeOutboxStore.ts
@@ -27,6 +27,7 @@ import {
   P2TRSignatureFraudNonceReleaseRequest,
   P2TRSignatureFraudOutboxCriticalAlert,
   P2TRSignatureFraudSignerQuarantine,
+  P2TRSignatureFraudSigningLane,
   computeP2TRSignatureFraudNonceReleaseRequestID,
   computeP2TRSignatureFraudNonceReleaseResolutionEvidenceDigest,
   appendSignerQuarantine,
@@ -443,7 +444,7 @@ export class InMemoryOutboxStore
         const quarantine: P2TRSignatureFraudSignerQuarantine = {
           laneID: request.reservation.laneID,
           signerIdentity: request.reservation.signerIdentity,
-          expectedSender: request.reservation.sender.toPrefixedString(),
+          expectedSender: request.reservation.sender,
           reasonCode: "reservation-provider-failure",
           quarantinedAtUnixMs: result.recordedAtUnixMs,
           reason: result.detail,

--- a/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudChallengeOutbox.test.ts
@@ -424,9 +424,9 @@ const refingerprintProvenance = (
 }
 
 class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
-  readonly laneID = SIGNER_LANE_ID
-  readonly signerIdentity = SIGNER_IDENTITY
-  readonly transactionSender = TRANSACTION_SENDER
+  readonly laneID: string = SIGNER_LANE_ID
+  readonly signerIdentity: string = SIGNER_IDENTITY
+  readonly transactionSender: string = TRANSACTION_SENDER
   readonly wallet = new Wallet(`0x${"42".repeat(32)}`)
   calls = 0
   replacementCalls = 0
@@ -529,8 +529,8 @@ class FixedPreparer implements P2TRSignatureFraudChallengeTransactionPreparer {
     this.releasedReservations.push(reservation.reservationID.toPrefixedString())
     const key = releaseRequestID.toPrefixedString()
     const outcome = this.acknowledgedReleaseRequests.has(key)
-      ? "already-released"
-      : "released"
+      ? ("already-released" as const)
+      : ("released" as const)
     this.acknowledgedReleaseRequests.add(key)
     return {
       releaseRequestID,
@@ -1168,18 +1168,14 @@ const dispatcher = (
     }
   )
 
-const withCanonicalAttestations = (
-  resolution: Omit<
-    Exclude<
-      P2TRSignatureFraudChallengeOutboxResolution,
-      { status: "pending" | "unknown" }
-    >,
-    "canonicalAttestations"
+const withCanonicalAttestations = <
+  Resolution extends Exclude<
+    P2TRSignatureFraudChallengeOutboxResolution,
+    { status: "pending" | "unknown" }
   >
-): Exclude<
-  P2TRSignatureFraudChallengeOutboxResolution,
-  { status: "pending" | "unknown" }
-> => {
+>(
+  resolution: Omit<Resolution, "canonicalAttestations">
+): Resolution => {
   const placeholderDigest = `0x${"00".repeat(32)}`
   const provisional = {
     ...resolution,
@@ -1199,10 +1195,7 @@ const withCanonicalAttestations = (
         attestedAtUnixMs: 1_500,
       },
     ],
-  } as unknown as Exclude<
-    P2TRSignatureFraudChallengeOutboxResolution,
-    { status: "pending" | "unknown" }
-  >
+  } as unknown as Resolution
   const evidenceDigest =
     computeP2TRSignatureFraudResolutionEvidenceDigest(provisional)
   return {
@@ -1656,7 +1649,14 @@ test("commits the generation-cap alert before rejecting enqueue", async () => {
     observationID,
     1_000
   )
-  const disposition = withCanonicalAttestations({
+  // Naming the variant keeps the literal narrow: inferring it back out of
+  // `Omit<Resolution, ...>` is not reliable.
+  const disposition = withCanonicalAttestations<
+    Extract<
+      P2TRSignatureFraudChallengeOutboxResolution,
+      { status: "terminal-reverted" }
+    >
+  >({
     status: "terminal-reverted",
     observedHead: {
       blockNumber: 500,
@@ -1677,7 +1677,7 @@ test("commits the generation-cap alert before rejecting enqueue", async () => {
       challengeKey: first.intent.bridgeChallengeKey.toPrefixedString(),
       readAtBlock: 500,
     },
-  } as Parameters<typeof withCanonicalAttestations>[0])
+  })
   const capped: P2TRSignatureFraudChallengeOutboxRecord = {
     ...first,
     status: "generation-required",

--- a/services/watchtower/test/P2TRSignatureFraudWatchtowerService.test.ts
+++ b/services/watchtower/test/P2TRSignatureFraudWatchtowerService.test.ts
@@ -25,6 +25,8 @@ import {
   P2TRSignatureFraudWitnessObservation,
   P2TRSignatureFraudWatchtowerBridgeLifecycleEvent,
   P2TRSignatureFraudWatchtowerBridgeLifecycleEventSource,
+  P2TRSignatureFraudSpendType,
+  P2TRWatchtowerChallengeRecord,
   P2TRSignatureFraudWatchtowerTransactionSource,
   P2TRWatchtowerConfirmedTransaction,
   P2TRWatchtowerChallengeRecordJSON,
@@ -308,6 +310,7 @@ const emptyCycleReport = (): P2TRSignatureFraudWatchtowerCycleReport => ({
       byStatus: {
         observed: 0,
         submitting: 0,
+        "broadcast-pending": 0,
         submitted: 0,
         rejected: 0,
         "defeat-eligible": 0,
@@ -352,6 +355,34 @@ const emptyCycleReport = (): P2TRSignatureFraudWatchtowerCycleReport => ({
     alertSinkFailures: 0,
   },
 })
+
+/**
+ * The service discovers each of these structurally rather than requiring it on
+ * the dependency interface, so a double that offers one has to widen its own
+ * type -- otherwise the excess-property check rejects the literal.
+ */
+type CommittingBridgeLifecycleEventSource =
+  P2TRSignatureFraudWatchtowerBridgeLifecycleEventSource & {
+    commitBridgeLifecycleScan(): Promise<void>
+  }
+
+type IdempotentChallengeSubmitter = P2TRSignatureFraudChallengeSubmitter & {
+  p2trSignatureFraudWatchtowerIdempotentSubmissions: true
+}
+
+/**
+ * Attaches a capability probe the dependency interface deliberately omits. The
+ * spread keeps the base type, so only the probe is added -- and the result is
+ * no longer a fresh literal, which is what the excess-property check trips on.
+ */
+const withCapabilityProbe = <Base, Probe extends object>(
+  base: Base,
+  probe: Probe
+): Base & Probe => ({ ...base, ...probe })
+
+const committingBridgeLifecycleSource = (
+  source: CommittingBridgeLifecycleEventSource
+): CommittingBridgeLifecycleEventSource => source
 
 test("persists watchtower records to an operator state file atomically", async () => {
   const directory = await mkdtemp(join(tmpdir(), "p2tr-watchtower-"))
@@ -712,7 +743,7 @@ test("keeps mutated persisted observations inert while automatic submission is d
       })),
       [vector.walletIDHex]
     )
-    const rejectedRecord = {
+    const rejectedRecord: P2TRWatchtowerChallengeRecord = {
       ...createP2TRWatchtowerChallengeRecord(observation.observationID),
       observation: {
         ...observation,
@@ -785,7 +816,7 @@ test("keeps stored rejected challenges inert during observation-only restart cyc
       draftPayloadBounds,
       draftBridgeChallengeDomain
     )
-    const rejectedRecord = {
+    const rejectedRecord: P2TRWatchtowerChallengeRecord = {
       ...createP2TRWatchtowerChallengeRecord(observation.observationID),
       observation: {
         ...observation,
@@ -886,13 +917,15 @@ test("keeps rejected challenges inert when lifecycle verification fails", async 
       },
       {
         bitcoinClient: {} as BitcoinClient,
-        challengeSubmitter: {
-          p2trSignatureFraudWatchtowerIdempotentSubmissions: true,
-          async submitSignatureFraudChallenge() {
-            submissionCount++
-            throw new Error("temporary submitter outage")
+        challengeSubmitter: withCapabilityProbe(
+          {
+            async submitSignatureFraudChallenge() {
+              submissionCount++
+              throw new Error("temporary submitter outage")
+            },
           },
-        },
+          { p2trSignatureFraudWatchtowerIdempotentSubmissions: true as const }
+        ),
         transactionSource: emptyTransactionSource,
         bridgeLifecycleEventSource: {
           async listBridgeLifecycleEvents() {
@@ -945,7 +978,7 @@ test("wires observation-only file-backed runtime config into service and loop op
       draftPayloadBounds,
       draftBridgeChallengeDomain
     )
-    const rejectedRecord = {
+    const rejectedRecord: P2TRWatchtowerChallengeRecord = {
       ...createP2TRWatchtowerChallengeRecord(observation.observationID),
       observation: {
         ...observation,
@@ -1039,7 +1072,7 @@ test("defaults service cycles to observation-only submission policy", async () =
       })),
       [vector.walletIDHex]
     )
-    const rejectedRecord = {
+    const rejectedRecord: P2TRWatchtowerChallengeRecord = {
       ...createP2TRWatchtowerChallengeRecord(observation.observationID),
       observation,
       status: "rejected" as const,
@@ -1280,14 +1313,14 @@ test("reconciles honest-spend proofs for classified flexible-sighash replacement
             return { transactions: confirmedTransactions, complete: true }
           },
         },
-        bridgeLifecycleEventSource: {
+        bridgeLifecycleEventSource: committingBridgeLifecycleSource({
           async listBridgeLifecycleEvents() {
             return lifecycleEvents
           },
           async commitBridgeLifecycleScan() {
             committedBridgeLifecycleScan = true
           },
-        },
+        }),
         persistence,
       }
     )
@@ -1398,7 +1431,7 @@ test("reconciles honest-spend proofs after metadata-only confirmations", async (
         bitcoinClient: {} as BitcoinClient,
         challengeSubmitter: new FakeSubmitter(),
         transactionSource: emptyTransactionSource,
-        bridgeLifecycleEventSource: {
+        bridgeLifecycleEventSource: committingBridgeLifecycleSource({
           async listBridgeLifecycleEvents() {
             return [
               {
@@ -1411,7 +1444,7 @@ test("reconciles honest-spend proofs after metadata-only confirmations", async (
           async commitBridgeLifecycleScan() {
             committedBridgeLifecycleScan = true
           },
-        },
+        }),
         persistence,
       }
     )
@@ -1579,11 +1612,13 @@ test("hard-disables automatic submission before checking spend policy", () => {
 })
 
 test("hard-disables automatic submission for every unresolved spend type", () => {
-  ;[
-    P2TR_SIGNATURE_FRAUD_SPEND_TYPE_UNCLASSIFIED,
-    P2TR_SIGNATURE_FRAUD_SPEND_TYPE_WALLET_CLOSING,
-    P2TR_SIGNATURE_FRAUD_SPEND_TYPE_HEARTBEAT,
-  ].forEach((spendType) => {
+  ;(
+    [
+      P2TR_SIGNATURE_FRAUD_SPEND_TYPE_UNCLASSIFIED,
+      P2TR_SIGNATURE_FRAUD_SPEND_TYPE_WALLET_CLOSING,
+      P2TR_SIGNATURE_FRAUD_SPEND_TYPE_HEARTBEAT,
+    ] as P2TRSignatureFraudSpendType[]
+  ).forEach((spendType) => {
     assert.throws(
       () =>
         new P2TRSignatureFraudWatchtowerService(
@@ -1859,11 +1894,10 @@ test("requires transactional-production dependencies for the production indexing
     () =>
       new P2TRSignatureFraudWatchtowerService(productionObservationConfig, {
         bitcoinClient: {} as BitcoinClient,
-        transactionSource: {
-          ...emptyTransactionSource,
+        transactionSource: withCapabilityProbe(emptyTransactionSource, {
           p2trSignatureFraudWatchtowerStoreProfile:
             "single-process-rehearsal" as const,
-        },
+        }),
         bridgeLifecycleEventSource: transactionalBridgeLifecycleSource(),
         persistence: transactionalChallengeRecordPersistence(),
         transactionCoordinator: transactionalCoordinator(),
@@ -1904,10 +1938,10 @@ test("requires transactional-production dependencies for the production indexing
         bitcoinClient: {} as BitcoinClient,
         transactionSource: transactionalConfirmedTransactionSource(),
         bridgeLifecycleEventSource: transactionalBridgeLifecycleSource(),
-        persistence: {
-          ...transactionalChallengeRecordPersistence(),
-          p2trSignatureFraudWatchtowerTransactionalStoreID: undefined,
-        },
+        persistence: withCapabilityProbe(
+          transactionalChallengeRecordPersistence(),
+          { p2trSignatureFraudWatchtowerTransactionalStoreID: undefined }
+        ),
         transactionCoordinator: transactionalCoordinator(),
         alertSink: noopAlertSink,
       }),
@@ -1918,10 +1952,10 @@ test("requires transactional-production dependencies for the production indexing
     () =>
       new P2TRSignatureFraudWatchtowerService(productionObservationConfig, {
         bitcoinClient: {} as BitcoinClient,
-        transactionSource: {
-          ...transactionalConfirmedTransactionSource(),
-          p2trSignatureFraudWatchtowerTransactionalStoreID: undefined,
-        },
+        transactionSource: withCapabilityProbe(
+          transactionalConfirmedTransactionSource(),
+          { p2trSignatureFraudWatchtowerTransactionalStoreID: undefined }
+        ),
         bridgeLifecycleEventSource: transactionalBridgeLifecycleSource(),
         persistence: transactionalChallengeRecordPersistence(),
         transactionCoordinator: transactionalCoordinator(),
@@ -2335,7 +2369,7 @@ test("does not retain rolled-back production lifecycle records across cycles", a
     draftPayloadBounds,
     draftBridgeChallengeDomain
   )
-  const rejectedRecord = {
+  const rejectedRecord: P2TRWatchtowerChallengeRecord = {
     ...createP2TRWatchtowerChallengeRecord(observation.observationID),
     observation: {
       ...observation,
@@ -2434,7 +2468,7 @@ test("applies Bridge lifecycle events and reports cycle metrics", async () => {
       ),
     ])
     let committedBridgeLifecycleScan = false
-    const bridgeLifecycleEventSource = {
+    const bridgeLifecycleEventSource: CommittingBridgeLifecycleEventSource = {
       async listBridgeLifecycleEvents() {
         return [
           {
@@ -2481,7 +2515,7 @@ test("commits Bridge lifecycle scans that only contain unrelated proof events", 
 
   try {
     let committedBridgeLifecycleScan = false
-    const bridgeLifecycleEventSource = {
+    const bridgeLifecycleEventSource: CommittingBridgeLifecycleEventSource = {
       async listBridgeLifecycleEvents() {
         return [
           {
@@ -2558,7 +2592,7 @@ test("surfaces Bridge lifecycle scan cursor commit failures", async () => {
         logs.push({ level: "error", message, fields })
       },
     }
-    const bridgeLifecycleEventSource = {
+    const bridgeLifecycleEventSource: CommittingBridgeLifecycleEventSource = {
       async listBridgeLifecycleEvents() {
         return [
           {
@@ -2971,7 +3005,7 @@ test("does not commit Bridge lifecycle scan cursor after event failures", async 
         bitcoinClient: {} as BitcoinClient,
         challengeSubmitter: new FakeSubmitter(),
         transactionSource: emptyTransactionSource,
-        bridgeLifecycleEventSource: {
+        bridgeLifecycleEventSource: committingBridgeLifecycleSource({
           async listBridgeLifecycleEvents() {
             return [
               {
@@ -2983,7 +3017,7 @@ test("does not commit Bridge lifecycle scan cursor after event failures", async 
           async commitBridgeLifecycleScan() {
             committedBridgeLifecycleScan = true
           },
-        },
+        }),
         persistence: new FileBackedP2TRWatchtowerChallengeRecordPersistence(
           statePath
         ),
@@ -3019,7 +3053,9 @@ test("runs watchtower loop cycles sequentially with report callbacks", async () 
       pollIntervalMs: 1,
       maxCycles: 3,
       delay: async () => {},
-      onCycleReport: (report) => reports.push(report),
+      onCycleReport: (report) => {
+        reports.push(report)
+      },
     }
   )
 
@@ -3082,7 +3118,9 @@ test("makes watchtower loop cycle failure policy explicit", async () => {
       maxCycles: 2,
       continueOnError: true,
       delay: async () => {},
-      onCycleError: (error) => failures.push((error as Error).message),
+      onCycleError: (error) => {
+        failures.push((error as Error).message)
+      },
     }
   )
 

--- a/services/watchtower/test/PostgresP2TRProductionEthereumHistoryAccumulator.test.ts
+++ b/services/watchtower/test/PostgresP2TRProductionEthereumHistoryAccumulator.test.ts
@@ -143,7 +143,7 @@ describe("durable production Ethereum history accumulator", () => {
 
   it("destroys the database session when BEGIN outcome is ambiguous", async () => {
     const beginFailure = new Error("connection lost during begin")
-    let releaseError: Error | undefined
+    let releaseError: Error | boolean | undefined
     const client: P2TRPostgresClient = {
       query: async () => {
         throw beginFailure
@@ -168,7 +168,7 @@ describe("durable production Ethereum history accumulator", () => {
 function existingAccumulatorHarness(options?: { commitFailure?: Error }) {
   const queries: { sql: string; values?: readonly unknown[] }[] = []
   const providerBlockCalls: number[] = []
-  let releaseError: Error | undefined
+  let releaseError: Error | boolean | undefined
   const descriptors = eventDescriptors()
   const provider = providerFor(providerBlockCalls, [])
   let accumulator!: PostgresP2TRProductionEthereumHistoryAccumulator

--- a/services/watchtower/test/PostgresP2TRTransactionSession.test.ts
+++ b/services/watchtower/test/PostgresP2TRTransactionSession.test.ts
@@ -380,6 +380,7 @@ function readinessInput(): P2TRProductionReadinessCertificateInput {
       transactions: 1,
       receipts: 1,
       logs: 1,
+      requiredEvents: 1,
     },
     failureGeneration: 0,
     clearedFailureGeneration: 0,

--- a/services/watchtower/test/VerifiedP2TRProductionEthereumProvider.test.ts
+++ b/services/watchtower/test/VerifiedP2TRProductionEthereumProvider.test.ts
@@ -11,6 +11,7 @@ import {
   hashP2TRActivationLinkedLibraryDescriptorSet,
   hashP2TRActivationLinkedLibraryInventory,
   P2TR_ECDSA_FRAUD_ROUTER_CURRENT_V3,
+  P2TR_FROST_WALLET_GROUP_INVENTORY_SCHEMA,
   type P2TRActivationLinkedLibraryBinding,
   type P2TRProductionEthereumState,
 } from "../src/P2TRProductionActivation.js"
@@ -146,11 +147,11 @@ describe("verified production Ethereum provider", () => {
       ...base,
       getCode: async (target: string) =>
         target.toLowerCase() === libraryAddress ? libraryCode : ownerCode,
-    } as JsonRpcP2TRCanonicalEthereumProvider
+    } as unknown as JsonRpcP2TRCanonicalEthereumProvider
     const runtime = configuredProvider(provider, ownerCode, linkedLibraries)
     await (
       runtime as unknown as {
-        verifyContractBindings(point: typeof point): Promise<void>
+        verifyContractBindings(at: typeof point): Promise<void>
       }
     ).verifyContractBindings(point)
 
@@ -159,14 +160,14 @@ describe("verified production Ethereum provider", () => {
         ...provider,
         getCode: async (target: string) =>
           target.toLowerCase() === libraryAddress ? "0x60026000" : ownerCode,
-      } as JsonRpcP2TRCanonicalEthereumProvider,
+      } as unknown as JsonRpcP2TRCanonicalEthereumProvider,
       ownerCode,
       linkedLibraries
     )
     await assert.rejects(
       (
         corrupt as unknown as {
-          verifyContractBindings(point: typeof point): Promise<void>
+          verifyContractBindings(at: typeof point): Promise<void>
         }
       ).verifyContractBindings(point),
       /linked-library runtime code changed/
@@ -394,6 +395,25 @@ function configuredExactProvider(
       registryFrostInactivityAddress:
         "0x0000000000000000000000000000000000000007",
       activeOnlyGetWalletSemantics: true,
+    },
+    requiredEventCoverage: {
+      blocks: 1,
+      transactions: 1,
+      receipts: 1,
+      logs: 1,
+      requiredEvents: 1,
+    },
+    frostWalletGroupInventory: {
+      schema: P2TR_FROST_WALLET_GROUP_INVENTORY_SCHEMA,
+      point,
+      snapshotGeneration: 1,
+      inventoryRoot: `0x${"26".repeat(32)}`,
+      walletCount: 0,
+      minimumActualGroupSize: 0,
+      maximumActualGroupSize: 0,
+      membershipAmbiguityCount: 0,
+      groupSizeViolationCount: 0,
+      complete: true,
     },
   } satisfies Omit<
     P2TRProductionEthereumState,

--- a/services/watchtower/tsconfig.test.json
+++ b/services/watchtower/tsconfig.test.json
@@ -4,5 +4,10 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  // `exclude` is inherited, not replaced, by `extends`. The base config
+  // excludes `test` so that a build emits only `src`, which silently cancelled
+  // the `include` above: this project compiled zero test files and reported
+  // success. Restate `exclude` without `test`.
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
`services/watchtower/tsconfig.test.json` adds `test/**/*.ts` to `include`, but
`extends` merges `compilerOptions` and inherits everything else — so the base
config's `exclude: ["dist", "node_modules", "test"]`, which exists so a build
emits only `src`, cancelled it. `pnpm typecheck` compiled zero test files and
reported success.

Restating `exclude` without `test` is the whole fix. The other 48 changes are
what that surfaced.

## Genuine drift

Doubles and fixtures that had diverged from the interfaces they claim to
implement — exactly what a typecheck is for:

- a challenge-status summary omitting `broadcast-pending`
- a journal-health fixture missing `requiredEvents`
- a pinned protocol state missing `requiredEventCoverage` and
  `frostWalletGroupInventory`
- a deposit reveal source missing all three verification members
  (`providerIdentity`, `getBlockNumber`, `getCanonicalBlockHash`)
- `P2TRSignatureFraudSigningLane` used but never imported
- `expectedSender` reading `.toPrefixedString()` off a reservation sender that
  is already a `string` — a TypeError had that path ever run
- `FixedPreparer` fixing its lane identity to its own string literals, so
  `SecondLanePreparer` could not legally override them
- a release acknowledgement widening `outcome` out of its union

## Inference, not drift

`withCanonicalAttestations` took `Omit<Union, …>`, which collapses to the keys
the union shares, so every caller cast its literal to the whole union and lost
the variant it had just written. It is generic now.

Capability probes the service discovers structurally — `commitBridgeLifecycleScan`,
`p2trSignatureFraudWatchtowerIdempotentSubmissions`, the store-profile markers —
are deliberately absent from the dependency interfaces. The doubles that carry
them now say so in their own types instead of tripping the excess-property
check. (`satisfies` does not help here: it preserves literal freshness.)

## Verification

No test behaviour changes. 462 passing before and after, with
`P2TR_WATCHTOWER_TEST_POSTGRES_URL` set so the PostgreSQL suites actually run —
note CI does not set it, so those never run there.

Both `tsc` projects clean; prettier clean.

Stacked on #1048.